### PR TITLE
REQ-081 migrate Java services persistence seams

### DIFF
--- a/deploy/docker/admin-audit/Dockerfile
+++ b/deploy/docker/admin-audit/Dockerfile
@@ -13,6 +13,8 @@ FROM eclipse-temurin:25-jre
 RUN useradd --system --create-home --home-dir /home/app app
 WORKDIR /app
 COPY --from=builder /src/services/admin-audit/target/*.jar /app/service.jar
+# MigrationRunner reads ./migrations relative to WORKDIR /app at startup.
+COPY services/admin-audit/migrations /app/migrations
 USER app
 ENV PORT=8080 SERVER_PORT=8080 REDIS_URL=redis://localhost:6379
 EXPOSE 8080

--- a/deploy/docker/booking-orchestration/Dockerfile
+++ b/deploy/docker/booking-orchestration/Dockerfile
@@ -13,6 +13,8 @@ FROM eclipse-temurin:25-jre
 RUN useradd --system --create-home --home-dir /home/app app
 WORKDIR /app
 COPY --from=builder /src/services/booking-orchestration/target/*.jar /app/service.jar
+# MigrationRunner reads ./migrations relative to WORKDIR /app at startup.
+COPY services/booking-orchestration/migrations /app/migrations
 USER app
 ENV PORT=8080 SERVER_PORT=8080 REDIS_URL=redis://localhost:6379
 EXPOSE 8080

--- a/deploy/docker/finance-settlement/Dockerfile
+++ b/deploy/docker/finance-settlement/Dockerfile
@@ -13,6 +13,8 @@ FROM eclipse-temurin:25-jre
 RUN useradd --system --create-home --home-dir /home/app app
 WORKDIR /app
 COPY --from=builder /src/services/finance-settlement/target/*.jar /app/service.jar
+# MigrationRunner reads ./migrations relative to WORKDIR /app at startup.
+COPY services/finance-settlement/migrations /app/migrations
 USER app
 ENV PORT=8080 SERVER_PORT=8080 REDIS_URL=redis://localhost:6379
 EXPOSE 8080

--- a/deploy/docker/journey-order/Dockerfile
+++ b/deploy/docker/journey-order/Dockerfile
@@ -13,6 +13,8 @@ FROM eclipse-temurin:25-jre
 RUN useradd --system --create-home --home-dir /home/app app
 WORKDIR /app
 COPY --from=builder /src/services/journey-order/target/*.jar /app/service.jar
+# MigrationRunner reads ./migrations relative to WORKDIR /app at startup.
+COPY services/journey-order/migrations /app/migrations
 USER app
 ENV PORT=8080 SERVER_PORT=8080 REDIS_URL=redis://localhost:6379
 EXPOSE 8080

--- a/deploy/docker/post-sales/Dockerfile
+++ b/deploy/docker/post-sales/Dockerfile
@@ -13,6 +13,8 @@ FROM eclipse-temurin:25-jre
 RUN useradd --system --create-home --home-dir /home/app app
 WORKDIR /app
 COPY --from=builder /src/services/post-sales/target/*.jar /app/service.jar
+# MigrationRunner reads ./migrations relative to WORKDIR /app at startup.
+COPY services/post-sales/migrations /app/migrations
 USER app
 ENV PORT=8080 SERVER_PORT=8080 REDIS_URL=redis://localhost:6379
 EXPOSE 8080

--- a/deploy/docker/traveler-profile/Dockerfile
+++ b/deploy/docker/traveler-profile/Dockerfile
@@ -13,6 +13,8 @@ FROM eclipse-temurin:25-jre
 RUN useradd --system --create-home --home-dir /home/app app
 WORKDIR /app
 COPY --from=builder /src/services/traveler-profile/target/*.jar /app/service.jar
+# MigrationRunner reads ./migrations relative to WORKDIR /app at startup.
+COPY services/traveler-profile/migrations /app/migrations
 USER app
 ENV PORT=8080 SERVER_PORT=8080 REDIS_URL=redis://localhost:6379
 EXPOSE 8080

--- a/services/admin-audit/migrations/001_admin_audit_persistence.sql
+++ b/services/admin-audit/migrations/001_admin_audit_persistence.sql
@@ -1,0 +1,56 @@
+CREATE TABLE IF NOT EXISTS operator_identity_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_operator_identity_snapshots_email
+  ON operator_identity_snapshots (lower(data->>'email'));
+
+CREATE TABLE IF NOT EXISTS manual_action_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_manual_action_snapshots_business_ref
+  ON manual_action_snapshots ((data->>'businessRef'));
+
+CREATE TABLE IF NOT EXISTS audit_entry_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_entry_snapshots_resource_recorded
+  ON audit_entry_snapshots ((data->>'resourceRef'), ((data->>'recordedAt')::timestamptz) DESC);
+
+CREATE TABLE IF NOT EXISTS outbox (
+  seq          bigserial PRIMARY KEY,
+  event_id     text NOT NULL UNIQUE,
+  stream       text NOT NULL,
+  envelope     jsonb NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  published_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq
+  ON outbox (seq)
+  WHERE published_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS processed_events (
+  event_id     text PRIMARY KEY,
+  stream       text,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS idempotency_records (
+  key           text PRIMARY KEY,
+  request_hash  text NOT NULL,
+  status_code   int NOT NULL,
+  response_body jsonb,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);

--- a/services/admin-audit/pom.xml
+++ b/services/admin-audit/pom.xml
@@ -27,6 +27,19 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/HealthController.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/HealthController.java
@@ -1,21 +1,34 @@
 package com.trainticket.adminaudit;
 
 import java.time.Clock;
+import com.trainticket.adminaudit.infrastructure.persistence.AdminAuditReadiness;
 import java.time.Instant;
 import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthController {
     private final Clock clock;
+    private final AdminAuditReadiness readiness;
 
     public HealthController() {
-        this(Clock.systemUTC());
+        this(Clock.systemUTC(), new AdminAuditReadiness(java.util.Optional.empty()));
+    }
+
+    public HealthController(AdminAuditReadiness readiness) {
+        this(Clock.systemUTC(), readiness);
     }
 
     HealthController(Clock clock) {
+        this(clock, new AdminAuditReadiness(java.util.Optional.empty()));
+    }
+
+    HealthController(Clock clock, AdminAuditReadiness readiness) {
         this.clock = clock;
+        this.readiness = readiness;
     }
 
     @GetMapping({"/health", "/healthz"})
@@ -29,8 +42,10 @@ public class HealthController {
     }
 
     @GetMapping({"/ready", "/readyz"})
-    public Map<String, Object> ready() {
-        return Map.of("status", "ready", "serviceId", Application.profile().serviceId());
+    public ResponseEntity<Map<String, Object>> ready() {
+        boolean ready = readiness.isReady();
+        Map<String, Object> body = Map.of("status", ready ? "ready" : "not_ready", "serviceId", Application.profile().serviceId());
+        return ResponseEntity.status(ready ? HttpStatus.OK : HttpStatus.SERVICE_UNAVAILABLE).body(body);
     }
 
     @GetMapping("/metadata")

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/RedisMessagingConfiguration.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/RedisMessagingConfiguration.java
@@ -8,6 +8,7 @@ import com.trainticket.adminaudit.application.ports.SubscribeFailedException;
 import com.trainticket.platformkit.messaging.RedisEventPublisher;
 import com.trainticket.platformkit.messaging.RedisEventSubscriber;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,11 +18,13 @@ import org.springframework.context.annotation.Configuration;
 public class RedisMessagingConfiguration {
 
     @Bean(destroyMethod = "close")
+    @ConditionalOnMissingBean(EventPublisher.class)
     RedisEventPublisher platformRedisEventPublisher(@Value("${REDIS_URL:redis://localhost:6379}") String redisUrl, ObjectMapper objectMapper) {
         return RedisEventPublisher.fromUrl(redisUrl, objectMapper);
     }
 
     @Bean
+    @ConditionalOnMissingBean(EventPublisher.class)
     EventPublisher redisEventPublisher(RedisEventPublisher publisher) {
         return envelope -> {
             try {

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/infrastructure/persistence/AdminAuditPersistenceConfiguration.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/infrastructure/persistence/AdminAuditPersistenceConfiguration.java
@@ -1,0 +1,90 @@
+package com.trainticket.adminaudit.infrastructure.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.adminaudit.application.ports.EventPublisher;
+import com.trainticket.platformkit.idempotency.IdempotencyStore;
+import com.trainticket.platformkit.messaging.LettuceRedisStreamOperations;
+import com.trainticket.platformkit.persistence.DataSources;
+import com.trainticket.platformkit.persistence.DbIdempotencyStore;
+import com.trainticket.platformkit.persistence.MigrationRunner;
+import com.trainticket.platformkit.persistence.OutboxAppender;
+import com.trainticket.platformkit.persistence.OutboxRelay;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import jakarta.annotation.PostConstruct;
+import java.nio.file.Path;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@ConditionalOnExpression("'${DATABASE_URL:}' != ''")
+public class AdminAuditPersistenceConfiguration {
+    @Bean(destroyMethod = "close")
+    @Primary
+    DataSource adminauditDataSource(@Value("${DATABASE_URL:}") String databaseUrl) {
+        return DataSources.fromDatabaseUrl(databaseUrl);
+    }
+
+    @Bean
+    @Primary
+    PlatformTransactionManager adminauditTransactionManager(DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
+    }
+
+    @Bean
+    MigrationRunner adminauditMigrationRunner(DataSource dataSource, PlatformTransactionManager transactionManager) {
+        MigrationRunner runner = new MigrationRunner(dataSource, transactionManager);
+        runner.run(Path.of("migrations"));
+        return runner;
+    }
+
+    @Bean
+    OutboxAppender adminauditOutboxAppender(DataSource dataSource, ObjectMapper objectMapper) {
+        return new OutboxAppender(dataSource, objectMapper);
+    }
+
+    @Bean
+    @Primary
+    EventPublisher adminauditOutboxEventPublisher(OutboxAppender outboxAppender, ObjectMapper objectMapper) {
+        return new TransactionalOutboxEventPublisher(outboxAppender, objectMapper);
+    }
+
+    @Bean
+    @Primary
+    IdempotencyStore adminauditDbIdempotencyStore(DataSource dataSource, ObjectMapper objectMapper) {
+        return new DbIdempotencyStore(dataSource, objectMapper);
+    }
+
+    @Bean(destroyMethod = "close")
+    AdminAuditOutboxRelayLifecycle adminauditOutboxRelayLifecycle(DataSource dataSource, @Value("${REDIS_URL:redis://localhost:6379}") String redisUrl) {
+        return new AdminAuditOutboxRelayLifecycle(dataSource, redisUrl);
+    }
+
+    static final class AdminAuditOutboxRelayLifecycle implements AutoCloseable {
+        private final RedisClient client;
+        private final StatefulRedisConnection<String, String> connection;
+        private final OutboxRelay relay;
+
+        AdminAuditOutboxRelayLifecycle(DataSource dataSource, String redisUrl) {
+            this.client = RedisClient.create(redisUrl == null || redisUrl.isBlank() ? "redis://localhost:6379" : redisUrl);
+            this.connection = client.connect();
+            this.relay = new OutboxRelay(dataSource, new LettuceRedisStreamOperations(connection));
+        }
+
+        @PostConstruct
+        void start() { relay.start(); }
+
+        @Override
+        public void close() {
+            relay.close();
+            connection.close();
+            client.shutdown();
+        }
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/infrastructure/persistence/AdminAuditReadiness.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/infrastructure/persistence/AdminAuditReadiness.java
@@ -1,0 +1,29 @@
+package com.trainticket.adminaudit.infrastructure.persistence;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AdminAuditReadiness {
+    private final Optional<DataSource> dataSource;
+
+    public AdminAuditReadiness(Optional<DataSource> dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public boolean isReady() {
+        if (dataSource.isEmpty()) {
+            return true;
+        }
+        try (Connection connection = dataSource.get().getConnection(); Statement statement = connection.createStatement()) {
+            statement.setQueryTimeout(1);
+            statement.execute("SELECT 1");
+            return true;
+        } catch (Exception exception) {
+            return false;
+        }
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/infrastructure/persistence/JacksonAdminAuditJson.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/infrastructure/persistence/JacksonAdminAuditJson.java
@@ -1,0 +1,32 @@
+package com.trainticket.adminaudit.infrastructure.persistence;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+final class JacksonAdminAuditJson {
+    private JacksonAdminAuditJson() {
+    }
+
+    record OperatorIdentitySnapshot(@JsonValue ObjectNode data) {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static OperatorIdentitySnapshot of(ObjectNode data) {
+            return new OperatorIdentitySnapshot(data);
+        }
+    }
+
+    record ManualActionSnapshot(@JsonValue ObjectNode data) {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static ManualActionSnapshot of(ObjectNode data) {
+            return new ManualActionSnapshot(data);
+        }
+    }
+
+    record AuditEntrySnapshot(@JsonValue ObjectNode data) {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static AuditEntrySnapshot of(ObjectNode data) {
+            return new AuditEntrySnapshot(data);
+        }
+    }
+
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/infrastructure/persistence/TransactionalOutboxEventPublisher.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/infrastructure/persistence/TransactionalOutboxEventPublisher.java
@@ -1,0 +1,28 @@
+package com.trainticket.adminaudit.infrastructure.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.adminaudit.application.ports.EventPublisher;
+import com.trainticket.adminaudit.application.ports.PublishFailedException;
+import com.trainticket.platformkit.messaging.EventEnvelope;
+import com.trainticket.platformkit.persistence.OutboxAppender;
+import java.util.Objects;
+
+public class TransactionalOutboxEventPublisher implements EventPublisher {
+    private final OutboxAppender outboxAppender;
+    private final ObjectMapper objectMapper;
+
+    public TransactionalOutboxEventPublisher(OutboxAppender outboxAppender, ObjectMapper objectMapper) {
+        this.outboxAppender = Objects.requireNonNull(outboxAppender, "outboxAppender is required");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper is required");
+    }
+
+    @Override
+    public void publish(EventEnvelope envelope) {
+        try {
+            outboxAppender.append(envelope, objectMapper.writeValueAsString(envelope));
+        } catch (JsonProcessingException exception) {
+            throw new PublishFailedException("event envelope could not be serialized", exception);
+        }
+    }
+}

--- a/services/admin-audit/src/test/java/com/trainticket/adminaudit/ApplicationTest.java
+++ b/services/admin-audit/src/test/java/com/trainticket/adminaudit/ApplicationTest.java
@@ -45,7 +45,7 @@ class ApplicationTest {
         );
 
         assertEquals("live", controller.live().get("status"));
-        assertEquals("ready", controller.ready().get("status"));
+        assertEquals("ready", controller.ready().getBody().get("status"));
         Map<String, Object> metadata = controller.metadata();
         assertEquals("2026-01-01T00:00:00Z", metadata.get("generatedAt"));
         assertEquals("admin-audit", assertInstanceOf(ServiceProfile.class, metadata.get("service")).serviceId());

--- a/services/admin-audit/src/test/java/com/trainticket/adminaudit/infrastructure/persistence/JacksonAdminAuditJsonTest.java
+++ b/services/admin-audit/src/test/java/com/trainticket/adminaudit/infrastructure/persistence/JacksonAdminAuditJsonTest.java
@@ -1,0 +1,26 @@
+package com.trainticket.adminaudit.infrastructure.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+class JacksonAdminAuditJsonTest {
+    @Test
+    void snapshotSerializesBusinessFieldsAtTopLevel() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode data = objectMapper.createObjectNode();
+        data.put("businessField", "value");
+
+        String json = objectMapper.writeValueAsString(new JacksonAdminAuditJson.OperatorIdentitySnapshot(data));
+        JsonNode root = objectMapper.readTree(json);
+
+        assertEquals("value", root.path("businessField").asText());
+        assertTrue(root.has("businessField"));
+        assertFalse(root.has("data"));
+    }
+}

--- a/services/booking-orchestration/migrations/001_booking_orchestration_persistence.sql
+++ b/services/booking-orchestration/migrations/001_booking_orchestration_persistence.sql
@@ -1,0 +1,58 @@
+CREATE TABLE IF NOT EXISTS booking_saga_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_booking_saga_snapshots_journey_order_id
+  ON booking_saga_snapshots ((data->>'journeyOrderId'));
+CREATE INDEX IF NOT EXISTS idx_booking_saga_snapshots_correlation_id
+  ON booking_saga_snapshots ((data->>'correlationId'));
+
+CREATE TABLE IF NOT EXISTS segment_booking_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_segment_booking_snapshots_saga_id
+  ON segment_booking_snapshots ((data->>'sagaId'));
+CREATE INDEX IF NOT EXISTS idx_segment_booking_snapshots_hold_id
+  ON segment_booking_snapshots ((data->>'capacityHoldId'));
+CREATE INDEX IF NOT EXISTS idx_segment_booking_snapshots_idempotency_key
+  ON segment_booking_snapshots ((data->>'idempotencyKey'));
+
+CREATE TABLE IF NOT EXISTS payment_intent_saga_refs (
+  payment_intent_id text PRIMARY KEY,
+  saga_id           text NOT NULL,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS outbox (
+  seq          bigserial PRIMARY KEY,
+  event_id     text NOT NULL UNIQUE,
+  stream       text NOT NULL,
+  envelope     jsonb NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  published_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq
+  ON outbox (seq)
+  WHERE published_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS processed_events (
+  event_id     text PRIMARY KEY,
+  stream       text,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS idempotency_records (
+  key           text PRIMARY KEY,
+  request_hash  text NOT NULL,
+  status_code   int NOT NULL,
+  response_body jsonb,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);

--- a/services/booking-orchestration/pom.xml
+++ b/services/booking-orchestration/pom.xml
@@ -27,6 +27,19 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
       <version>1.46.0</version>

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/HealthController.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/HealthController.java
@@ -1,21 +1,34 @@
 package com.trainticket.bookingorchestration;
 
 import java.time.Clock;
+import com.trainticket.bookingorchestration.infrastructure.persistence.BookingOrchestrationReadiness;
 import java.time.Instant;
 import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthController {
     private final Clock clock;
+    private final BookingOrchestrationReadiness readiness;
 
     public HealthController() {
-        this(Clock.systemUTC());
+        this(Clock.systemUTC(), new BookingOrchestrationReadiness(java.util.Optional.empty()));
+    }
+
+    public HealthController(BookingOrchestrationReadiness readiness) {
+        this(Clock.systemUTC(), readiness);
     }
 
     HealthController(Clock clock) {
+        this(clock, new BookingOrchestrationReadiness(java.util.Optional.empty()));
+    }
+
+    HealthController(Clock clock, BookingOrchestrationReadiness readiness) {
         this.clock = clock;
+        this.readiness = readiness;
     }
 
     @GetMapping({"/health", "/healthz"})
@@ -29,8 +42,10 @@ public class HealthController {
     }
 
     @GetMapping({"/ready", "/readyz"})
-    public Map<String, Object> ready() {
-        return Map.of("status", "ready", "serviceId", Application.profile().serviceId());
+    public ResponseEntity<Map<String, Object>> ready() {
+        boolean ready = readiness.isReady();
+        Map<String, Object> body = Map.of("status", ready ? "ready" : "not_ready", "serviceId", Application.profile().serviceId());
+        return ResponseEntity.status(ready ? HttpStatus.OK : HttpStatus.SERVICE_UNAVAILABLE).body(body);
     }
 
     @GetMapping("/metadata")

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisMessagingConfig.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisMessagingConfig.java
@@ -10,6 +10,7 @@ import com.trainticket.platformkit.messaging.RedisEventSubscriber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -19,12 +20,14 @@ public class RedisMessagingConfig {
     private static final Logger log = LoggerFactory.getLogger(RedisMessagingConfig.class);
 
     @Bean(destroyMethod = "close")
+    @ConditionalOnMissingBean(EventPublisher.class)
     public RedisEventPublisher platformRedisEventPublisher(@Value("${REDIS_URL:redis://localhost:6379}") String redisUrl, ObjectMapper objectMapper) {
         log.info("Connecting platform Redis event publisher");
         return RedisEventPublisher.fromUrl(redisUrl, objectMapper);
     }
 
     @Bean
+    @ConditionalOnMissingBean(EventPublisher.class)
     public EventPublisher redisEventPublisher(RedisEventPublisher publisher) {
         return envelope -> {
             try {

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/infrastructure/persistence/BookingOrchestrationPersistenceConfiguration.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/infrastructure/persistence/BookingOrchestrationPersistenceConfiguration.java
@@ -1,0 +1,90 @@
+package com.trainticket.bookingorchestration.infrastructure.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.bookingorchestration.application.EventPublisher;
+import com.trainticket.platformkit.idempotency.IdempotencyStore;
+import com.trainticket.platformkit.messaging.LettuceRedisStreamOperations;
+import com.trainticket.platformkit.persistence.DataSources;
+import com.trainticket.platformkit.persistence.DbIdempotencyStore;
+import com.trainticket.platformkit.persistence.MigrationRunner;
+import com.trainticket.platformkit.persistence.OutboxAppender;
+import com.trainticket.platformkit.persistence.OutboxRelay;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import jakarta.annotation.PostConstruct;
+import java.nio.file.Path;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@ConditionalOnExpression("'${DATABASE_URL:}' != ''")
+public class BookingOrchestrationPersistenceConfiguration {
+    @Bean(destroyMethod = "close")
+    @Primary
+    DataSource bookingorchestrationDataSource(@Value("${DATABASE_URL:}") String databaseUrl) {
+        return DataSources.fromDatabaseUrl(databaseUrl);
+    }
+
+    @Bean
+    @Primary
+    PlatformTransactionManager bookingorchestrationTransactionManager(DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
+    }
+
+    @Bean
+    MigrationRunner bookingorchestrationMigrationRunner(DataSource dataSource, PlatformTransactionManager transactionManager) {
+        MigrationRunner runner = new MigrationRunner(dataSource, transactionManager);
+        runner.run(Path.of("migrations"));
+        return runner;
+    }
+
+    @Bean
+    OutboxAppender bookingorchestrationOutboxAppender(DataSource dataSource, ObjectMapper objectMapper) {
+        return new OutboxAppender(dataSource, objectMapper);
+    }
+
+    @Bean
+    @Primary
+    EventPublisher bookingorchestrationOutboxEventPublisher(OutboxAppender outboxAppender, ObjectMapper objectMapper) {
+        return new TransactionalOutboxEventPublisher(outboxAppender, objectMapper);
+    }
+
+    @Bean
+    @Primary
+    IdempotencyStore bookingorchestrationDbIdempotencyStore(DataSource dataSource, ObjectMapper objectMapper) {
+        return new DbIdempotencyStore(dataSource, objectMapper);
+    }
+
+    @Bean(destroyMethod = "close")
+    BookingOrchestrationOutboxRelayLifecycle bookingorchestrationOutboxRelayLifecycle(DataSource dataSource, @Value("${REDIS_URL:redis://localhost:6379}") String redisUrl) {
+        return new BookingOrchestrationOutboxRelayLifecycle(dataSource, redisUrl);
+    }
+
+    static final class BookingOrchestrationOutboxRelayLifecycle implements AutoCloseable {
+        private final RedisClient client;
+        private final StatefulRedisConnection<String, String> connection;
+        private final OutboxRelay relay;
+
+        BookingOrchestrationOutboxRelayLifecycle(DataSource dataSource, String redisUrl) {
+            this.client = RedisClient.create(redisUrl == null || redisUrl.isBlank() ? "redis://localhost:6379" : redisUrl);
+            this.connection = client.connect();
+            this.relay = new OutboxRelay(dataSource, new LettuceRedisStreamOperations(connection));
+        }
+
+        @PostConstruct
+        void start() { relay.start(); }
+
+        @Override
+        public void close() {
+            relay.close();
+            connection.close();
+            client.shutdown();
+        }
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/infrastructure/persistence/BookingOrchestrationReadiness.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/infrastructure/persistence/BookingOrchestrationReadiness.java
@@ -1,0 +1,29 @@
+package com.trainticket.bookingorchestration.infrastructure.persistence;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BookingOrchestrationReadiness {
+    private final Optional<DataSource> dataSource;
+
+    public BookingOrchestrationReadiness(Optional<DataSource> dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public boolean isReady() {
+        if (dataSource.isEmpty()) {
+            return true;
+        }
+        try (Connection connection = dataSource.get().getConnection(); Statement statement = connection.createStatement()) {
+            statement.setQueryTimeout(1);
+            statement.execute("SELECT 1");
+            return true;
+        } catch (Exception exception) {
+            return false;
+        }
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/infrastructure/persistence/JacksonBookingOrchestrationJson.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/infrastructure/persistence/JacksonBookingOrchestrationJson.java
@@ -1,0 +1,25 @@
+package com.trainticket.bookingorchestration.infrastructure.persistence;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+final class JacksonBookingOrchestrationJson {
+    private JacksonBookingOrchestrationJson() {
+    }
+
+    record BookingSagaSnapshot(@JsonValue ObjectNode data) {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static BookingSagaSnapshot of(ObjectNode data) {
+            return new BookingSagaSnapshot(data);
+        }
+    }
+
+    record SegmentBookingSnapshot(@JsonValue ObjectNode data) {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static SegmentBookingSnapshot of(ObjectNode data) {
+            return new SegmentBookingSnapshot(data);
+        }
+    }
+
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/infrastructure/persistence/TransactionalOutboxEventPublisher.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/infrastructure/persistence/TransactionalOutboxEventPublisher.java
@@ -1,0 +1,28 @@
+package com.trainticket.bookingorchestration.infrastructure.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.bookingorchestration.application.EventPublisher;
+import com.trainticket.bookingorchestration.application.PublishFailed;
+import com.trainticket.platformkit.messaging.EventEnvelope;
+import com.trainticket.platformkit.persistence.OutboxAppender;
+import java.util.Objects;
+
+public class TransactionalOutboxEventPublisher implements EventPublisher {
+    private final OutboxAppender outboxAppender;
+    private final ObjectMapper objectMapper;
+
+    public TransactionalOutboxEventPublisher(OutboxAppender outboxAppender, ObjectMapper objectMapper) {
+        this.outboxAppender = Objects.requireNonNull(outboxAppender, "outboxAppender is required");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper is required");
+    }
+
+    @Override
+    public void publish(EventEnvelope envelope) {
+        try {
+            outboxAppender.append(envelope, objectMapper.writeValueAsString(envelope));
+        } catch (JsonProcessingException exception) {
+            throw new PublishFailed("event envelope could not be serialized", exception);
+        }
+    }
+}

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/ApplicationTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/ApplicationTest.java
@@ -37,7 +37,7 @@ class ApplicationTest {
         );
 
         assertEquals("live", controller.live().get("status"));
-        assertEquals("ready", controller.ready().get("status"));
+        assertEquals("ready", controller.ready().getBody().get("status"));
         Map<String, Object> metadata = controller.metadata();
         assertEquals("2026-01-01T00:00:00Z", metadata.get("generatedAt"));
         assertEquals("booking-orchestration", assertInstanceOf(ServiceProfile.class, metadata.get("service")).serviceId());

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/infrastructure/persistence/JacksonBookingOrchestrationJsonTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/infrastructure/persistence/JacksonBookingOrchestrationJsonTest.java
@@ -1,0 +1,26 @@
+package com.trainticket.bookingorchestration.infrastructure.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+class JacksonBookingOrchestrationJsonTest {
+    @Test
+    void snapshotSerializesBusinessFieldsAtTopLevel() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode data = objectMapper.createObjectNode();
+        data.put("businessField", "value");
+
+        String json = objectMapper.writeValueAsString(new JacksonBookingOrchestrationJson.BookingSagaSnapshot(data));
+        JsonNode root = objectMapper.readTree(json);
+
+        assertEquals("value", root.path("businessField").asText());
+        assertTrue(root.has("businessField"));
+        assertFalse(root.has("data"));
+    }
+}

--- a/services/finance-settlement/migrations/001_finance_settlement_persistence.sql
+++ b/services/finance-settlement/migrations/001_finance_settlement_persistence.sql
@@ -1,0 +1,65 @@
+CREATE TABLE IF NOT EXISTS revenue_recognition_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_revenue_recognition_snapshots_order_id
+  ON revenue_recognition_snapshots ((data->>'orderId'), ((data->>'recognizedAt')::timestamptz));
+
+CREATE TABLE IF NOT EXISTS reconciliation_case_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_reconciliation_case_snapshots_order_id
+  ON reconciliation_case_snapshots ((data->>'orderId'), ((data->>'openedAt')::timestamptz));
+
+CREATE TABLE IF NOT EXISTS invoice_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_invoice_snapshots_order_id
+  ON invoice_snapshots ((data->>'orderId'));
+
+CREATE TABLE IF NOT EXISTS payment_intent_order_refs (
+  payment_intent_id text PRIMARY KEY,
+  order_reference   text NOT NULL,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS segment_booking_order_refs (
+  segment_booking_id text PRIMARY KEY,
+  order_reference    text NOT NULL,
+  created_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS outbox (
+  seq          bigserial PRIMARY KEY,
+  event_id     text NOT NULL UNIQUE,
+  stream       text NOT NULL,
+  envelope     jsonb NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  published_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq
+  ON outbox (seq)
+  WHERE published_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS processed_events (
+  event_id     text PRIMARY KEY,
+  stream       text,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS idempotency_records (
+  key           text PRIMARY KEY,
+  request_hash  text NOT NULL,
+  status_code   int NOT NULL,
+  response_body jsonb,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);

--- a/services/finance-settlement/pom.xml
+++ b/services/finance-settlement/pom.xml
@@ -27,6 +27,19 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
       <version>1.46.0</version>

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/HealthController.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/HealthController.java
@@ -1,21 +1,34 @@
 package com.trainticket.financesettlement;
 
 import java.time.Clock;
+import com.trainticket.financesettlement.infrastructure.persistence.FinanceSettlementReadiness;
 import java.time.Instant;
 import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthController {
     private final Clock clock;
+    private final FinanceSettlementReadiness readiness;
 
     public HealthController() {
-        this(Clock.systemUTC());
+        this(Clock.systemUTC(), new FinanceSettlementReadiness(java.util.Optional.empty()));
+    }
+
+    public HealthController(FinanceSettlementReadiness readiness) {
+        this(Clock.systemUTC(), readiness);
     }
 
     HealthController(Clock clock) {
+        this(clock, new FinanceSettlementReadiness(java.util.Optional.empty()));
+    }
+
+    HealthController(Clock clock, FinanceSettlementReadiness readiness) {
         this.clock = clock;
+        this.readiness = readiness;
     }
 
     @GetMapping({"/health", "/healthz"})
@@ -29,8 +42,10 @@ public class HealthController {
     }
 
     @GetMapping({"/ready", "/readyz"})
-    public Map<String, Object> ready() {
-        return Map.of("status", "ready", "serviceId", Application.profile().serviceId());
+    public ResponseEntity<Map<String, Object>> ready() {
+        boolean ready = readiness.isReady();
+        Map<String, Object> body = Map.of("status", ready ? "ready" : "not_ready", "serviceId", Application.profile().serviceId());
+        return ResponseEntity.status(ready ? HttpStatus.OK : HttpStatus.SERVICE_UNAVAILABLE).body(body);
     }
 
     @GetMapping("/metadata")

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/adapters/messaging/RedisMessagingConfiguration.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/adapters/messaging/RedisMessagingConfiguration.java
@@ -8,6 +8,7 @@ import com.trainticket.financesettlement.application.PublishFailedException;
 import com.trainticket.financesettlement.application.SubscribeFailedException;
 import com.trainticket.platformkit.messaging.RedisEventPublisher;
 import com.trainticket.platformkit.messaging.RedisEventSubscriber;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
@@ -18,7 +19,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(name = "finance.messaging.redis.enabled", havingValue = "true", matchIfMissing = true)
 public class RedisMessagingConfiguration {
     @Bean(destroyMethod = "close") RedisEventPublisher platformRedisEventPublisher(ObjectMapper objectMapper, RedisMessagingProperties properties) { return RedisEventPublisher.fromUrl(properties.url(), objectMapper); }
-    @Bean @Primary EventPublisher redisEventPublisher(RedisEventPublisher publisher) { return envelope -> { try { publisher.publish(envelope); } catch (com.trainticket.platformkit.messaging.PublishFailedException e) { throw new PublishFailedException(e.getMessage(), e); } }; }
+    @Bean @Primary @ConditionalOnMissingBean(EventPublisher.class) EventPublisher redisEventPublisher(RedisEventPublisher publisher) { return envelope -> { try { publisher.publish(envelope); } catch (com.trainticket.platformkit.messaging.PublishFailedException e) { throw new PublishFailedException(e.getMessage(), e); } }; }
     @Bean(destroyMethod = "close") RedisEventSubscriber platformRedisEventSubscriber(ObjectMapper objectMapper, RedisMessagingProperties properties) { return RedisEventSubscriber.fromUrl(properties.url(), objectMapper); }
     @Bean @Primary EventSubscriber redisEventSubscriber(RedisEventSubscriber subscriber) { return (streams, group, consumerName, handler) -> { try { subscriber.subscribe(streams, group, consumerName, envelope -> switch (handler.handle(envelope)) { case SUCCESS -> com.trainticket.platformkit.messaging.HandlerResult.SUCCESS; case TRANSIENT_FAILURE -> com.trainticket.platformkit.messaging.HandlerResult.TRANSIENT_FAILURE; case FATAL_FAILURE -> com.trainticket.platformkit.messaging.HandlerResult.FATAL_FAILURE; }); } catch (com.trainticket.platformkit.messaging.SubscribeFailedException e) { throw new SubscribeFailedException(e.getMessage(), e); } }; }
     @Bean SmartLifecycle financeSubscriptionLifecycle(EventSubscriber subscriber, RedisMessagingProperties properties, FinanceSettlementEventHandler handler) { return new SmartLifecycle() { private boolean running; public void start(){ subscriber.subscribe(RedisMessagingProperties.SUBSCRIBED_STREAMS, RedisMessagingProperties.CONSUMER_GROUP, properties.consumerName(), handler); running=true;} public void stop(){running=false;} public boolean isRunning(){return running;} }; }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/FinanceSettlementPersistenceConfiguration.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/FinanceSettlementPersistenceConfiguration.java
@@ -1,0 +1,90 @@
+package com.trainticket.financesettlement.infrastructure.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.financesettlement.application.EventPublisher;
+import com.trainticket.platformkit.idempotency.IdempotencyStore;
+import com.trainticket.platformkit.messaging.LettuceRedisStreamOperations;
+import com.trainticket.platformkit.persistence.DataSources;
+import com.trainticket.platformkit.persistence.DbIdempotencyStore;
+import com.trainticket.platformkit.persistence.MigrationRunner;
+import com.trainticket.platformkit.persistence.OutboxAppender;
+import com.trainticket.platformkit.persistence.OutboxRelay;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import jakarta.annotation.PostConstruct;
+import java.nio.file.Path;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@ConditionalOnExpression("'${DATABASE_URL:}' != ''")
+public class FinanceSettlementPersistenceConfiguration {
+    @Bean(destroyMethod = "close")
+    @Primary
+    DataSource financesettlementDataSource(@Value("${DATABASE_URL:}") String databaseUrl) {
+        return DataSources.fromDatabaseUrl(databaseUrl);
+    }
+
+    @Bean
+    @Primary
+    PlatformTransactionManager financesettlementTransactionManager(DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
+    }
+
+    @Bean
+    MigrationRunner financesettlementMigrationRunner(DataSource dataSource, PlatformTransactionManager transactionManager) {
+        MigrationRunner runner = new MigrationRunner(dataSource, transactionManager);
+        runner.run(Path.of("migrations"));
+        return runner;
+    }
+
+    @Bean
+    OutboxAppender financesettlementOutboxAppender(DataSource dataSource, ObjectMapper objectMapper) {
+        return new OutboxAppender(dataSource, objectMapper);
+    }
+
+    @Bean
+    @Primary
+    EventPublisher financesettlementOutboxEventPublisher(OutboxAppender outboxAppender, ObjectMapper objectMapper) {
+        return new TransactionalOutboxEventPublisher(outboxAppender, objectMapper);
+    }
+
+    @Bean
+    @Primary
+    IdempotencyStore financesettlementDbIdempotencyStore(DataSource dataSource, ObjectMapper objectMapper) {
+        return new DbIdempotencyStore(dataSource, objectMapper);
+    }
+
+    @Bean(destroyMethod = "close")
+    FinanceSettlementOutboxRelayLifecycle financesettlementOutboxRelayLifecycle(DataSource dataSource, @Value("${REDIS_URL:redis://localhost:6379}") String redisUrl) {
+        return new FinanceSettlementOutboxRelayLifecycle(dataSource, redisUrl);
+    }
+
+    static final class FinanceSettlementOutboxRelayLifecycle implements AutoCloseable {
+        private final RedisClient client;
+        private final StatefulRedisConnection<String, String> connection;
+        private final OutboxRelay relay;
+
+        FinanceSettlementOutboxRelayLifecycle(DataSource dataSource, String redisUrl) {
+            this.client = RedisClient.create(redisUrl == null || redisUrl.isBlank() ? "redis://localhost:6379" : redisUrl);
+            this.connection = client.connect();
+            this.relay = new OutboxRelay(dataSource, new LettuceRedisStreamOperations(connection));
+        }
+
+        @PostConstruct
+        void start() { relay.start(); }
+
+        @Override
+        public void close() {
+            relay.close();
+            connection.close();
+            client.shutdown();
+        }
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/FinanceSettlementReadiness.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/FinanceSettlementReadiness.java
@@ -1,0 +1,29 @@
+package com.trainticket.financesettlement.infrastructure.persistence;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FinanceSettlementReadiness {
+    private final Optional<DataSource> dataSource;
+
+    public FinanceSettlementReadiness(Optional<DataSource> dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public boolean isReady() {
+        if (dataSource.isEmpty()) {
+            return true;
+        }
+        try (Connection connection = dataSource.get().getConnection(); Statement statement = connection.createStatement()) {
+            statement.setQueryTimeout(1);
+            statement.execute("SELECT 1");
+            return true;
+        } catch (Exception exception) {
+            return false;
+        }
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/JacksonFinanceSettlementJson.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/JacksonFinanceSettlementJson.java
@@ -1,0 +1,32 @@
+package com.trainticket.financesettlement.infrastructure.persistence;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+final class JacksonFinanceSettlementJson {
+    private JacksonFinanceSettlementJson() {
+    }
+
+    record RevenueRecognitionSnapshot(@JsonValue ObjectNode data) {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static RevenueRecognitionSnapshot of(ObjectNode data) {
+            return new RevenueRecognitionSnapshot(data);
+        }
+    }
+
+    record ReconciliationCaseSnapshot(@JsonValue ObjectNode data) {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static ReconciliationCaseSnapshot of(ObjectNode data) {
+            return new ReconciliationCaseSnapshot(data);
+        }
+    }
+
+    record InvoiceSnapshot(@JsonValue ObjectNode data) {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static InvoiceSnapshot of(ObjectNode data) {
+            return new InvoiceSnapshot(data);
+        }
+    }
+
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/TransactionalOutboxEventPublisher.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/TransactionalOutboxEventPublisher.java
@@ -1,0 +1,28 @@
+package com.trainticket.financesettlement.infrastructure.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.financesettlement.application.EventPublisher;
+import com.trainticket.financesettlement.application.PublishFailedException;
+import com.trainticket.platformkit.messaging.EventEnvelope;
+import com.trainticket.platformkit.persistence.OutboxAppender;
+import java.util.Objects;
+
+public class TransactionalOutboxEventPublisher implements EventPublisher {
+    private final OutboxAppender outboxAppender;
+    private final ObjectMapper objectMapper;
+
+    public TransactionalOutboxEventPublisher(OutboxAppender outboxAppender, ObjectMapper objectMapper) {
+        this.outboxAppender = Objects.requireNonNull(outboxAppender, "outboxAppender is required");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper is required");
+    }
+
+    @Override
+    public void publish(EventEnvelope envelope) {
+        try {
+            outboxAppender.append(envelope, objectMapper.writeValueAsString(envelope));
+        } catch (JsonProcessingException exception) {
+            throw new PublishFailedException("event envelope could not be serialized", exception);
+        }
+    }
+}

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/ApplicationTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/ApplicationTest.java
@@ -37,7 +37,7 @@ class ApplicationTest {
         );
 
         assertEquals("live", controller.live().get("status"));
-        assertEquals("ready", controller.ready().get("status"));
+        assertEquals("ready", controller.ready().getBody().get("status"));
         Map<String, Object> metadata = controller.metadata();
         assertEquals("2026-01-01T00:00:00Z", metadata.get("generatedAt"));
         assertEquals("finance-settlement", assertInstanceOf(ServiceProfile.class, metadata.get("service")).serviceId());

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/infrastructure/persistence/JacksonFinanceSettlementJsonTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/infrastructure/persistence/JacksonFinanceSettlementJsonTest.java
@@ -1,0 +1,26 @@
+package com.trainticket.financesettlement.infrastructure.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+class JacksonFinanceSettlementJsonTest {
+    @Test
+    void snapshotSerializesBusinessFieldsAtTopLevel() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode data = objectMapper.createObjectNode();
+        data.put("businessField", "value");
+
+        String json = objectMapper.writeValueAsString(new JacksonFinanceSettlementJson.RevenueRecognitionSnapshot(data));
+        JsonNode root = objectMapper.readTree(json);
+
+        assertEquals("value", root.path("businessField").asText());
+        assertTrue(root.has("businessField"));
+        assertFalse(root.has("data"));
+    }
+}

--- a/services/journey-order/migrations/001_journey_order_persistence.sql
+++ b/services/journey-order/migrations/001_journey_order_persistence.sql
@@ -1,0 +1,44 @@
+CREATE TABLE IF NOT EXISTS journey_order_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_journey_order_snapshots_account_created
+  ON journey_order_snapshots ((data->>'accountId'), ((data->>'createdAt')::timestamptz) DESC);
+CREATE INDEX IF NOT EXISTS idx_journey_order_snapshots_status
+  ON journey_order_snapshots ((data->>'status'));
+
+CREATE TABLE IF NOT EXISTS account_order_state_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS outbox (
+  seq          bigserial PRIMARY KEY,
+  event_id     text NOT NULL UNIQUE,
+  stream       text NOT NULL,
+  envelope     jsonb NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  published_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq
+  ON outbox (seq)
+  WHERE published_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS processed_events (
+  event_id     text PRIMARY KEY,
+  stream       text,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS idempotency_records (
+  key           text PRIMARY KEY,
+  request_hash  text NOT NULL,
+  status_code   int NOT NULL,
+  response_body jsonb,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);

--- a/services/journey-order/pom.xml
+++ b/services/journey-order/pom.xml
@@ -35,6 +35,19 @@
       <artifactId>lettuce-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/HealthController.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/HealthController.java
@@ -1,21 +1,34 @@
 package com.trainticket.journeyorder;
 
 import java.time.Clock;
+import com.trainticket.journeyorder.infrastructure.persistence.JourneyOrderReadiness;
 import java.time.Instant;
 import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthController {
     private final Clock clock;
+    private final JourneyOrderReadiness readiness;
 
     public HealthController() {
-        this(Clock.systemUTC());
+        this(Clock.systemUTC(), new JourneyOrderReadiness(java.util.Optional.empty()));
+    }
+
+    public HealthController(JourneyOrderReadiness readiness) {
+        this(Clock.systemUTC(), readiness);
     }
 
     HealthController(Clock clock) {
+        this(clock, new JourneyOrderReadiness(java.util.Optional.empty()));
+    }
+
+    HealthController(Clock clock, JourneyOrderReadiness readiness) {
         this.clock = clock;
+        this.readiness = readiness;
     }
 
     @GetMapping({"/health", "/healthz"})
@@ -29,8 +42,10 @@ public class HealthController {
     }
 
     @GetMapping({"/ready", "/readyz"})
-    public Map<String, Object> ready() {
-        return Map.of("status", "ready", "serviceId", Application.profile().serviceId());
+    public ResponseEntity<Map<String, Object>> ready() {
+        boolean ready = readiness.isReady();
+        Map<String, Object> body = Map.of("status", ready ? "ready" : "not_ready", "serviceId", Application.profile().serviceId());
+        return ResponseEntity.status(ready ? HttpStatus.OK : HttpStatus.SERVICE_UNAVAILABLE).body(body);
     }
 
     @GetMapping("/metadata")

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/infrastructure/persistence/JacksonJourneyOrderJson.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/infrastructure/persistence/JacksonJourneyOrderJson.java
@@ -1,0 +1,25 @@
+package com.trainticket.journeyorder.infrastructure.persistence;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+final class JacksonJourneyOrderJson {
+    private JacksonJourneyOrderJson() {
+    }
+
+    record JourneyOrderSnapshot(@JsonValue ObjectNode data) {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static JourneyOrderSnapshot of(ObjectNode data) {
+            return new JourneyOrderSnapshot(data);
+        }
+    }
+
+    record AccountOrderStateSnapshot(@JsonValue ObjectNode data) {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static AccountOrderStateSnapshot of(ObjectNode data) {
+            return new AccountOrderStateSnapshot(data);
+        }
+    }
+
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/infrastructure/persistence/JourneyOrderPersistenceConfiguration.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/infrastructure/persistence/JourneyOrderPersistenceConfiguration.java
@@ -1,0 +1,90 @@
+package com.trainticket.journeyorder.infrastructure.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.journeyorder.application.port.out.EventPublisher;
+import com.trainticket.platformkit.idempotency.IdempotencyStore;
+import com.trainticket.platformkit.messaging.LettuceRedisStreamOperations;
+import com.trainticket.platformkit.persistence.DataSources;
+import com.trainticket.platformkit.persistence.DbIdempotencyStore;
+import com.trainticket.platformkit.persistence.MigrationRunner;
+import com.trainticket.platformkit.persistence.OutboxAppender;
+import com.trainticket.platformkit.persistence.OutboxRelay;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import jakarta.annotation.PostConstruct;
+import java.nio.file.Path;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@ConditionalOnExpression("'${DATABASE_URL:}' != ''")
+public class JourneyOrderPersistenceConfiguration {
+    @Bean(destroyMethod = "close")
+    @Primary
+    DataSource journeyorderDataSource(@Value("${DATABASE_URL:}") String databaseUrl) {
+        return DataSources.fromDatabaseUrl(databaseUrl);
+    }
+
+    @Bean
+    @Primary
+    PlatformTransactionManager journeyorderTransactionManager(DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
+    }
+
+    @Bean
+    MigrationRunner journeyorderMigrationRunner(DataSource dataSource, PlatformTransactionManager transactionManager) {
+        MigrationRunner runner = new MigrationRunner(dataSource, transactionManager);
+        runner.run(Path.of("migrations"));
+        return runner;
+    }
+
+    @Bean
+    OutboxAppender journeyorderOutboxAppender(DataSource dataSource, ObjectMapper objectMapper) {
+        return new OutboxAppender(dataSource, objectMapper);
+    }
+
+    @Bean
+    @Primary
+    EventPublisher journeyorderOutboxEventPublisher(OutboxAppender outboxAppender, ObjectMapper objectMapper) {
+        return new TransactionalOutboxEventPublisher(outboxAppender, objectMapper);
+    }
+
+    @Bean
+    @Primary
+    IdempotencyStore journeyorderDbIdempotencyStore(DataSource dataSource, ObjectMapper objectMapper) {
+        return new DbIdempotencyStore(dataSource, objectMapper);
+    }
+
+    @Bean(destroyMethod = "close")
+    JourneyOrderOutboxRelayLifecycle journeyorderOutboxRelayLifecycle(DataSource dataSource, @Value("${REDIS_URL:redis://localhost:6379}") String redisUrl) {
+        return new JourneyOrderOutboxRelayLifecycle(dataSource, redisUrl);
+    }
+
+    static final class JourneyOrderOutboxRelayLifecycle implements AutoCloseable {
+        private final RedisClient client;
+        private final StatefulRedisConnection<String, String> connection;
+        private final OutboxRelay relay;
+
+        JourneyOrderOutboxRelayLifecycle(DataSource dataSource, String redisUrl) {
+            this.client = RedisClient.create(redisUrl == null || redisUrl.isBlank() ? "redis://localhost:6379" : redisUrl);
+            this.connection = client.connect();
+            this.relay = new OutboxRelay(dataSource, new LettuceRedisStreamOperations(connection));
+        }
+
+        @PostConstruct
+        void start() { relay.start(); }
+
+        @Override
+        public void close() {
+            relay.close();
+            connection.close();
+            client.shutdown();
+        }
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/infrastructure/persistence/JourneyOrderReadiness.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/infrastructure/persistence/JourneyOrderReadiness.java
@@ -1,0 +1,29 @@
+package com.trainticket.journeyorder.infrastructure.persistence;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JourneyOrderReadiness {
+    private final Optional<DataSource> dataSource;
+
+    public JourneyOrderReadiness(Optional<DataSource> dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public boolean isReady() {
+        if (dataSource.isEmpty()) {
+            return true;
+        }
+        try (Connection connection = dataSource.get().getConnection(); Statement statement = connection.createStatement()) {
+            statement.setQueryTimeout(1);
+            statement.execute("SELECT 1");
+            return true;
+        } catch (Exception exception) {
+            return false;
+        }
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/infrastructure/persistence/TransactionalOutboxEventPublisher.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/infrastructure/persistence/TransactionalOutboxEventPublisher.java
@@ -1,0 +1,28 @@
+package com.trainticket.journeyorder.infrastructure.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.journeyorder.application.port.out.EventPublisher;
+import com.trainticket.journeyorder.application.port.out.EventPublisher.PublishFailed;
+import com.trainticket.platformkit.messaging.EventEnvelope;
+import com.trainticket.platformkit.persistence.OutboxAppender;
+import java.util.Objects;
+
+public class TransactionalOutboxEventPublisher implements EventPublisher {
+    private final OutboxAppender outboxAppender;
+    private final ObjectMapper objectMapper;
+
+    public TransactionalOutboxEventPublisher(OutboxAppender outboxAppender, ObjectMapper objectMapper) {
+        this.outboxAppender = Objects.requireNonNull(outboxAppender, "outboxAppender is required");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper is required");
+    }
+
+    @Override
+    public void publish(EventEnvelope envelope) {
+        try {
+            outboxAppender.append(envelope, objectMapper.writeValueAsString(envelope));
+        } catch (JsonProcessingException exception) {
+            throw new PublishFailed("event envelope could not be serialized", exception);
+        }
+    }
+}

--- a/services/journey-order/src/test/java/com/trainticket/journeyorder/ApplicationTest.java
+++ b/services/journey-order/src/test/java/com/trainticket/journeyorder/ApplicationTest.java
@@ -37,7 +37,7 @@ class ApplicationTest {
         );
 
         assertEquals("live", controller.live().get("status"));
-        assertEquals("ready", controller.ready().get("status"));
+        assertEquals("ready", controller.ready().getBody().get("status"));
         Map<String, Object> metadata = controller.metadata();
         assertEquals("2026-01-01T00:00:00Z", metadata.get("generatedAt"));
         assertEquals("journey-order", assertInstanceOf(ServiceProfile.class, metadata.get("service")).serviceId());

--- a/services/journey-order/src/test/java/com/trainticket/journeyorder/infrastructure/persistence/JacksonJourneyOrderJsonTest.java
+++ b/services/journey-order/src/test/java/com/trainticket/journeyorder/infrastructure/persistence/JacksonJourneyOrderJsonTest.java
@@ -1,0 +1,26 @@
+package com.trainticket.journeyorder.infrastructure.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+class JacksonJourneyOrderJsonTest {
+    @Test
+    void snapshotSerializesBusinessFieldsAtTopLevel() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode data = objectMapper.createObjectNode();
+        data.put("businessField", "value");
+
+        String json = objectMapper.writeValueAsString(new JacksonJourneyOrderJson.JourneyOrderSnapshot(data));
+        JsonNode root = objectMapper.readTree(json);
+
+        assertEquals("value", root.path("businessField").asText());
+        assertTrue(root.has("businessField"));
+        assertFalse(root.has("data"));
+    }
+}

--- a/services/post-sales/migrations/001_post_sales_persistence.sql
+++ b/services/post-sales/migrations/001_post_sales_persistence.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS post_sales_case_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_post_sales_case_snapshots_order_id
+  ON post_sales_case_snapshots ((data->>'orderId'));
+CREATE INDEX IF NOT EXISTS idx_post_sales_case_snapshots_status
+  ON post_sales_case_snapshots ((data->>'status'));
+CREATE UNIQUE INDEX IF NOT EXISTS idx_post_sales_case_snapshots_idempotency_key
+  ON post_sales_case_snapshots ((data->>'idempotencyKey'));
+
+CREATE TABLE IF NOT EXISTS outbox (
+  seq          bigserial PRIMARY KEY,
+  event_id     text NOT NULL UNIQUE,
+  stream       text NOT NULL,
+  envelope     jsonb NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  published_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq
+  ON outbox (seq)
+  WHERE published_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS processed_events (
+  event_id     text PRIMARY KEY,
+  stream       text,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS idempotency_records (
+  key           text PRIMARY KEY,
+  request_hash  text NOT NULL,
+  status_code   int NOT NULL,
+  response_body jsonb,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);

--- a/services/post-sales/pom.xml
+++ b/services/post-sales/pom.xml
@@ -27,6 +27,19 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>

--- a/services/post-sales/src/main/java/com/trainticket/postsales/HealthController.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/HealthController.java
@@ -1,21 +1,34 @@
 package com.trainticket.postsales;
 
 import java.time.Clock;
+import com.trainticket.postsales.infrastructure.persistence.PostSalesReadiness;
 import java.time.Instant;
 import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthController {
     private final Clock clock;
+    private final PostSalesReadiness readiness;
 
     public HealthController() {
-        this(Clock.systemUTC());
+        this(Clock.systemUTC(), new PostSalesReadiness(java.util.Optional.empty()));
+    }
+
+    public HealthController(PostSalesReadiness readiness) {
+        this(Clock.systemUTC(), readiness);
     }
 
     HealthController(Clock clock) {
+        this(clock, new PostSalesReadiness(java.util.Optional.empty()));
+    }
+
+    HealthController(Clock clock, PostSalesReadiness readiness) {
         this.clock = clock;
+        this.readiness = readiness;
     }
 
     @GetMapping({"/health", "/healthz"})
@@ -29,8 +42,10 @@ public class HealthController {
     }
 
     @GetMapping({"/ready", "/readyz"})
-    public Map<String, Object> ready() {
-        return Map.of("status", "ready", "serviceId", Application.profile().serviceId());
+    public ResponseEntity<Map<String, Object>> ready() {
+        boolean ready = readiness.isReady();
+        Map<String, Object> body = Map.of("status", ready ? "ready" : "not_ready", "serviceId", Application.profile().serviceId());
+        return ResponseEntity.status(ready ? HttpStatus.OK : HttpStatus.SERVICE_UNAVAILABLE).body(body);
     }
 
     @GetMapping("/metadata")

--- a/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisMessagingConfiguration.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisMessagingConfiguration.java
@@ -10,6 +10,7 @@ import com.trainticket.postsales.application.PublishFailedException;
 import com.trainticket.postsales.application.SubscribeFailedException;
 import jakarta.annotation.PostConstruct;
 import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
@@ -19,7 +20,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(name = "post-sales.messaging.redis.enabled", havingValue = "true", matchIfMissing = true)
 public class RedisMessagingConfiguration {
     @Bean(destroyMethod = "close") RedisEventPublisher platformRedisEventPublisher(ObjectMapper objectMapper, RedisMessagingProperties properties) { return RedisEventPublisher.fromUrl(properties.redisUrl(), objectMapper); }
-    @Bean @Primary EventPublisher redisEventPublisher(RedisEventPublisher publisher) { return envelope -> { try { publisher.publish(envelope); } catch (com.trainticket.platformkit.messaging.PublishFailedException e) { throw new PublishFailedException(e.getMessage(), e); } }; }
+    @Bean @Primary @ConditionalOnMissingBean(EventPublisher.class) EventPublisher redisEventPublisher(RedisEventPublisher publisher) { return envelope -> { try { publisher.publish(envelope); } catch (com.trainticket.platformkit.messaging.PublishFailedException e) { throw new PublishFailedException(e.getMessage(), e); } }; }
     @Bean(destroyMethod = "close") RedisEventSubscriber platformRedisEventSubscriber(ObjectMapper objectMapper, RedisMessagingProperties properties) { return RedisEventSubscriber.fromUrl(properties.redisUrl(), objectMapper); }
     @Bean @Primary EventSubscriber redisEventSubscriber(RedisEventSubscriber subscriber) { return (streams, group, consumerName, handler) -> { try { subscriber.subscribe(streams, group, consumerName, envelope -> switch (handler.handle(envelope)) { case SUCCESS -> com.trainticket.platformkit.messaging.HandlerResult.SUCCESS; case TRANSIENT_FAILURE -> com.trainticket.platformkit.messaging.HandlerResult.TRANSIENT_FAILURE; case FATAL_FAILURE -> com.trainticket.platformkit.messaging.HandlerResult.FATAL_FAILURE; }); } catch (com.trainticket.platformkit.messaging.SubscribeFailedException e) { throw new SubscribeFailedException(e.getMessage(), e); } }; }
     @Bean RedisSubscriptionLifecycle redisSubscriptionLifecycle(EventSubscriber subscriber, RedisMessagingProperties properties, PostSalesEventHandler handler) { return new RedisSubscriptionLifecycle(subscriber, properties, handler); }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/JacksonPostSalesJson.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/JacksonPostSalesJson.java
@@ -1,0 +1,18 @@
+package com.trainticket.postsales.infrastructure.persistence;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+final class JacksonPostSalesJson {
+    private JacksonPostSalesJson() {
+    }
+
+    record PostSalesCaseSnapshot(@JsonValue ObjectNode data) {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static PostSalesCaseSnapshot of(ObjectNode data) {
+            return new PostSalesCaseSnapshot(data);
+        }
+    }
+
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostSalesPersistenceConfiguration.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostSalesPersistenceConfiguration.java
@@ -1,0 +1,90 @@
+package com.trainticket.postsales.infrastructure.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.postsales.application.EventPublisher;
+import com.trainticket.platformkit.idempotency.IdempotencyStore;
+import com.trainticket.platformkit.messaging.LettuceRedisStreamOperations;
+import com.trainticket.platformkit.persistence.DataSources;
+import com.trainticket.platformkit.persistence.DbIdempotencyStore;
+import com.trainticket.platformkit.persistence.MigrationRunner;
+import com.trainticket.platformkit.persistence.OutboxAppender;
+import com.trainticket.platformkit.persistence.OutboxRelay;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import jakarta.annotation.PostConstruct;
+import java.nio.file.Path;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@ConditionalOnExpression("'${DATABASE_URL:}' != ''")
+public class PostSalesPersistenceConfiguration {
+    @Bean(destroyMethod = "close")
+    @Primary
+    DataSource postsalesDataSource(@Value("${DATABASE_URL:}") String databaseUrl) {
+        return DataSources.fromDatabaseUrl(databaseUrl);
+    }
+
+    @Bean
+    @Primary
+    PlatformTransactionManager postsalesTransactionManager(DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
+    }
+
+    @Bean
+    MigrationRunner postsalesMigrationRunner(DataSource dataSource, PlatformTransactionManager transactionManager) {
+        MigrationRunner runner = new MigrationRunner(dataSource, transactionManager);
+        runner.run(Path.of("migrations"));
+        return runner;
+    }
+
+    @Bean
+    OutboxAppender postsalesOutboxAppender(DataSource dataSource, ObjectMapper objectMapper) {
+        return new OutboxAppender(dataSource, objectMapper);
+    }
+
+    @Bean
+    @Primary
+    EventPublisher postsalesOutboxEventPublisher(OutboxAppender outboxAppender, ObjectMapper objectMapper) {
+        return new TransactionalOutboxEventPublisher(outboxAppender, objectMapper);
+    }
+
+    @Bean
+    @Primary
+    IdempotencyStore postsalesDbIdempotencyStore(DataSource dataSource, ObjectMapper objectMapper) {
+        return new DbIdempotencyStore(dataSource, objectMapper);
+    }
+
+    @Bean(destroyMethod = "close")
+    PostSalesOutboxRelayLifecycle postsalesOutboxRelayLifecycle(DataSource dataSource, @Value("${REDIS_URL:redis://localhost:6379}") String redisUrl) {
+        return new PostSalesOutboxRelayLifecycle(dataSource, redisUrl);
+    }
+
+    static final class PostSalesOutboxRelayLifecycle implements AutoCloseable {
+        private final RedisClient client;
+        private final StatefulRedisConnection<String, String> connection;
+        private final OutboxRelay relay;
+
+        PostSalesOutboxRelayLifecycle(DataSource dataSource, String redisUrl) {
+            this.client = RedisClient.create(redisUrl == null || redisUrl.isBlank() ? "redis://localhost:6379" : redisUrl);
+            this.connection = client.connect();
+            this.relay = new OutboxRelay(dataSource, new LettuceRedisStreamOperations(connection));
+        }
+
+        @PostConstruct
+        void start() { relay.start(); }
+
+        @Override
+        public void close() {
+            relay.close();
+            connection.close();
+            client.shutdown();
+        }
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostSalesReadiness.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostSalesReadiness.java
@@ -1,0 +1,29 @@
+package com.trainticket.postsales.infrastructure.persistence;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostSalesReadiness {
+    private final Optional<DataSource> dataSource;
+
+    public PostSalesReadiness(Optional<DataSource> dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public boolean isReady() {
+        if (dataSource.isEmpty()) {
+            return true;
+        }
+        try (Connection connection = dataSource.get().getConnection(); Statement statement = connection.createStatement()) {
+            statement.setQueryTimeout(1);
+            statement.execute("SELECT 1");
+            return true;
+        } catch (Exception exception) {
+            return false;
+        }
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/TransactionalOutboxEventPublisher.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/TransactionalOutboxEventPublisher.java
@@ -1,0 +1,28 @@
+package com.trainticket.postsales.infrastructure.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.postsales.application.EventPublisher;
+import com.trainticket.postsales.application.PublishFailedException;
+import com.trainticket.platformkit.messaging.EventEnvelope;
+import com.trainticket.platformkit.persistence.OutboxAppender;
+import java.util.Objects;
+
+public class TransactionalOutboxEventPublisher implements EventPublisher {
+    private final OutboxAppender outboxAppender;
+    private final ObjectMapper objectMapper;
+
+    public TransactionalOutboxEventPublisher(OutboxAppender outboxAppender, ObjectMapper objectMapper) {
+        this.outboxAppender = Objects.requireNonNull(outboxAppender, "outboxAppender is required");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper is required");
+    }
+
+    @Override
+    public void publish(EventEnvelope envelope) {
+        try {
+            outboxAppender.append(envelope, objectMapper.writeValueAsString(envelope));
+        } catch (JsonProcessingException exception) {
+            throw new PublishFailedException("event envelope could not be serialized", exception);
+        }
+    }
+}

--- a/services/post-sales/src/test/java/com/trainticket/postsales/ApplicationTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/ApplicationTest.java
@@ -37,7 +37,7 @@ class ApplicationTest {
         );
 
         assertEquals("live", controller.live().get("status"));
-        assertEquals("ready", controller.ready().get("status"));
+        assertEquals("ready", controller.ready().getBody().get("status"));
         Map<String, Object> metadata = controller.metadata();
         assertEquals("2026-01-01T00:00:00Z", metadata.get("generatedAt"));
         assertEquals("post-sales", assertInstanceOf(ServiceProfile.class, metadata.get("service")).serviceId());

--- a/services/post-sales/src/test/java/com/trainticket/postsales/infrastructure/persistence/JacksonPostSalesJsonTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/infrastructure/persistence/JacksonPostSalesJsonTest.java
@@ -1,0 +1,26 @@
+package com.trainticket.postsales.infrastructure.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+class JacksonPostSalesJsonTest {
+    @Test
+    void snapshotSerializesBusinessFieldsAtTopLevel() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode data = objectMapper.createObjectNode();
+        data.put("businessField", "value");
+
+        String json = objectMapper.writeValueAsString(new JacksonPostSalesJson.PostSalesCaseSnapshot(data));
+        JsonNode root = objectMapper.readTree(json);
+
+        assertEquals("value", root.path("businessField").asText());
+        assertTrue(root.has("businessField"));
+        assertFalse(root.has("data"));
+    }
+}

--- a/services/traveler-profile/migrations/001_traveler_profile_persistence.sql
+++ b/services/traveler-profile/migrations/001_traveler_profile_persistence.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS traveler_profile_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_traveler_profile_snapshots_account_id
+  ON traveler_profile_snapshots ((data->>'accountId'));
+CREATE INDEX IF NOT EXISTS idx_traveler_profile_snapshots_status
+  ON traveler_profile_snapshots ((data->>'status'));
+
+CREATE TABLE IF NOT EXISTS outbox (
+  seq          bigserial PRIMARY KEY,
+  event_id     text NOT NULL UNIQUE,
+  stream       text NOT NULL,
+  envelope     jsonb NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  published_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq
+  ON outbox (seq)
+  WHERE published_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS processed_events (
+  event_id     text PRIMARY KEY,
+  stream       text,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS idempotency_records (
+  key           text PRIMARY KEY,
+  request_hash  text NOT NULL,
+  status_code   int NOT NULL,
+  response_body jsonb,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);

--- a/services/traveler-profile/pom.xml
+++ b/services/traveler-profile/pom.xml
@@ -27,6 +27,19 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
       <version>1.46.0</version>

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/HealthController.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/HealthController.java
@@ -1,21 +1,34 @@
 package com.trainticket.travelerprofile;
 
 import java.time.Clock;
+import com.trainticket.travelerprofile.infrastructure.persistence.TravelerProfileReadiness;
 import java.time.Instant;
 import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthController {
     private final Clock clock;
+    private final TravelerProfileReadiness readiness;
 
     public HealthController() {
-        this(Clock.systemUTC());
+        this(Clock.systemUTC(), new TravelerProfileReadiness(java.util.Optional.empty()));
+    }
+
+    public HealthController(TravelerProfileReadiness readiness) {
+        this(Clock.systemUTC(), readiness);
     }
 
     HealthController(Clock clock) {
+        this(clock, new TravelerProfileReadiness(java.util.Optional.empty()));
+    }
+
+    HealthController(Clock clock, TravelerProfileReadiness readiness) {
         this.clock = clock;
+        this.readiness = readiness;
     }
 
     @GetMapping({"/health", "/healthz"})
@@ -29,8 +42,10 @@ public class HealthController {
     }
 
     @GetMapping({"/ready", "/readyz"})
-    public Map<String, Object> ready() {
-        return Map.of("status", "ready", "serviceId", Application.profile().serviceId());
+    public ResponseEntity<Map<String, Object>> ready() {
+        boolean ready = readiness.isReady();
+        Map<String, Object> body = Map.of("status", ready ? "ready" : "not_ready", "serviceId", Application.profile().serviceId());
+        return ResponseEntity.status(ready ? HttpStatus.OK : HttpStatus.SERVICE_UNAVAILABLE).body(body);
     }
 
     @GetMapping("/metadata")

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/messaging/RedisMessagingConfiguration.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/messaging/RedisMessagingConfiguration.java
@@ -8,6 +8,7 @@ import com.trainticket.travelerprofile.application.EventSubscriber;
 import com.trainticket.travelerprofile.application.PublishFailedException;
 import com.trainticket.travelerprofile.application.SubscribeFailedException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,7 +17,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(name = "traveler-profile.redis.enabled", havingValue = "true", matchIfMissing = true)
 public class RedisMessagingConfiguration {
     @Bean(destroyMethod = "close") RedisEventPublisher platformRedisEventPublisher(ObjectMapper objectMapper, @Value("${REDIS_URL:${redis.url:redis://localhost:6379}}") String redisUrl) { return RedisEventPublisher.fromUrl(redisUrl, objectMapper); }
-    @Bean EventPublisher redisEventPublisher(RedisEventPublisher publisher) { return envelope -> { try { publisher.publish(envelope); } catch (com.trainticket.platformkit.messaging.PublishFailedException e) { throw new PublishFailedException(e.getMessage(), e); } }; }
+    @Bean @ConditionalOnMissingBean(EventPublisher.class) EventPublisher redisEventPublisher(RedisEventPublisher publisher) { return envelope -> { try { publisher.publish(envelope); } catch (com.trainticket.platformkit.messaging.PublishFailedException e) { throw new PublishFailedException(e.getMessage(), e); } }; }
     @Bean(destroyMethod = "close") RedisEventSubscriber platformRedisEventSubscriber(ObjectMapper objectMapper, @Value("${REDIS_URL:${redis.url:redis://localhost:6379}}") String redisUrl) { return RedisEventSubscriber.fromUrl(redisUrl, objectMapper); }
     @Bean EventSubscriber redisEventSubscriber(RedisEventSubscriber subscriber) { return (streams, group, consumerName, handler) -> { try { subscriber.subscribe(streams, group, consumerName, envelope -> switch (handler.handle(envelope)) { case SUCCESS -> com.trainticket.platformkit.messaging.HandlerResult.SUCCESS; case TRANSIENT_FAILURE -> com.trainticket.platformkit.messaging.HandlerResult.TRANSIENT_FAILURE; case FATAL_FAILURE -> com.trainticket.platformkit.messaging.HandlerResult.FATAL_FAILURE; }); } catch (com.trainticket.platformkit.messaging.SubscribeFailedException e) { throw new SubscribeFailedException(e.getMessage(), e); } }; }
 }

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/infrastructure/persistence/JacksonTravelerProfileJson.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/infrastructure/persistence/JacksonTravelerProfileJson.java
@@ -1,0 +1,18 @@
+package com.trainticket.travelerprofile.infrastructure.persistence;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+final class JacksonTravelerProfileJson {
+    private JacksonTravelerProfileJson() {
+    }
+
+    record TravelerProfileSnapshot(@JsonValue ObjectNode data) {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        static TravelerProfileSnapshot of(ObjectNode data) {
+            return new TravelerProfileSnapshot(data);
+        }
+    }
+
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/infrastructure/persistence/TransactionalOutboxEventPublisher.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/infrastructure/persistence/TransactionalOutboxEventPublisher.java
@@ -1,0 +1,28 @@
+package com.trainticket.travelerprofile.infrastructure.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.travelerprofile.application.EventPublisher;
+import com.trainticket.travelerprofile.application.PublishFailedException;
+import com.trainticket.platformkit.messaging.EventEnvelope;
+import com.trainticket.platformkit.persistence.OutboxAppender;
+import java.util.Objects;
+
+public class TransactionalOutboxEventPublisher implements EventPublisher {
+    private final OutboxAppender outboxAppender;
+    private final ObjectMapper objectMapper;
+
+    public TransactionalOutboxEventPublisher(OutboxAppender outboxAppender, ObjectMapper objectMapper) {
+        this.outboxAppender = Objects.requireNonNull(outboxAppender, "outboxAppender is required");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper is required");
+    }
+
+    @Override
+    public void publish(EventEnvelope envelope) {
+        try {
+            outboxAppender.append(envelope, objectMapper.writeValueAsString(envelope));
+        } catch (JsonProcessingException exception) {
+            throw new PublishFailedException("event envelope could not be serialized", exception);
+        }
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/infrastructure/persistence/TravelerProfilePersistenceConfiguration.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/infrastructure/persistence/TravelerProfilePersistenceConfiguration.java
@@ -1,0 +1,90 @@
+package com.trainticket.travelerprofile.infrastructure.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.travelerprofile.application.EventPublisher;
+import com.trainticket.platformkit.idempotency.IdempotencyStore;
+import com.trainticket.platformkit.messaging.LettuceRedisStreamOperations;
+import com.trainticket.platformkit.persistence.DataSources;
+import com.trainticket.platformkit.persistence.DbIdempotencyStore;
+import com.trainticket.platformkit.persistence.MigrationRunner;
+import com.trainticket.platformkit.persistence.OutboxAppender;
+import com.trainticket.platformkit.persistence.OutboxRelay;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import jakarta.annotation.PostConstruct;
+import java.nio.file.Path;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@ConditionalOnExpression("'${DATABASE_URL:}' != ''")
+public class TravelerProfilePersistenceConfiguration {
+    @Bean(destroyMethod = "close")
+    @Primary
+    DataSource travelerprofileDataSource(@Value("${DATABASE_URL:}") String databaseUrl) {
+        return DataSources.fromDatabaseUrl(databaseUrl);
+    }
+
+    @Bean
+    @Primary
+    PlatformTransactionManager travelerprofileTransactionManager(DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
+    }
+
+    @Bean
+    MigrationRunner travelerprofileMigrationRunner(DataSource dataSource, PlatformTransactionManager transactionManager) {
+        MigrationRunner runner = new MigrationRunner(dataSource, transactionManager);
+        runner.run(Path.of("migrations"));
+        return runner;
+    }
+
+    @Bean
+    OutboxAppender travelerprofileOutboxAppender(DataSource dataSource, ObjectMapper objectMapper) {
+        return new OutboxAppender(dataSource, objectMapper);
+    }
+
+    @Bean
+    @Primary
+    EventPublisher travelerprofileOutboxEventPublisher(OutboxAppender outboxAppender, ObjectMapper objectMapper) {
+        return new TransactionalOutboxEventPublisher(outboxAppender, objectMapper);
+    }
+
+    @Bean
+    @Primary
+    IdempotencyStore travelerprofileDbIdempotencyStore(DataSource dataSource, ObjectMapper objectMapper) {
+        return new DbIdempotencyStore(dataSource, objectMapper);
+    }
+
+    @Bean(destroyMethod = "close")
+    TravelerProfileOutboxRelayLifecycle travelerprofileOutboxRelayLifecycle(DataSource dataSource, @Value("${REDIS_URL:redis://localhost:6379}") String redisUrl) {
+        return new TravelerProfileOutboxRelayLifecycle(dataSource, redisUrl);
+    }
+
+    static final class TravelerProfileOutboxRelayLifecycle implements AutoCloseable {
+        private final RedisClient client;
+        private final StatefulRedisConnection<String, String> connection;
+        private final OutboxRelay relay;
+
+        TravelerProfileOutboxRelayLifecycle(DataSource dataSource, String redisUrl) {
+            this.client = RedisClient.create(redisUrl == null || redisUrl.isBlank() ? "redis://localhost:6379" : redisUrl);
+            this.connection = client.connect();
+            this.relay = new OutboxRelay(dataSource, new LettuceRedisStreamOperations(connection));
+        }
+
+        @PostConstruct
+        void start() { relay.start(); }
+
+        @Override
+        public void close() {
+            relay.close();
+            connection.close();
+            client.shutdown();
+        }
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/infrastructure/persistence/TravelerProfileReadiness.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/infrastructure/persistence/TravelerProfileReadiness.java
@@ -1,0 +1,29 @@
+package com.trainticket.travelerprofile.infrastructure.persistence;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TravelerProfileReadiness {
+    private final Optional<DataSource> dataSource;
+
+    public TravelerProfileReadiness(Optional<DataSource> dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public boolean isReady() {
+        if (dataSource.isEmpty()) {
+            return true;
+        }
+        try (Connection connection = dataSource.get().getConnection(); Statement statement = connection.createStatement()) {
+            statement.setQueryTimeout(1);
+            statement.execute("SELECT 1");
+            return true;
+        } catch (Exception exception) {
+            return false;
+        }
+    }
+}

--- a/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/ApplicationTest.java
+++ b/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/ApplicationTest.java
@@ -37,7 +37,7 @@ class ApplicationTest {
         );
 
         assertEquals("live", controller.live().get("status"));
-        assertEquals("ready", controller.ready().get("status"));
+        assertEquals("ready", controller.ready().getBody().get("status"));
         Map<String, Object> metadata = controller.metadata();
         assertEquals("2026-01-01T00:00:00Z", metadata.get("generatedAt"));
         assertEquals("traveler-profile", assertInstanceOf(ServiceProfile.class, metadata.get("service")).serviceId());

--- a/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/infrastructure/persistence/JacksonTravelerProfileJsonTest.java
+++ b/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/infrastructure/persistence/JacksonTravelerProfileJsonTest.java
@@ -1,0 +1,26 @@
+package com.trainticket.travelerprofile.infrastructure.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+class JacksonTravelerProfileJsonTest {
+    @Test
+    void snapshotSerializesBusinessFieldsAtTopLevel() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode data = objectMapper.createObjectNode();
+        data.put("businessField", "value");
+
+        String json = objectMapper.writeValueAsString(new JacksonTravelerProfileJson.TravelerProfileSnapshot(data));
+        JsonNode root = objectMapper.readTree(json);
+
+        assertEquals("value", root.path("businessField").asText());
+        assertTrue(root.has("businessField"));
+        assertFalse(root.has("data"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add Postgres migration scripts for admin-audit, booking-orchestration, finance-settlement, journey-order, post-sales, and traveler-profile with snapshot/outbox/processed/idempotency tables.
- Wire DATABASE_URL-gated persistence configuration, transactional outbox publishers, outbox relay lifecycle, DB idempotency store, and SELECT 1 readiness probes.
- Copy migrations into service images and add transparent snapshot JSON serialization tests.

## Validation
- mvn -q -f platform/java-kit/pom.xml -DskipTests install
- for s in admin-audit booking-orchestration finance-settlement journey-order post-sales traveler-profile; do mvn -q -f services//pom.xml test; done
- make check