### PR TITLE
REQ-085 migrate entitlement ticketing persistence

### DIFF
--- a/deploy/docker/entitlement-ticketing/Dockerfile
+++ b/deploy/docker/entitlement-ticketing/Dockerfile
@@ -5,12 +5,14 @@ COPY platform/shared-kernel-rust ./platform/shared-kernel-rust
 COPY platform/rust-kit ./platform/rust-kit
 COPY services/entitlement-ticketing/Cargo.toml services/entitlement-ticketing/Cargo.lock ./services/entitlement-ticketing/
 COPY services/entitlement-ticketing/src ./services/entitlement-ticketing/src
+COPY services/entitlement-ticketing/migrations ./services/entitlement-ticketing/migrations
 RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/services/entitlement-ticketing/target     cargo build --release --manifest-path services/entitlement-ticketing/Cargo.toml &&     cp services/entitlement-ticketing/target/release/entitlement-ticketing /usr/local/bin/entitlement-ticketing
 
 FROM debian:bookworm-slim
 RUN useradd --system --create-home --home-dir /home/app app &&     apt-get update && apt-get install -y --no-install-recommends ca-certificates &&     rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/bin/entitlement-ticketing /usr/local/bin/entitlement-ticketing
+COPY --from=builder /src/services/entitlement-ticketing/migrations /app/migrations
 USER app
-ENV PORT=8080 REDIS_URL=redis://localhost:6379
+ENV PORT=8080 REDIS_URL=redis://localhost:6379 MIGRATIONS_DIR=/app/migrations
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/entitlement-ticketing"]

--- a/services/entitlement-ticketing/Cargo.lock
+++ b/services/entitlement-ticketing/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,6 +35,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -96,6 +111,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +145,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -140,7 +182,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -172,6 +214,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +253,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,13 +293,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -224,6 +324,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -239,10 +354,17 @@ dependencies = [
  "serde",
  "serde_json",
  "shared-kernel",
+ "sqlx",
  "tokio",
  "tower",
  "uuid",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -255,10 +377,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -309,6 +470,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -369,6 +541,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -376,7 +559,72 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -587,6 +835,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,16 +862,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.9.0",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -626,6 +930,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -651,12 +965,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -680,6 +1031,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,12 +1081,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -726,13 +1157,43 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom",
- "rand_core",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -766,6 +1227,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rust-kit"
 version = "0.1.0"
 dependencies = [
@@ -778,8 +1291,43 @@ dependencies = [
  "serde_json",
  "sha2",
  "shared-kernel",
+ "sqlx",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -793,6 +1341,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -861,6 +1415,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +1469,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +1489,9 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -936,10 +1514,240 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1000,6 +1808,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,7 +1856,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
 dependencies = [
  "pin-project-lite",
- "rand",
+ "rand 0.10.2",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1086,7 +1920,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1105,10 +1951,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1134,11 +2007,17 @@ version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.3",
  "js-sys",
- "rand",
+ "rand 0.10.2",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1151,6 +2030,12 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1195,6 +2080,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]
@@ -1258,11 +2171,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1276,19 +2198,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1298,9 +2241,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1316,9 +2271,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1328,9 +2295,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1368,6 +2347,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,6 +2386,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/services/entitlement-ticketing/Cargo.toml
+++ b/services/entitlement-ticketing/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shared-kernel = { path = "../../platform/shared-kernel-rust" }
 rust-kit = { path = "../../platform/rust-kit", features = ["redis-impl"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "chrono", "json"] }
 tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "net", "signal", "sync", "time"] }
 uuid = { version = "1.0", features = ["v7", "fast-rng"] }
 

--- a/services/entitlement-ticketing/migrations/001_entitlement_ticketing_storage.sql
+++ b/services/entitlement-ticketing/migrations/001_entitlement_ticketing_storage.sql
@@ -1,0 +1,48 @@
+CREATE TABLE IF NOT EXISTS entitlement_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  journey_order_id text GENERATED ALWAYS AS (data ->> 'journeyOrderId') STORED,
+  segment_booking_id text GENERATED ALWAYS AS (data ->> 'segmentBookingId') STORED,
+  credential_no text GENERATED ALWAYS AS (data #>> '{credentialRef,credentialNo}') STORED,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_entitlement_journey_order_id
+  ON entitlement_snapshots (journey_order_id);
+
+CREATE INDEX IF NOT EXISTS idx_entitlement_segment_booking_id
+  ON entitlement_snapshots (segment_booking_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_entitlement_credential_no_unique
+  ON entitlement_snapshots (credential_no)
+  WHERE credential_no IS NOT NULL;
+
+CREATE SEQUENCE IF NOT EXISTS entitlement_ticket_no_seq;
+
+CREATE TABLE IF NOT EXISTS outbox (
+  seq          bigserial PRIMARY KEY,
+  event_id     text NOT NULL UNIQUE,
+  stream       text NOT NULL,
+  envelope     jsonb NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  published_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq
+  ON outbox (seq)
+  WHERE published_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS processed_events (
+  event_id     text PRIMARY KEY,
+  stream       text,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS idempotency_records (
+  key           text PRIMARY KEY,
+  request_hash  text NOT NULL,
+  status_code   int NOT NULL,
+  response_body jsonb,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);

--- a/services/entitlement-ticketing/src/adapters/mod.rs
+++ b/services/entitlement-ticketing/src/adapters/mod.rs
@@ -1,1 +1,2 @@
 pub mod messaging;
+pub mod storage;

--- a/services/entitlement-ticketing/src/adapters/storage/mod.rs
+++ b/services/entitlement-ticketing/src/adapters/storage/mod.rs
@@ -1,0 +1,1388 @@
+use crate::*;
+use rust_kit::messaging::stream_for_producer;
+use rust_kit::storage::{
+    DbIdempotencyStore, IdempotencyTxDecision, OutboxAppender, PgTransaction, Snapshot,
+    SnapshotRepository, Storage, StorageError, mark_event_processing,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sqlx::PgPool;
+
+const ENTITLEMENT_TABLE: &str = "entitlement_snapshots";
+const PRODUCER: &str = "entitlement-ticketing";
+const MAX_RETRIES: usize = 3;
+
+type PgResult<T> = Result<T, ApiErrorKind>;
+
+#[derive(Clone)]
+pub struct PostgresEntitlementService {
+    storage: Storage,
+    entitlement_repo: SnapshotRepository,
+}
+
+impl PostgresEntitlementService {
+    pub async fn from_env() -> Result<Self, StorageError> {
+        let storage = Storage::from_env().await?;
+        let migrations_dir =
+            std::env::var("MIGRATIONS_DIR").unwrap_or_else(|_| "/app/migrations".into());
+        match storage.migrate_dir(&migrations_dir).await {
+            Ok(()) => {}
+            Err(primary_error) => {
+                if migrations_dir == "/app/migrations" {
+                    storage
+                        .migrate_dir("services/entitlement-ticketing/migrations")
+                        .await?;
+                } else {
+                    return Err(primary_error);
+                }
+            }
+        }
+        Self::from_storage(storage)
+    }
+    pub fn new(pool: PgPool) -> Result<Self, StorageError> {
+        let storage = Storage::new(pool);
+        storage.mark_migrations_ready();
+        Self::from_storage(storage)
+    }
+    pub fn from_storage(storage: Storage) -> Result<Self, StorageError> {
+        Ok(Self {
+            storage,
+            entitlement_repo: SnapshotRepository::new(ENTITLEMENT_TABLE)?,
+        })
+    }
+    pub fn pool(&self) -> &PgPool {
+        self.storage.pool()
+    }
+    pub async fn is_ready(&self) -> bool {
+        self.storage.is_ready().await
+    }
+
+    async fn idempotency_replay<T: for<'de> Deserialize<'de>>(
+        &self,
+        key: &str,
+        fingerprint: &str,
+    ) -> PgResult<Option<T>> {
+        let Some(record) = DbIdempotencyStore::new(self.pool().clone())
+            .get_async(key)
+            .await
+            .map_err(to_api_storage)?
+        else {
+            return Ok(None);
+        };
+        if record.fingerprint != fingerprint {
+            return Err(ApiErrorKind::IdempotencyKeyReused(
+                "Idempotency-Key was reused with a different request body".into(),
+            ));
+        }
+        serde_json::from_value(record.body)
+            .map(Some)
+            .map_err(|e| ApiErrorKind::Unavailable(e.to_string()))
+    }
+    async fn claim_idempotency<T: for<'de> Deserialize<'de>>(
+        &self,
+        tx: &mut PgTransaction<'_>,
+        key: &str,
+        fingerprint: &str,
+    ) -> PgResult<Option<T>> {
+        match DbIdempotencyStore::claim_response(tx, key, fingerprint)
+            .await
+            .map_err(to_api_storage)?
+        {
+            IdempotencyTxDecision::Claimed => Ok(None),
+            IdempotencyTxDecision::Replay(record) => serde_json::from_value(record.body)
+                .map(Some)
+                .map_err(|e| ApiErrorKind::Unavailable(e.to_string())),
+        }
+    }
+    async fn finish_idempotency(
+        &self,
+        tx: &mut PgTransaction<'_>,
+        key: &str,
+        fingerprint: &str,
+        status: u16,
+        body: Value,
+    ) -> PgResult<()> {
+        DbIdempotencyStore::record_response(tx, key, fingerprint, status, body)
+            .await
+            .map_err(to_api_storage)?;
+        Ok(())
+    }
+    async fn next_credential_no(&self, tx: &mut PgTransaction<'_>) -> PgResult<String> {
+        let (seq,): (i64,) = sqlx::query_as("SELECT nextval('entitlement_ticket_no_seq')")
+            .fetch_one(&mut **tx)
+            .await
+            .map_err(to_api_storage)?;
+        Ok(format!("ETK-{seq:012}"))
+    }
+    async fn save_entitlement(
+        &self,
+        tx: &mut PgTransaction<'_>,
+        entitlement: &Entitlement,
+        expected: Option<i64>,
+    ) -> PgResult<i64> {
+        self.entitlement_repo
+            .save(
+                tx,
+                entitlement.id().as_str(),
+                expected,
+                &EntitlementSnapshot::from_domain(entitlement),
+            )
+            .await
+            .map_err(to_api_storage)
+    }
+    async fn load_entitlement(
+        &self,
+        tx: &mut PgTransaction<'_>,
+        id: &str,
+    ) -> PgResult<Option<Snapshot<EntitlementSnapshot>>> {
+        self.entitlement_repo
+            .get::<EntitlementSnapshot>(&mut **tx, id)
+            .await
+            .map_err(to_api_storage)
+    }
+    pub async fn handle_subscribed_event(
+        &self,
+        envelope: application::EventEnvelope,
+    ) -> Result<(), application::HandlerError> {
+        self.apply_subscribed_event(envelope)
+            .await
+            .map_err(|error| match error {
+                InboundEventError::Transient(m) => application::HandlerError::Transient(m),
+                InboundEventError::Fatal(m) => application::HandlerError::Fatal(m),
+            })
+    }
+    async fn apply_subscribed_event(
+        &self,
+        envelope: application::EventEnvelope,
+    ) -> Result<(), InboundEventError> {
+        match envelope.event_type.as_str() {
+            "BoardingVerified" => self.apply_boarding_verified(envelope).await,
+            "FulfillmentCompleted" => self.apply_fulfillment_completed(envelope).await,
+            "NoShowRecorded" => self.apply_no_show_recorded(envelope).await,
+            "PostSalesApproved" => self.apply_post_sales_approved(envelope).await,
+            "SegmentTicketed" => self.apply_segment_ticketed(envelope).await,
+            _ => Ok(()),
+        }
+    }
+    async fn apply_boarding_verified(
+        &self,
+        envelope: application::EventEnvelope,
+    ) -> Result<(), InboundEventError> {
+        for field in [
+            "fulfillmentRecordId",
+            "entitlementId",
+            "segmentBookingId",
+            "journeyOrderId",
+            "travelerId",
+            "segmentRef",
+            "source",
+            "sourceEventId",
+            "occurredAt",
+            "receivedAt",
+        ] {
+            require_string(&envelope.payload, field)?;
+        }
+        let entitlement_id = require_string(&envelope.payload, "entitlementId")?;
+        let fact_ref = require_string(&envelope.payload, "sourceEventId")?;
+        self.accept_fulfillment_fact(
+            envelope,
+            &entitlement_id,
+            FulfillmentFact::BoardingVerified {
+                fact_ref: FulfillmentFactRef::new(fact_ref).map_err(inbound_fatal)?,
+            },
+            "event bus boarding verified",
+            false,
+        )
+        .await
+    }
+    async fn apply_fulfillment_completed(
+        &self,
+        envelope: application::EventEnvelope,
+    ) -> Result<(), InboundEventError> {
+        for field in [
+            "fulfillmentRecordId",
+            "entitlementId",
+            "segmentBookingId",
+            "journeyOrderId",
+            "travelerId",
+            "completedAt",
+            "completionSource",
+        ] {
+            require_string(&envelope.payload, field)?;
+        }
+        let entitlement_id = require_string(&envelope.payload, "entitlementId")?;
+        let fact_ref = require_string(&envelope.payload, "fulfillmentRecordId")?;
+        self.accept_fulfillment_fact(
+            envelope,
+            &entitlement_id,
+            FulfillmentFact::BoardingComplete {
+                fact_ref: FulfillmentFactRef::new(fact_ref).map_err(inbound_fatal)?,
+            },
+            "event bus fulfillment completed",
+            true,
+        )
+        .await
+    }
+    async fn apply_no_show_recorded(
+        &self,
+        envelope: application::EventEnvelope,
+    ) -> Result<(), InboundEventError> {
+        for field in [
+            "fulfillmentRecordId",
+            "entitlementId",
+            "segmentBookingId",
+            "journeyOrderId",
+            "travelerId",
+            "segmentRef",
+            "reason",
+            "assessedAt",
+        ] {
+            require_string(&envelope.payload, field)?;
+        }
+        let entitlement_id = require_string(&envelope.payload, "entitlementId")?;
+        let fact_ref = require_string(&envelope.payload, "fulfillmentRecordId")?;
+        self.accept_fulfillment_fact(
+            envelope,
+            &entitlement_id,
+            FulfillmentFact::NoShowRecorded {
+                fact_ref: FulfillmentFactRef::new(fact_ref).map_err(inbound_fatal)?,
+            },
+            "event bus no-show recorded",
+            false,
+        )
+        .await
+    }
+    async fn apply_segment_ticketed(
+        &self,
+        envelope: application::EventEnvelope,
+    ) -> Result<(), InboundEventError> {
+        require_string(&envelope.payload, "segmentBookingId")?;
+        require_string(&envelope.payload, "entitlementId")?;
+        let mut tx = self.pool().begin().await.map_err(inbound_transient)?;
+        mark_once(&mut tx, &envelope).await?;
+        tx.commit().await.map_err(inbound_transient)?;
+        Ok(())
+    }
+    async fn accept_fulfillment_fact(
+        &self,
+        envelope: application::EventEnvelope,
+        entitlement_id: &str,
+        fact: FulfillmentFact,
+        audit_reason: &'static str,
+        ignore_missing_boarding: bool,
+    ) -> Result<(), InboundEventError> {
+        for attempt in 0..MAX_RETRIES {
+            let result = self
+                .try_accept_fulfillment_fact(
+                    &envelope,
+                    entitlement_id,
+                    fact.clone(),
+                    audit_reason,
+                    ignore_missing_boarding,
+                )
+                .await;
+            match result {
+                Err(InboundEventError::Transient(m))
+                    if m.contains("optimistic concurrency conflict")
+                        && attempt + 1 < MAX_RETRIES =>
+                {
+                    continue;
+                }
+                result => return result,
+            }
+        }
+        Err(InboundEventError::Transient(
+            "entitlement write conflict".into(),
+        ))
+    }
+    async fn try_accept_fulfillment_fact(
+        &self,
+        envelope: &application::EventEnvelope,
+        entitlement_id: &str,
+        fact: FulfillmentFact,
+        audit_reason: &'static str,
+        ignore_missing_boarding: bool,
+    ) -> Result<(), InboundEventError> {
+        let mut tx = self.pool().begin().await.map_err(inbound_transient)?;
+        if !mark_once(&mut tx, envelope).await? {
+            tx.rollback().await.map_err(inbound_transient)?;
+            return Ok(());
+        }
+        let Some(snapshot) = self
+            .load_entitlement(&mut tx, entitlement_id)
+            .await
+            .map_err(inbound_from_api_error)?
+        else {
+            tx.commit().await.map_err(inbound_transient)?;
+            return Ok(());
+        };
+        let mut entitlement = snapshot
+            .data
+            .try_into_domain()
+            .map_err(inbound_from_api_error)?;
+        let accepted = entitlement.accept_fulfillment_fact(AcceptFulfillmentFact {
+            command_id: CommandId::new(format!("cmd-{}", uuid::Uuid::now_v7()))
+                .map_err(inbound_fatal)?,
+            fact,
+            audit: audit_builder(&envelope.correlation_id, audit_reason).map_err(inbound_fatal)?,
+        });
+        if ignore_missing_boarding
+            && matches!(
+                accepted,
+                Err(EntitlementError::BoardingRequiredForCompletion)
+            )
+        {
+            tx.commit().await.map_err(inbound_transient)?;
+            return Ok(());
+        }
+        accepted.map_err(inbound_fatal)?;
+        self.save_entitlement(&mut tx, &entitlement, Some(snapshot.version))
+            .await
+            .map_err(inbound_from_api_error)?;
+        tx.commit().await.map_err(inbound_transient)?;
+        Ok(())
+    }
+    async fn apply_post_sales_approved(
+        &self,
+        envelope: application::EventEnvelope,
+    ) -> Result<(), InboundEventError> {
+        let case_id = require_string(&envelope.payload, "caseId")?;
+        let order_id = require_string(&envelope.payload, "orderId")?;
+        if envelope
+            .payload
+            .get("approvedActions")
+            .is_none_or(Value::is_null)
+        {
+            return Err(InboundEventError::Fatal("missing approvedActions".into()));
+        }
+        let actions = approved_void_actions(envelope.payload.get("approvedActions"));
+        if actions.is_empty() {
+            let mut tx = self.pool().begin().await.map_err(inbound_transient)?;
+            mark_once(&mut tx, &envelope).await?;
+            tx.commit().await.map_err(inbound_transient)?;
+            return Ok(());
+        }
+        for attempt in 0..MAX_RETRIES {
+            let result = self
+                .try_apply_post_sales_approved(&envelope, &case_id, &order_id, &actions)
+                .await;
+            match result {
+                Err(InboundEventError::Transient(m))
+                    if m.contains("optimistic concurrency conflict")
+                        && attempt + 1 < MAX_RETRIES =>
+                {
+                    continue;
+                }
+                result => return result,
+            }
+        }
+        Err(InboundEventError::Transient(
+            "entitlement write conflict".into(),
+        ))
+    }
+    async fn try_apply_post_sales_approved(
+        &self,
+        envelope: &application::EventEnvelope,
+        case_id: &str,
+        order_id: &str,
+        actions: &[ApprovedVoidAction],
+    ) -> Result<(), InboundEventError> {
+        let mut tx = self.pool().begin().await.map_err(inbound_transient)?;
+        if !mark_once(&mut tx, envelope).await? {
+            tx.rollback().await.map_err(inbound_transient)?;
+            return Ok(());
+        }
+        let snapshots = self
+            .load_entitlements_for_order(&mut tx, order_id)
+            .await
+            .map_err(inbound_from_api_error)?;
+        for snapshot in snapshots {
+            if !actions
+                .iter()
+                .any(|action| action.matches_entitlement(&snapshot.id))
+            {
+                continue;
+            }
+            let action = actions
+                .iter()
+                .find(|action| action.matches_entitlement(&snapshot.id));
+            let reason = action
+                .map(|a| a.reason.clone())
+                .unwrap_or(VoidReason::Refund);
+            let policy = action
+                .map(|a| a.policy.clone())
+                .unwrap_or(VoidPolicy::Normal);
+            let mut entitlement = snapshot
+                .data
+                .try_into_domain()
+                .map_err(inbound_from_api_error)?;
+            let events = entitlement
+                .void(VoidEntitlement {
+                    command_id: CommandId::new(format!("cmd-{}", uuid::Uuid::now_v7()))
+                        .map_err(inbound_fatal)?,
+                    reason: reason.clone(),
+                    policy: policy.clone(),
+                    business_case_ref: BusinessCaseRef::new(case_id.to_string())
+                        .map_err(inbound_fatal)?,
+                    audit: audit_builder(&envelope.correlation_id, "event bus post-sales approved")
+                        .map_err(inbound_fatal)?,
+                })
+                .map_err(inbound_fatal)?;
+            if events.is_empty() {
+                continue;
+            }
+            self.save_entitlement(&mut tx, &entitlement, Some(snapshot.version))
+                .await
+                .map_err(inbound_from_api_error)?;
+            let outbound = entitlement_voided_envelope(
+                &entitlement,
+                &reason,
+                &policy,
+                Some(case_id.to_string()),
+                &envelope.correlation_id,
+            )
+            .map_err(inbound_from_api_error)?;
+            OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &outbound)
+                .await
+                .map_err(inbound_transient)?;
+        }
+        tx.commit().await.map_err(inbound_transient)?;
+        Ok(())
+    }
+    async fn load_entitlements_for_order(
+        &self,
+        tx: &mut PgTransaction<'_>,
+        order_id: &str,
+    ) -> PgResult<Vec<Snapshot<EntitlementSnapshot>>> {
+        let sql = format!(
+            "SELECT id, version, data FROM {ENTITLEMENT_TABLE} WHERE journey_order_id = $1 ORDER BY id"
+        );
+        let rows: Vec<(String, i64, Value)> = sqlx::query_as(&sql)
+            .bind(order_id)
+            .fetch_all(&mut **tx)
+            .await
+            .map_err(to_api_storage)?;
+        rows.into_iter()
+            .map(|(id, version, data)| {
+                Ok(Snapshot {
+                    id,
+                    version,
+                    data: serde_json::from_value(data)
+                        .map_err(|e| ApiErrorKind::Unavailable(e.to_string()))?,
+                })
+            })
+            .collect()
+    }
+}
+#[async_trait::async_trait]
+impl EntitlementApi for PostgresEntitlementService {
+    async fn issue(
+        &self,
+        command: IssueEntitlementRequest,
+        key: String,
+        correlation_id: String,
+    ) -> PgResult<IssueEntitlementResponse> {
+        validate_issue_request(&command)?;
+        let fingerprint = serde_json::to_string(&command).unwrap_or_default();
+        if let Some(response) = self
+            .idempotency_replay::<IssueEntitlementResponse>(&key, &fingerprint)
+            .await?
+        {
+            return Ok(response);
+        }
+        for attempt in 0..MAX_RETRIES {
+            let result = self
+                .try_issue(&command, &key, &fingerprint, &correlation_id)
+                .await;
+            match result {
+                Err(ApiErrorKind::Conflict(m))
+                    if m.contains("optimistic concurrency conflict")
+                        && attempt + 1 < MAX_RETRIES =>
+                {
+                    continue;
+                }
+                result => return result,
+            }
+        }
+        Err(ApiErrorKind::Conflict("entitlement write conflict".into()))
+    }
+    async fn void(
+        &self,
+        entitlement_id: String,
+        command: VoidEntitlementRequest,
+        key: String,
+        correlation_id: String,
+    ) -> PgResult<VoidEntitlementResponse> {
+        validate_prefixed_uuid(&entitlement_id, "entitlementId", "ent-")?;
+        if command
+            .business_case_ref
+            .as_deref()
+            .is_some_and(|v| v.trim().is_empty())
+        {
+            return Err(ApiErrorKind::ValidationFailed(
+                "businessCaseRef must not be blank when provided".into(),
+            ));
+        }
+        let fingerprint = format!(
+            "{}:{}",
+            entitlement_id,
+            serde_json::to_string(&command).unwrap_or_default()
+        );
+        if let Some(response) = self
+            .idempotency_replay::<VoidEntitlementResponse>(&key, &fingerprint)
+            .await?
+        {
+            return Ok(response);
+        }
+        for attempt in 0..MAX_RETRIES {
+            let result = self
+                .try_void(
+                    &entitlement_id,
+                    &command,
+                    &key,
+                    &fingerprint,
+                    &correlation_id,
+                )
+                .await;
+            match result {
+                Err(ApiErrorKind::Conflict(m))
+                    if m.contains("optimistic concurrency conflict")
+                        && attempt + 1 < MAX_RETRIES =>
+                {
+                    continue;
+                }
+                result => return result,
+            }
+        }
+        Err(ApiErrorKind::Conflict("entitlement write conflict".into()))
+    }
+    async fn get(&self, entitlement_id: String) -> PgResult<EntitlementDetails> {
+        validate_prefixed_uuid(&entitlement_id, "entitlementId", "ent-")?;
+        let snapshot = self
+            .entitlement_repo
+            .get::<EntitlementSnapshot>(self.pool(), &entitlement_id)
+            .await
+            .map_err(to_api_storage)?
+            .ok_or_else(|| ApiErrorKind::NotFound("entitlement not found".into()))?;
+        Ok(snapshot.data.to_details())
+    }
+    async fn list(
+        &self,
+        journey_order_id: String,
+        limit: usize,
+        offset: usize,
+    ) -> PgResult<PaginatedEntitlements> {
+        validate_prefixed_uuid(&journey_order_id, "journeyOrderId", "ord-")?;
+        let sql = format!(
+            "SELECT data, count(*) OVER() AS total FROM {ENTITLEMENT_TABLE} WHERE journey_order_id = $1 ORDER BY id LIMIT $2 OFFSET $3"
+        );
+        let rows: Vec<(Value, i64)> = sqlx::query_as(&sql)
+            .bind(&journey_order_id)
+            .bind(i64::try_from(limit).unwrap_or(i64::MAX))
+            .bind(i64::try_from(offset).unwrap_or(i64::MAX))
+            .fetch_all(self.pool())
+            .await
+            .map_err(to_api_storage)?;
+        let total = rows.first().map(|row| row.1 as usize).unwrap_or(0);
+        let items = rows
+            .into_iter()
+            .map(|(data, _)| {
+                serde_json::from_value::<EntitlementSnapshot>(data)
+                    .map(|s| s.to_details())
+                    .map_err(|e| ApiErrorKind::Unavailable(e.to_string()))
+            })
+            .collect::<PgResult<Vec<_>>>()?;
+        Ok(PaginatedEntitlements {
+            items,
+            total,
+            limit,
+            offset,
+        })
+    }
+}
+
+impl PostgresEntitlementService {
+    async fn try_issue(
+        &self,
+        command: &IssueEntitlementRequest,
+        key: &str,
+        fingerprint: &str,
+        correlation_id: &str,
+    ) -> PgResult<IssueEntitlementResponse> {
+        let mut tx = self.pool().begin().await.map_err(to_api_storage)?;
+        if let Some(response) = self
+            .claim_idempotency::<IssueEntitlementResponse>(&mut tx, key, fingerprint)
+            .await?
+        {
+            tx.commit().await.map_err(to_api_storage)?;
+            return Ok(response);
+        }
+        let entitlement_id = format!("ent-{}", uuid::Uuid::now_v7());
+        let issued_at = current_rfc3339();
+        let credential_no = self.next_credential_no(&mut tx).await?;
+        let response = IssueEntitlementResponse {
+            entitlement_id: entitlement_id.clone(),
+            segment_booking_id: command.segment_booking_id.clone(),
+            journey_order_id: command.journey_order_id.clone(),
+            credential_no: credential_no.clone(),
+            credential_type: CredentialTypeDto::ETicket,
+            status: EntitlementStatusDto::Issued,
+            issued_at: issued_at.clone(),
+        };
+        let (mut aggregate, _) = Entitlement::request(RequestEntitlement {
+            command_id: CommandId::new(format!("cmd-{}", uuid::Uuid::now_v7()))
+                .map_err(ApiErrorKind::from)?,
+            entitlement_id: EntitlementId::new(entitlement_id.clone())
+                .map_err(ApiErrorKind::from)?,
+            journey_order_ref: JourneyOrderRef::new(command.journey_order_id.clone())
+                .map_err(ApiErrorKind::from)?,
+            segment_booking_ref: SegmentBookingRef::new(command.segment_booking_id.clone())
+                .map_err(ApiErrorKind::from)?,
+            traveler_ref: TravelerRef::new(command.traveler_ref.clone())
+                .map_err(ApiErrorKind::from)?,
+            segment_ref: SegmentRef::new(command.segment_ref.clone())
+                .map_err(ApiErrorKind::from)?,
+            purpose: command.issue_purpose.clone().into(),
+            validity_window: ValidityWindow::new(
+                UnixMillis::new(current_unix_millis()),
+                UnixMillis::new(current_unix_millis().saturating_add(86_400_000)),
+            )
+            .map_err(ApiErrorKind::from)?,
+            audit: audit_builder(correlation_id, "HTTP issue entitlement")
+                .map_err(ApiErrorKind::from)?,
+        })
+        .map_err(ApiErrorKind::from)?;
+        let mut registry = CredentialRegistry::new();
+        aggregate
+            .issue(
+                IssueEntitlement {
+                    command_id: CommandId::new(format!("cmd-{}", uuid::Uuid::now_v7()))
+                        .map_err(ApiErrorKind::from)?,
+                    idempotency_key: aggregate.idempotency_key().clone(),
+                    preconditions: default_preconditions().map_err(ApiErrorKind::from)?,
+                    credential_ref: credential_ref(&credential_no).map_err(ApiErrorKind::from)?,
+                    refund_request_fact: None,
+                    audit: audit_builder(correlation_id, "HTTP issue entitlement")
+                        .map_err(ApiErrorKind::from)?,
+                },
+                &mut registry,
+            )
+            .map_err(ApiErrorKind::from)?;
+        self.save_entitlement(&mut tx, &aggregate, None).await?;
+        let outbound = entitlement_issued_envelope(&response, command, correlation_id)?;
+        OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &outbound)
+            .await
+            .map_err(to_api_storage)?;
+        self.finish_idempotency(
+            &mut tx,
+            key,
+            fingerprint,
+            201,
+            serde_json::to_value(&response)
+                .map_err(|e| ApiErrorKind::Unavailable(e.to_string()))?,
+        )
+        .await?;
+        tx.commit().await.map_err(to_api_storage)?;
+        Ok(response)
+    }
+    async fn try_void(
+        &self,
+        entitlement_id: &str,
+        command: &VoidEntitlementRequest,
+        key: &str,
+        fingerprint: &str,
+        correlation_id: &str,
+    ) -> PgResult<VoidEntitlementResponse> {
+        let mut tx = self.pool().begin().await.map_err(to_api_storage)?;
+        if let Some(response) = self
+            .claim_idempotency::<VoidEntitlementResponse>(&mut tx, key, fingerprint)
+            .await?
+        {
+            tx.commit().await.map_err(to_api_storage)?;
+            return Ok(response);
+        }
+        let snapshot = self
+            .load_entitlement(&mut tx, entitlement_id)
+            .await?
+            .ok_or_else(|| ApiErrorKind::NotFound("entitlement not found".into()))?;
+        let mut aggregate = snapshot.data.try_into_domain()?;
+        let business_case_ref = command
+            .business_case_ref
+            .clone()
+            .unwrap_or_else(|| format!("case-{}", uuid::Uuid::now_v7()));
+        let reason: VoidReason = command.reason.clone().into();
+        let policy: VoidPolicy = command.policy.clone().into();
+        let events = aggregate
+            .void(VoidEntitlement {
+                command_id: CommandId::new(format!("cmd-{}", uuid::Uuid::now_v7()))
+                    .map_err(ApiErrorKind::from)?,
+                reason: reason.clone(),
+                policy: policy.clone(),
+                business_case_ref: BusinessCaseRef::new(business_case_ref.clone())
+                    .map_err(ApiErrorKind::from)?,
+                audit: audit_builder(correlation_id, "HTTP void entitlement")
+                    .map_err(ApiErrorKind::from)?,
+            })
+            .map_err(ApiErrorKind::from)?;
+        if events.is_empty() {
+            return Err(ApiErrorKind::PreconditionFailed(
+                "entitlement is already voided".into(),
+            ));
+        }
+        let voided_at = current_rfc3339();
+        self.save_entitlement(&mut tx, &aggregate, Some(snapshot.version))
+            .await?;
+        let response = VoidEntitlementResponse {
+            entitlement_id: entitlement_id.to_string(),
+            status: EntitlementStatusDto::Voided,
+            voided_at,
+        };
+        let outbound = entitlement_voided_envelope(
+            &aggregate,
+            &reason,
+            &policy,
+            command.business_case_ref.clone(),
+            correlation_id,
+        )?;
+        OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &outbound)
+            .await
+            .map_err(to_api_storage)?;
+        self.finish_idempotency(
+            &mut tx,
+            key,
+            fingerprint,
+            200,
+            serde_json::to_value(&response)
+                .map_err(|e| ApiErrorKind::Unavailable(e.to_string()))?,
+        )
+        .await?;
+        tx.commit().await.map_err(to_api_storage)?;
+        Ok(response)
+    }
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EntitlementSnapshot {
+    entitlement_id: String,
+    journey_order_id: String,
+    segment_booking_id: String,
+    traveler_ref: String,
+    segment_ref: String,
+    purpose: String,
+    validity_starts_at: u64,
+    validity_ends_at: u64,
+    status: StatusSnapshot,
+    credential_ref: Option<CredentialRefSnapshot>,
+    fulfillment_use_state: FulfillmentUseStateSnapshot,
+    audit_trail: Vec<AuditSnapshot>,
+    processed_command_ids: Vec<String>,
+}
+
+impl EntitlementSnapshot {
+    fn from_domain(entitlement: &Entitlement) -> Self {
+        let mut processed_command_ids: Vec<_> = entitlement
+            .processed_command_ids
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        processed_command_ids.sort();
+        Self {
+            entitlement_id: entitlement.id.to_string(),
+            journey_order_id: entitlement.journey_order_ref.to_string(),
+            segment_booking_id: entitlement.segment_booking_ref.to_string(),
+            traveler_ref: entitlement.traveler_ref.to_string(),
+            segment_ref: entitlement.segment_ref.to_string(),
+            purpose: purpose_to_contract(&entitlement.purpose).to_string(),
+            validity_starts_at: entitlement.validity_window.starts_at().as_u64(),
+            validity_ends_at: entitlement.validity_window.ends_at().as_u64(),
+            status: StatusSnapshot::from_domain(&entitlement.status),
+            credential_ref: entitlement
+                .credential_ref
+                .as_ref()
+                .map(CredentialRefSnapshot::from_domain),
+            fulfillment_use_state: FulfillmentUseStateSnapshot::from_domain(
+                &entitlement.fulfillment_use_state,
+            ),
+            audit_trail: entitlement
+                .audit_trail
+                .iter()
+                .map(AuditSnapshot::from_domain)
+                .collect(),
+            processed_command_ids,
+        }
+    }
+    fn try_into_domain(self) -> PgResult<Entitlement> {
+        let purpose = parse_purpose(&self.purpose)?;
+        Ok(Entitlement {
+            id: EntitlementId::new(self.entitlement_id).map_err(ApiErrorKind::from)?,
+            journey_order_ref: JourneyOrderRef::new(self.journey_order_id.clone())
+                .map_err(ApiErrorKind::from)?,
+            segment_booking_ref: SegmentBookingRef::new(self.segment_booking_id.clone())
+                .map_err(ApiErrorKind::from)?,
+            traveler_ref: TravelerRef::new(self.traveler_ref.clone())
+                .map_err(ApiErrorKind::from)?,
+            segment_ref: SegmentRef::new(self.segment_ref).map_err(ApiErrorKind::from)?,
+            purpose: purpose.clone(),
+            idempotency_key: IssueIdempotencyKey::new(
+                SegmentBookingRef::new(self.segment_booking_id).map_err(ApiErrorKind::from)?,
+                TravelerRef::new(self.traveler_ref).map_err(ApiErrorKind::from)?,
+                purpose,
+            ),
+            validity_window: ValidityWindow::new(
+                UnixMillis::new(self.validity_starts_at),
+                UnixMillis::new(self.validity_ends_at),
+            )
+            .map_err(ApiErrorKind::from)?,
+            status: self.status.try_into_domain()?,
+            credential_ref: self
+                .credential_ref
+                .map(CredentialRefSnapshot::try_into_domain)
+                .transpose()?,
+            fulfillment_use_state: self.fulfillment_use_state.try_into_domain()?,
+            audit_trail: self
+                .audit_trail
+                .into_iter()
+                .map(AuditSnapshot::try_into_domain)
+                .collect::<PgResult<Vec<_>>>()?,
+            processed_command_ids: self
+                .processed_command_ids
+                .into_iter()
+                .map(CommandId::new)
+                .collect::<Result<std::collections::HashSet<_>, _>>()
+                .map_err(ApiErrorKind::from)?,
+        })
+    }
+    fn to_details(&self) -> EntitlementDetails {
+        let (status, voided_at) = match &self.status {
+            StatusSnapshot::Voided => (
+                EntitlementStatusDto::Voided,
+                self.audit_trail
+                    .iter()
+                    .rev()
+                    .find(|a| a.action == "void")
+                    .map(|a| unix_millis_to_rfc3339(a.occurred_at)),
+            ),
+            StatusSnapshot::Suspended { .. } => (EntitlementStatusDto::Suspended, None),
+            StatusSnapshot::NoShow => (EntitlementStatusDto::NoShow, None),
+            _ if matches!(
+                self.fulfillment_use_state,
+                FulfillmentUseStateSnapshot::BoardingVerified { .. }
+                    | FulfillmentUseStateSnapshot::BoardingComplete { .. }
+            ) =>
+            {
+                (EntitlementStatusDto::Boarded, None)
+            }
+            _ => (EntitlementStatusDto::Issued, None),
+        };
+        EntitlementDetails {
+            entitlement_id: self.entitlement_id.clone(),
+            segment_booking_id: self.segment_booking_id.clone(),
+            journey_order_id: self.journey_order_id.clone(),
+            traveler_ref: self.traveler_ref.clone(),
+            segment_ref: self.segment_ref.clone(),
+            credential_no: self
+                .credential_ref
+                .as_ref()
+                .map(|c| c.credential_no.clone())
+                .unwrap_or_default(),
+            credential_type: self
+                .credential_ref
+                .as_ref()
+                .map(|c| c.credential_type.to_dto())
+                .unwrap_or(CredentialTypeDto::ETicket),
+            status,
+            issued_at: self
+                .audit_trail
+                .iter()
+                .find(|a| a.action == "issue")
+                .map(|a| unix_millis_to_rfc3339(a.occurred_at))
+                .unwrap_or_else(current_rfc3339),
+            voided_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "SCREAMING_SNAKE_CASE")]
+enum StatusSnapshot {
+    Requested,
+    Issued,
+    IssueFailed { retryable: bool },
+    Suspended { previous: Box<StatusSnapshot> },
+    Voided,
+    Expired,
+    NoShow,
+}
+impl StatusSnapshot {
+    fn from_domain(s: &EntitlementStatus) -> Self {
+        match s {
+            EntitlementStatus::Requested => Self::Requested,
+            EntitlementStatus::Issued => Self::Issued,
+            EntitlementStatus::IssueFailed { retryable } => Self::IssueFailed {
+                retryable: *retryable,
+            },
+            EntitlementStatus::Suspended { previous } => Self::Suspended {
+                previous: Box::new(Self::from_domain(previous)),
+            },
+            EntitlementStatus::Voided => Self::Voided,
+            EntitlementStatus::Expired => Self::Expired,
+            EntitlementStatus::NoShow => Self::NoShow,
+        }
+    }
+    fn try_into_domain(self) -> PgResult<EntitlementStatus> {
+        Ok(match self {
+            Self::Requested => EntitlementStatus::Requested,
+            Self::Issued => EntitlementStatus::Issued,
+            Self::IssueFailed { retryable } => EntitlementStatus::IssueFailed { retryable },
+            Self::Suspended { previous } => EntitlementStatus::Suspended {
+                previous: Box::new(previous.try_into_domain()?),
+            },
+            Self::Voided => EntitlementStatus::Voided,
+            Self::Expired => EntitlementStatus::Expired,
+            Self::NoShow => EntitlementStatus::NoShow,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CredentialRefSnapshot {
+    credential_id: String,
+    credential_type: CredentialTypeSnapshot,
+    credential_no: String,
+    provider_credential_ref: Option<ProviderCredentialRefSnapshot>,
+    display: CredentialDisplaySnapshot,
+}
+impl CredentialRefSnapshot {
+    fn from_domain(c: &CredentialRef) -> Self {
+        Self {
+            credential_id: c.credential_id.to_string(),
+            credential_type: CredentialTypeSnapshot::from_domain(&c.credential_type),
+            credential_no: c.credential_no.clone(),
+            provider_credential_ref: c
+                .provider_credential_ref
+                .as_ref()
+                .map(ProviderCredentialRefSnapshot::from_domain),
+            display: CredentialDisplaySnapshot::from_domain(&c.display),
+        }
+    }
+    fn try_into_domain(self) -> PgResult<CredentialRef> {
+        CredentialRef::new(
+            CredentialId::new(self.credential_id).map_err(ApiErrorKind::from)?,
+            self.credential_type.to_domain(),
+            self.credential_no,
+            self.provider_credential_ref
+                .map(ProviderCredentialRefSnapshot::try_into_domain)
+                .transpose()?,
+            self.display.try_into_domain()?,
+        )
+        .map_err(ApiErrorKind::from)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum CredentialTypeSnapshot {
+    ETicket,
+    PaperTicket,
+    PickupCode,
+    BoardingPass,
+    FerryTicket,
+    CoachETicket,
+    RideCode,
+}
+impl CredentialTypeSnapshot {
+    fn from_domain(v: &CredentialType) -> Self {
+        match v {
+            CredentialType::ETicket => Self::ETicket,
+            CredentialType::PaperTicket => Self::PaperTicket,
+            CredentialType::PickupCode => Self::PickupCode,
+            CredentialType::BoardingPass => Self::BoardingPass,
+            CredentialType::FerryTicket => Self::FerryTicket,
+            CredentialType::CoachETicket => Self::CoachETicket,
+            CredentialType::RideCode => Self::RideCode,
+        }
+    }
+    fn to_domain(&self) -> CredentialType {
+        match self {
+            Self::ETicket => CredentialType::ETicket,
+            Self::PaperTicket => CredentialType::PaperTicket,
+            Self::PickupCode => CredentialType::PickupCode,
+            Self::BoardingPass => CredentialType::BoardingPass,
+            Self::FerryTicket => CredentialType::FerryTicket,
+            Self::CoachETicket => CredentialType::CoachETicket,
+            Self::RideCode => CredentialType::RideCode,
+        }
+    }
+    fn to_dto(&self) -> CredentialTypeDto {
+        match self {
+            Self::ETicket => CredentialTypeDto::ETicket,
+            Self::PaperTicket => CredentialTypeDto::PaperTicket,
+            Self::PickupCode => CredentialTypeDto::PickupCode,
+            Self::BoardingPass => CredentialTypeDto::BoardingPass,
+            Self::FerryTicket => CredentialTypeDto::FerryTicket,
+            Self::CoachETicket => CredentialTypeDto::CoachETicket,
+            Self::RideCode => CredentialTypeDto::RideCode,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ProviderCredentialRefSnapshot {
+    provider_ref: String,
+    confirmation_no: String,
+    ticket_no: String,
+    mapped_status: String,
+}
+impl ProviderCredentialRefSnapshot {
+    fn from_domain(v: &ProviderCredentialRef) -> Self {
+        Self {
+            provider_ref: v.provider_ref.to_string(),
+            confirmation_no: v.confirmation_no.clone(),
+            ticket_no: v.ticket_no.clone(),
+            mapped_status: v.mapped_status.clone(),
+        }
+    }
+    fn try_into_domain(self) -> PgResult<ProviderCredentialRef> {
+        ProviderCredentialRef::new(
+            ProviderRef::new(self.provider_ref).map_err(ApiErrorKind::from)?,
+            self.confirmation_no,
+            self.ticket_no,
+            self.mapped_status,
+        )
+        .map_err(ApiErrorKind::from)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CredentialDisplaySnapshot {
+    masked_code: String,
+    display_version: u32,
+    barcode_format: Option<String>,
+}
+impl CredentialDisplaySnapshot {
+    fn from_domain(v: &CredentialDisplayReference) -> Self {
+        Self {
+            masked_code: v.masked_code.clone(),
+            display_version: v.display_version,
+            barcode_format: v.barcode_format.clone(),
+        }
+    }
+    fn try_into_domain(self) -> PgResult<CredentialDisplayReference> {
+        CredentialDisplayReference::new(self.masked_code, self.display_version, self.barcode_format)
+            .map_err(ApiErrorKind::from)
+    }
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "SCREAMING_SNAKE_CASE")]
+enum FulfillmentUseStateSnapshot {
+    NotUsed,
+    CheckInAccepted { fact_ref: String },
+    BoardingVerified { fact_ref: String },
+    BoardingComplete { fact_ref: String },
+    NoShowRecorded { fact_ref: String },
+}
+impl FulfillmentUseStateSnapshot {
+    fn from_domain(v: &FulfillmentUseState) -> Self {
+        match v {
+            FulfillmentUseState::NotUsed => Self::NotUsed,
+            FulfillmentUseState::CheckInAccepted { fact_ref } => Self::CheckInAccepted {
+                fact_ref: fact_ref.to_string(),
+            },
+            FulfillmentUseState::BoardingVerified { fact_ref } => Self::BoardingVerified {
+                fact_ref: fact_ref.to_string(),
+            },
+            FulfillmentUseState::BoardingComplete { fact_ref } => Self::BoardingComplete {
+                fact_ref: fact_ref.to_string(),
+            },
+            FulfillmentUseState::NoShowRecorded { fact_ref } => Self::NoShowRecorded {
+                fact_ref: fact_ref.to_string(),
+            },
+        }
+    }
+    fn try_into_domain(self) -> PgResult<FulfillmentUseState> {
+        Ok(match self {
+            Self::NotUsed => FulfillmentUseState::NotUsed,
+            Self::CheckInAccepted { fact_ref } => FulfillmentUseState::CheckInAccepted {
+                fact_ref: FulfillmentFactRef::new(fact_ref).map_err(ApiErrorKind::from)?,
+            },
+            Self::BoardingVerified { fact_ref } => FulfillmentUseState::BoardingVerified {
+                fact_ref: FulfillmentFactRef::new(fact_ref).map_err(ApiErrorKind::from)?,
+            },
+            Self::BoardingComplete { fact_ref } => FulfillmentUseState::BoardingComplete {
+                fact_ref: FulfillmentFactRef::new(fact_ref).map_err(ApiErrorKind::from)?,
+            },
+            Self::NoShowRecorded { fact_ref } => FulfillmentUseState::NoShowRecorded {
+                fact_ref: FulfillmentFactRef::new(fact_ref).map_err(ApiErrorKind::from)?,
+            },
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AuditSnapshot {
+    action: String,
+    reason: String,
+    actor_type: String,
+    actor_id: String,
+    occurred_at: u64,
+    correlation_id: String,
+}
+impl AuditSnapshot {
+    fn from_domain(v: &EntitlementLifecycleAudit) -> Self {
+        Self {
+            action: v.action.to_string(),
+            reason: v.reason.clone(),
+            actor_type: actor_type_to_contract(&v.actor_type).to_string(),
+            actor_id: v.actor_id.clone(),
+            occurred_at: v.occurred_at.as_u64(),
+            correlation_id: v.correlation_id.to_string(),
+        }
+    }
+    fn try_into_domain(self) -> PgResult<EntitlementLifecycleAudit> {
+        let action: &'static str = match self.action.as_str() {
+            "request" => "request",
+            "issue" => "issue",
+            "fail_issue" => "fail_issue",
+            "suspend" => "suspend",
+            "resume" => "resume",
+            "void" => "void",
+            "expire" => "expire",
+            "accept_fulfillment_fact" => "accept_fulfillment_fact",
+            "suspend_after_late_refund" => "suspend_after_late_refund",
+            _ => "restore",
+        };
+        EntitlementLifecycleAudit::new(
+            action,
+            self.reason,
+            parse_actor_type(&self.actor_type),
+            self.actor_id,
+            UnixMillis::new(self.occurred_at),
+            CorrelationId::new(self.correlation_id).map_err(ApiErrorKind::from)?,
+        )
+        .map_err(ApiErrorKind::from)
+    }
+}
+
+fn validate_issue_request(c: &IssueEntitlementRequest) -> PgResult<()> {
+    validate_prefixed_uuid(&c.segment_booking_id, "segmentBookingId", "sb-")?;
+    validate_prefixed_uuid(&c.journey_order_id, "journeyOrderId", "ord-")?;
+    validate_prefixed_uuid(&c.traveler_ref, "travelerRef", "tvl-")?;
+    validate_prefixed_uuid(&c.segment_ref, "segmentRef", "seg-")?;
+    Ok(())
+}
+fn to_api_storage(error: impl std::fmt::Display) -> ApiErrorKind {
+    let message = error.to_string();
+    if message.contains("IDEMPOTENCY_KEY_REUSED") {
+        ApiErrorKind::IdempotencyKeyReused(
+            "Idempotency-Key was reused with a different request body".into(),
+        )
+    } else if message.contains("optimistic concurrency conflict")
+        || message.contains("duplicate key value")
+    {
+        ApiErrorKind::Conflict(message)
+    } else {
+        ApiErrorKind::Unavailable(message)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum InboundEventError {
+    Transient(String),
+    Fatal(String),
+}
+fn inbound_transient(error: impl std::fmt::Display) -> InboundEventError {
+    InboundEventError::Transient(error.to_string())
+}
+fn inbound_fatal(error: impl std::fmt::Display) -> InboundEventError {
+    InboundEventError::Fatal(error.to_string())
+}
+fn inbound_from_api_error(error: ApiErrorKind) -> InboundEventError {
+    match error {
+        ApiErrorKind::Unavailable(m) => InboundEventError::Transient(m),
+        ApiErrorKind::Conflict(m) if m.contains("optimistic concurrency conflict") => {
+            InboundEventError::Transient(m)
+        }
+        error => InboundEventError::Fatal(error.message().to_string()),
+    }
+}
+async fn mark_once(
+    tx: &mut PgTransaction<'_>,
+    envelope: &application::EventEnvelope,
+) -> Result<bool, InboundEventError> {
+    mark_event_processing(
+        tx,
+        &envelope.event_id,
+        &stream_for_producer(&envelope.producer),
+    )
+    .await
+    .map_err(inbound_transient)
+}
+fn require_string(payload: &Value, field: &'static str) -> Result<String, InboundEventError> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|v| !v.trim().is_empty())
+        .map(ToString::to_string)
+        .ok_or_else(|| InboundEventError::Fatal(format!("missing {field}")))
+}
+
+fn entitlement_issued_envelope(
+    response: &IssueEntitlementResponse,
+    command: &IssueEntitlementRequest,
+    correlation_id: &str,
+) -> PgResult<application::EventEnvelope> {
+    application::EventEnvelope::try_new(
+        "EntitlementIssued",
+        response.issued_at.clone(),
+        rust_kit::messaging::valid_or_generated_correlation_id(correlation_id),
+        None::<String>,
+        PRODUCER,
+        serde_json::to_value(EntitlementIssuedPayload {
+            entitlement_id: response.entitlement_id.clone(),
+            segment_booking_id: command.segment_booking_id.clone(),
+            journey_order_id: command.journey_order_id.clone(),
+            traveler_ref: command.traveler_ref.clone(),
+            segment_ref: command.segment_ref.clone(),
+            issue_purpose: command.issue_purpose.to_contract(),
+            credential_no: response.credential_no.clone(),
+            credential_type: response.credential_type.to_contract(),
+            issued_at: response.issued_at.clone(),
+        })
+        .map_err(|e| ApiErrorKind::Unavailable(e.to_string()))?,
+    )
+    .map_err(|e| ApiErrorKind::Unavailable(e.to_string()))
+}
+fn entitlement_voided_envelope(
+    aggregate: &Entitlement,
+    reason: &VoidReason,
+    policy: &VoidPolicy,
+    business_case_ref: Option<String>,
+    correlation_id: &str,
+) -> PgResult<application::EventEnvelope> {
+    let voided_at = current_rfc3339();
+    application::EventEnvelope::try_new(
+        "EntitlementVoided",
+        voided_at.clone(),
+        rust_kit::messaging::valid_or_generated_correlation_id(correlation_id),
+        None::<String>,
+        PRODUCER,
+        serde_json::to_value(EntitlementVoidedPayload {
+            entitlement_id: aggregate.id.to_string(),
+            segment_booking_id: aggregate.segment_booking_ref.to_string(),
+            voided_at,
+            reason: reason_to_contract(reason),
+            policy: policy_to_contract(policy),
+            business_case_ref,
+        })
+        .map_err(|e| ApiErrorKind::Unavailable(e.to_string()))?,
+    )
+    .map_err(|e| ApiErrorKind::Unavailable(e.to_string()))
+}
+fn unix_millis_to_rfc3339(millis: u64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(millis as i64)
+        .unwrap_or_else(chrono::Utc::now)
+        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+fn purpose_to_contract(v: &IssuePurpose) -> &'static str {
+    match v {
+        IssuePurpose::Initial => "INITIAL",
+        IssuePurpose::Replacement => "REPLACEMENT",
+        IssuePurpose::ManualRecovery => "MANUAL_RECOVERY",
+        IssuePurpose::ProviderRebuild => "PROVIDER_REBUILD",
+        IssuePurpose::DisruptionReplacement => "DISRUPTION_REPLACEMENT",
+    }
+}
+fn parse_purpose(v: &str) -> PgResult<IssuePurpose> {
+    Ok(match v {
+        "INITIAL" => IssuePurpose::Initial,
+        "REPLACEMENT" => IssuePurpose::Replacement,
+        "MANUAL_RECOVERY" => IssuePurpose::ManualRecovery,
+        "PROVIDER_REBUILD" => IssuePurpose::ProviderRebuild,
+        "DISRUPTION_REPLACEMENT" => IssuePurpose::DisruptionReplacement,
+        _ => {
+            return Err(ApiErrorKind::Unavailable(format!(
+                "unknown issue purpose {v}"
+            )));
+        }
+    })
+}
+fn actor_type_to_contract(v: &ActorType) -> &'static str {
+    match v {
+        ActorType::System => "SYSTEM",
+        ActorType::Operator => "OPERATOR",
+        ActorType::Saga => "SAGA",
+        ActorType::ProviderAdapter => "PROVIDER_ADAPTER",
+    }
+}
+fn parse_actor_type(v: &str) -> ActorType {
+    match v {
+        "OPERATOR" => ActorType::Operator,
+        "SAGA" => ActorType::Saga,
+        "PROVIDER_ADAPTER" => ActorType::ProviderAdapter,
+        _ => ActorType::System,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn issue_request() -> IssueEntitlementRequest {
+        IssueEntitlementRequest {
+            segment_booking_id: "sb-0194f2e0-7b3e-7610-8284-5c26e8b0aa11".to_string(),
+            journey_order_id: "ord-0194f2e0-7b3e-7610-8284-5c26e8b0aa12".to_string(),
+            traveler_ref: "tvl-0194f2e0-7b3e-7610-8284-5c26e8b0aa13".to_string(),
+            segment_ref: "seg-0194f2e0-7b3e-7610-8284-5c26e8b0aa14".to_string(),
+            issue_purpose: IssuePurposeDto::Initial,
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires TEST_DATABASE_URL pointing at a disposable Postgres database"]
+    async fn optimistic_concurrency_conflict_uses_real_two_write_race() {
+        let database_url =
+            std::env::var("TEST_DATABASE_URL").expect("TEST_DATABASE_URL is required");
+        let storage = Storage::connect(&database_url).await.unwrap();
+        storage
+            .migrate_dir("services/entitlement-ticketing/migrations")
+            .await
+            .unwrap();
+        let service = PostgresEntitlementService::from_storage(storage).unwrap();
+        let issued = service
+            .issue(
+                issue_request(),
+                "0194f2e0-7b3e-7610-8284-5c26e8b0aa01".to_string(),
+                "corr-0194f2e0-7b3e-7610-8284-5c26e8b0aa02".to_string(),
+            )
+            .await
+            .unwrap();
+
+        let mut read_tx = service.pool().begin().await.unwrap();
+        let snapshot = service
+            .load_entitlement(&mut read_tx, &issued.entitlement_id)
+            .await
+            .unwrap()
+            .unwrap();
+        read_tx.commit().await.unwrap();
+
+        let aggregate = snapshot.data.clone().try_into_domain().unwrap();
+        let mut first_tx = service.pool().begin().await.unwrap();
+        service
+            .save_entitlement(&mut first_tx, &aggregate, Some(snapshot.version))
+            .await
+            .unwrap();
+        first_tx.commit().await.unwrap();
+
+        let mut second_tx = service.pool().begin().await.unwrap();
+        let conflict = service
+            .save_entitlement(&mut second_tx, &aggregate, Some(snapshot.version))
+            .await
+            .unwrap_err();
+        second_tx.rollback().await.unwrap();
+        assert!(matches!(conflict, ApiErrorKind::Conflict(_)));
+    }
+}

--- a/services/entitlement-ticketing/src/adapters/storage/mod.rs
+++ b/services/entitlement-ticketing/src/adapters/storage/mod.rs
@@ -355,7 +355,8 @@ impl PostgresEntitlementService {
         {
             return Err(InboundEventError::Fatal("missing approvedActions".into()));
         }
-        let actions = approved_void_actions(envelope.payload.get("approvedActions"));
+        let actions = approved_void_actions(envelope.payload.get("approvedActions"))
+            .map_err(InboundEventError::Fatal)?;
         if actions.is_empty() {
             let mut tx = self.pool().begin().await.map_err(inbound_transient)?;
             mark_once(&mut tx, &envelope).await?;
@@ -397,21 +398,14 @@ impl PostgresEntitlementService {
             .await
             .map_err(inbound_from_api_error)?;
         for snapshot in snapshots {
-            if !actions
+            let Some(action) = actions
                 .iter()
-                .any(|action| action.matches_entitlement(&snapshot.id))
-            {
+                .find(|action| action.matches_entitlement(&snapshot.id))
+            else {
                 continue;
-            }
-            let action = actions
-                .iter()
-                .find(|action| action.matches_entitlement(&snapshot.id));
-            let reason = action
-                .map(|a| a.reason.clone())
-                .unwrap_or(VoidReason::Refund);
-            let policy = action
-                .map(|a| a.policy.clone())
-                .unwrap_or(VoidPolicy::Normal);
+            };
+            let reason = action.reason.clone();
+            let policy = action.policy.clone();
             let mut entitlement = snapshot
                 .data
                 .try_into_domain()
@@ -1273,6 +1267,11 @@ fn entitlement_voided_envelope(
         serde_json::to_value(EntitlementVoidedPayload {
             entitlement_id: aggregate.id.to_string(),
             segment_booking_id: aggregate.segment_booking_ref.to_string(),
+            references: EntitlementVoidedReferences {
+                segment_booking_ref: aggregate.segment_booking_ref.to_string(),
+                order_ref: Some(aggregate.journey_order_ref.to_string()),
+                traveler_ref: Some(aggregate.traveler_ref.to_string()),
+            },
             voided_at,
             reason: reason_to_contract(reason),
             policy: policy_to_contract(policy),
@@ -1339,6 +1338,21 @@ mod tests {
             segment_ref: "seg-0194f2e0-7b3e-7610-8284-5c26e8b0aa14".to_string(),
             issue_purpose: IssuePurposeDto::Initial,
         }
+    }
+
+    #[test]
+    fn post_sales_void_action_contract_violations_are_fatal_before_db_writes() {
+        let missing_entitlement = approved_void_actions(Some(&serde_json::json!({
+            "steps": [{"type": "VOID_ENTITLEMENT", "reason": "REFUND", "policy": "NORMAL"}]
+        })))
+        .unwrap_err();
+        assert!(missing_entitlement.contains("entitlementId"));
+
+        let invalid_reason = approved_void_actions(Some(&serde_json::json!({
+            "steps": [{"type": "VOID_ENTITLEMENT", "entitlementId": "ent-0194f2e0-7b3e-7610-8284-5c26e8b0aa15", "reason": "OTHER", "policy": "NORMAL"}]
+        })))
+        .unwrap_err();
+        assert!(invalid_reason.contains("invalid reason"));
     }
 
     #[tokio::test]

--- a/services/entitlement-ticketing/src/lib.rs
+++ b/services/entitlement-ticketing/src/lib.rs
@@ -60,22 +60,26 @@ pub fn runtime_config() -> RuntimeConfig {
         .with_observer(OpenTelemetryObserver::from_env(profile().service_id))
 }
 
-pub fn router() -> Router {
-    let publisher = Arc::new(
-        adapters::messaging::RedisEventPublisher::from_env()
-            .expect("REDIS_URL must be a valid Redis connection URL"),
+pub async fn router() -> Router {
+    let service = Arc::new(
+        adapters::storage::PostgresEntitlementService::from_env()
+            .await
+            .expect("failed to initialize Postgres entitlement storage"),
     );
-    router_with_state(Arc::new(InMemoryEntitlementService::new(publisher)))
+    router_with_postgres_state(service)
 }
 
-pub fn build_runtime() -> Result<(Router, JoinHandle<()>), application::SubscribeFailed> {
+pub async fn build_runtime() -> Result<(Router, JoinHandle<()>), application::SubscribeFailed> {
     use crate::application::EventSubscriber;
 
-    let publisher = Arc::new(
-        adapters::messaging::RedisEventPublisher::from_env()
+    let redis_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+    let service = Arc::new(
+        adapters::storage::PostgresEntitlementService::from_env()
+            .await
             .map_err(|error| application::SubscribeFailed(error.to_string()))?,
     );
-    let service = Arc::new(InMemoryEntitlementService::new(publisher));
+    rust_kit::storage::spawn_outbox_relay(service.pool().clone(), redis_url);
     let subscriber = adapters::messaging::RedisEventSubscriber::from_env()?;
     let streams = adapters::messaging::RedisEventSubscriber::entitlement_streams();
     let group = adapters::messaging::RedisEventSubscriber::entitlement_group().to_string();
@@ -98,7 +102,7 @@ pub fn build_runtime() -> Result<(Router, JoinHandle<()>), application::Subscrib
             .await
             .expect("entitlement-ticketing Redis subscriber stopped");
     });
-    Ok((router_with_state(service), subscriber_handle))
+    Ok((router_with_postgres_state(service), subscriber_handle))
 }
 
 pub fn router_with_state<S>(service: Arc<S>) -> Router
@@ -121,6 +125,74 @@ where
         )
         .with_state(app_state);
     apply_service_runtime(router_with_config(runtime_config()).merge(routes))
+}
+
+pub fn router_with_postgres_state(
+    service: Arc<adapters::storage::PostgresEntitlementService>,
+) -> Router {
+    let app_state = ApiState {
+        service: service.clone(),
+    };
+    let routes = Router::new()
+        .route(
+            "/api/v1/entitlements",
+            post(issue_entitlement::<adapters::storage::PostgresEntitlementService>)
+                .get(list_entitlements::<adapters::storage::PostgresEntitlementService>),
+        )
+        .route(
+            "/api/v1/entitlements/{entitlement_id}",
+            get(get_entitlement::<adapters::storage::PostgresEntitlementService>),
+        )
+        .route(
+            "/api/v1/entitlements/{entitlement_id}/void",
+            post(void_entitlement::<adapters::storage::PostgresEntitlementService>),
+        )
+        .with_state(app_state);
+    let metadata = serde_json::to_value(metadata()).unwrap_or_else(|_| serde_json::json!({}));
+    let standard_router = Router::new()
+        .route("/health", get(health_handler))
+        .route("/healthz", get(health_handler))
+        .route("/live", get(live_handler))
+        .route("/livez", get(live_handler))
+        .route("/ready", get(postgres_ready_handler))
+        .route("/readyz", get(postgres_ready_handler))
+        .route(
+            "/metadata",
+            get(move || {
+                let metadata = metadata.clone();
+                async move { Json(metadata) }
+            }),
+        )
+        .layer(Extension(service));
+    apply_service_runtime(Router::new().merge(standard_router).merge(routes))
+}
+
+#[derive(Debug, Serialize)]
+struct ProbeResponse {
+    status: &'static str,
+}
+
+async fn health_handler() -> Json<ProbeResponse> {
+    Json(ProbeResponse { status: health() })
+}
+
+async fn live_handler() -> Json<ProbeResponse> {
+    Json(ProbeResponse { status: "alive" })
+}
+
+async fn postgres_ready_handler(
+    Extension(service): Extension<Arc<adapters::storage::PostgresEntitlementService>>,
+) -> (StatusCode, Json<ProbeResponse>) {
+    if service.is_ready().await {
+        (StatusCode::OK, Json(ProbeResponse { status: "ready" }))
+    } else {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ProbeResponse {
+                status: "not_ready",
+            }),
+        )
+    }
 }
 
 pub fn apply_service_runtime(router: Router) -> Router {
@@ -598,19 +670,19 @@ impl FulfillmentUseState {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Entitlement {
-    id: EntitlementId,
-    journey_order_ref: JourneyOrderRef,
-    segment_booking_ref: SegmentBookingRef,
-    traveler_ref: TravelerRef,
-    segment_ref: SegmentRef,
-    purpose: IssuePurpose,
-    idempotency_key: IssueIdempotencyKey,
-    validity_window: ValidityWindow,
-    status: EntitlementStatus,
-    credential_ref: Option<CredentialRef>,
-    fulfillment_use_state: FulfillmentUseState,
-    audit_trail: Vec<EntitlementLifecycleAudit>,
-    processed_command_ids: HashSet<CommandId>,
+    pub(crate) id: EntitlementId,
+    pub(crate) journey_order_ref: JourneyOrderRef,
+    pub(crate) segment_booking_ref: SegmentBookingRef,
+    pub(crate) traveler_ref: TravelerRef,
+    pub(crate) segment_ref: SegmentRef,
+    pub(crate) purpose: IssuePurpose,
+    pub(crate) idempotency_key: IssueIdempotencyKey,
+    pub(crate) validity_window: ValidityWindow,
+    pub(crate) status: EntitlementStatus,
+    pub(crate) credential_ref: Option<CredentialRef>,
+    pub(crate) fulfillment_use_state: FulfillmentUseState,
+    pub(crate) audit_trail: Vec<EntitlementLifecycleAudit>,
+    pub(crate) processed_command_ids: HashSet<CommandId>,
 }
 
 impl Entitlement {
@@ -2006,7 +2078,7 @@ pub enum EntitlementStatusDto {
 }
 
 impl IssuePurposeDto {
-    fn to_contract(&self) -> &'static str {
+    pub(crate) fn to_contract(&self) -> &'static str {
         match self {
             Self::Initial => "INITIAL",
             Self::Replacement => "REPLACEMENT",
@@ -2018,7 +2090,7 @@ impl IssuePurposeDto {
 }
 
 impl VoidReasonDto {
-    fn to_contract(&self) -> &'static str {
+    pub(crate) fn to_contract(&self) -> &'static str {
         match self {
             Self::Refund => "REFUND",
             Self::Change => "CHANGE",
@@ -2030,7 +2102,7 @@ impl VoidReasonDto {
 }
 
 impl VoidPolicyDto {
-    fn to_contract(&self) -> &'static str {
+    pub(crate) fn to_contract(&self) -> &'static str {
         match self {
             Self::Normal => "NORMAL",
             Self::ExceptionalRule => "EXCEPTIONAL_RULE",
@@ -2039,7 +2111,7 @@ impl VoidPolicyDto {
 }
 
 impl CredentialTypeDto {
-    fn to_contract(&self) -> &'static str {
+    pub(crate) fn to_contract(&self) -> &'static str {
         match self {
             Self::ETicket => "E_TICKET",
             Self::PaperTicket => "PAPER_TICKET",
@@ -2213,6 +2285,7 @@ impl Default for InMemoryEntitlementService {
     }
 }
 
+#[allow(dead_code)]
 impl InMemoryEntitlementService {
     pub fn new(publisher: Arc<dyn application::EventPublisher>) -> Self {
         Self {
@@ -2600,6 +2673,7 @@ struct InMemoryState {
     credential_registry: CredentialRegistry,
     idempotency: HashMap<String, IdempotentRecord>,
     pending_publications: HashMap<String, PendingPublication>,
+    #[allow(dead_code)]
     pending_events: HashMap<PendingEventKey, PendingBusPublication>,
     sequence: u64,
 }
@@ -2624,6 +2698,7 @@ struct PendingEventKey {
     event_type: &'static str,
 }
 
+#[allow(dead_code)]
 impl PendingEventKey {
     fn new(aggregate_id: &str, event_type: &'static str) -> Self {
         Self {
@@ -2634,6 +2709,7 @@ impl PendingEventKey {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 struct PendingBusPublication {
     event_type: &'static str,
     payload: Value,
@@ -3043,7 +3119,7 @@ fn parse_void_reason(value: &str) -> VoidReason {
     }
 }
 
-fn reason_to_contract(value: &VoidReason) -> &'static str {
+pub(crate) fn reason_to_contract(value: &VoidReason) -> &'static str {
     match value {
         VoidReason::Refund => "REFUND",
         VoidReason::Change => "CHANGE",
@@ -3060,7 +3136,7 @@ fn parse_void_policy(value: &str) -> VoidPolicy {
     }
 }
 
-fn policy_to_contract(value: &VoidPolicy) -> &'static str {
+pub(crate) fn policy_to_contract(value: &VoidPolicy) -> &'static str {
     match value {
         VoidPolicy::Normal => "NORMAL",
         VoidPolicy::ExceptionalRule => "EXCEPTIONAL_RULE",
@@ -3090,15 +3166,15 @@ fn validate_prefixed_uuid(value: &str, field: &'static str, prefix: &'static str
     Ok(())
 }
 
-fn current_rfc3339() -> String {
+pub(crate) fn current_rfc3339() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }
 
-fn current_unix_millis() -> u64 {
+pub(crate) fn current_unix_millis() -> u64 {
     chrono::Utc::now().timestamp_millis().max(0) as u64
 }
 
-fn audit_builder(
+pub(crate) fn audit_builder(
     correlation_id: &str,
     reason: &'static str,
 ) -> Result<AuditBuilder, EntitlementError> {
@@ -3109,7 +3185,7 @@ fn audit_builder(
     ))
 }
 
-fn default_preconditions() -> Result<IssuePreconditions, EntitlementError> {
+pub(crate) fn default_preconditions() -> Result<IssuePreconditions, EntitlementError> {
     let now = UnixMillis::new(current_unix_millis());
     Ok(IssuePreconditions::accepted(
         AcceptedFact::new(
@@ -3140,7 +3216,7 @@ fn default_preconditions() -> Result<IssuePreconditions, EntitlementError> {
     ))
 }
 
-fn credential_ref(credential_no: &str) -> Result<CredentialRef, EntitlementError> {
+pub(crate) fn credential_ref(credential_no: &str) -> Result<CredentialRef, EntitlementError> {
     CredentialRef::new(
         CredentialId::new(format!("cred-{}", uuid::Uuid::now_v7()))?,
         CredentialType::ETicket,

--- a/services/entitlement-ticketing/src/lib.rs
+++ b/services/entitlement-ticketing/src/lib.rs
@@ -2004,11 +2004,22 @@ struct EntitlementIssuedPayload {
 struct EntitlementVoidedPayload {
     entitlement_id: String,
     segment_booking_id: String,
+    references: EntitlementVoidedReferences,
     voided_at: String,
     reason: &'static str,
     policy: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     business_case_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct EntitlementVoidedReferences {
+    segment_booking_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    order_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    traveler_ref: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -2551,7 +2562,8 @@ impl InMemoryEntitlementService {
             .to_string();
         validate_prefixed_uuid(&order_id, "orderId", "ord-")?;
 
-        let actions = approved_void_actions(payload.get("approvedActions"));
+        let actions = approved_void_actions(payload.get("approvedActions"))
+            .map_err(ApiErrorKind::ValidationFailed)?;
         if actions.is_empty() {
             return Ok(());
         }
@@ -2596,26 +2608,20 @@ impl InMemoryEntitlementService {
 
         let mut pending_keys = Vec::new();
         for entitlement_id in entitlement_ids {
-            if !actions
+            let Some(action) = actions
                 .iter()
-                .any(|action| action.matches_entitlement(&entitlement_id))
-            {
+                .find(|action| action.matches_entitlement(&entitlement_id))
+            else {
                 continue;
-            }
-            let action = actions
-                .iter()
-                .find(|action| action.matches_entitlement(&entitlement_id));
-            let reason = action
-                .map(|action| action.reason.clone())
-                .unwrap_or(VoidReason::Refund);
-            let policy = action
-                .map(|action| action.policy.clone())
-                .unwrap_or(VoidPolicy::Normal);
-            let segment_booking_id = state
+            };
+            let reason = action.reason.clone();
+            let policy = action.policy.clone();
+            let entitlement_details = state
                 .entitlements
                 .get(&entitlement_id)
-                .map(|entitlement| entitlement.segment_booking_id.clone())
+                .cloned()
                 .ok_or_else(|| ApiErrorKind::NotFound("entitlement not found".to_string()))?;
+            let segment_booking_id = entitlement_details.segment_booking_id.clone();
             let pending_key = PendingEventKey::new(&entitlement_id, "EntitlementVoided");
             if state.pending_events.contains_key(&pending_key) {
                 pending_keys.push(pending_key);
@@ -2647,7 +2653,12 @@ impl InMemoryEntitlementService {
             }
             let payload = EntitlementVoidedPayload {
                 entitlement_id: entitlement_id.clone(),
-                segment_booking_id,
+                segment_booking_id: segment_booking_id.clone(),
+                references: EntitlementVoidedReferences {
+                    segment_booking_ref: segment_booking_id,
+                    order_ref: Some(entitlement_details.journey_order_id),
+                    traveler_ref: Some(entitlement_details.traveler_ref),
+                },
                 voided_at,
                 reason: reason_to_contract(&reason),
                 policy: policy_to_contract(&policy),
@@ -2918,12 +2929,12 @@ impl EntitlementApi for InMemoryEntitlementService {
                 .state
                 .lock()
                 .expect("entitlement service lock poisoned");
-            let segment_booking_id = state
+            let entitlement_details = state
                 .entitlements
                 .get(&entitlement_id)
-                .ok_or_else(|| ApiErrorKind::NotFound("entitlement not found".to_string()))?
-                .segment_booking_id
-                .clone();
+                .cloned()
+                .ok_or_else(|| ApiErrorKind::NotFound("entitlement not found".to_string()))?;
+            let segment_booking_id = entitlement_details.segment_booking_id.clone();
             let aggregate = state.aggregates.get_mut(&entitlement_id).ok_or_else(|| {
                 ApiErrorKind::NotFound("entitlement aggregate not found".to_string())
             })?;
@@ -2956,7 +2967,12 @@ impl EntitlementApi for InMemoryEntitlementService {
             }
             let event_payload = EntitlementVoidedPayload {
                 entitlement_id: entitlement_id.clone(),
-                segment_booking_id,
+                segment_booking_id: segment_booking_id.clone(),
+                references: EntitlementVoidedReferences {
+                    segment_booking_ref: segment_booking_id,
+                    order_ref: Some(entitlement_details.journey_order_id),
+                    traveler_ref: Some(entitlement_details.traveler_ref),
+                },
                 voided_at: voided_at.clone(),
                 reason: command.reason.to_contract(),
                 policy: command.policy.to_contract(),
@@ -3035,33 +3051,34 @@ impl EntitlementApi for InMemoryEntitlementService {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ApprovedVoidAction {
-    entitlement_ref: Option<String>,
+    entitlement_ref: String,
     reason: VoidReason,
     policy: VoidPolicy,
 }
 
 impl ApprovedVoidAction {
     fn matches_entitlement(&self, entitlement_id: &str) -> bool {
-        self.entitlement_ref
-            .as_deref()
-            .is_none_or(|reference| reference == entitlement_id)
+        self.entitlement_ref == entitlement_id
     }
 }
 
-fn approved_void_actions(value: Option<&Value>) -> Vec<ApprovedVoidAction> {
+fn approved_void_actions(value: Option<&Value>) -> Result<Vec<ApprovedVoidAction>, String> {
     let Some(value) = value else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     let mut actions = Vec::new();
-    collect_void_actions(value, &mut actions);
-    actions
+    collect_void_actions(value, &mut actions)?;
+    Ok(actions)
 }
 
-fn collect_void_actions(value: &Value, actions: &mut Vec<ApprovedVoidAction>) {
+fn collect_void_actions(
+    value: &Value,
+    actions: &mut Vec<ApprovedVoidAction>,
+) -> Result<(), String> {
     match value {
         Value::Array(items) => {
             for item in items {
-                collect_void_actions(item, actions);
+                collect_void_actions(item, actions)?;
             }
         }
         Value::Object(map) => {
@@ -3069,33 +3086,37 @@ fn collect_void_actions(value: &Value, actions: &mut Vec<ApprovedVoidAction>) {
                 || action_type(map.get("actionType")).is_some_and(is_void_action_type)
                 || action_type(map.get("stepType")).is_some_and(is_void_action_type)
             {
+                let entitlement_ref = map
+                    .get("entitlementId")
+                    .and_then(Value::as_str)
+                    .filter(|v| !v.trim().is_empty())
+                    .ok_or_else(|| "VOID_ENTITLEMENT missing entitlementId".to_string())?
+                    .to_string();
+                let reason = map
+                    .get("reason")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| "VOID_ENTITLEMENT missing reason".to_string())
+                    .and_then(parse_void_reason)?;
+                let policy = map
+                    .get("policy")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| "VOID_ENTITLEMENT missing policy".to_string())
+                    .and_then(parse_void_policy)?;
                 actions.push(ApprovedVoidAction {
-                    entitlement_ref: map
-                        .get("entitlementId")
-                        .and_then(Value::as_str)
-                        .or_else(|| map.get("entitlementRef").and_then(Value::as_str))
-                        .or_else(|| map.get("targetRef").and_then(Value::as_str))
-                        .map(ToString::to_string),
-                    reason: map
-                        .get("reason")
-                        .and_then(Value::as_str)
-                        .map(parse_void_reason)
-                        .unwrap_or(VoidReason::Refund),
-                    policy: map
-                        .get("policy")
-                        .and_then(Value::as_str)
-                        .map(parse_void_policy)
-                        .unwrap_or(VoidPolicy::Normal),
+                    entitlement_ref,
+                    reason,
+                    policy,
                 });
             }
             for nested in map.values() {
                 if nested.is_array() || nested.is_object() {
-                    collect_void_actions(nested, actions);
+                    collect_void_actions(nested, actions)?;
                 }
             }
         }
         _ => {}
     }
+    Ok(())
 }
 
 fn action_type(value: Option<&Value>) -> Option<&str> {
@@ -3109,13 +3130,14 @@ fn is_void_action_type(value: &str) -> bool {
     )
 }
 
-fn parse_void_reason(value: &str) -> VoidReason {
+fn parse_void_reason(value: &str) -> Result<VoidReason, String> {
     match value {
-        "CHANGE" => VoidReason::Change,
-        "DISRUPTION" => VoidReason::Disruption,
-        "RISK" => VoidReason::Risk,
-        "MANUAL_CORRECTION" => VoidReason::ManualCorrection,
-        _ => VoidReason::Refund,
+        "REFUND" => Ok(VoidReason::Refund),
+        "CHANGE" => Ok(VoidReason::Change),
+        "DISRUPTION" => Ok(VoidReason::Disruption),
+        "RISK" => Ok(VoidReason::Risk),
+        "MANUAL_CORRECTION" => Ok(VoidReason::ManualCorrection),
+        other => Err(format!("VOID_ENTITLEMENT invalid reason {other}")),
     }
 }
 
@@ -3129,10 +3151,11 @@ pub(crate) fn reason_to_contract(value: &VoidReason) -> &'static str {
     }
 }
 
-fn parse_void_policy(value: &str) -> VoidPolicy {
+fn parse_void_policy(value: &str) -> Result<VoidPolicy, String> {
     match value {
-        "EXCEPTIONAL_RULE" => VoidPolicy::ExceptionalRule,
-        _ => VoidPolicy::Normal,
+        "NORMAL" => Ok(VoidPolicy::Normal),
+        "EXCEPTIONAL_RULE" => Ok(VoidPolicy::ExceptionalRule),
+        other => Err(format!("VOID_ENTITLEMENT invalid policy {other}")),
     }
 }
 
@@ -3552,7 +3575,7 @@ mod api_domain_wiring_tests {
                     "caseId": "psc-0194f2e0-7b3e-7610-0284-5c26e8b0f777",
                     "orderId": "ord-0194f2e0-7b3e-7610-0284-5c26e8b0f222",
                     "approvedActions": [
-                        {"type": "VOID_ENTITLEMENT", "reason": "REFUND", "policy": "NORMAL"}
+                        {"type": "VOID_ENTITLEMENT", "entitlementId": issue_response.entitlement_id, "reason": "REFUND", "policy": "NORMAL"}
                     ]
                 }),
             ))
@@ -3584,6 +3607,27 @@ mod api_domain_wiring_tests {
             "psc-0194f2e0-7b3e-7610-0284-5c26e8b0f777"
         );
         assert!(voided.payload.get("status").is_none());
+    }
+
+    #[test]
+    fn post_sales_void_action_requires_contract_fields_and_enums() {
+        let missing_entitlement = approved_void_actions(Some(&json!({
+            "steps": [{"type": "VOID_ENTITLEMENT", "reason": "REFUND", "policy": "NORMAL"}]
+        })))
+        .unwrap_err();
+        assert!(missing_entitlement.contains("entitlementId"));
+
+        let missing_reason = approved_void_actions(Some(&json!({
+            "steps": [{"type": "VOID_ENTITLEMENT", "entitlementId": "ent-0194f2e0-7b3e-7610-0284-5c26e8b0f111", "policy": "NORMAL"}]
+        })))
+        .unwrap_err();
+        assert!(missing_reason.contains("reason"));
+
+        let invalid_policy = approved_void_actions(Some(&json!({
+            "steps": [{"type": "VOID_ENTITLEMENT", "entitlementId": "ent-0194f2e0-7b3e-7610-0284-5c26e8b0f111", "reason": "REFUND", "policy": "FORCE"}]
+        })))
+        .unwrap_err();
+        assert!(invalid_policy.contains("invalid policy"));
     }
 
     #[tokio::test]

--- a/services/entitlement-ticketing/src/main.rs
+++ b/services/entitlement-ticketing/src/main.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (app, subscriber_handle) = entitlement_ticketing::build_runtime()?;
+    let (app, subscriber_handle) = entitlement_ticketing::build_runtime().await?;
     let port = std::env::var("PORT")
         .ok()
         .and_then(|value| value.parse::<u16>().ok())

--- a/services/entitlement-ticketing/tests/skeleton.rs
+++ b/services/entitlement-ticketing/tests/skeleton.rs
@@ -266,6 +266,18 @@ async fn published_entitlement_events_use_contract_payload_shapes() {
         voided_payload["segmentBookingId"],
         "sb-0194f2e0-7b3e-7610-0284-5c26e8b0c111"
     );
+    assert_eq!(
+        voided_payload["references"]["segmentBookingRef"],
+        "sb-0194f2e0-7b3e-7610-0284-5c26e8b0c111"
+    );
+    assert_eq!(
+        voided_payload["references"]["orderRef"],
+        "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c222"
+    );
+    assert_eq!(
+        voided_payload["references"]["travelerRef"],
+        "tvl-0194f2e0-7b3e-7610-0284-5c26e8b0c333"
+    );
     assert!(voided_payload["voidedAt"].as_str().unwrap().ends_with('Z'));
     assert_eq!(voided_payload["reason"], "REFUND");
     assert_eq!(voided_payload["policy"], "NORMAL");


### PR DESCRIPTION
## Summary
- migrate entitlement-ticketing runtime to Postgres snapshots with optimistic concurrency, idempotency records, processed_events, and outbox relay
- add entitlement-ticketing migrations and Docker image migration copy/MIGRATIONS_DIR wiring
- add storage-backed readiness probe and inbound event handling for fulfillment/post-sales contracts

## Validation
- cargo test --manifest-path services/entitlement-ticketing/Cargo.toml
- cargo test --manifest-path services/capacity-availability/Cargo.toml
- make check