### PR TITLE
REQ-082 migrate Python services to Postgres outbox

### DIFF
--- a/deploy/docker/reporting/Dockerfile
+++ b/deploy/docker/reporting/Dockerfile
@@ -11,7 +11,8 @@ RUN --mount=type=cache,target=/root/.cache/uv uv venv /opt/venv &&     uv pip in
 FROM python:3.12-slim
 RUN useradd --system --create-home --home-dir /home/app app
 COPY --from=builder /opt/venv /opt/venv
-ENV PATH=/opt/venv/bin:$PATH PORT=8080 REDIS_URL=redis://localhost:6379
+COPY services/reporting/migrations /app/migrations
+ENV PATH=/opt/venv/bin:$PATH PORT=8080 REDIS_URL=redis://localhost:6379 MIGRATIONS_DIR=/app/migrations
 USER app
 EXPOSE 8080
 CMD ["sh", "-c", "exec uvicorn reporting.api:create_production_app --factory --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/deploy/docker/risk-compliance/Dockerfile
+++ b/deploy/docker/risk-compliance/Dockerfile
@@ -11,7 +11,8 @@ RUN --mount=type=cache,target=/root/.cache/uv uv venv /opt/venv &&     uv pip in
 FROM python:3.12-slim
 RUN useradd --system --create-home --home-dir /home/app app
 COPY --from=builder /opt/venv /opt/venv
-ENV PATH=/opt/venv/bin:$PATH PORT=8080 REDIS_URL=redis://localhost:6379
+COPY services/risk-compliance/migrations /app/migrations
+ENV PATH=/opt/venv/bin:$PATH PORT=8080 REDIS_URL=redis://localhost:6379 MIGRATIONS_DIR=/app/migrations
 USER app
 EXPOSE 8080
 CMD ["sh", "-c", "exec uvicorn risk_compliance.api:create_app --factory --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/deploy/docker/trip-planning/Dockerfile
+++ b/deploy/docker/trip-planning/Dockerfile
@@ -11,7 +11,8 @@ RUN --mount=type=cache,target=/root/.cache/uv uv venv /opt/venv &&     uv pip in
 FROM python:3.12-slim
 RUN useradd --system --create-home --home-dir /home/app app
 COPY --from=builder /opt/venv /opt/venv
-ENV PATH=/opt/venv/bin:$PATH PORT=8080 REDIS_URL=redis://localhost:6379
+COPY services/trip-planning/migrations /app/migrations
+ENV PATH=/opt/venv/bin:$PATH PORT=8080 REDIS_URL=redis://localhost:6379 MIGRATIONS_DIR=/app/migrations
 USER app
 EXPOSE 8080
 CMD ["sh", "-c", "exec uvicorn trip_planning.api:create_app --factory --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/services/reporting/migrations/001_reporting_storage.sql
+++ b/services/reporting/migrations/001_reporting_storage.sql
@@ -1,0 +1,49 @@
+CREATE TABLE IF NOT EXISTS metric_definition_snapshots (
+  id text PRIMARY KEY,
+  version bigint NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_metric_definition_snapshots_category_id ON metric_definition_snapshots ((data->>'category'), id);
+CREATE TABLE IF NOT EXISTS dashboard_read_model_snapshots (
+  id text PRIMARY KEY,
+  version bigint NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS consumed_event_log_snapshots (
+  id text PRIMARY KEY,
+  version bigint NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS reporting_rebuild_runs (
+  rebuild_id text PRIMARY KEY,
+  dashboard_id text NOT NULL,
+  rebuilt_at timestamptz NOT NULL,
+  status text NOT NULL,
+  event_count bigint NOT NULL,
+  digest text NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_reporting_rebuild_runs_dashboard_rebuilt ON reporting_rebuild_runs (dashboard_id, rebuilt_at DESC);
+CREATE TABLE IF NOT EXISTS outbox (
+  seq bigserial PRIMARY KEY,
+  event_id text NOT NULL UNIQUE,
+  stream text NOT NULL,
+  envelope jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  published_at timestamptz
+);
+CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq ON outbox(seq) WHERE published_at IS NULL;
+CREATE TABLE IF NOT EXISTS processed_events (
+  event_id text PRIMARY KEY,
+  stream text,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS idempotency_records (
+  key text PRIMARY KEY,
+  request_hash text NOT NULL,
+  status_code int NOT NULL,
+  response_body jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/services/reporting/pyproject.toml
+++ b/services/reporting/pyproject.toml
@@ -5,6 +5,8 @@ description = "Reporting service skeleton"
 requires-python = ">=3.11"
 dependencies = [
   "train-ticket-platform",
+  "psycopg[binary]>=3.2.0",
+  "psycopg-pool>=3.2.0",
 ]
 
 [dependency-groups]

--- a/services/reporting/src/reporting/adapters/storage/__init__.py
+++ b/services/reporting/src/reporting/adapters/storage/__init__.py
@@ -1,0 +1,3 @@
+from .postgres import PostgresReportingApplicationService
+
+__all__ = ["PostgresReportingApplicationService"]

--- a/services/reporting/src/reporting/adapters/storage/postgres.py
+++ b/services/reporting/src/reporting/adapters/storage/postgres.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from reporting.application.service import PRODUCER, RebuildRun, default_repository, rfc3339_utc, utc_now, REBUILD_DEBOUNCE_SECONDS
+from reporting.domain import DashboardReadModel, MetricCategory, MetricDefinition, MetricGranularity, MetricRef, MetricStatus, ReadModelSnapshot, ReadModelStatus
+from reporting.ids import prefixed_uuid7
+from train_ticket_platform.events import EventEnvelope
+from train_ticket_platform.storage import OutboxAppender, ProcessedEventsGuard, SnapshotRepository
+
+
+def _dt(value: datetime | str | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return rfc3339_utc(value)
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _metric_to_json(metric: MetricDefinition) -> dict[str, Any]:
+    return {
+        "metricId": metric.metric_id,
+        "name": metric.name,
+        "description": metric.description,
+        "owner": metric.owner,
+        "category": metric.category.value,
+        "granularity": metric.granularity.value,
+        "version": metric.version,
+        "expression": metric.expression,
+        "status": metric.status.value,
+        "publishedAt": _dt(metric.published_at),
+        "dependsOnMetricIds": list(metric.depends_on_metric_ids),
+        "sourceLineage": list(metric.source_lineage),
+        "deprecatedAt": _dt(metric.deprecated_at),
+    }
+
+
+def _metric_from_json(data: Mapping[str, Any] | str) -> MetricDefinition:
+    if isinstance(data, str):
+        data = json.loads(data)
+    return MetricDefinition(
+        metric_id=str(data["metricId"]),
+        name=str(data["name"]),
+        description=str(data.get("description", "")),
+        owner=str(data["owner"]),
+        category=MetricCategory(str(data["category"])),
+        granularity=MetricGranularity(str(data["granularity"])),
+        version=str(data["version"]),
+        expression=str(data["expression"]),
+        status=MetricStatus(str(data.get("status", MetricStatus.DRAFT.value))),
+        published_at=_parse_dt(data.get("publishedAt")),
+        depends_on_metric_ids=tuple(str(item) for item in data.get("dependsOnMetricIds", ())),
+        source_lineage=tuple(str(item) for item in data.get("sourceLineage", ())),
+        deprecated_at=_parse_dt(data.get("deprecatedAt")),
+    )
+
+
+def _ref_to_json(ref: MetricRef) -> dict[str, str]:
+    return {"metricId": ref.metric_id, "version": ref.version}
+
+
+def _ref_from_json(data: Mapping[str, Any]) -> MetricRef:
+    return MetricRef(str(data["metricId"]), str(data["version"]))
+
+
+def _snapshot_to_json(snapshot: ReadModelSnapshot | None) -> dict[str, Any] | None:
+    if snapshot is None:
+        return None
+    return {
+        "rebuildId": snapshot.rebuild_id,
+        "rebuiltAt": _dt(snapshot.rebuilt_at),
+        "metrics": [_ref_to_json(ref) for ref in snapshot.metrics],
+        "eventCount": snapshot.event_count,
+        "digest": snapshot.digest,
+    }
+
+
+def _snapshot_from_json(data: Mapping[str, Any] | None) -> ReadModelSnapshot | None:
+    if data is None:
+        return None
+    return ReadModelSnapshot(str(data["rebuildId"]), _parse_dt(str(data["rebuiltAt"])) or utc_now(), tuple(_ref_from_json(item) for item in data.get("metrics", ())), int(data["eventCount"]), str(data["digest"]))
+
+
+def _dashboard_to_json(dashboard: DashboardReadModel) -> dict[str, Any]:
+    return {
+        "dashboardId": dashboard.dashboard_id,
+        "name": dashboard.name,
+        "description": dashboard.description,
+        "status": dashboard.status.value,
+        "metrics": [_ref_to_json(ref) for ref in dashboard.metrics],
+        "currentSnapshot": _snapshot_to_json(dashboard.current_snapshot),
+        "lastBuiltAt": _dt(dashboard.last_built_at),
+        "sourceEvents": list(dashboard.source_events),
+    }
+
+
+def _dashboard_from_json(data: Mapping[str, Any] | str) -> DashboardReadModel:
+    if isinstance(data, str):
+        data = json.loads(data)
+    return DashboardReadModel(
+        dashboard_id=str(data["dashboardId"]),
+        name=str(data["name"]),
+        description=str(data.get("description", "")),
+        status=ReadModelStatus(str(data.get("status", ReadModelStatus.BUILDING.value))),
+        metrics=tuple(_ref_from_json(item) for item in data.get("metrics", ())),
+        current_snapshot=_snapshot_from_json(data.get("currentSnapshot")),
+        last_built_at=_parse_dt(data.get("lastBuiltAt")),
+        source_events=tuple(str(item) for item in data.get("sourceEvents", ())),
+    )
+
+
+class PostgresReportingApplicationService:
+    def __init__(self, pool: Any, outbox: OutboxAppender | None = None) -> None:
+        self._pool = pool
+        self._outbox = outbox or OutboxAppender()
+        self._processed = ProcessedEventsGuard()
+        self._metrics = SnapshotRepository("metric_definition_snapshots")
+        self._dashboards = SnapshotRepository("dashboard_read_model_snapshots")
+        self._seed_defaults()
+
+    def _seed_defaults(self) -> None:
+        defaults = default_repository()
+        with self._pool.connection() as conn:
+            with conn.transaction():
+                for metric in defaults.metrics.values():
+                    if self._metrics.get(conn, metric.metric_id) is None:
+                        self._metrics.save(conn, metric.metric_id, _metric_to_json(metric))
+                for dashboard in defaults.dashboards.values():
+                    if self._dashboards.get(conn, dashboard.dashboard_id) is None:
+                        self._dashboards.save(conn, dashboard.dashboard_id, _dashboard_to_json(dashboard))
+                for runs in defaults.rebuild_runs.values():
+                    for run in runs:
+                        self._save_rebuild_run(conn, run)
+
+    def list_metrics(self, *, category: MetricCategory | None, limit: int, offset: int) -> tuple[list[MetricDefinition], int]:
+        with self._pool.connection() as conn:
+            if category is None:
+                total = int(conn.execute("SELECT count(*) FROM metric_definition_snapshots").fetchone()[0])
+                rows = conn.execute("SELECT data FROM metric_definition_snapshots ORDER BY id LIMIT %s OFFSET %s", (limit, offset)).fetchall()
+            else:
+                total = int(conn.execute("SELECT count(*) FROM metric_definition_snapshots WHERE data->>'category' = %s", (category.value,)).fetchone()[0])
+                rows = conn.execute("SELECT data FROM metric_definition_snapshots WHERE data->>'category' = %s ORDER BY id LIMIT %s OFFSET %s", (category.value, limit, offset)).fetchall()
+        return [_metric_from_json(row[0]) for row in rows], total
+
+    def get_metric(self, metric_id: str) -> MetricDefinition | None:
+        with self._pool.connection() as conn:
+            snap = self._metrics.get(conn, metric_id)
+        return None if snap is None else _metric_from_json(snap[1])
+
+    def get_dashboard(self, dashboard_id: str) -> DashboardReadModel | None:
+        with self._pool.connection() as conn:
+            snap = self._dashboards.get(conn, dashboard_id)
+        return None if snap is None else _dashboard_from_json(snap[1])
+
+    def list_rebuilds(self, dashboard_id: str, *, limit: int, offset: int) -> tuple[list[RebuildRun], int]:
+        with self._pool.connection() as conn:
+            total = int(conn.execute("SELECT count(*) FROM reporting_rebuild_runs WHERE dashboard_id = %s", (dashboard_id,)).fetchone()[0])
+            rows = conn.execute("SELECT rebuild_id, dashboard_id, rebuilt_at, status, event_count, digest FROM reporting_rebuild_runs WHERE dashboard_id = %s ORDER BY rebuilt_at DESC LIMIT %s OFFSET %s", (dashboard_id, limit, offset)).fetchall()
+        return [RebuildRun(str(r[0]), str(r[1]), r[2].astimezone(UTC), str(r[3]), int(r[4]), str(r[5])) for r in rows], total
+
+    def handle_event(self, envelope: EventEnvelope):
+        from train_ticket_platform.messaging import HandlerResult
+        try:
+            with self._pool.connection() as conn:
+                with conn.transaction():
+                    if not self._processed.try_mark_processed(conn, envelope.eventId, f"events:{envelope.producer}"):
+                        return HandlerResult.success()
+                    dashboards = self._all_dashboards(conn)
+                    for dashboard, version in dashboards:
+                        if not dashboard.source_events or envelope.eventType in dashboard.source_events:
+                            stale = dashboard.mark_stale()
+                            new_version = self._dashboards.save(conn, stale.dashboard_id, _dashboard_to_json(stale), version)
+                            self._maybe_rebuild(conn, stale, new_version, envelope)
+        except Exception as exc:
+            return HandlerResult.transient_error(str(exc))
+        return HandlerResult.success()
+
+    def _all_dashboards(self, conn: Any) -> list[tuple[DashboardReadModel, int]]:
+        return [(_dashboard_from_json(row[2]), int(row[1])) for row in conn.execute("SELECT id, version, data FROM dashboard_read_model_snapshots").fetchall()]
+
+    def _processed_count(self, conn: Any) -> int:
+        return int(conn.execute("SELECT count(*) FROM processed_events").fetchone()[0])
+
+    def _maybe_rebuild(self, conn: Any, dashboard: DashboardReadModel, version: int, envelope: EventEnvelope) -> None:
+        if dashboard.status is not ReadModelStatus.STALE:
+            return
+        now = utc_now()
+        if dashboard.last_built_at is not None and (now - dashboard.last_built_at).total_seconds() < REBUILD_DEBOUNCE_SECONDS:
+            return
+        event_count = self._processed_count(conn)
+        digest = "sha256-" + hashlib.sha256(f"{dashboard.dashboard_id}:{event_count}:{rfc3339_utc(now)}".encode()).hexdigest()[:16]
+        rebuild_id = prefixed_uuid7("rebuild")
+        rebuilt = dashboard.rebuild(rebuild_id, now, event_count, digest)
+        self._dashboards.save(conn, rebuilt.dashboard_id, _dashboard_to_json(rebuilt), version)
+        self._save_rebuild_run(conn, RebuildRun(rebuild_id, rebuilt.dashboard_id, now, "COMPLETED", event_count, digest))
+        self._outbox.append(conn, self._read_model_rebuilt_envelope(rebuilt.dashboard_id, rebuild_id, now, event_count, digest, envelope))
+
+    def _save_rebuild_run(self, conn: Any, run: RebuildRun) -> None:
+        conn.execute("INSERT INTO reporting_rebuild_runs(rebuild_id, dashboard_id, rebuilt_at, status, event_count, digest) VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (rebuild_id) DO NOTHING", (run.rebuild_id, run.dashboard_id, run.rebuilt_at, run.status, run.event_count, run.digest))
+
+    def _read_model_rebuilt_envelope(self, dashboard_id: str, rebuild_id: str, rebuilt_at: datetime, event_count: int, digest: str, source: EventEnvelope) -> EventEnvelope:
+        return EventEnvelope(eventId=prefixed_uuid7("evt"), eventType="ReadModelRebuilt", occurredAt=rfc3339_utc(rebuilt_at), correlationId=source.correlationId if source.correlationId and source.correlationId.startswith("corr-") else prefixed_uuid7("corr"), causationId=source.eventId, producer=PRODUCER, schemaVersion=1, payload={"dashboardId": dashboard_id, "rebuildId": rebuild_id, "rebuiltAt": rfc3339_utc(rebuilt_at), "eventCount": event_count, "digest": digest})
+
+    def publish_domain_event(self, *, event_type: str, payload: Mapping[str, Any], correlation_id: str | None, causation_id: str | None, occurred_at: datetime | None = None) -> EventEnvelope:
+        envelope = EventEnvelope(eventId=prefixed_uuid7("evt"), eventType=event_type, occurredAt=rfc3339_utc(occurred_at or utc_now()), correlationId=correlation_id if correlation_id and correlation_id.startswith("corr-") else prefixed_uuid7("corr"), producer=PRODUCER, schemaVersion=1, payload=dict(payload), causationId=causation_id if causation_id and (causation_id.startswith("cmd-") or causation_id.startswith("evt-")) else None)
+        with self._pool.connection() as conn:
+            with conn.transaction():
+                self._outbox.append(conn, envelope)
+        return envelope

--- a/services/reporting/src/reporting/api.py
+++ b/services/reporting/src/reporting/api.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager, asynccontextmanager, nullcontext
+import os
+from pathlib import Path
 from typing import Any, Protocol
-from fastapi import FastAPI, Query, Request
+from fastapi import FastAPI, Query, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -11,6 +13,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from .application.service import ReportingApplicationService, RebuildRun, rfc3339_utc
 from .domain import DashboardReadModel, MetricCategory, MetricDefinition, ReportingError
 from train_ticket_platform.idempotency import configure_idempotency_middleware
+from train_ticket_platform.storage import DatabaseConfig, DatabasePool, OutboxRelay, PostgresIdempotencyStore, ReadinessGate, run_migrations
 
 from .ids import uuid7
 from .runtime import health, profile
@@ -204,7 +207,10 @@ def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, o
         return {"status": health()}
 
     @app.get("/readyz")
-    def readyz_endpoint() -> dict[str, str]:
+    def readyz_endpoint(response: Response) -> dict[str, str]:
+        if not _storage_ready(app):
+            response.status_code = 503
+            return {"status": "not-ready"}
         return {"status": health()}
 
     @app.get("/health")
@@ -216,7 +222,10 @@ def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, o
         return {"status": health()}
 
     @app.get("/ready")
-    def ready_endpoint() -> dict[str, str]:
+    def ready_endpoint(response: Response) -> dict[str, str]:
+        if not _storage_ready(app):
+            response.status_code = 503
+            return {"status": "not-ready"}
         return {"status": health()}
 
     @app.get("/metadata")
@@ -300,18 +309,52 @@ def configure_error_handlers(app: FastAPI) -> None:
         return JSONResponse(status_code=exc.status_code, content=_error_body(request, code, message))
 
 
+
+def _storage_ready(app: FastAPI) -> bool:
+    gate = getattr(app.state, "readiness", None)
+    if gate is not None and not gate.ready:
+        return False
+    pool = getattr(app.state, "database_pool", None)
+    if pool is None:
+        return True
+    try:
+        with pool.connection() as conn:
+            conn.execute("SELECT 1").fetchone()
+        return True
+    except Exception:
+        if gate is not None:
+            gate.mark_failed("database readiness check failed")
+        return False
+
+
+def _postgres_service_from_env(app: FastAPI) -> tuple[ReportingApplicationService, Any | None]:
+    config = DatabaseConfig.from_env()
+    if config is None:
+        return ReportingApplicationService(), None
+    from .adapters.storage import PostgresReportingApplicationService
+
+    readiness = ReadinessGate()
+    pool = DatabasePool(config)
+    app.state.database_pool = pool
+    app.state.readiness = readiness
+    env_dir = os.environ.get("MIGRATIONS_DIR")
+    migrations_dir = Path(env_dir) if env_dir else Path(__file__).resolve().parents[2] / "migrations"
+    run_migrations(pool, migrations_dir, readiness)
+    service = PostgresReportingApplicationService(pool)
+    relay = OutboxRelay(pool)
+    relay.start()
+    app.state.outbox_relay = relay
+    return service, PostgresIdempotencyStore(pool)
+
 def create_app(
     tracer: TraceHook | None = None,
     otel_tracer: RuntimeTracer | None = None,
     service: ReportingApplicationService | None = None,
     enable_messaging: bool = False,
 ) -> FastAPI:
-    app_service = service or ReportingApplicationService()
+    default_idempotency_store = None
+    app_service = service
     messaging_runtime = None
-    if enable_messaging:
-        from .adapters.messaging.runtime import MessagingRuntime
-
-        messaging_runtime = MessagingRuntime(app_service)
 
     @asynccontextmanager
     async def lifespan(_: FastAPI):
@@ -322,13 +365,24 @@ def create_app(
         finally:
             if messaging_runtime is not None:
                 messaging_runtime.stop()
+            relay = getattr(_.state, "outbox_relay", None)
+            if relay is not None:
+                relay.stop()
+            pool = getattr(_.state, "database_pool", None)
+            if pool is not None:
+                pool.close()
 
     app = FastAPI(title="Reporting", version="0.1.0", lifespan=lifespan)
+    if app_service is None:
+        app_service, default_idempotency_store = _postgres_service_from_env(app)
+    if enable_messaging:
+        from .adapters.messaging.runtime import MessagingRuntime
+        messaging_runtime = MessagingRuntime(app_service)
     configure_error_handlers(app)
     configure_runtime_endpoints(app, tracer, otel_tracer or opentelemetry_tracer_from_env(profile()["service_id"]))
     configure_reporting_endpoints(app, app_service)
     app.state.reporting_service = app_service
-    configure_idempotency_middleware(app, require_key=True, include_path_prefixes=("/api/v1/test-command",))
+    configure_idempotency_middleware(app, default_idempotency_store, require_key=True, include_path_prefixes=("/api/v1/test-command",))
     return app
 
 

--- a/services/reporting/uv.lock
+++ b/services/reporting/uv.lock
@@ -142,6 +142,87 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -300,6 +381,8 @@ name = "reporting"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
     { name = "train-ticket-platform" },
 ]
 
@@ -310,7 +393,11 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "train-ticket-platform", editable = "../../platform/python-kit" }]
+requires-dist = [
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
+    { name = "psycopg-pool", specifier = ">=3.2.0" },
+    { name = "train-ticket-platform", editable = "../../platform/python-kit" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -338,6 +425,8 @@ source = { editable = "../../platform/python-kit" }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx2" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
     { name = "redis" },
     { name = "uuid6" },
 ]
@@ -346,6 +435,8 @@ dependencies = [
 requires-dist = [
     { name = "fastapi", specifier = "==0.138.1" },
     { name = "httpx2", specifier = ">=2.5.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
+    { name = "psycopg-pool", specifier = ">=3.2.0" },
     { name = "redis", specifier = ">=5.0.0" },
     { name = "uuid6", specifier = ">=2024.7.10" },
 ]
@@ -384,6 +475,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]

--- a/services/risk-compliance/migrations/001_risk_compliance_storage.sql
+++ b/services/risk-compliance/migrations/001_risk_compliance_storage.sql
@@ -1,0 +1,49 @@
+CREATE TABLE IF NOT EXISTS risk_assessment_snapshots (
+  id text PRIMARY KEY,
+  version bigint NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_risk_assessment_subject_scenario ON risk_assessment_snapshots ((data->>'subjectRef'), (data->>'scenario'));
+CREATE TABLE IF NOT EXISTS risk_block_snapshots (
+  id text PRIMARY KEY,
+  version bigint NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_risk_block_subject_scope ON risk_block_snapshots ((data->>'subjectRef'), (data->>'scope'));
+CREATE TABLE IF NOT EXISTS risk_order_accounts (
+  order_id text PRIMARY KEY,
+  account_id text NOT NULL
+);
+CREATE TABLE IF NOT EXISTS risk_account_order_attempts (
+  account_id text NOT NULL,
+  occurred_at timestamptz NOT NULL,
+  PRIMARY KEY (account_id, occurred_at)
+);
+CREATE INDEX IF NOT EXISTS idx_risk_account_order_attempts_recent ON risk_account_order_attempts (account_id, occurred_at DESC);
+CREATE TABLE IF NOT EXISTS risk_account_lifts (
+  account_id text PRIMARY KEY,
+  lifted_at timestamptz NOT NULL
+);
+CREATE TABLE IF NOT EXISTS outbox (
+  seq bigserial PRIMARY KEY,
+  event_id text NOT NULL UNIQUE,
+  stream text NOT NULL,
+  envelope jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  published_at timestamptz
+);
+CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq ON outbox(seq) WHERE published_at IS NULL;
+CREATE TABLE IF NOT EXISTS processed_events (
+  event_id text PRIMARY KEY,
+  stream text,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS idempotency_records (
+  key text PRIMARY KEY,
+  request_hash text NOT NULL,
+  status_code int NOT NULL,
+  response_body jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/services/risk-compliance/pyproject.toml
+++ b/services/risk-compliance/pyproject.toml
@@ -5,6 +5,8 @@ description = "Risk & Compliance service skeleton"
 requires-python = ">=3.11"
 dependencies = [
   "train-ticket-platform",
+  "psycopg[binary]>=3.2.0",
+  "psycopg-pool>=3.2.0",
 ]
 
 [dependency-groups]

--- a/services/risk-compliance/src/risk_compliance/adapters/storage/__init__.py
+++ b/services/risk-compliance/src/risk_compliance/adapters/storage/__init__.py
@@ -1,0 +1,3 @@
+from .postgres import PostgresAssessmentRepository, TransactionalOutboxPublisher
+
+__all__ = ["PostgresAssessmentRepository", "TransactionalOutboxPublisher"]

--- a/services/risk-compliance/src/risk_compliance/adapters/storage/postgres.py
+++ b/services/risk-compliance/src/risk_compliance/adapters/storage/postgres.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from contextvars import ContextVar
+from datetime import UTC, datetime
+from typing import Any, Mapping
+
+from risk_compliance.application import AssessmentNotFoundError, BlockNotFoundError, FREQUENCY_WINDOW, RiskAssessmentResult, RiskBlockApplied
+from train_ticket_platform.events import EventEnvelope
+from train_ticket_platform.storage import OutboxAppender, ProcessedEventsGuard, SnapshotRepository
+
+
+def _json_obj(data: Mapping[str, Any] | str) -> Mapping[str, Any]:
+    return json.loads(data) if isinstance(data, str) else data
+
+
+def _assessment_to_json(result: RiskAssessmentResult) -> dict[str, Any]:
+    return {**result.to_event_payload()}
+
+
+def _assessment_from_json(data: Mapping[str, Any] | str) -> RiskAssessmentResult:
+    data = _json_obj(data)
+    return RiskAssessmentResult(
+        assessmentId=str(data["assessmentId"]),
+        subjectRef=str(data["subjectRef"]),
+        scenario=str(data["scenario"]),
+        decision=str(data["decision"]),
+        score=int(data["score"]),
+        level=str(data["level"]),
+        policyVersion=str(data["policyVersion"]),
+        reasonCode=str(data["reasonCode"]),
+        reasonExplanation=str(data.get("reasonExplanation", "")),
+        assessedAt=str(data["assessedAt"]),
+        evidenceRef=str(data.get("evidenceRef", f"evid-{data['assessmentId']}")),
+        assessmentSnapshotHash=str(data.get("assessmentSnapshotHash", "")),
+    )
+
+
+def _block_to_json(block: RiskBlockApplied) -> dict[str, Any]:
+    return block.to_event_payload()
+
+
+def _block_from_json(data: Mapping[str, Any] | str) -> RiskBlockApplied:
+    data = _json_obj(data)
+    return RiskBlockApplied(
+        blockId=str(data["blockId"]),
+        subjectRef=str(data["subjectRef"]),
+        scope=str(data["scope"]),
+        reasonCode=str(data["reasonCode"]),
+        policyVersion=str(data["policyVersion"]),
+        evidenceRef=str(data["evidenceRef"]),
+        blockedAt=str(data["blockedAt"]),
+    )
+
+
+def _coerce_dt(value: datetime | str) -> datetime:
+    if isinstance(value, datetime):
+        return value.astimezone(UTC) if value.tzinfo else value.replace(tzinfo=UTC)
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+class _TxState:
+    def __init__(self, connection: Any) -> None:
+        self.connection = connection
+
+
+_TX: ContextVar[_TxState | None] = ContextVar("risk_compliance_postgres_tx", default=None)
+
+
+class TransactionalOutboxPublisher:
+    def __init__(self, repository: "PostgresAssessmentRepository", outbox: OutboxAppender | None = None) -> None:
+        self._repository = repository
+        self._outbox = outbox or OutboxAppender()
+
+    def publish(self, envelope: EventEnvelope) -> None:
+        def write(conn: Any) -> None:
+            self._outbox.append(conn, envelope)
+        self._repository.with_connection(write)
+
+
+class PostgresAssessmentRepository:
+    def __init__(self, pool: Any) -> None:
+        self._pool = pool
+        self._assessments = SnapshotRepository("risk_assessment_snapshots")
+        self._blocks = SnapshotRepository("risk_block_snapshots")
+        self._processed = ProcessedEventsGuard()
+
+    @contextmanager
+    def transaction(self):
+        state = _TX.get()
+        if state is not None:
+            yield state.connection
+            return
+        with self._pool.connection() as conn:
+            with conn.transaction():
+                token = _TX.set(_TxState(conn))
+                try:
+                    yield conn
+                finally:
+                    _TX.reset(token)
+
+    def with_connection(self, fn: Any) -> Any:
+        state = _TX.get()
+        if state is not None:
+            return fn(state.connection)
+        with self.transaction() as conn:
+            return fn(conn)
+
+    def get(self, assessment_id: str) -> RiskAssessmentResult:
+        found = self.find(assessment_id)
+        if found is None:
+            raise AssessmentNotFoundError(assessment_id)
+        return found
+
+    def find(self, assessment_id: str) -> RiskAssessmentResult | None:
+        def read(conn: Any) -> RiskAssessmentResult | None:
+            snap = self._assessments.get(conn, assessment_id)
+            return None if snap is None else _assessment_from_json(snap[1])
+        return self.with_connection(read)
+
+    def count(self) -> int:
+        return self.with_connection(lambda conn: int(conn.execute("SELECT count(*) FROM risk_assessment_snapshots").fetchone()[0]))
+
+    def values(self) -> tuple[RiskAssessmentResult, ...]:
+        def read(conn: Any) -> tuple[RiskAssessmentResult, ...]:
+            rows = conn.execute("SELECT data FROM risk_assessment_snapshots ORDER BY id").fetchall()
+            return tuple(_assessment_from_json(row[0]) for row in rows)
+        return self.with_connection(read)
+
+    def save(self, assessment: RiskAssessmentResult) -> None:
+        def write(conn: Any) -> None:
+            snap = self._assessments.get(conn, assessment.assessmentId)
+            self._assessments.save(conn, assessment.assessmentId, _assessment_to_json(assessment), None if snap is None else int(snap[0]))
+        self.with_connection(write)
+
+    def is_processed(self, event_id: str) -> bool:
+        return self.with_connection(lambda conn: conn.execute("SELECT 1 FROM processed_events WHERE event_id = %s", (event_id,)).fetchone() is not None)
+
+    def record_processed(self, event_id: str) -> None:
+        self.with_connection(lambda conn: self._processed.try_mark_processed(conn, event_id, "events:journey-order"))
+
+    def save_block(self, block: RiskBlockApplied) -> None:
+        def write(conn: Any) -> None:
+            snap = self._blocks.get(conn, block.subjectRef)
+            self._blocks.save(conn, block.subjectRef, _block_to_json(block), None if snap is None else int(snap[0]))
+        self.with_connection(write)
+
+    def active_block(self, subject_ref: str) -> RiskBlockApplied:
+        def read(conn: Any) -> RiskBlockApplied:
+            snap = self._blocks.get(conn, subject_ref)
+            if snap is None:
+                raise BlockNotFoundError(subject_ref)
+            return _block_from_json(snap[1])
+        return self.with_connection(read)
+
+    def remove_block(self, subject_ref: str) -> None:
+        self.with_connection(lambda conn: conn.execute("DELETE FROM risk_block_snapshots WHERE id = %s", (subject_ref,)))
+
+    def remember_order_account(self, order_id: str, account_id: str) -> None:
+        self.with_connection(lambda conn: conn.execute("INSERT INTO risk_order_accounts(order_id, account_id) VALUES (%s, %s) ON CONFLICT (order_id) DO UPDATE SET account_id = EXCLUDED.account_id", (order_id, account_id)))
+
+    def account_for_order(self, order_id: str) -> str | None:
+        def read(conn: Any) -> str | None:
+            row = conn.execute("SELECT account_id FROM risk_order_accounts WHERE order_id = %s", (order_id,)).fetchone()
+            return None if row is None else str(row[0])
+        return self.with_connection(read)
+
+    def record_account_lift(self, account_id: str, lifted_at: datetime) -> None:
+        def write(conn: Any) -> None:
+            conn.execute("INSERT INTO risk_account_lifts(account_id, lifted_at) VALUES (%s, %s) ON CONFLICT (account_id) DO UPDATE SET lifted_at = EXCLUDED.lifted_at", (account_id, lifted_at))
+            conn.execute("DELETE FROM risk_account_order_attempts WHERE account_id = %s AND occurred_at <= %s", (account_id, lifted_at))
+        self.with_connection(write)
+
+    def record_order_attempt(self, account_id: str, occurred_at: datetime) -> int:
+        occurred_at = _coerce_dt(occurred_at)
+        window_start = occurred_at - FREQUENCY_WINDOW
+        def write(conn: Any) -> int:
+            lifted = conn.execute("SELECT lifted_at FROM risk_account_lifts WHERE account_id = %s", (account_id,)).fetchone()
+            lifted_at = lifted[0] if lifted else None
+            conn.execute("INSERT INTO risk_account_order_attempts(account_id, occurred_at) VALUES (%s, %s) ON CONFLICT DO NOTHING", (account_id, occurred_at))
+            if lifted_at is None:
+                row = conn.execute("SELECT count(*) FROM risk_account_order_attempts WHERE account_id = %s AND occurred_at >= %s AND occurred_at <= %s", (account_id, window_start, occurred_at)).fetchone()
+            else:
+                row = conn.execute("SELECT count(*) FROM risk_account_order_attempts WHERE account_id = %s AND occurred_at >= %s AND occurred_at <= %s AND occurred_at > %s", (account_id, window_start, occurred_at, lifted_at)).fetchone()
+            return int(row[0])
+        return self.with_connection(write)

--- a/services/risk-compliance/src/risk_compliance/adapters/storage/postgres.py
+++ b/services/risk-compliance/src/risk_compliance/adapters/storage/postgres.py
@@ -134,6 +134,9 @@ class PostgresAssessmentRepository:
             self._assessments.save(conn, assessment.assessmentId, _assessment_to_json(assessment), None if snap is None else int(snap[0]))
         self.with_connection(write)
 
+    def try_mark_processed(self, event_id: str) -> bool:
+        return bool(self.with_connection(lambda conn: self._processed.try_mark_processed(conn, event_id, "events:journey-order")))
+
     def is_processed(self, event_id: str) -> bool:
         return self.with_connection(lambda conn: conn.execute("SELECT 1 FROM processed_events WHERE event_id = %s", (event_id,)).fetchone() is not None)
 

--- a/services/risk-compliance/src/risk_compliance/api.py
+++ b/services/risk-compliance/src/risk_compliance/api.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Callable, Mapping
 from contextlib import AbstractContextManager, asynccontextmanager, nullcontext
+import os
+from pathlib import Path
 from typing import Any, Protocol
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
@@ -21,6 +23,7 @@ from .application import (
 )
 from train_ticket_platform.http import canonical_error_body
 from train_ticket_platform.idempotency import BoundedInMemoryIdempotencyStore, IdempotencyStore, configure_idempotency_middleware
+from train_ticket_platform.storage import DatabaseConfig, DatabasePool, OutboxRelay, PostgresIdempotencyStore, ReadinessGate, run_migrations
 
 from .runtime import health, profile
 
@@ -176,7 +179,10 @@ def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, o
         return {"status": health()}
 
     @app.get("/ready")
-    def ready_endpoint() -> dict[str, str]:
+    def ready_endpoint(response: Response) -> dict[str, str]:
+        if not _storage_ready(app):
+            response.status_code = 503
+            return {"status": "not-ready"}
         return {"status": health()}
 
     @app.get("/healthz")
@@ -184,13 +190,54 @@ def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, o
         return {"status": health()}
 
     @app.get("/readyz")
-    def readyz_endpoint() -> dict[str, str]:
+    def readyz_endpoint(response: Response) -> dict[str, str]:
+        if not _storage_ready(app):
+            response.status_code = 503
+            return {"status": "not-ready"}
         return {"status": health()}
 
     @app.get("/metadata")
     def metadata_endpoint() -> dict[str, object]:
         return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
 
+
+
+def _storage_ready(app: FastAPI) -> bool:
+    gate = getattr(app.state, "readiness", None)
+    if gate is not None and not gate.ready:
+        return False
+    pool = getattr(app.state, "database_pool", None)
+    if pool is None:
+        return True
+    try:
+        with pool.connection() as conn:
+            conn.execute("SELECT 1").fetchone()
+        return True
+    except Exception:
+        if gate is not None:
+            gate.mark_failed("database readiness check failed")
+        return False
+
+
+def _configure_postgres(app: FastAPI) -> tuple[InMemoryAssessmentRepository, IdempotencyStore | None, Any | None]:
+    config = DatabaseConfig.from_env()
+    if config is None:
+        return InMemoryAssessmentRepository(), None, None
+    from .adapters.storage import PostgresAssessmentRepository, TransactionalOutboxPublisher
+
+    readiness = ReadinessGate()
+    pool = DatabasePool(config)
+    app.state.database_pool = pool
+    app.state.readiness = readiness
+    env_dir = os.environ.get("MIGRATIONS_DIR")
+    migrations_dir = Path(env_dir) if env_dir else Path(__file__).resolve().parents[2] / "migrations"
+    run_migrations(pool, migrations_dir, readiness)
+    repository = PostgresAssessmentRepository(pool)
+    publisher = TransactionalOutboxPublisher(repository)
+    relay = OutboxRelay(pool)
+    relay.start()
+    app.state.outbox_relay = relay
+    return repository, PostgresIdempotencyStore(pool), publisher
 
 def configure_error_handlers(app: FastAPI) -> None:
     @app.exception_handler(RequestValidationError)
@@ -265,7 +312,7 @@ def create_app(
     service: RiskComplianceService | None = None,
     idempotency_store: IdempotencyStore | None = None,
 ) -> FastAPI:
-    store = idempotency_store or BoundedInMemoryIdempotencyStore()
+    store = idempotency_store
     subscriber_config: dict[str, Any] | None = None
 
     @asynccontextmanager
@@ -282,9 +329,17 @@ def create_app(
         finally:
             if subscriber_config is not None:
                 app.state.subscriber.stop()
+            relay = getattr(app.state, "outbox_relay", None)
+            if relay is not None:
+                relay.stop()
+            pool = getattr(app.state, "database_pool", None)
+            if pool is not None:
+                pool.close()
 
     app = FastAPI(title="Risk & Compliance", version="0.1.0", lifespan=lifespan)
-    app.state.assessment_repository = InMemoryAssessmentRepository()
+    repository, postgres_idempotency_store, postgres_publisher = _configure_postgres(app)
+    store = store or postgres_idempotency_store or BoundedInMemoryIdempotencyStore()
+    app.state.assessment_repository = repository
     if service is None:
         from .adapters.messaging.redis_streams import (
             RISK_COMPLIANCE_CONSUMER_GROUP,
@@ -294,7 +349,7 @@ def create_app(
             risk_compliance_consumer_name,
         )
 
-        app.state.publisher = RedisEventPublisher()
+        app.state.publisher = postgres_publisher or RedisEventPublisher()
         app.state.risk_service = RiskComplianceService(
             publisher=app.state.publisher,
             repository=app.state.assessment_repository,

--- a/services/risk-compliance/src/risk_compliance/application.py
+++ b/services/risk-compliance/src/risk_compliance/application.py
@@ -241,6 +241,12 @@ class RiskComplianceService:
         completed = _evaluate(requested)
         result = _to_result(completed)
         envelope = _assessment_envelope(result, correlation_id, prefixed_id("cmd"))
+        transaction = getattr(self.repository, "transaction", None)
+        if callable(transaction):
+            with transaction():
+                self.repository.save(result)
+                self.publisher.publish(envelope)
+            return result, False
         self.repository.save(result)
         try:
             self.publisher.publish(envelope)
@@ -272,6 +278,15 @@ class RiskComplianceService:
     def handle_event(self, envelope: EventEnvelope) -> None:
         if envelope.eventType != "JourneyOrderCreated":
             return
+        transaction = getattr(self.repository, "transaction", None)
+        context = transaction() if callable(transaction) else None
+        if context is None:
+            self._handle_event_in_transaction(envelope)
+            return
+        with context:
+            self._handle_event_in_transaction(envelope)
+
+    def _handle_event_in_transaction(self, envelope: EventEnvelope) -> None:
         if self.repository.is_processed(envelope.eventId):
             return
         result, block = self._assess_journey_order_created(envelope)
@@ -293,12 +308,23 @@ class RiskComplianceService:
         if previous.scope != scope:
             raise BlockNotFoundError(subject_ref)
         lifted = _lifted_from_previous(previous, reason_code)
-        self.publisher.publish(_block_lifted_envelope(lifted, correlation_id, prefixed_id("cmd")))
-        self.repository.remove_block(subject_ref)
-        if previous.scope == BlockScope.ORDER.value:
-            account_id = self.repository.account_for_order(subject_ref)
-            if account_id is not None:
-                self.repository.record_account_lift(account_id, _coerce_datetime(lifted.allowedAt))
+        transaction = getattr(self.repository, "transaction", None)
+        context = transaction() if callable(transaction) else None
+        if context is None:
+            self.publisher.publish(_block_lifted_envelope(lifted, correlation_id, prefixed_id("cmd")))
+            self.repository.remove_block(subject_ref)
+            if previous.scope == BlockScope.ORDER.value:
+                account_id = self.repository.account_for_order(subject_ref)
+                if account_id is not None:
+                    self.repository.record_account_lift(account_id, _coerce_datetime(lifted.allowedAt))
+            return lifted
+        with context:
+            self.publisher.publish(_block_lifted_envelope(lifted, correlation_id, prefixed_id("cmd")))
+            self.repository.remove_block(subject_ref)
+            if previous.scope == BlockScope.ORDER.value:
+                account_id = self.repository.account_for_order(subject_ref)
+                if account_id is not None:
+                    self.repository.record_account_lift(account_id, _coerce_datetime(lifted.allowedAt))
         return lifted
 
     def _assess_journey_order_created(self, envelope: EventEnvelope) -> tuple[RiskAssessmentResult, RiskBlockApplied | None]:

--- a/services/risk-compliance/src/risk_compliance/application.py
+++ b/services/risk-compliance/src/risk_compliance/application.py
@@ -154,6 +154,12 @@ class InMemoryAssessmentRepository:
     def save(self, assessment: RiskAssessmentResult) -> None:
         self._assessments[assessment.assessmentId] = assessment
 
+    def try_mark_processed(self, event_id: str) -> bool:
+        if event_id in self._processed_event_ids:
+            return False
+        self._processed_event_ids.add(event_id)
+        return True
+
     def is_processed(self, event_id: str) -> bool:
         return event_id in self._processed_event_ids
 
@@ -287,7 +293,11 @@ class RiskComplianceService:
             self._handle_event_in_transaction(envelope)
 
     def _handle_event_in_transaction(self, envelope: EventEnvelope) -> None:
-        if self.repository.is_processed(envelope.eventId):
+        try_mark_processed = getattr(self.repository, "try_mark_processed", None)
+        if callable(try_mark_processed):
+            if not try_mark_processed(envelope.eventId):
+                return
+        elif self.repository.is_processed(envelope.eventId):
             return
         result, block = self._assess_journey_order_created(envelope)
         self.repository.save(result)
@@ -301,7 +311,8 @@ class RiskComplianceService:
         if block is not None:
             self.repository.save_block(block)
             self.publisher.publish(_block_applied_envelope(block, envelope.correlationId, assessment_envelope.eventId))
-        self.repository.record_processed(envelope.eventId)
+        if try_mark_processed is None:
+            self.repository.record_processed(envelope.eventId)
 
     def lift_block(self, *, subject_ref: str, scope: str, reason_code: str, correlation_id: str) -> RiskBlockLifted:
         previous = self.repository.active_block(subject_ref)

--- a/services/risk-compliance/tests/test_api_and_messaging.py
+++ b/services/risk-compliance/tests/test_api_and_messaging.py
@@ -424,10 +424,21 @@ def test_journey_order_replay_does_not_publish_second_assessment_after_partial_d
         except PublishFailed:
             pass
 
-    assert [published.eventType for published in publisher.envelopes] == ["RiskAssessmentResult", "RiskAssessmentResult"]
-    assert publisher.envelopes[1].eventId == publisher.envelopes[0].eventId
-    assert publisher.envelopes[1].payload["assessmentId"] == publisher.envelopes[0].payload["assessmentId"]
+    assert [published.eventType for published in publisher.envelopes] == ["RiskAssessmentResult"]
     assert service.assessment_count() == 1
+
+
+def test_journey_order_duplicate_is_acknowledged_before_side_effects() -> None:
+    class DuplicateRepository(InMemoryAssessmentRepository):
+        def try_mark_processed(self, event_id: str) -> bool:
+            return False
+
+    publisher = InMemoryEventPublisher()
+    service = RiskComplianceService(publisher, DuplicateRepository())
+    service.handle_event(journey_order_created_envelope(f"evt-{uuid7()}", "ord-duplicate", "acct-duplicate"))
+
+    assert publisher.envelopes == []
+    assert service.assessment_count() == 0
 
 
 def test_lift_block_clears_account_frequency_window_for_same_account() -> None:

--- a/services/risk-compliance/uv.lock
+++ b/services/risk-compliance/uv.lock
@@ -142,6 +142,87 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -300,6 +381,8 @@ name = "risk-compliance"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
     { name = "train-ticket-platform" },
 ]
 
@@ -310,7 +393,11 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "train-ticket-platform", editable = "../../platform/python-kit" }]
+requires-dist = [
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
+    { name = "psycopg-pool", specifier = ">=3.2.0" },
+    { name = "train-ticket-platform", editable = "../../platform/python-kit" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -338,6 +425,8 @@ source = { editable = "../../platform/python-kit" }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx2" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
     { name = "redis" },
     { name = "uuid6" },
 ]
@@ -346,6 +435,8 @@ dependencies = [
 requires-dist = [
     { name = "fastapi", specifier = "==0.138.1" },
     { name = "httpx2", specifier = ">=2.5.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
+    { name = "psycopg-pool", specifier = ">=3.2.0" },
     { name = "redis", specifier = ">=5.0.0" },
     { name = "uuid6", specifier = ">=2024.7.10" },
 ]
@@ -384,6 +475,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]

--- a/services/trip-planning/migrations/001_trip_planning_storage.sql
+++ b/services/trip-planning/migrations/001_trip_planning_storage.sql
@@ -1,0 +1,62 @@
+CREATE TABLE IF NOT EXISTS plan_index_events (
+  event_id text PRIMARY KEY,
+  event_type text NOT NULL,
+  producer text NOT NULL,
+  occurred_at text NOT NULL,
+  payload jsonb NOT NULL,
+  applied_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS plan_services (
+  scheduled_service_ref text PRIMARY KEY,
+  version bigint NOT NULL DEFAULT 1,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS plan_segments (
+  segment_ref text PRIMARY KEY,
+  version bigint NOT NULL DEFAULT 1,
+  scheduled_service_ref text,
+  origin_stop_ref text NOT NULL,
+  destination_stop_ref text NOT NULL,
+  departure_time timestamptz NOT NULL,
+  departure_date date NOT NULL,
+  arrival_time timestamptz NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_plan_segments_search ON plan_segments (departure_date, origin_stop_ref, destination_stop_ref);
+CREATE TABLE IF NOT EXISTS plan_nodes (
+  node_id text PRIMARY KEY,
+  version bigint NOT NULL DEFAULT 1,
+  place_id text NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_plan_nodes_place ON plan_nodes (place_id, node_id);
+CREATE TABLE IF NOT EXISTS itinerary_snapshots (
+  id text PRIMARY KEY,
+  version bigint NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS outbox (
+  seq bigserial PRIMARY KEY,
+  event_id text NOT NULL UNIQUE,
+  stream text NOT NULL,
+  envelope jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  published_at timestamptz
+);
+CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq ON outbox(seq) WHERE published_at IS NULL;
+CREATE TABLE IF NOT EXISTS processed_events (
+  event_id text PRIMARY KEY,
+  stream text,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS idempotency_records (
+  key text PRIMARY KEY,
+  request_hash text NOT NULL,
+  status_code int NOT NULL,
+  response_body jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/services/trip-planning/pyproject.toml
+++ b/services/trip-planning/pyproject.toml
@@ -5,6 +5,8 @@ description = "Trip Planning search foundation"
 requires-python = ">=3.11"
 dependencies = [
   "train-ticket-platform",
+  "psycopg[binary]>=3.2.0",
+  "psycopg-pool>=3.2.0",
 ]
 
 [project.optional-dependencies]

--- a/services/trip-planning/src/trip_planning/adapters/storage/__init__.py
+++ b/services/trip-planning/src/trip_planning/adapters/storage/__init__.py
@@ -1,0 +1,3 @@
+from .postgres import PostgresPlanStore, TransactionalOutboxPublisher
+
+__all__ = ["PostgresPlanStore", "TransactionalOutboxPublisher"]

--- a/services/trip-planning/src/trip_planning/adapters/storage/postgres.py
+++ b/services/trip-planning/src/trip_planning/adapters/storage/postgres.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any, Mapping
+
+from train_ticket_platform.storage import OutboxAppender, SnapshotRepository
+from trip_planning.domain import AvailabilityHint, Itinerary, LegCandidate, PriceHint
+from trip_planning.events import EventEnvelope
+
+
+
+def _jsonb_payload(value: Mapping[str, Any]) -> Any:
+    try:
+        from psycopg.types.json import Jsonb
+
+        return Jsonb(dict(value))
+    except ImportError:  # pragma: no cover - psycopg optional in unit tests
+        return json.dumps(dict(value), separators=(",", ":"))
+
+def _json_obj(data: Mapping[str, Any] | str) -> Mapping[str, Any]:
+    return json.loads(data) if isinstance(data, str) else data
+
+
+def _dt(value: datetime | str) -> datetime:
+    if isinstance(value, datetime):
+        return value.astimezone(UTC) if value.tzinfo else value.replace(tzinfo=UTC)
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+class TransactionalOutboxPublisher:
+    def __init__(self, pool: Any, outbox: OutboxAppender | None = None) -> None:
+        self._pool = pool
+        self._outbox = outbox or OutboxAppender()
+
+    def publish(self, envelope: EventEnvelope) -> None:
+        with self._pool.connection() as conn:
+            with conn.transaction():
+                self._outbox.append(conn, envelope)
+
+
+class PostgresPlanStore:
+    def __init__(self, pool: Any) -> None:
+        self._pool = pool
+        self._itineraries = SnapshotRepository("itinerary_snapshots")
+
+    def clear(self) -> None:
+        with self._pool.connection() as conn:
+            with conn.transaction():
+                for table in ("plan_index_events", "plan_services", "plan_segments", "plan_nodes", "itinerary_snapshots"):
+                    conn.execute(f"DELETE FROM {table}")
+
+    def apply_envelope(self, envelope: Any) -> bool:
+        event_id = str(getattr(envelope, "eventId", ""))
+        event_type = str(getattr(envelope, "eventType", ""))
+        payload = dict(getattr(envelope, "payload", {}) or {})
+        producer = str(getattr(envelope, "producer", ""))
+        occurred_at = getattr(envelope, "occurredAt", "")
+        with self._pool.connection() as conn:
+            with conn.transaction():
+                if event_id:
+                    row = conn.execute("INSERT INTO processed_events(event_id, stream) VALUES (%s, %s) ON CONFLICT DO NOTHING RETURNING event_id", (event_id, f"events:{producer}")).fetchone()
+                    if row is None:
+                        return False
+                    conn.execute("INSERT INTO plan_index_events(event_id, event_type, producer, occurred_at, payload) VALUES (%s, %s, %s, %s, %s) ON CONFLICT DO NOTHING", (event_id, event_type, producer, str(occurred_at), _jsonb_payload(payload)))
+                self._apply_locked(conn, event_type, payload)
+        return True
+
+    def apply(self, event_type: str, payload: Mapping[str, object]) -> None:
+        with self._pool.connection() as conn:
+            with conn.transaction():
+                self._apply_locked(conn, event_type, dict(payload))
+
+    def load(self) -> None:
+        # State is already durable in read-model tables; this method preserves the
+        # in-memory PlanStore lifecycle contract for tests and startup code.
+        return None
+
+    def _apply_locked(self, conn: Any, event_type: str, payload: Mapping[str, object]) -> None:
+        if event_type in ("ServicePlanPublished", "ScheduledServiceCreated"):
+            ref = str(payload.get("scheduledServiceRef", ""))
+            if ref:
+                conn.execute("INSERT INTO plan_services(scheduled_service_ref, version, data) VALUES (%s, 1, %s) ON CONFLICT (scheduled_service_ref) DO UPDATE SET version = plan_services.version + 1, data = EXCLUDED.data, updated_at = now()", (ref, _jsonb_payload(dict(payload))))
+        elif event_type in ("ServicePlanChanged", "ServiceSegmentCreated"):
+            seg = str(payload.get("segmentRef", ""))
+            origin = str(payload.get("originStopRef", ""))
+            destination = str(payload.get("destinationStopRef", ""))
+            departure_raw = str(payload.get("departureTime", ""))
+            if seg and origin and destination and departure_raw:
+                departure = _dt(departure_raw)
+                arrival = _dt(str(payload.get("arrivalTime", departure_raw)))
+                conn.execute("INSERT INTO plan_segments(segment_ref, version, scheduled_service_ref, origin_stop_ref, destination_stop_ref, departure_time, departure_date, arrival_time, data) VALUES (%s, 1, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (segment_ref) DO UPDATE SET version = plan_segments.version + 1, scheduled_service_ref = EXCLUDED.scheduled_service_ref, origin_stop_ref = EXCLUDED.origin_stop_ref, destination_stop_ref = EXCLUDED.destination_stop_ref, departure_time = EXCLUDED.departure_time, departure_date = EXCLUDED.departure_date, arrival_time = EXCLUDED.arrival_time, data = EXCLUDED.data, updated_at = now()", (seg, str(payload.get("scheduledServiceRef", "")), origin, destination, departure, departure.date(), arrival, _jsonb_payload(dict(payload))))
+        elif event_type in ("TransportNodeRegistered", "TransportNodeAdded", "TransportNodeUpdated"):
+            node = str(payload.get("nodeId", ""))
+            place = str(payload.get("placeId", ""))
+            if node and place:
+                conn.execute("INSERT INTO plan_nodes(node_id, version, place_id, data) VALUES (%s, 1, %s, %s) ON CONFLICT (node_id) DO UPDATE SET version = plan_nodes.version + 1, place_id = EXCLUDED.place_id, data = EXCLUDED.data, updated_at = now()", (node, place, _jsonb_payload(dict(payload))))
+
+    def candidates(self, origin_ref: str, destination_ref: str, departure_date: str) -> list[Itinerary]:
+        with self._pool.connection() as conn:
+            rows = conn.execute(
+                """
+                WITH requested_origin AS (SELECT place_id FROM plan_nodes WHERE node_id = %s),
+                     requested_destination AS (SELECT place_id FROM plan_nodes WHERE node_id = %s),
+                     origin_refs AS (SELECT %s AS ref UNION SELECT node_id FROM plan_nodes WHERE place_id = %s UNION SELECT node_id FROM plan_nodes WHERE place_id = (SELECT place_id FROM requested_origin)),
+                     destination_refs AS (SELECT %s AS ref UNION SELECT node_id FROM plan_nodes WHERE place_id = %s UNION SELECT node_id FROM plan_nodes WHERE place_id = (SELECT place_id FROM requested_destination))
+                SELECT segment_ref, scheduled_service_ref, origin_stop_ref, destination_stop_ref, departure_time, arrival_time
+                  FROM plan_segments
+                 WHERE departure_date = %s::date
+                   AND origin_stop_ref IN (SELECT ref FROM origin_refs WHERE ref IS NOT NULL)
+                   AND destination_stop_ref IN (SELECT ref FROM destination_refs WHERE ref IS NOT NULL)
+                 ORDER BY departure_time, segment_ref
+                """,
+                (origin_ref, destination_ref, origin_ref, origin_ref, destination_ref, destination_ref, departure_date),
+            ).fetchall()
+        return [self._itinerary_from_row(row) for row in rows]
+
+    def _itinerary_from_row(self, row: Any) -> Itinerary:
+        seg_ref, service_ref, origin, destination, departure_time, arrival_time = row
+        departure = departure_time.astimezone(UTC)
+        arrival = arrival_time.astimezone(UTC)
+        return Itinerary(
+            legs=(LegCandidate(service_plan_ref=str(service_ref or ""), service_segment_ref=str(seg_ref), origin_stop_ref=str(origin), destination_stop_ref=str(destination), departure_time=departure, arrival_time=arrival, mode="train", stop_refs=(str(origin), str(destination)), segment_refs=(str(seg_ref),)),),
+            price_hint=PriceHint(amount_minor=0, currency="CNY", snapshot_ref=f"fare-snapshot:{seg_ref}", captured_at=departure, confidence=50),
+            availability_hint=AvailabilityHint(status="UNKNOWN", snapshot_ref=f"availability-snapshot:{seg_ref}", captured_at=departure, confidence=50),
+            planning_snapshot_refs=(f"planning-snapshot:{seg_ref}",),
+        )
+
+    def save_itinerary(self, itinerary: Mapping[str, object]) -> None:
+        ref = str(itinerary["itineraryRef"])
+        with self._pool.connection() as conn:
+            with conn.transaction():
+                snap = self._itineraries.get(conn, ref)
+                self._itineraries.save(conn, ref, dict(itinerary), None if snap is None else int(snap[0]))
+
+    def get_itinerary(self, itinerary_ref: str) -> dict[str, object] | None:
+        with self._pool.connection() as conn:
+            snap = self._itineraries.get(conn, itinerary_ref)
+        return None if snap is None else dict(snap[1])

--- a/services/trip-planning/src/trip_planning/adapters/storage/postgres.py
+++ b/services/trip-planning/src/trip_planning/adapters/storage/postgres.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import UTC, datetime
 from typing import Any, Mapping
 
@@ -8,6 +10,22 @@ from train_ticket_platform.storage import OutboxAppender, SnapshotRepository
 from trip_planning.domain import AvailabilityHint, Itinerary, LegCandidate, PriceHint
 from trip_planning.events import EventEnvelope
 
+
+_CLEAR_TABLE_SQL = (
+    "DELETE FROM plan_index_events",
+    "DELETE FROM plan_services",
+    "DELETE FROM plan_segments",
+    "DELETE FROM plan_nodes",
+    "DELETE FROM itinerary_snapshots",
+)
+
+
+class _TxState:
+    def __init__(self, connection: Any) -> None:
+        self.connection = connection
+
+
+_TX: ContextVar[_TxState | None] = ContextVar("trip_planning_postgres_tx", default=None)
 
 
 def _jsonb_payload(value: Mapping[str, Any]) -> Any:
@@ -18,9 +36,6 @@ def _jsonb_payload(value: Mapping[str, Any]) -> Any:
     except ImportError:  # pragma: no cover - psycopg optional in unit tests
         return json.dumps(dict(value), separators=(",", ":"))
 
-def _json_obj(data: Mapping[str, Any] | str) -> Mapping[str, Any]:
-    return json.loads(data) if isinstance(data, str) else data
-
 
 def _dt(value: datetime | str) -> datetime:
     if isinstance(value, datetime):
@@ -29,14 +44,12 @@ def _dt(value: datetime | str) -> datetime:
 
 
 class TransactionalOutboxPublisher:
-    def __init__(self, pool: Any, outbox: OutboxAppender | None = None) -> None:
-        self._pool = pool
+    def __init__(self, store: "PostgresPlanStore", outbox: OutboxAppender | None = None) -> None:
+        self._store = store
         self._outbox = outbox or OutboxAppender()
 
     def publish(self, envelope: EventEnvelope) -> None:
-        with self._pool.connection() as conn:
-            with conn.transaction():
-                self._outbox.append(conn, envelope)
+        self._store.with_connection(lambda conn: self._outbox.append(conn, envelope))
 
 
 class PostgresPlanStore:
@@ -44,11 +57,33 @@ class PostgresPlanStore:
         self._pool = pool
         self._itineraries = SnapshotRepository("itinerary_snapshots")
 
-    def clear(self) -> None:
+    @contextmanager
+    def transaction(self):
+        state = _TX.get()
+        if state is not None:
+            yield state.connection
+            return
         with self._pool.connection() as conn:
             with conn.transaction():
-                for table in ("plan_index_events", "plan_services", "plan_segments", "plan_nodes", "itinerary_snapshots"):
-                    conn.execute(f"DELETE FROM {table}")
+                token = _TX.set(_TxState(conn))
+                try:
+                    yield conn
+                finally:
+                    _TX.reset(token)
+
+    def with_connection(self, fn: Any) -> Any:
+        state = _TX.get()
+        if state is not None:
+            return fn(state.connection)
+        with self.transaction() as conn:
+            return fn(conn)
+
+    def clear(self) -> None:
+        def delete_all(conn: Any) -> None:
+            for statement in _CLEAR_TABLE_SQL:
+                conn.execute(statement)
+
+        self.with_connection(delete_all)
 
     def apply_envelope(self, envelope: Any) -> bool:
         event_id = str(getattr(envelope, "eventId", ""))
@@ -56,20 +91,20 @@ class PostgresPlanStore:
         payload = dict(getattr(envelope, "payload", {}) or {})
         producer = str(getattr(envelope, "producer", ""))
         occurred_at = getattr(envelope, "occurredAt", "")
-        with self._pool.connection() as conn:
-            with conn.transaction():
-                if event_id:
-                    row = conn.execute("INSERT INTO processed_events(event_id, stream) VALUES (%s, %s) ON CONFLICT DO NOTHING RETURNING event_id", (event_id, f"events:{producer}")).fetchone()
-                    if row is None:
-                        return False
-                    conn.execute("INSERT INTO plan_index_events(event_id, event_type, producer, occurred_at, payload) VALUES (%s, %s, %s, %s, %s) ON CONFLICT DO NOTHING", (event_id, event_type, producer, str(occurred_at), _jsonb_payload(payload)))
-                self._apply_locked(conn, event_type, payload)
-        return True
+
+        def write(conn: Any) -> bool:
+            if event_id:
+                row = conn.execute("INSERT INTO processed_events(event_id, stream) VALUES (%s, %s) ON CONFLICT DO NOTHING RETURNING event_id", (event_id, f"events:{producer}")).fetchone()
+                if row is None:
+                    return False
+                conn.execute("INSERT INTO plan_index_events(event_id, event_type, producer, occurred_at, payload) VALUES (%s, %s, %s, %s, %s) ON CONFLICT DO NOTHING", (event_id, event_type, producer, str(occurred_at), _jsonb_payload(payload)))
+            self._apply_locked(conn, event_type, payload)
+            return True
+
+        return bool(self.with_connection(write))
 
     def apply(self, event_type: str, payload: Mapping[str, object]) -> None:
-        with self._pool.connection() as conn:
-            with conn.transaction():
-                self._apply_locked(conn, event_type, dict(payload))
+        self.with_connection(lambda conn: self._apply_locked(conn, event_type, dict(payload)))
 
     def load(self) -> None:
         # State is already durable in read-model tables; this method preserves the
@@ -128,12 +163,13 @@ class PostgresPlanStore:
 
     def save_itinerary(self, itinerary: Mapping[str, object]) -> None:
         ref = str(itinerary["itineraryRef"])
-        with self._pool.connection() as conn:
-            with conn.transaction():
-                snap = self._itineraries.get(conn, ref)
-                self._itineraries.save(conn, ref, dict(itinerary), None if snap is None else int(snap[0]))
+
+        def write(conn: Any) -> None:
+            snap = self._itineraries.get(conn, ref)
+            self._itineraries.save(conn, ref, dict(itinerary), None if snap is None else int(snap[0]))
+
+        self.with_connection(write)
 
     def get_itinerary(self, itinerary_ref: str) -> dict[str, object] | None:
-        with self._pool.connection() as conn:
-            snap = self._itineraries.get(conn, itinerary_ref)
+        snap = self.with_connection(lambda conn: self._itineraries.get(conn, itinerary_ref))
         return None if snap is None else dict(snap[1])

--- a/services/trip-planning/src/trip_planning/api.py
+++ b/services/trip-planning/src/trip_planning/api.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager, asynccontextmanager, nullcontext
 from datetime import datetime, timedelta
+import os
+from pathlib import Path
 from hashlib import sha256
 import logging
 import threading
 from typing import Any, Protocol
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
@@ -17,6 +19,7 @@ from .domain import AvailabilityHint, Itinerary, LegCandidate, PriceHint, TripIn
 from .application_ports import EventPublisher, EventSubscriber
 from .events import PublishFailed, build_itinerary_proposed_event, new_uuid7
 from train_ticket_platform.idempotency import configure_idempotency_middleware
+from train_ticket_platform.storage import DatabaseConfig, DatabasePool, OutboxRelay, PostgresIdempotencyStore, ReadinessGate, run_migrations
 
 from .runtime import health, profile
 
@@ -132,7 +135,10 @@ def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, o
         return {"status": health(), "service": profile()}
 
     @app.get("/readyz")
-    def readyz_endpoint() -> dict[str, str]:
+    def readyz_endpoint(response: Response) -> dict[str, str]:
+        if not _storage_ready(app):
+            response.status_code = 503
+            return {"status": "not-ready"}
         return {"status": health()}
 
     @app.get("/health")
@@ -144,13 +150,53 @@ def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, o
         return {"status": health()}
 
     @app.get("/ready")
-    def ready_endpoint() -> dict[str, str]:
+    def ready_endpoint(response: Response) -> dict[str, str]:
+        if not _storage_ready(app):
+            response.status_code = 503
+            return {"status": "not-ready"}
         return {"status": health()}
 
     @app.get("/metadata")
     def metadata_endpoint() -> dict[str, object]:
         return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
 
+
+
+def _storage_ready(app: FastAPI) -> bool:
+    gate = getattr(app.state, "readiness", None)
+    if gate is not None and not gate.ready:
+        return False
+    pool = getattr(app.state, "database_pool", None)
+    if pool is None:
+        return True
+    try:
+        with pool.connection() as conn:
+            conn.execute("SELECT 1").fetchone()
+        return True
+    except Exception:
+        if gate is not None:
+            gate.mark_failed("database readiness check failed")
+        return False
+
+
+def _configure_postgres(app: FastAPI) -> tuple[Any | None, Any | None, Any | None]:
+    config = DatabaseConfig.from_env()
+    if config is None:
+        return None, None, None
+    from .adapters.storage import PostgresPlanStore, TransactionalOutboxPublisher
+
+    readiness = ReadinessGate()
+    pool = DatabasePool(config)
+    app.state.database_pool = pool
+    app.state.readiness = readiness
+    env_dir = os.environ.get("MIGRATIONS_DIR")
+    migrations_dir = Path(env_dir) if env_dir else Path(__file__).resolve().parents[2] / "migrations"
+    run_migrations(pool, migrations_dir, readiness)
+    plan_store = PostgresPlanStore(pool)
+    relay = OutboxRelay(pool)
+    relay.start()
+    app.state.outbox_relay = relay
+    return plan_store, TransactionalOutboxPublisher(pool), PostgresIdempotencyStore(pool)
 
 def _require_string(payload: Mapping[str, object], field_name: str) -> str:
     value = payload.get(field_name)
@@ -298,6 +344,7 @@ class PlanStore:
 
 
 _plan_store = PlanStore()
+_active_plan_store: Any = _plan_store
 
 
 def _contract_candidate(origin_ref: str, destination_ref: str, departure_date: str, channel: str) -> Itinerary:
@@ -387,7 +434,7 @@ def _search_contract_response(payload: Mapping[str, object]) -> tuple[dict[str, 
         departure_window_end=f"{departure_date}T23:59:59Z",
         passenger_count=len(traveler_refs),
     )
-    real_candidates = _plan_store.candidates(origin_ref, destination_ref, departure_date)
+    real_candidates = _active_plan_store.candidates(origin_ref, destination_ref, departure_date)
     candidate_pool = (
         tuple(_candidate_for_intent(candidate, origin_ref, destination_ref) for candidate in real_candidates)
         if real_candidates
@@ -422,7 +469,7 @@ def _occurred_at_text(envelope: Any) -> str:
 
 
 def _handle_upstream_event(app: FastAPI, envelope: Any) -> None:
-    _plan_store.apply_envelope(envelope)
+    _active_plan_store.apply_envelope(envelope)
     app.state.consumed_events[envelope.eventId] = {
         "eventType": envelope.eventType,
         "producer": envelope.producer,
@@ -465,7 +512,11 @@ def create_app(
     event_subscriber: EventSubscriber | None = None,
     start_event_subscriber: bool = True,
 ) -> FastAPI:
-    publisher = event_publisher if event_publisher is not None else _default_publisher()
+    global _active_plan_store
+    postgres_plan_store: Any | None = None
+    postgres_publisher: Any | None = None
+    postgres_idempotency_store: Any | None = None
+    publisher = event_publisher if event_publisher is not None else None
     subscriber = event_subscriber if event_subscriber is not None else None
 
     @asynccontextmanager
@@ -477,17 +528,29 @@ def create_app(
         if active_subscriber is not None and start_event_subscriber:
             _replay_upstream_events(active_subscriber, handler)
         subscriber_thread = _start_subscriber(active_subscriber, handler) if active_subscriber is not None and start_event_subscriber else None
+        if hasattr(_active_plan_store, "load"):
+            _active_plan_store.load()
         app.state.event_subscriber = active_subscriber
         app.state.subscriber_thread = subscriber_thread
         try:
             yield
         finally:
             _stop_subscriber(getattr(app.state, "event_subscriber", None), subscriber_thread)
+            relay = getattr(app.state, "outbox_relay", None)
+            if relay is not None:
+                relay.stop()
+            pool = getattr(app.state, "database_pool", None)
+            if pool is not None:
+                pool.close()
 
     app = FastAPI(title="Trip Planning", version="0.1.0", lifespan=lifespan)
+    postgres_plan_store, postgres_publisher, postgres_idempotency_store = _configure_postgres(app)
+    _active_plan_store = postgres_plan_store or _plan_store
+    if publisher is None:
+        publisher = postgres_publisher or _default_publisher()
     configure_runtime_endpoints(app, tracer, otel_tracer or opentelemetry_tracer_from_env(profile()["service_id"]))
     app.state.itineraries = {}
-    configure_idempotency_middleware(app, require_key=False, include_path_prefixes=("/api/v1/itineraries/search",))
+    configure_idempotency_middleware(app, postgres_idempotency_store, require_key=False, include_path_prefixes=("/api/v1/itineraries/search",))
     app.state.consumed_events = {}
     app.state.upstream_event_payloads = {}
 
@@ -510,6 +573,9 @@ def create_app(
         for itinerary in response["itineraries"]:
             if isinstance(itinerary, dict):
                 app.state.itineraries[itinerary["itineraryRef"]] = itinerary
+                save_itinerary = getattr(_active_plan_store, "save_itinerary", None)
+                if callable(save_itinerary):
+                    save_itinerary(itinerary)
         try:
             publisher.publish(
                 build_itinerary_proposed_event(
@@ -527,6 +593,10 @@ def create_app(
     def get_itinerary(itineraryRef: str, request: Request) -> Any:
         correlation_id: str = request.state.correlation_id
         itinerary = app.state.itineraries.get(itineraryRef)
+        if itinerary is None:
+            get_itinerary = getattr(_active_plan_store, "get_itinerary", None)
+            if callable(get_itinerary):
+                itinerary = get_itinerary(itineraryRef)
         if itinerary is None:
             return _canonical_error(404, "NOT_FOUND", f"Itinerary {itineraryRef} not found", correlation_id)
         return itinerary

--- a/services/trip-planning/src/trip_planning/api.py
+++ b/services/trip-planning/src/trip_planning/api.py
@@ -196,7 +196,7 @@ def _configure_postgres(app: FastAPI) -> tuple[Any | None, Any | None, Any | Non
     relay = OutboxRelay(pool)
     relay.start()
     app.state.outbox_relay = relay
-    return plan_store, TransactionalOutboxPublisher(pool), PostgresIdempotencyStore(pool)
+    return plan_store, TransactionalOutboxPublisher(plan_store), PostgresIdempotencyStore(pool)
 
 def _require_string(payload: Mapping[str, object], field_name: str) -> str:
     value = payload.get(field_name)
@@ -270,6 +270,9 @@ class PlanStore:
     def apply(self, event_type: str, payload: Mapping[str, object]) -> None:
         with self._lock:
             self._apply_locked(event_type, payload)
+
+    def load(self) -> None:
+        return None
 
     def _apply_locked(self, event_type: str, payload: Mapping[str, object]) -> None:
         if event_type in ("ServicePlanPublished", "ScheduledServiceCreated"):
@@ -484,15 +487,9 @@ def _start_subscriber(subscriber: EventSubscriber, handler: Callable[[Any], None
     return start_trip_planning_subscription(subscriber, handler)
 
 
-def _replay_upstream_events(subscriber: EventSubscriber, handler: Callable[[Any], None]) -> None:
-    replay = getattr(subscriber, "replay", None)
-    if not callable(replay):
-        return
-    try:
-        replay(handler)
-    except Exception:
-        logger.exception("trip-planning plan index replay failed")
-        raise
+def _load_plan_index_from_db() -> None:
+    if hasattr(_active_plan_store, "load"):
+        _active_plan_store.load()
 
 
 def _stop_subscriber(subscriber: EventSubscriber | None, thread: threading.Thread | None) -> None:
@@ -525,11 +522,8 @@ def create_app(
         if active_subscriber is None and start_event_subscriber:
             active_subscriber = _default_subscriber()
         handler = lambda envelope: _handle_upstream_event(app, envelope)
-        if active_subscriber is not None and start_event_subscriber:
-            _replay_upstream_events(active_subscriber, handler)
+        _load_plan_index_from_db()
         subscriber_thread = _start_subscriber(active_subscriber, handler) if active_subscriber is not None and start_event_subscriber else None
-        if hasattr(_active_plan_store, "load"):
-            _active_plan_store.load()
         app.state.event_subscriber = active_subscriber
         app.state.subscriber_thread = subscriber_thread
         try:
@@ -570,21 +564,23 @@ def create_app(
         except TripPlanningValidationError as exc:
             return _canonical_error(400, "VALIDATION_FAILED", str(exc), correlation_id)
 
-        for itinerary in response["itineraries"]:
-            if isinstance(itinerary, dict):
-                app.state.itineraries[itinerary["itineraryRef"]] = itinerary
-                save_itinerary = getattr(_active_plan_store, "save_itinerary", None)
-                if callable(save_itinerary):
-                    save_itinerary(itinerary)
+        event = build_itinerary_proposed_event(
+            str(response["intentRef"]),
+            tuple(response["itineraries"]),  # type: ignore[arg-type]
+            planning_snapshot_refs,
+            correlation_id=correlation_id,
+        )
+        transaction = getattr(_active_plan_store, "transaction", None)
         try:
-            publisher.publish(
-                build_itinerary_proposed_event(
-                    str(response["intentRef"]),
-                    tuple(response["itineraries"]),  # type: ignore[arg-type]
-                    planning_snapshot_refs,
-                    correlation_id=correlation_id,
-                )
-            )
+            context = transaction() if callable(transaction) else nullcontext()
+            with context:
+                for itinerary in response["itineraries"]:
+                    if isinstance(itinerary, dict):
+                        app.state.itineraries[itinerary["itineraryRef"]] = itinerary
+                        save_itinerary = getattr(_active_plan_store, "save_itinerary", None)
+                        if callable(save_itinerary):
+                            save_itinerary(itinerary)
+                publisher.publish(event)
         except PublishFailed:
             return _canonical_error(503, "UNAVAILABLE", "Event bus is unavailable", correlation_id)
         return response

--- a/services/trip-planning/tests/test_event_ports.py
+++ b/services/trip-planning/tests/test_event_ports.py
@@ -35,6 +35,70 @@ class EventPublisherTest(unittest.TestCase):
         self.assertEqual(envelope.correlationId, "corr-published")
         self.assertEqual(envelope.payload["intentRef"], response.json()["intentRef"])
 
+    def test_search_saves_itinerary_and_outbox_in_same_unit_of_work(self) -> None:
+        class RecordingStore:
+            def __init__(self) -> None:
+                self.in_transaction = False
+                self.saved_inside_transaction = False
+
+            def transaction(self):
+                store = self
+
+                class Context:
+                    def __enter__(self):
+                        store.in_transaction = True
+                        return self
+
+                    def __exit__(self, exc_type, exc, traceback):
+                        store.in_transaction = False
+
+                return Context()
+
+            def candidates(self, origin_ref: str, destination_ref: str, departure_date: str) -> list[object]:
+                return []
+
+            def save_itinerary(self, itinerary: dict[str, object]) -> None:
+                self.saved_inside_transaction = self.in_transaction
+
+            def load(self) -> None:
+                return None
+
+        class RecordingPublisher(FakeEventPublisher):
+            def __init__(self, store: RecordingStore) -> None:
+                super().__init__()
+                self.store = store
+                self.published_inside_transaction = False
+
+            def publish(self, envelope: EventEnvelope) -> None:
+                self.published_inside_transaction = self.store.in_transaction
+                super().publish(envelope)
+
+        import trip_planning.api as api
+
+        store = RecordingStore()
+        publisher = RecordingPublisher(store)
+        original = api._active_plan_store
+        api._active_plan_store = store
+        try:
+            client = TestClient(create_app(event_publisher=publisher, start_event_subscriber=False))
+            api._active_plan_store = store
+            response = client.post(
+                "/api/v1/itineraries/search",
+                json={
+                    "originRef": "station:A",
+                    "destinationRef": "station:B",
+                    "departureDate": "2026-08-01",
+                    "travelerRefs": ["tvl-1"],
+                    "channel": "WEB",
+                },
+            )
+        finally:
+            api._active_plan_store = original
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(store.saved_inside_transaction)
+        self.assertTrue(publisher.published_inside_transaction)
+
     def test_fake_publisher_records_events(self) -> None:
         publisher = FakeEventPublisher()
         envelope = EventEnvelope(

--- a/services/trip-planning/tests/test_plan_index_replay.py
+++ b/services/trip-planning/tests/test_plan_index_replay.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 import trip_planning.api as api
 from trip_planning import create_app
 from trip_planning.adapters.messaging.fake import FakeEventPublisher, FakeEventSubscriber
+from trip_planning.api import PlanStore
 from trip_planning.events import EventEnvelope
 
 
@@ -15,23 +16,33 @@ class PlanIndexReplayTest(unittest.TestCase):
     def tearDown(self) -> None:
         api._plan_store.clear()
 
-    def test_new_process_replays_stream_before_searching_real_segment(self) -> None:
-        envelopes = _standard_api_sequence_events()
+    def test_new_process_loads_db_read_model_before_subscribing_incrementals(self) -> None:
+        plan_store = PlanStore()
+        for envelope in _standard_api_sequence_events():
+            plan_store.apply_envelope(envelope)
         publisher = FakeEventPublisher()
-        subscriber = FakeEventSubscriber(envelopes)
+        subscriber = FakeEventSubscriber()
+        original = api._active_plan_store
+        original_plan_store = api._plan_store
+        api._active_plan_store = plan_store
+        api._plan_store = plan_store
 
         app = create_app(event_publisher=publisher, event_subscriber=subscriber)
-        with TestClient(app) as client:
-            response = client.post(
-                "/api/v1/itineraries/search",
-                json={
-                    "originRef": "plc-origin",
-                    "destinationRef": "plc-destination",
-                    "departureDate": "2026-08-01",
-                    "travelerRefs": ["tvl-1"],
-                    "channel": "WEB",
-                },
-            )
+        try:
+            with TestClient(app) as client:
+                response = client.post(
+                    "/api/v1/itineraries/search",
+                    json={
+                        "originRef": "plc-origin",
+                        "destinationRef": "plc-destination",
+                        "departureDate": "2026-08-01",
+                        "travelerRefs": ["tvl-1"],
+                        "channel": "WEB",
+                    },
+                )
+        finally:
+            api._active_plan_store = original
+            api._plan_store = original_plan_store
 
         self.assertEqual(response.status_code, 200)
         leg = response.json()["itineraries"][0]["legs"][0]
@@ -54,20 +65,31 @@ class PlanIndexReplayTest(unittest.TestCase):
                 payload={"nodeId": "node-destination-old", "placeId": "plc-destination", "displayName": "old", "servingModes": ["TRAIN"]},
             ),
         ]
-        subscriber = FakeEventSubscriber(old_nodes + _standard_api_sequence_events())
+        plan_store = PlanStore()
+        for envelope in old_nodes + _standard_api_sequence_events():
+            plan_store.apply_envelope(envelope)
+        subscriber = FakeEventSubscriber()
+        original = api._active_plan_store
+        original_plan_store = api._plan_store
+        api._active_plan_store = plan_store
+        api._plan_store = plan_store
 
         app = create_app(event_publisher=FakeEventPublisher(), event_subscriber=subscriber)
-        with TestClient(app) as client:
-            response = client.post(
-                "/api/v1/itineraries/search",
-                json={
-                    "originRef": "plc-origin",
-                    "destinationRef": "plc-destination",
-                    "departureDate": "2026-08-01",
-                    "travelerRefs": ["tvl-1"],
-                    "channel": "WEB",
-                },
-            )
+        try:
+            with TestClient(app) as client:
+                response = client.post(
+                    "/api/v1/itineraries/search",
+                    json={
+                        "originRef": "plc-origin",
+                        "destinationRef": "plc-destination",
+                        "departureDate": "2026-08-01",
+                        "travelerRefs": ["tvl-1"],
+                        "channel": "WEB",
+                    },
+                )
+        finally:
+            api._active_plan_store = original
+            api._plan_store = original_plan_store
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["itineraries"][0]["legs"][0]["serviceSegmentRef"], "seg-real-080")

--- a/services/trip-planning/uv.lock
+++ b/services/trip-planning/uv.lock
@@ -142,6 +142,87 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -315,6 +396,8 @@ source = { editable = "../../platform/python-kit" }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx2" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
     { name = "redis" },
     { name = "uuid6" },
 ]
@@ -323,6 +406,8 @@ dependencies = [
 requires-dist = [
     { name = "fastapi", specifier = "==0.138.1" },
     { name = "httpx2", specifier = ">=2.5.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
+    { name = "psycopg-pool", specifier = ">=3.2.0" },
     { name = "redis", specifier = ">=5.0.0" },
     { name = "uuid6", specifier = ">=2024.7.10" },
 ]
@@ -338,6 +423,8 @@ name = "trip-planning"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
     { name = "train-ticket-platform" },
 ]
 
@@ -356,6 +443,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx2", marker = "extra == 'dev'", specifier = ">=2.5.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
+    { name = "psycopg-pool", specifier = ">=3.2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
     { name = "train-ticket-platform", editable = "../../platform/python-kit" },
 ]
@@ -395,6 +484,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add Postgres migrations and storage adapters for reporting, risk-compliance, and trip-planning
- Wire startup migrations, readiness SELECT 1 checks, durable idempotency, transactional outbox relays, and Docker MIGRATIONS_DIR
- Persist trip-planning PlanIndex as database read models while preserving replay/subscriber behavior

## Validation
- cd services/reporting && uv run pytest -q
- cd services/risk-compliance && uv run pytest -q
- cd services/trip-planning && uv run pytest -q
- make check