### PR TITLE
REQ-080 trip-planning plan-index replay fix

### DIFF
--- a/services/trip-planning/src/trip_planning/adapters/messaging/fake.py
+++ b/services/trip-planning/src/trip_planning/adapters/messaging/fake.py
@@ -20,10 +20,9 @@ class FakeEventPublisher:
 class FakeEventSubscriber:
     def __init__(self, envelopes: Sequence[EventEnvelope] | None = None) -> None:
         self.handlers: list[tuple[Sequence[str], str, str, Callable[[EventEnvelope], Any]]] = []
+        self.envelopes = list(envelopes or ())
         self.seen: set[str] = set()
         self.stopped = False
-        for envelope in envelopes or ():
-            self.simulate_message(envelope)
 
     def subscribe(self, streams: Sequence[str], group: str, consumer_name: str, handler: Callable[[EventEnvelope], Any]) -> None:
         self.handlers.append((list(streams), group, consumer_name, handler))
@@ -32,7 +31,12 @@ class FakeEventSubscriber:
         if envelope.eventId in self.seen:
             return
         self.seen.add(envelope.eventId)
+        self.envelopes.append(envelope)
         for _streams, _group, _consumer_name, handler in self.handlers:
+            handler(envelope)
+
+    def replay(self, handler: Callable[[EventEnvelope], Any]) -> None:
+        for envelope in self.envelopes:
             handler(envelope)
 
     def stop(self) -> None:

--- a/services/trip-planning/src/trip_planning/adapters/messaging/redis_streams.py
+++ b/services/trip-planning/src/trip_planning/adapters/messaging/redis_streams.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import json
+import logging
 import threading
-from typing import Any
+import time
+from typing import Any, Mapping
 
-from train_ticket_platform.messaging import RedisEventPublisher, RedisEventSubscriber, default_consumer_name
+from train_ticket_platform.messaging import RedisEventPublisher, RedisEventSubscriber as PlatformRedisEventSubscriber, default_consumer_name
+
+from trip_planning.events import EventEnvelope
 
 TRIP_PLANNING_SUBSCRIPTIONS = (
     "events:place-network",
@@ -12,6 +17,9 @@ TRIP_PLANNING_SUBSCRIPTIONS = (
     "events:capacity-availability",
 )
 TRIP_PLANNING_CONSUMER_GROUP = "trip-planning"
+SUBSCRIBER_RESTART_DELAY_SECONDS = 1.0
+
+logger = logging.getLogger(__name__)
 
 
 def trip_planning_consumer_name() -> str:
@@ -19,21 +27,82 @@ def trip_planning_consumer_name() -> str:
 
 
 def start_trip_planning_subscription(subscriber: Any, handler: Callable[[Any], None]) -> threading.Thread:
-    if hasattr(subscriber, "start_in_background"):
-        try:
-            return subscriber.start_in_background(
-                list(TRIP_PLANNING_SUBSCRIPTIONS),
-                TRIP_PLANNING_CONSUMER_GROUP,
-                handler,
-                consumer_name=trip_planning_consumer_name(),
-            )
-        except TypeError:
-            return subscriber.start_in_background(handler, consumer_name=trip_planning_consumer_name())
     thread = threading.Thread(
-        target=subscriber.subscribe,
-        args=(list(TRIP_PLANNING_SUBSCRIPTIONS), TRIP_PLANNING_CONSUMER_GROUP, trip_planning_consumer_name(), handler),
+        target=_run_with_restart,
+        args=(subscriber, handler),
         daemon=True,
-        name="trip-planning-event-subscriber",
+        name="trip-planning-event-subscriber-supervisor",
     )
     thread.start()
     return thread
+
+
+def _run_with_restart(subscriber: Any, handler: Callable[[Any], None]) -> None:
+    while not _stop_requested(subscriber):
+        try:
+            _subscribe_once(subscriber, handler)
+            return
+        except Exception:
+            if _stop_requested(subscriber):
+                return
+            logger.error("trip-planning event subscriber stopped unexpectedly; restarting", exc_info=True)
+            time.sleep(SUBSCRIBER_RESTART_DELAY_SECONDS)
+
+
+def _subscribe_once(subscriber: Any, handler: Callable[[Any], None]) -> None:
+    subscriber.subscribe(
+        list(TRIP_PLANNING_SUBSCRIPTIONS),
+        TRIP_PLANNING_CONSUMER_GROUP,
+        trip_planning_consumer_name(),
+        handler,
+    )
+
+
+def _stop_requested(subscriber: Any) -> bool:
+    stop_requested = getattr(subscriber, "_stop_requested", None)
+    if hasattr(stop_requested, "is_set"):
+        return bool(stop_requested.is_set())
+    stopped = getattr(subscriber, "stopped", None)
+    if isinstance(stopped, bool):
+        return stopped
+    return False
+
+
+def _extract_envelope_json(fields: Mapping[Any, Any]) -> str:
+    for key in (b"envelope", "envelope", b"d", "d"):
+        envelope = fields.get(key)
+        if isinstance(envelope, bytes):
+            return envelope.decode("utf-8")
+        if isinstance(envelope, str):
+            return envelope
+    return ""
+
+
+def replay_trip_planning_streams(redis_client: Any, handler: Callable[[Any], None]) -> None:
+    for stream in TRIP_PLANNING_SUBSCRIPTIONS:
+        _ensure_group_before_replay(redis_client, stream)
+        for _entry_id, fields in redis_client.xrange(stream, min="-", max="+") or []:
+            envelope_json = _extract_envelope_json(fields)
+            if not envelope_json:
+                continue
+            handler(EventEnvelope.from_json_dict(json.loads(envelope_json)))
+
+
+def _ensure_group_before_replay(redis_client: Any, stream: str) -> None:
+    create_group = getattr(redis_client, "xgroup_create", None)
+    if not callable(create_group):
+        return
+    try:
+        create_group(stream, TRIP_PLANNING_CONSUMER_GROUP, id="$", mkstream=True)
+    except Exception as exc:
+        if "BUSYGROUP" not in str(exc):
+            raise
+
+
+class RedisEventSubscriber(PlatformRedisEventSubscriber):
+    def replay(self, handler: Callable[[Any], None]) -> None:
+        replay_trip_planning_streams(self._client, handler)
+
+
+def create_redis_event_subscriber() -> RedisEventSubscriber:
+    return RedisEventSubscriber()

--- a/services/trip-planning/src/trip_planning/api.py
+++ b/services/trip-planning/src/trip_planning/api.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager, asynccontextmanager, nullcontext
 from datetime import datetime, timedelta
 from hashlib import sha256
+import logging
 import threading
 from typing import Any, Protocol
 
@@ -22,6 +23,7 @@ from .runtime import health, profile
 REQUEST_ID_HEADER = "X-Request-Id"
 CORRELATION_ID_HEADER = "X-Correlation-Id"
 TraceHook = Callable[[str, Mapping[str, object]], None]
+logger = logging.getLogger(__name__)
 
 
 class RuntimeSpan(AbstractContextManager["RuntimeSpan"], Protocol):
@@ -200,34 +202,53 @@ class PlanStore:
         self.services: dict[str, dict[str, object]] = {}
         self.segments: dict[str, dict[str, object]] = {}
         self.node_place: dict[str, str] = {}
+        self.applied_event_ids: set[str] = set()
+
+    def clear(self) -> None:
+        with self._lock:
+            self.services.clear()
+            self.segments.clear()
+            self.node_place.clear()
+            self.applied_event_ids.clear()
+
+    def apply_envelope(self, envelope: Any) -> bool:
+        event_id = str(getattr(envelope, "eventId", ""))
+        with self._lock:
+            if event_id and event_id in self.applied_event_ids:
+                return False
+            self._apply_locked(str(envelope.eventType), envelope.payload)
+            if event_id:
+                self.applied_event_ids.add(event_id)
+        return True
 
     def apply(self, event_type: str, payload: Mapping[str, object]) -> None:
         with self._lock:
-            if event_type in ("ServicePlanPublished", "ScheduledServiceCreated"):
-                ref = str(payload.get("scheduledServiceRef", ""))
-                if ref:
-                    self.services[ref] = dict(payload)
-            elif event_type in ("ServicePlanChanged", "ServiceSegmentCreated"):
-                seg = str(payload.get("segmentRef", ""))
-                if seg and payload.get("originStopRef"):
-                    self.segments[seg] = dict(payload)
-            elif event_type in ("TransportNodeRegistered", "TransportNodeAdded", "TransportNodeUpdated"):
-                node = str(payload.get("nodeId", ""))
-                place = str(payload.get("placeId", ""))
-                if node and place:
-                    self.node_place[node] = place
+            self._apply_locked(event_type, payload)
+
+    def _apply_locked(self, event_type: str, payload: Mapping[str, object]) -> None:
+        if event_type in ("ServicePlanPublished", "ScheduledServiceCreated"):
+            ref = str(payload.get("scheduledServiceRef", ""))
+            if ref:
+                self.services[ref] = dict(payload)
+        elif event_type in ("ServicePlanChanged", "ServiceSegmentCreated"):
+            seg = str(payload.get("segmentRef", ""))
+            if seg and payload.get("originStopRef"):
+                self.segments[seg] = dict(payload)
+        elif event_type in ("TransportNodeRegistered", "TransportNodeAdded", "TransportNodeUpdated"):
+            node = str(payload.get("nodeId", ""))
+            place = str(payload.get("placeId", ""))
+            if node and place:
+                self.node_place[node] = place
 
     def _matches(self, stop_ref: str, requested: str) -> bool:
-        return stop_ref == requested or self.node_place.get(stop_ref) == requested
-
-    def resolve_stop_ref(self, requested: str) -> str:
-        """Map a place ref to one of its transport nodes (phase 1: first
-        registered node wins). Node refs and unknown refs pass through."""
-        with self._lock:
-            for node, place in self.node_place.items():
-                if place == requested:
-                    return node
-        return requested
+        requested_place = self.node_place.get(requested)
+        stop_place = self.node_place.get(stop_ref)
+        return (
+            stop_ref == requested
+            or stop_place == requested
+            or (requested_place is not None and stop_ref == requested_place)
+            or (requested_place is not None and stop_place == requested_place)
+        )
 
     def candidates(self, origin_ref: str, destination_ref: str, departure_date: str) -> list[Itinerary]:
         found: list[Itinerary] = []
@@ -317,6 +338,20 @@ def _contract_candidate(origin_ref: str, destination_ref: str, departure_date: s
     )
 
 
+def _candidate_for_intent(candidate: Itinerary, origin_ref: str, destination_ref: str) -> Itinerary:
+    if candidate.origin_ref == origin_ref and candidate.destination_ref == destination_ref:
+        return candidate
+    return Itinerary(
+        legs=candidate.legs,
+        itinerary_ref=candidate.itinerary_ref,
+        price_hint=candidate.price_hint,
+        availability_hint=candidate.availability_hint,
+        planning_snapshot_refs=candidate.planning_snapshot_refs,
+        search_origin_ref=origin_ref,
+        search_destination_ref=destination_ref,
+    )
+
+
 def _itinerary_to_contract(itinerary: Itinerary) -> dict[str, object]:
     return {
         "itineraryRef": itinerary.itinerary_ref,
@@ -345,17 +380,19 @@ def _itinerary_to_contract(itinerary: Itinerary) -> dict[str, object]:
 
 def _search_contract_response(payload: Mapping[str, object]) -> tuple[dict[str, object], tuple[str, ...]]:
     origin_ref, destination_ref, departure_date, traveler_refs, channel, max_results = _validate_contract_search_payload(payload)
-    resolved_origin = _plan_store.resolve_stop_ref(origin_ref)
-    resolved_destination = _plan_store.resolve_stop_ref(destination_ref)
     intent = TripIntent(
-        origin_ref=resolved_origin,
-        destination_ref=resolved_destination,
+        origin_ref=origin_ref,
+        destination_ref=destination_ref,
         departure_window_start=f"{departure_date}T00:00:00Z",
         departure_window_end=f"{departure_date}T23:59:59Z",
         passenger_count=len(traveler_refs),
     )
-    real_candidates = _plan_store.candidates(resolved_origin, resolved_destination, departure_date)
-    candidate_pool = tuple(real_candidates) if real_candidates else (_contract_candidate(resolved_origin, resolved_destination, departure_date, channel),)
+    real_candidates = _plan_store.candidates(origin_ref, destination_ref, departure_date)
+    candidate_pool = (
+        tuple(_candidate_for_intent(candidate, origin_ref, destination_ref) for candidate in real_candidates)
+        if real_candidates
+        else (_contract_candidate(origin_ref, destination_ref, departure_date, channel),)
+    )
     result = search_itineraries(intent, candidate_pool)
     selected = result.candidates[:max_results]
     itineraries = [_itinerary_to_contract(itinerary) for itinerary, _score in selected]
@@ -374,17 +411,22 @@ def _default_publisher() -> EventPublisher:
 
 
 def _default_subscriber() -> EventSubscriber:
-    from .adapters.messaging.redis_streams import RedisEventSubscriber
+    from .adapters.messaging.redis_streams import create_redis_event_subscriber
 
-    return RedisEventSubscriber()
+    return create_redis_event_subscriber()
+
+
+def _occurred_at_text(envelope: Any) -> str:
+    occurred_at = getattr(envelope, "occurredAt", "")
+    return occurred_at.isoformat() if hasattr(occurred_at, "isoformat") else str(occurred_at)
 
 
 def _handle_upstream_event(app: FastAPI, envelope: Any) -> None:
-    _plan_store.apply(envelope.eventType, envelope.payload)
+    _plan_store.apply_envelope(envelope)
     app.state.consumed_events[envelope.eventId] = {
         "eventType": envelope.eventType,
         "producer": envelope.producer,
-        "occurredAt": envelope.occurredAt.isoformat(),
+        "occurredAt": _occurred_at_text(envelope),
     }
     app.state.upstream_event_payloads[envelope.eventId] = dict(envelope.payload)
 
@@ -393,6 +435,17 @@ def _start_subscriber(subscriber: EventSubscriber, handler: Callable[[Any], None
     from .adapters.messaging.subscriber import start_trip_planning_subscription
 
     return start_trip_planning_subscription(subscriber, handler)
+
+
+def _replay_upstream_events(subscriber: EventSubscriber, handler: Callable[[Any], None]) -> None:
+    replay = getattr(subscriber, "replay", None)
+    if not callable(replay):
+        return
+    try:
+        replay(handler)
+    except Exception:
+        logger.exception("trip-planning plan index replay failed")
+        raise
 
 
 def _stop_subscriber(subscriber: EventSubscriber | None, thread: threading.Thread | None) -> None:
@@ -421,6 +474,8 @@ def create_app(
         if active_subscriber is None and start_event_subscriber:
             active_subscriber = _default_subscriber()
         handler = lambda envelope: _handle_upstream_event(app, envelope)
+        if active_subscriber is not None and start_event_subscriber:
+            _replay_upstream_events(active_subscriber, handler)
         subscriber_thread = _start_subscriber(active_subscriber, handler) if active_subscriber is not None and start_event_subscriber else None
         app.state.event_subscriber = active_subscriber
         app.state.subscriber_thread = subscriber_thread

--- a/services/trip-planning/src/trip_planning/domain.py
+++ b/services/trip-planning/src/trip_planning/domain.py
@@ -346,6 +346,8 @@ class Itinerary:
     price_hint: PriceHint | None = None
     availability_hint: AvailabilityHint | None = None
     planning_snapshot_refs: tuple[str, ...] = field(default_factory=tuple)
+    search_origin_ref: str | None = None
+    search_destination_ref: str | None = None
 
     def __post_init__(self) -> None:
         legs = tuple(self.legs)
@@ -376,15 +378,17 @@ class Itinerary:
             planning_snapshot_refs=tuple(
                 data.get("planning_snapshot_refs", data.get("planningSnapshotRefs", ()))
             ),
+            search_origin_ref=data.get("search_origin_ref", data.get("searchOriginRef")),
+            search_destination_ref=data.get("search_destination_ref", data.get("searchDestinationRef")),
         )
 
     @property
     def origin_ref(self) -> str:
-        return self.legs[0].origin_stop_ref
+        return self.search_origin_ref or self.legs[0].origin_stop_ref
 
     @property
     def destination_ref(self) -> str:
-        return self.legs[-1].destination_stop_ref
+        return self.search_destination_ref or self.legs[-1].destination_stop_ref
 
     @property
     def departure_time(self) -> datetime:

--- a/services/trip-planning/tests/test_plan_index_replay.py
+++ b/services/trip-planning/tests/test_plan_index_replay.py
@@ -1,0 +1,122 @@
+import unittest
+
+from fastapi.testclient import TestClient
+
+import trip_planning.api as api
+from trip_planning import create_app
+from trip_planning.adapters.messaging.fake import FakeEventPublisher, FakeEventSubscriber
+from trip_planning.events import EventEnvelope
+
+
+class PlanIndexReplayTest(unittest.TestCase):
+    def setUp(self) -> None:
+        api._plan_store.clear()
+
+    def tearDown(self) -> None:
+        api._plan_store.clear()
+
+    def test_new_process_replays_stream_before_searching_real_segment(self) -> None:
+        envelopes = _standard_api_sequence_events()
+        publisher = FakeEventPublisher()
+        subscriber = FakeEventSubscriber(envelopes)
+
+        app = create_app(event_publisher=publisher, event_subscriber=subscriber)
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/v1/itineraries/search",
+                json={
+                    "originRef": "plc-origin",
+                    "destinationRef": "plc-destination",
+                    "departureDate": "2026-08-01",
+                    "travelerRefs": ["tvl-1"],
+                    "channel": "WEB",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        leg = response.json()["itineraries"][0]["legs"][0]
+        self.assertEqual(leg["serviceSegmentRef"], "seg-real-080")
+        self.assertEqual(leg["originStopRef"], "node-origin-new")
+        self.assertEqual(leg["destinationStopRef"], "node-destination-new")
+
+    def test_place_search_matches_any_node_for_same_place_not_first_node_only(self) -> None:
+        old_nodes = [
+            EventEnvelope(
+                eventId="evt-old-origin-node",
+                eventType="TransportNodeRegistered",
+                producer="place-network",
+                payload={"nodeId": "node-origin-old", "placeId": "plc-origin", "displayName": "old", "servingModes": ["TRAIN"]},
+            ),
+            EventEnvelope(
+                eventId="evt-old-destination-node",
+                eventType="TransportNodeRegistered",
+                producer="place-network",
+                payload={"nodeId": "node-destination-old", "placeId": "plc-destination", "displayName": "old", "servingModes": ["TRAIN"]},
+            ),
+        ]
+        subscriber = FakeEventSubscriber(old_nodes + _standard_api_sequence_events())
+
+        app = create_app(event_publisher=FakeEventPublisher(), event_subscriber=subscriber)
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/v1/itineraries/search",
+                json={
+                    "originRef": "plc-origin",
+                    "destinationRef": "plc-destination",
+                    "departureDate": "2026-08-01",
+                    "travelerRefs": ["tvl-1"],
+                    "channel": "WEB",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["itineraries"][0]["legs"][0]["serviceSegmentRef"], "seg-real-080")
+
+
+def _standard_api_sequence_events() -> list[EventEnvelope]:
+    return [
+        EventEnvelope(
+            eventId="evt-origin-node",
+            eventType="TransportNodeRegistered",
+            producer="place-network",
+            payload={"nodeId": "node-origin-new", "placeId": "plc-origin", "displayName": "origin", "servingModes": ["TRAIN"]},
+        ),
+        EventEnvelope(
+            eventId="evt-destination-node",
+            eventType="TransportNodeRegistered",
+            producer="place-network",
+            payload={"nodeId": "node-destination-new", "placeId": "plc-destination", "displayName": "destination", "servingModes": ["TRAIN"]},
+        ),
+        EventEnvelope(
+            eventId="evt-scheduled-service",
+            eventType="ServicePlanPublished",
+            producer="service-plan",
+            payload={
+                "scheduledServiceRef": "ss-real-080",
+                "serviceNumber": "G5080",
+                "status": "PUBLISHED",
+                "carrierId": "car-1",
+                "departureTime": "2026-08-01T09:00:00Z",
+                "arrivalTime": "2026-08-01T10:00:00Z",
+                "originNodeId": "node-origin-new",
+                "destinationNodeId": "node-destination-new",
+            },
+        ),
+        EventEnvelope(
+            eventId="evt-service-segment",
+            eventType="ServicePlanChanged",
+            producer="service-plan",
+            payload={
+                "segmentRef": "seg-real-080",
+                "scheduledServiceRef": "ss-real-080",
+                "originStopRef": "node-origin-new",
+                "destinationStopRef": "node-destination-new",
+                "departureTime": "2026-08-01T09:00:00Z",
+                "arrivalTime": "2026-08-01T10:00:00Z",
+            },
+        ),
+    ]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/trip-planning/tests/test_subscriber_supervisor.py
+++ b/services/trip-planning/tests/test_subscriber_supervisor.py
@@ -1,0 +1,41 @@
+import time
+import unittest
+
+import trip_planning.adapters.messaging.redis_streams as redis_streams
+from trip_planning.adapters.messaging.redis_streams import start_trip_planning_subscription
+from trip_planning.events import EventEnvelope
+
+
+class SubscriberSupervisorTest(unittest.TestCase):
+    def test_restarts_subscriber_after_unexpected_exit(self) -> None:
+        original_delay = redis_streams.SUBSCRIBER_RESTART_DELAY_SECONDS
+        redis_streams.SUBSCRIBER_RESTART_DELAY_SECONDS = 0.01
+
+        class FlakySubscriber:
+            def __init__(self) -> None:
+                self.calls = 0
+                self.stopped = False
+
+            def subscribe(self, streams, group, consumer_name, handler) -> None:  # type: ignore[no-untyped-def]
+                self.calls += 1
+                if self.calls == 1:
+                    raise RuntimeError("boom")
+                handler(EventEnvelope(eventId="evt-after-restart", eventType="ServicePlanPublished", producer="service-plan", payload={"scheduledServiceRef": "ss-1"}))
+
+        subscriber = FlakySubscriber()
+        received: list[str] = []
+        try:
+            thread = start_trip_planning_subscription(subscriber, lambda envelope: received.append(envelope.eventId))
+            deadline = time.time() + 1
+            while thread.is_alive() and time.time() < deadline:
+                time.sleep(0.01)
+        finally:
+            redis_streams.SUBSCRIBER_RESTART_DELAY_SECONDS = original_delay
+
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(subscriber.calls, 2)
+        self.assertEqual(received, ["evt-after-restart"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Root cause: PlanIndex is per-process memory; only the subscriber's worker had it. Fix: startup stream replay rebuilds the index in every worker + subscriber restart supervision. Live-verified: previously-synthetic route tuples now return real seg- refs; 01/02/03 = 36/36 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)