### PR TITLE
Hotfix: unwrap payment snapshot JSON (refund chain stuck APPROVED)

### DIFF
--- a/services/payment/migrations/002_unwrap_snapshot_wrapper.sql
+++ b/services/payment/migrations/002_unwrap_snapshot_wrapper.sql
@@ -1,0 +1,14 @@
+-- 001 shipped with snapshot DTOs that Jackson-wrapped the aggregate as
+-- {"data": {...}}; unwrap any such rows so raw JSONB queries (businessRef
+-- lookup) see the aggregate fields at the top level.
+UPDATE payment_intent_snapshots
+SET data = data->'data'
+WHERE data ? 'data'
+  AND jsonb_typeof(data->'data') = 'object'
+  AND (SELECT count(*) FROM jsonb_object_keys(data)) = 1;
+
+UPDATE refund_snapshots
+SET data = data->'data'
+WHERE data ? 'data'
+  AND jsonb_typeof(data->'data') = 'object'
+  AND (SELECT count(*) FROM jsonb_object_keys(data)) = 1;

--- a/services/payment/src/main/java/com/trainticket/payment/infrastructure/persistence/JacksonPaymentJson.java
+++ b/services/payment/src/main/java/com/trainticket/payment/infrastructure/persistence/JacksonPaymentJson.java
@@ -1,5 +1,7 @@
 package com.trainticket.payment.infrastructure.persistence;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -175,10 +177,21 @@ final class JacksonPaymentJson {
         return value;
     }
 
-    record PaymentIntentSnapshot(ObjectNode data) {
+    // @JsonValue/@JsonCreator keep the column payload as the aggregate JSON
+    // itself; a bare record would wrap it as {"data": {...}} and break every
+    // raw JSONB query (e.g. the businessRef refund lookup).
+    record PaymentIntentSnapshot(@JsonValue ObjectNode data) {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static PaymentIntentSnapshot of(ObjectNode data) {
+            return new PaymentIntentSnapshot(data);
+        }
     }
 
-    record RefundSnapshot(ObjectNode data) {
+    record RefundSnapshot(@JsonValue ObjectNode data) {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static RefundSnapshot of(ObjectNode data) {
+            return new RefundSnapshot(data);
+        }
     }
 
     private static PaymentEvent toPaymentEvent(EventEnvelope envelope, com.fasterxml.jackson.databind.JsonNode payload) {


### PR DESCRIPTION
Live-gate catch: JSONB businessRef lookup saw {"data":{...}} wrapper, refunds never executed after the payment Postgres migration. Fix DTO serialization + migration to unwrap existing rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)