### PR TITLE
REQ-083 migrate account customer offer to Postgres outbox

### DIFF
--- a/deploy/docker/account/Dockerfile
+++ b/deploy/docker/account/Dockerfile
@@ -7,6 +7,7 @@ RUN --mount=type=cache,target=/root/.npm cd platform/ts-kit && npm ci && npm run
 COPY services/account/package.json services/account/package-lock.json services/account/tsconfig.json ./services/account/
 RUN --mount=type=cache,target=/root/.npm cd services/account && npm ci --install-links
 COPY services/account/src ./services/account/src
+COPY services/account/migrations ./services/account/migrations
 RUN cd services/account && npx tsc --noEmit false --outDir dist
 
 FROM node:26-alpine
@@ -15,6 +16,7 @@ RUN addgroup -S app && adduser -S app -G app
 COPY --from=builder --chown=app:app /src/services/account/package.json ./package.json
 COPY --from=builder --chown=app:app /src/services/account/node_modules ./node_modules
 COPY --from=builder --chown=app:app /src/services/account/dist ./dist
+COPY --from=builder --chown=app:app /src/services/account/migrations ./migrations
 USER app
 ENV PORT=8080 REDIS_URL=redis://localhost:6379
 EXPOSE 8080

--- a/deploy/docker/customer-service/Dockerfile
+++ b/deploy/docker/customer-service/Dockerfile
@@ -7,6 +7,7 @@ RUN --mount=type=cache,target=/root/.npm cd platform/ts-kit && npm ci && npm run
 COPY services/customer-service/package.json services/customer-service/package-lock.json services/customer-service/tsconfig.json ./services/customer-service/
 RUN --mount=type=cache,target=/root/.npm cd services/customer-service && npm ci --install-links
 COPY services/customer-service/src ./services/customer-service/src
+COPY services/customer-service/migrations ./services/customer-service/migrations
 RUN cd services/customer-service && npx tsc --noEmit false --outDir dist
 
 FROM node:26-alpine
@@ -15,6 +16,7 @@ RUN addgroup -S app && adduser -S app -G app
 COPY --from=builder --chown=app:app /src/services/customer-service/package.json ./package.json
 COPY --from=builder --chown=app:app /src/services/customer-service/node_modules ./node_modules
 COPY --from=builder --chown=app:app /src/services/customer-service/dist ./dist
+COPY --from=builder --chown=app:app /src/services/customer-service/migrations ./migrations
 USER app
 ENV PORT=8080 REDIS_URL=redis://localhost:6379
 EXPOSE 8080

--- a/deploy/docker/offer-management/Dockerfile
+++ b/deploy/docker/offer-management/Dockerfile
@@ -7,6 +7,7 @@ RUN --mount=type=cache,target=/root/.npm cd platform/ts-kit && npm ci && npm run
 COPY services/offer-management/package.json services/offer-management/package-lock.json services/offer-management/tsconfig.json ./services/offer-management/
 RUN --mount=type=cache,target=/root/.npm cd services/offer-management && npm ci --install-links
 COPY services/offer-management/src ./services/offer-management/src
+COPY services/offer-management/migrations ./services/offer-management/migrations
 RUN cd services/offer-management && npx tsc --noEmit false --outDir dist
 
 FROM node:26-alpine
@@ -15,6 +16,7 @@ RUN addgroup -S app && adduser -S app -G app
 COPY --from=builder --chown=app:app /src/services/offer-management/package.json ./package.json
 COPY --from=builder --chown=app:app /src/services/offer-management/node_modules ./node_modules
 COPY --from=builder --chown=app:app /src/services/offer-management/dist ./dist
+COPY --from=builder --chown=app:app /src/services/offer-management/migrations ./migrations
 USER app
 ENV PORT=8080 REDIS_URL=redis://localhost:6379
 EXPOSE 8080

--- a/services/account/migrations/001_account_storage.sql
+++ b/services/account/migrations/001_account_storage.sql
@@ -1,0 +1,44 @@
+CREATE TABLE IF NOT EXISTS account_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS account_snapshots_status_idx
+  ON account_snapshots ((data->>'status'), updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS account_preferences (
+  account_id     text NOT NULL,
+  preference_key text NOT NULL,
+  data           jsonb NOT NULL,
+  updated_at     timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (account_id, preference_key)
+);
+
+CREATE TABLE IF NOT EXISTS outbox (
+  seq          bigserial PRIMARY KEY,
+  event_id     text NOT NULL UNIQUE,
+  stream       text NOT NULL,
+  envelope     jsonb NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  published_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS outbox_unpublished_seq_idx
+  ON outbox (seq)
+  WHERE published_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS processed_events (
+  event_id     text PRIMARY KEY,
+  stream       text,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS idempotency_records (
+  key           text PRIMARY KEY,
+  request_hash  text NOT NULL,
+  status_code   int NOT NULL,
+  response_body jsonb,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);

--- a/services/account/package-lock.json
+++ b/services/account/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@trainticket/ts-kit": "file:../../platform/ts-kit",
+        "@types/pg": "^8.20.0",
         "fastify": "5.9.0",
-        "ioredis": "^5.4.2"
+        "ioredis": "^5.4.2",
+        "pg": "^8.22.0"
       },
       "devDependencies": {
         "@types/node": "26.0.1",
@@ -156,6 +158,17 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmmirror.com/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/abstract-logging": {
@@ -508,6 +521,95 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmmirror.com/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmmirror.com/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmmirror.com/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmmirror.com/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmmirror.com/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/pino": {
       "version": "10.3.1",
       "resolved": "https://registry.npmmirror.com/pino/-/pino-10.3.1.tgz",
@@ -544,6 +646,45 @@
       "resolved": "https://registry.npmmirror.com/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmmirror.com/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/process-warning": {
       "version": "5.0.0",
@@ -765,6 +906,15 @@
       "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     }
   }
 }

--- a/services/account/package.json
+++ b/services/account/package.json
@@ -9,8 +9,10 @@
   },
   "dependencies": {
     "@trainticket/ts-kit": "file:../../platform/ts-kit",
+    "@types/pg": "^8.20.0",
     "fastify": "5.9.0",
-    "ioredis": "^5.4.2"
+    "ioredis": "^5.4.2",
+    "pg": "^8.22.0"
   },
   "devDependencies": {
     "@types/node": "26.0.1",

--- a/services/account/src/adapters/storage/account-repository.ts
+++ b/services/account/src/adapters/storage/account-repository.ts
@@ -1,0 +1,88 @@
+import { type PoolClient, type QueryResult } from "pg";
+
+import { SnapshotRepository, type SnapshotRecord } from "@trainticket/ts-kit";
+
+import { Preference, UserAccount, type PreferenceSnapshot, type UserAccountSnapshot } from "../../domain.js";
+import { type AccountRepository } from "../../application.js";
+
+export class PostgresAccountRepository implements AccountRepository {
+  private readonly loadedAccountVersions = new Map<string, bigint | undefined>();
+
+  constructor(private readonly client: PoolClient) {}
+
+  async findAccount(accountId: string): Promise<UserAccount | undefined> {
+    const record = await new SnapshotRepository<StoredUserAccountSnapshot>(this.client, "account_snapshots").get(accountId);
+    this.loadedAccountVersions.set(accountId, record?.version);
+    return record ? UserAccount.fromSnapshot(reviveUserAccount(record.data)) : undefined;
+  }
+
+  async saveAccount(account: UserAccount): Promise<void> {
+    const snapshot = account.toSnapshot();
+    const expectedVersion = this.loadedAccountVersions.get(snapshot.accountId);
+    const saved = await saveAccountSnapshot(this.client, snapshot, expectedVersion);
+    this.loadedAccountVersions.set(snapshot.accountId, saved.version);
+  }
+
+  async findPreference(accountId: string, key: string): Promise<PreferenceSnapshot | undefined> {
+    const result = await this.client.query(
+      `SELECT data FROM account_preferences WHERE account_id = $1 AND preference_key = $2`,
+      [accountId, key],
+    ) as QueryResult<{ data: StoredPreferenceSnapshot }>;
+    const row = result.rows[0];
+    return row ? revivePreference(row.data) : undefined;
+  }
+
+  async savePreference(preference: Preference): Promise<void> {
+    const snapshot = preference.toSnapshot();
+    await this.client.query(
+      `INSERT INTO account_preferences (account_id, preference_key, data)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (account_id, preference_key)
+       DO UPDATE SET data = EXCLUDED.data, updated_at = now()`,
+      [snapshot.accountId, snapshot.key, serializeSnapshot(snapshot)],
+    );
+  }
+
+  async preferencesFor(accountId: string): Promise<PreferenceSnapshot[]> {
+    const result = await this.client.query(
+      `SELECT data FROM account_preferences WHERE account_id = $1 ORDER BY preference_key`,
+      [accountId],
+    ) as QueryResult<{ data: StoredPreferenceSnapshot }>;
+    return result.rows.map((row) => revivePreference(row.data));
+  }
+}
+
+export async function saveAccountSnapshot(client: PoolClient, snapshot: UserAccountSnapshot, expectedVersion?: bigint): Promise<SnapshotRecord<StoredUserAccountSnapshot>> {
+  return new SnapshotRepository<StoredUserAccountSnapshot>(client, "account_snapshots").save(snapshot.accountId, serializeStoredSnapshot(snapshot), expectedVersion);
+}
+
+type StoredUserAccountSnapshot = Omit<UserAccountSnapshot, "createdAt" | "frozenAt" | "closureStartedAt" | "closedAt"> & Readonly<{
+  createdAt: string;
+  frozenAt?: string;
+  closureStartedAt?: string;
+  closedAt?: string;
+}>;
+
+type StoredPreferenceSnapshot = Omit<PreferenceSnapshot, "updatedAt"> & Readonly<{ updatedAt: string }>;
+
+function serializeSnapshot<T>(snapshot: T): T {
+  return JSON.parse(JSON.stringify(snapshot)) as T;
+}
+
+function serializeStoredSnapshot(snapshot: UserAccountSnapshot): StoredUserAccountSnapshot {
+  return serializeSnapshot(snapshot) as unknown as StoredUserAccountSnapshot;
+}
+
+function reviveUserAccount(snapshot: StoredUserAccountSnapshot): UserAccountSnapshot {
+  return {
+    ...snapshot,
+    createdAt: new Date(snapshot.createdAt),
+    frozenAt: snapshot.frozenAt ? new Date(snapshot.frozenAt) : undefined,
+    closureStartedAt: snapshot.closureStartedAt ? new Date(snapshot.closureStartedAt) : undefined,
+    closedAt: snapshot.closedAt ? new Date(snapshot.closedAt) : undefined,
+  };
+}
+
+function revivePreference(snapshot: StoredPreferenceSnapshot): PreferenceSnapshot {
+  return { ...snapshot, updatedAt: new Date(snapshot.updatedAt) };
+}

--- a/services/account/src/adapters/storage/runtime.ts
+++ b/services/account/src/adapters/storage/runtime.ts
@@ -1,0 +1,81 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Redis } from "ioredis";
+import {
+  MigrationRunner,
+  OutboxAppender,
+  OutboxRelay,
+  PostgresIdempotencyStore,
+  checkPostgresReadiness,
+  createPostgresPool,
+  streamForProducer,
+  withTransaction,
+  type EventEnvelope,
+} from "@trainticket/ts-kit";
+import { type Pool } from "pg";
+
+import { AccountApplicationService } from "../../application.js";
+
+import { PostgresAccountRepository } from "./account-repository.js";
+
+export type AccountStorageRuntime = Readonly<{
+  ready: () => Promise<boolean>;
+  idempotencyStore: PostgresIdempotencyStore;
+  runCommand: <T>(operation: (application: AccountApplicationService) => Promise<T>) => Promise<T>;
+  stop: () => Promise<void>;
+}>;
+
+export async function startAccountStorage(): Promise<AccountStorageRuntime> {
+  const pool = createPostgresPool();
+  const migrations = new MigrationRunner(pool, migrationsDirectory());
+  try {
+    await migrations.apply();
+  } catch (error) {
+    console.error(sanitizedErrorForLog(error));
+  }
+
+  const redis = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", { lazyConnect: true });
+  await redis.connect();
+  const relay = new OutboxRelay(pool, redis, {
+    pollIntervalMs: 250,
+    onFailure: (error) => console.error(sanitizedErrorForLog(error)),
+  });
+  relay.start();
+
+  return {
+    ready: () => migrations.isReady ? checkPostgresReadiness(pool) : Promise.resolve(false),
+    idempotencyStore: new PostgresIdempotencyStore(pool),
+    runCommand: (operation) => withAccountTransaction(pool, operation),
+    stop: async () => {
+      await relay.stop();
+      await Promise.allSettled([redis.quit(), pool.end()]);
+    },
+  };
+}
+
+async function withAccountTransaction<T>(pool: Pool, operation: (application: AccountApplicationService) => Promise<T>): Promise<T> {
+  return withTransaction(pool, async (client) => {
+    const publisher = new TransactionalOutboxPublisher(new OutboxAppender(client));
+    return operation(new AccountApplicationService(new PostgresAccountRepository(client), publisher));
+  });
+}
+
+class TransactionalOutboxPublisher {
+  constructor(private readonly appender: OutboxAppender) {}
+
+  async publish(envelope: EventEnvelope): Promise<void> {
+    await this.appender.append(envelope, streamForProducer(envelope.producer));
+  }
+}
+
+export function migrationsDirectory(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), "../../../migrations");
+}
+
+function sanitizedErrorForLog(error: unknown): Readonly<{ name: string; message: string }> {
+  if (error instanceof Error) {
+    return { name: error.name || "Error", message: error.message || "Storage failed" };
+  }
+  return { name: typeof error, message: "Storage failed" };
+}

--- a/services/account/src/app.ts
+++ b/services/account/src/app.ts
@@ -31,7 +31,7 @@ export type HealthStatus = Readonly<{
 }>;
 
 export type ProbeStatus = Readonly<{
-  status: "ok";
+  status: "ok" | "not_ready";
   probe: "live" | "ready";
 }>;
 
@@ -70,6 +70,12 @@ export type AppOptions = Readonly<{
   repository?: AccountRepository;
   publisher?: EventPublisher;
   idempotencyStore?: IdempotencyStore;
+  storage?: AppStorage;
+}>;
+
+export type AppStorage = Readonly<{
+  ready: () => boolean | Promise<boolean>;
+  runCommand?: <T>(operation: (application: AccountApplicationService) => Promise<T>) => Promise<T>;
 }>;
 
 type OTelSpan = Readonly<{
@@ -133,6 +139,7 @@ export function createApp(options: AppOptions | InstrumentationHooks = {}): Fast
   const publisher = appOptions.publisher ?? new InMemoryEventPublisher();
   const idempotencyStore = appOptions.idempotencyStore ?? new InMemoryIdempotencyStore();
   const accountService = new AccountApplicationService(repository, publisher);
+  const runWithService = appOptions.storage?.runCommand ?? (<T>(operation: (application: AccountApplicationService) => Promise<T>) => operation(accountService));
   const app: FastifyInstance = Fastify({ logger: false });
   const spans = new WeakMap<FastifyRequest, TraceSpan>();
 
@@ -161,20 +168,20 @@ export function createApp(options: AppOptions | InstrumentationHooks = {}): Fast
 
   app.get("/live", async () => probeBody("live"));
   app.get("/livez", async () => probeBody("live"));
-  app.get("/ready", async () => probeBody("ready"));
-  app.get("/readyz", async () => probeBody("ready"));
+  app.get("/ready", async (_request, reply) => readyBody(reply, appOptions.storage));
+  app.get("/readyz", async (_request, reply) => readyBody(reply, appOptions.storage));
 
   app.post("/api/v1/accounts", async (request, reply) => {
     await runIdempotentOperation(request, reply, idempotencyStore, 201, async (context, causationId) => {
       const body = objectBody(request.body);
       assertOptionalString(body.accountId, "accountId");
-      return accountService.createAccount({ accountId: body.accountId as string | undefined, correlationId: context.correlationId, causationId });
+      return runWithService((service) => service.createAccount({ accountId: body.accountId as string | undefined, correlationId: context.correlationId, causationId }));
     });
   });
 
   app.get("/api/v1/accounts/:accountId", async (request, reply) => {
     try {
-      return await accountService.getAccount(accountIdParam(request));
+      return await runWithService((service) => service.getAccount(accountIdParam(request)));
     } catch (error) {
       sendApplicationError(reply, mapError(error), requestContext(request));
     }
@@ -186,7 +193,7 @@ export function createApp(options: AppOptions | InstrumentationHooks = {}): Fast
       const reason = requiredString(body.reason, "reason");
       const operator = requiredString(body.operator, "operator");
       assertOptionalString(body.caseRef, "caseRef");
-      return accountService.freezeAccount({ accountId: accountIdParam(request), reason, operator, caseRef: body.caseRef as string | undefined, correlationId: context.correlationId, causationId });
+      return runWithService((service) => service.freezeAccount({ accountId: accountIdParam(request), reason, operator, caseRef: body.caseRef as string | undefined, correlationId: context.correlationId, causationId }));
     });
   });
 
@@ -194,7 +201,7 @@ export function createApp(options: AppOptions | InstrumentationHooks = {}): Fast
     await runIdempotentOperation(request, reply, idempotencyStore, 200, { preconditionDomainCodes: "all" }, async (context, causationId) => {
       const body = objectBody(request.body);
       const reason = requiredString(body.reason, "reason");
-      return accountService.unfreezeAccount({ accountId: accountIdParam(request), reason, correlationId: context.correlationId, causationId });
+      return runWithService((service) => service.unfreezeAccount({ accountId: accountIdParam(request), reason, correlationId: context.correlationId, causationId }));
     });
   });
 
@@ -203,13 +210,13 @@ export function createApp(options: AppOptions | InstrumentationHooks = {}): Fast
       const body = objectBody(request.body);
       const preferenceKey = requiredString(body.preferenceKey, "preferenceKey");
       const value = requiredString(body.value, "value");
-      return accountService.updatePreference({ accountId: accountIdParam(request), preferenceKey, value, correlationId: context.correlationId, causationId });
+      return runWithService((service) => service.updatePreference({ accountId: accountIdParam(request), preferenceKey, value, correlationId: context.correlationId, causationId }));
     });
   });
 
   app.post("/api/v1/accounts/:accountId/start-closure", async (request, reply) => {
     await runIdempotentOperation(request, reply, idempotencyStore, 200, { preconditionDomainCodes: "all" }, async (context, causationId) =>
-      accountService.startClosure({ accountId: accountIdParam(request), correlationId: context.correlationId, causationId }),
+      runWithService((service) => service.startClosure({ accountId: accountIdParam(request), correlationId: context.correlationId, causationId })),
     );
   });
 
@@ -255,7 +262,7 @@ async function runIdempotentOperation(
 }
 
 function normalizeOptions(options: AppOptions | InstrumentationHooks): AppOptions {
-  if ("repository" in options || "publisher" in options || "idempotencyStore" in options || "instrumentation" in options) {
+  if ("repository" in options || "publisher" in options || "idempotencyStore" in options || "instrumentation" in options || "storage" in options) {
     return options as AppOptions;
   }
   return { instrumentation: options as InstrumentationHooks };
@@ -267,6 +274,14 @@ function healthBody(): HealthStatus {
 
 function probeBody(probe: ProbeStatus["probe"]): ProbeStatus {
   return { status: health(), probe };
+}
+
+async function readyBody(reply: { status: (statusCode: number) => unknown }, storage: AppStorage | undefined): Promise<ProbeStatus> {
+  if (storage && !await storage.ready()) {
+    reply.status(503);
+    return { status: "not_ready", probe: "ready" };
+  }
+  return probeBody("ready");
 }
 
 function traceContext(request: AppRequest, context: RequestContext = requestContext(request)): RequestTraceContext {

--- a/services/account/src/bootstrap.ts
+++ b/services/account/src/bootstrap.ts
@@ -1,6 +1,7 @@
 import { createApp, opentelemetryInstrumentationFromEnv, type InstrumentationHooks } from "./app.js";
 import { InMemoryAccountRepository } from "./application.js";
 import { RedisStreamEventPublisher } from "./adapters/messaging/publisher.js";
+import { startAccountStorage } from "./adapters/storage/runtime.js";
 
 export type BootstrapOptions = Readonly<{
   host?: string;
@@ -21,14 +22,18 @@ export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): numbe
 }
 
 export async function bootstrap(options: BootstrapOptions = {}) {
-  const publisher = new RedisStreamEventPublisher();
+  const storage = process.env.DATABASE_URL ? await startAccountStorage() : undefined;
+  const publisher = storage ? undefined : new RedisStreamEventPublisher();
   const app = createApp({
     instrumentation: options.instrumentation ?? opentelemetryInstrumentationFromEnv(),
     repository: new InMemoryAccountRepository(),
     publisher,
+    idempotencyStore: storage?.idempotencyStore,
+    storage,
   });
   app.addHook("onClose", async () => {
-    await publisher.close();
+    await publisher?.close();
+    await storage?.stop();
   });
   await app.listen({ host: runtimeHost(options), port: runtimePort(options) });
   return app;

--- a/services/account/src/domain.ts
+++ b/services/account/src/domain.ts
@@ -275,6 +275,10 @@ export class UserAccount {
 
   // ── Factory ──
 
+  static fromSnapshot(snapshot: UserAccountSnapshot): UserAccount {
+    return new UserAccount(deepFreeze({ ...snapshot }));
+  }
+
   static create(command: CreateAccount): { account: UserAccount; event: AccountCreated } {
     const accountId = command.accountId ?? generateAccountId();
     requireNonBlank(accountId, "accountId");
@@ -547,6 +551,10 @@ export class Preference {
   private constructor(private readonly snapshot: PreferenceSnapshot) {
     deepFreeze(this.snapshot);
     Object.freeze(this);
+  }
+
+  static fromSnapshot(snapshot: PreferenceSnapshot): Preference {
+    return new Preference(deepFreeze({ ...snapshot }));
   }
 
   static update(

--- a/services/customer-service/migrations/001_customer_service_storage.sql
+++ b/services/customer-service/migrations/001_customer_service_storage.sql
@@ -1,0 +1,89 @@
+CREATE OR REPLACE FUNCTION duplicate_classification(data jsonb)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT COALESCE(NULLIF(btrim(data->>'classification'), ''), '__UNCLASSIFIED__')
+$$;
+
+CREATE OR REPLACE FUNCTION duplicate_business_ref(data jsonb)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT COALESCE(
+    NULLIF(btrim(data->'businessReferences'->>'journeyOrderId'), ''),
+    NULLIF(btrim(data->'businessReferences'->>'postSalesCaseId'), ''),
+    NULLIF(btrim(data->'businessReferences'->>'paymentRef'), ''),
+    NULLIF(btrim(data->'businessReferences'->>'recoveryCaseId'), ''),
+    NULLIF(btrim(data->'businessReferences'->>'accountRef'), ''),
+    '__NO_BUSINESS_REF__'
+  )
+$$;
+
+CREATE TABLE IF NOT EXISTS support_case_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS support_case_snapshots_requester_idx
+  ON support_case_snapshots ((data->>'requesterRef'), updated_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS support_case_snapshots_business_duplicate_idx
+  ON support_case_snapshots ((data->>'requesterRef'), duplicate_classification(data), duplicate_business_ref(data));
+
+CREATE TABLE IF NOT EXISTS case_timelines (
+  case_id    text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS case_evidence_refs (
+  evidence_id text PRIMARY KEY,
+  case_id     text NOT NULL,
+  data        jsonb NOT NULL,
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS case_evidence_refs_case_idx
+  ON case_evidence_refs (case_id, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS manual_action_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS manual_action_snapshots_case_idx
+  ON manual_action_snapshots ((data->>'caseId'), updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS outbox (
+  seq          bigserial PRIMARY KEY,
+  event_id     text NOT NULL UNIQUE,
+  stream       text NOT NULL,
+  envelope     jsonb NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  published_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS outbox_unpublished_seq_idx
+  ON outbox (seq)
+  WHERE published_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS processed_events (
+  event_id     text PRIMARY KEY,
+  stream       text,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS idempotency_records (
+  key           text PRIMARY KEY,
+  request_hash  text NOT NULL,
+  status_code   int NOT NULL,
+  response_body jsonb,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);

--- a/services/customer-service/migrations/002_case_timelines_id_column.sql
+++ b/services/customer-service/migrations/002_case_timelines_id_column.sql
@@ -1,0 +1,3 @@
+-- case_timelines is managed by ts-kit SnapshotRepository, which requires the
+-- ruling's snapshot shape (id/version/data/updated_at); 001 shipped case_id.
+ALTER TABLE case_timelines RENAME COLUMN case_id TO id;

--- a/services/customer-service/package-lock.json
+++ b/services/customer-service/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@trainticket/ts-kit": "file:../../platform/ts-kit",
+        "@types/pg": "^8.20.0",
         "fastify": "5.9.0",
-        "ioredis": "5.4.1"
+        "ioredis": "5.4.1",
+        "pg": "^8.22.0"
       },
       "devDependencies": {
         "@types/node": "26.0.1",
@@ -187,6 +189,17 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmmirror.com/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/abstract-logging": {
@@ -553,6 +566,95 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmmirror.com/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmmirror.com/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmmirror.com/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmmirror.com/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmmirror.com/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/pino": {
       "version": "10.3.1",
       "resolved": "https://registry.npmmirror.com/pino/-/pino-10.3.1.tgz",
@@ -589,6 +691,45 @@
       "resolved": "https://registry.npmmirror.com/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmmirror.com/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/process-warning": {
       "version": "5.0.0",
@@ -810,6 +951,15 @@
       "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     }
   }
 }

--- a/services/customer-service/package.json
+++ b/services/customer-service/package.json
@@ -9,8 +9,10 @@
   },
   "dependencies": {
     "@trainticket/ts-kit": "file:../../platform/ts-kit",
+    "@types/pg": "^8.20.0",
     "fastify": "5.9.0",
-    "ioredis": "5.4.1"
+    "ioredis": "5.4.1",
+    "pg": "^8.22.0"
   },
   "devDependencies": {
     "@types/node": "26.0.1",

--- a/services/customer-service/src/adapters/storage/customer-service-repository.ts
+++ b/services/customer-service/src/adapters/storage/customer-service-repository.ts
@@ -1,0 +1,174 @@
+import { type PoolClient, type QueryResult } from "pg";
+
+import { SnapshotRepository, type SnapshotRecord } from "@trainticket/ts-kit";
+
+import {
+  CaseTimeline,
+  EvidenceRef,
+  ManualActionRequest,
+  SupportCase,
+  type CaseTimelineSnapshot,
+  type EvidenceRefSnapshot,
+  type ManualActionRequestSnapshot,
+  type SupportCaseSnapshot,
+} from "../../domain.js";
+import { type CustomerServiceRepository } from "../../application/ports/customer-service-repository.js";
+
+export class PostgresCustomerServiceRepository implements CustomerServiceRepository {
+  constructor(private readonly client: PoolClient) {}
+
+  async findCase(caseId: string): Promise<Readonly<{ aggregate: SupportCase; version: bigint }> | undefined> {
+    const record = await new SnapshotRepository<StoredSupportCaseSnapshot>(this.client, "support_case_snapshots").get(caseId);
+    return record ? { aggregate: SupportCase.fromSnapshot(reviveSupportCase(record.data)), version: record.version } : undefined;
+  }
+
+  async saveNewCase(snapshot: SupportCaseSnapshot): Promise<SnapshotRecord<StoredSupportCaseSnapshot>> {
+    return new SnapshotRepository<StoredSupportCaseSnapshot>(this.client, "support_case_snapshots").save(snapshot.caseId, serializeSupportCase(snapshot));
+  }
+
+  async saveCase(snapshot: SupportCaseSnapshot, expectedVersion: bigint): Promise<SnapshotRecord<StoredSupportCaseSnapshot>> {
+    return new SnapshotRepository<StoredSupportCaseSnapshot>(this.client, "support_case_snapshots").save(snapshot.caseId, serializeSupportCase(snapshot), expectedVersion);
+  }
+
+  async listCases(): Promise<SupportCase[]> {
+    const result = await this.client.query(
+      `SELECT data FROM support_case_snapshots ORDER BY updated_at`,
+    ) as QueryResult<{ data: StoredSupportCaseSnapshot }>;
+    return result.rows.map((row) => SupportCase.fromSnapshot(reviveSupportCase(row.data)));
+  }
+
+  async findDuplicateOpenCase(snapshot: SupportCaseSnapshot): Promise<SupportCaseSnapshot | undefined> {
+    const result = await this.client.query(
+      `SELECT data
+       FROM support_case_snapshots
+       WHERE data->>'requesterRef' = $1
+         AND duplicate_classification(data) = $2
+         AND duplicate_business_ref(data) = $3
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+      [snapshot.requesterRef, duplicateClassification(snapshot), duplicateBusinessRef(snapshot)],
+    ) as QueryResult<{ data: StoredSupportCaseSnapshot }>;
+    const row = result.rows[0];
+    return row ? reviveSupportCase(row.data) : undefined;
+  }
+
+  async findTimeline(caseId: string): Promise<Readonly<{ aggregate: CaseTimeline; version: bigint }> | undefined> {
+    const record = await new SnapshotRepository<StoredCaseTimelineSnapshot>(this.client, "case_timelines").get(caseId);
+    return record ? { aggregate: CaseTimeline.fromSnapshot(reviveTimeline(record.data)), version: record.version } : undefined;
+  }
+
+  async saveNewTimeline(snapshot: CaseTimelineSnapshot): Promise<SnapshotRecord<StoredCaseTimelineSnapshot>> {
+    return new SnapshotRepository<StoredCaseTimelineSnapshot>(this.client, "case_timelines").save(snapshot.caseId, serializeTimeline(snapshot));
+  }
+
+  async saveTimeline(snapshot: CaseTimelineSnapshot, expectedVersion: bigint): Promise<SnapshotRecord<StoredCaseTimelineSnapshot>> {
+    return new SnapshotRepository<StoredCaseTimelineSnapshot>(this.client, "case_timelines").save(snapshot.caseId, serializeTimeline(snapshot), expectedVersion);
+  }
+
+  async evidenceForCase(caseId: string): Promise<EvidenceRefSnapshot[]> {
+    const result = await this.client.query(
+      `SELECT data FROM case_evidence_refs WHERE case_id = $1 ORDER BY updated_at`,
+      [caseId],
+    ) as QueryResult<{ data: StoredEvidenceRefSnapshot }>;
+    return result.rows.map((row) => reviveEvidence(row.data));
+  }
+
+  async saveEvidence(snapshot: EvidenceRefSnapshot): Promise<void> {
+    await this.client.query(
+      `INSERT INTO case_evidence_refs (evidence_id, case_id, data)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (evidence_id)
+       DO UPDATE SET data = EXCLUDED.data, updated_at = now()`,
+      [snapshot.evidenceId, snapshot.caseId, serializeSnapshot(snapshot)],
+    );
+  }
+
+  async findManualAction(manualActionId: string): Promise<Readonly<{ aggregate: ManualActionRequest; version: bigint }> | undefined> {
+    const record = await new SnapshotRepository<StoredManualActionRequestSnapshot>(this.client, "manual_action_snapshots").get(manualActionId);
+    return record ? { aggregate: ManualActionRequest.fromSnapshot(reviveManualAction(record.data)), version: record.version } : undefined;
+  }
+
+  async saveNewManualAction(snapshot: ManualActionRequestSnapshot): Promise<SnapshotRecord<StoredManualActionRequestSnapshot>> {
+    return new SnapshotRepository<StoredManualActionRequestSnapshot>(this.client, "manual_action_snapshots").save(snapshot.manualActionId, serializeManualAction(snapshot));
+  }
+
+  async saveManualAction(snapshot: ManualActionRequestSnapshot, expectedVersion: bigint): Promise<SnapshotRecord<StoredManualActionRequestSnapshot>> {
+    return new SnapshotRepository<StoredManualActionRequestSnapshot>(this.client, "manual_action_snapshots").save(snapshot.manualActionId, serializeManualAction(snapshot), expectedVersion);
+  }
+}
+
+type StoredSupportCaseSnapshot = Omit<SupportCaseSnapshot, "openedAt" | "resolvedAt" | "closedAt" | "resolution" | "escalation"> & Readonly<{
+  openedAt: string;
+  resolvedAt?: string;
+  closedAt?: string;
+  resolution?: Omit<NonNullable<SupportCaseSnapshot["resolution"]>, "resolvedAt"> & Readonly<{ resolvedAt: string }>;
+  escalation?: Omit<NonNullable<SupportCaseSnapshot["escalation"]>, "escalatedAt"> & Readonly<{ escalatedAt: string }>;
+}>;
+type StoredEvidenceRefSnapshot = Omit<EvidenceRefSnapshot, "attachedAt"> & Readonly<{ attachedAt: string }>;
+type StoredManualActionRequestSnapshot = Omit<ManualActionRequestSnapshot, "requestedAt" | "outcomeRecordedAt"> & Readonly<{ requestedAt: string; outcomeRecordedAt?: string }>;
+type StoredCaseTimelineSnapshot = Omit<CaseTimelineSnapshot, "entries"> & Readonly<{ entries: readonly StoredTimelineEntrySnapshot[] }>;
+type StoredTimelineEntrySnapshot = Omit<CaseTimelineSnapshot["entries"][number], "occurredAt"> & Readonly<{ occurredAt: string }>;
+
+function serializeSnapshot<T>(snapshot: T): T {
+  return JSON.parse(JSON.stringify(snapshot)) as T;
+}
+
+function serializeSupportCase(snapshot: SupportCaseSnapshot): StoredSupportCaseSnapshot {
+  return serializeSnapshot(snapshot) as unknown as StoredSupportCaseSnapshot;
+}
+
+function serializeTimeline(snapshot: CaseTimelineSnapshot): StoredCaseTimelineSnapshot {
+  return serializeSnapshot(snapshot) as unknown as StoredCaseTimelineSnapshot;
+}
+
+function serializeManualAction(snapshot: ManualActionRequestSnapshot): StoredManualActionRequestSnapshot {
+  return serializeSnapshot(snapshot) as unknown as StoredManualActionRequestSnapshot;
+}
+
+function reviveSupportCase(snapshot: StoredSupportCaseSnapshot): SupportCaseSnapshot {
+  return {
+    ...snapshot,
+    openedAt: new Date(snapshot.openedAt),
+    resolvedAt: snapshot.resolvedAt ? new Date(snapshot.resolvedAt) : undefined,
+    closedAt: snapshot.closedAt ? new Date(snapshot.closedAt) : undefined,
+    resolution: snapshot.resolution ? { ...snapshot.resolution, resolvedAt: new Date(snapshot.resolution.resolvedAt) } : undefined,
+    escalation: snapshot.escalation ? { ...snapshot.escalation, escalatedAt: new Date(snapshot.escalation.escalatedAt) } : undefined,
+  };
+}
+
+function reviveEvidence(snapshot: StoredEvidenceRefSnapshot): EvidenceRefSnapshot {
+  return { ...snapshot, attachedAt: new Date(snapshot.attachedAt) };
+}
+
+function reviveManualAction(snapshot: StoredManualActionRequestSnapshot): ManualActionRequestSnapshot {
+  return {
+    ...snapshot,
+    requestedAt: new Date(snapshot.requestedAt),
+    outcomeRecordedAt: snapshot.outcomeRecordedAt ? new Date(snapshot.outcomeRecordedAt) : undefined,
+  };
+}
+
+function reviveTimeline(snapshot: StoredCaseTimelineSnapshot): CaseTimelineSnapshot {
+  return {
+    ...snapshot,
+    entries: snapshot.entries.map((entry) => ({ ...entry, occurredAt: new Date(entry.occurredAt) })),
+  };
+}
+
+export function duplicateClassification(snapshot: SupportCaseSnapshot): string {
+  return snapshot.classification?.trim() || "__UNCLASSIFIED__";
+}
+
+export function duplicateBusinessRef(snapshot: SupportCaseSnapshot): string {
+  const refs = snapshot.businessReferences;
+  return stringBusinessRef(refs.journeyOrderId)
+    ?? stringBusinessRef(refs.postSalesCaseId)
+    ?? stringBusinessRef(refs.paymentRef)
+    ?? stringBusinessRef(refs.recoveryCaseId)
+    ?? stringBusinessRef(refs.accountRef)
+    ?? "__NO_BUSINESS_REF__";
+}
+
+function stringBusinessRef(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}

--- a/services/customer-service/src/adapters/storage/runtime.ts
+++ b/services/customer-service/src/adapters/storage/runtime.ts
@@ -1,0 +1,94 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  MigrationRunner,
+  OutboxAppender,
+  OutboxRelay,
+  PostgresIdempotencyStore,
+  ProcessedEventsGuard,
+  checkPostgresReadiness,
+  createPostgresPool,
+  streamForProducer,
+  withTransaction,
+  type EventEnvelope,
+} from "@trainticket/ts-kit";
+import { Redis } from "ioredis";
+import { type Pool } from "pg";
+
+import { CustomerServiceApplication } from "../../application/customer-service.js";
+import { type EventPublisher } from "../../application/messaging.js";
+import { DEFAULT_REDIS_URL } from "../messaging/stream-config.js";
+import { PostgresCustomerServiceRepository } from "./customer-service-repository.js";
+
+export type CustomerServiceStorageRuntime = Readonly<{
+  ready: () => Promise<boolean>;
+  idempotencyStore: PostgresIdempotencyStore;
+  runCommand: <T>(operation: (application: CustomerServiceApplication) => Promise<T>) => Promise<T>;
+  handleIntegrationEvent: (envelope: EventEnvelope, stream?: string) => Promise<"ack" | "retry" | "dlq">;
+  stop: () => Promise<void>;
+}>;
+
+export async function startCustomerServiceStorage(): Promise<CustomerServiceStorageRuntime> {
+  const pool = createPostgresPool();
+  const migrations = new MigrationRunner(pool, migrationsDirectory());
+  try {
+    await migrations.apply();
+  } catch (error) {
+    console.error(sanitizedErrorForLog(error));
+  }
+
+  const redis = new Redis(process.env.REDIS_URL ?? DEFAULT_REDIS_URL, { lazyConnect: true });
+  await redis.connect();
+  const relay = new OutboxRelay(pool, redis as never, {
+    pollIntervalMs: 250,
+    onFailure: (error) => console.error(sanitizedErrorForLog(error)),
+  });
+  relay.start();
+
+  return {
+    ready: () => migrations.isReady ? checkPostgresReadiness(pool) : Promise.resolve(false),
+    idempotencyStore: new PostgresIdempotencyStore(pool),
+    runCommand: (operation) => withCustomerServiceTransaction(pool, operation),
+    handleIntegrationEvent: (envelope, stream) => withTransaction(pool, async (client): Promise<"ack" | "retry" | "dlq"> => {
+      const guard = new ProcessedEventsGuard(client);
+      if (!await guard.tryStart(envelope.eventId, stream)) {
+        return "ack";
+      }
+      const publisher = new TransactionalOutboxPublisher(new OutboxAppender(client));
+      const application = new CustomerServiceApplication(publisher, new PostgresCustomerServiceRepository(client));
+      await application.handleIntegrationEvent(envelope as import("../../application/messaging.js").EventEnvelope);
+      return "ack";
+    }),
+    stop: async () => {
+      await relay.stop();
+      await Promise.allSettled([redis.quit(), pool.end()]);
+    },
+  };
+}
+
+async function withCustomerServiceTransaction<T>(pool: Pool, operation: (application: CustomerServiceApplication) => Promise<T>): Promise<T> {
+  return withTransaction(pool, async (client) => {
+    const publisher = new TransactionalOutboxPublisher(new OutboxAppender(client));
+    return operation(new CustomerServiceApplication(publisher, new PostgresCustomerServiceRepository(client)));
+  });
+}
+
+class TransactionalOutboxPublisher implements EventPublisher {
+  constructor(private readonly appender: OutboxAppender) {}
+
+  async publish(envelope: EventEnvelope): Promise<void> {
+    await this.appender.append(envelope, streamForProducer(envelope.producer));
+  }
+}
+
+export function migrationsDirectory(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), "../../../migrations");
+}
+
+function sanitizedErrorForLog(error: unknown): Readonly<{ name: string; message: string }> {
+  if (error instanceof Error) {
+    return { name: error.name || "Error", message: error.message || "Storage failed" };
+  }
+  return { name: typeof error, message: "Storage failed" };
+}

--- a/services/customer-service/src/app.ts
+++ b/services/customer-service/src/app.ts
@@ -36,7 +36,7 @@ export type HealthStatus = Readonly<{
 }>;
 
 export type ProbeStatus = Readonly<{
-  status: "ok";
+  status: "ok" | "not_ready";
   probe: "live" | "ready";
 }>;
 
@@ -75,6 +75,12 @@ export type AppOptions = Readonly<{
   publisher?: EventPublisher;
   application?: CustomerServiceApplication;
   idempotencyStore?: IdempotencyStore;
+  storage?: AppStorage;
+}>;
+
+export type AppStorage = Readonly<{
+  ready: () => boolean | Promise<boolean>;
+  runCommand?: <T>(operation: (application: CustomerServiceApplication) => Promise<T>) => Promise<T>;
 }>;
 
 type OTelSpan = Readonly<{
@@ -143,6 +149,7 @@ export function createApp(options: InstrumentationHooks | AppOptions = {}): Fast
   const appOptions = normalizeOptions(options);
   const publisher = appOptions.publisher ?? new InMemoryEventPublisher();
   const application = appOptions.application ?? new CustomerServiceApplication(publisher);
+  const runWithApplication = appOptions.storage?.runCommand ?? (<T>(operation: (service: CustomerServiceApplication) => Promise<T>) => operation(application));
   const idempotencyStore = appOptions.idempotencyStore ?? new InMemoryIdempotencyStore();
   const instrumentation = appOptions.instrumentation ?? {};
   const spans = new WeakMap<FastifyRequest, TraceSpan>();
@@ -170,13 +177,13 @@ export function createApp(options: InstrumentationHooks | AppOptions = {}): Fast
   app.get("/metadata", async () => metadata());
   app.get("/live", async () => probeBody("live"));
   app.get("/livez", async () => probeBody("live"));
-  app.get("/ready", async () => probeBody("ready"));
-  app.get("/readyz", async () => probeBody("ready"));
+  app.get("/ready", async (_request, reply) => readyBody(reply, appOptions.storage));
+  app.get("/readyz", async (_request, reply) => readyBody(reply, appOptions.storage));
 
   app.post("/api/v1/support-cases", async (request, reply) => {
     const response = await withIdempotency(request, idempotencyStore, request.body ?? null, async () => {
       const body = validateOpenSupportCase(request.body);
-      const created = await application.openSupportCase(body, requestContext(request).correlationId, newCommandId());
+      const created = await runWithApplication((service) => service.openSupportCase(body, requestContext(request).correlationId, newCommandId()));
       return { statusCode: 201, body: openSupportCaseResponse(created) };
     });
     return reply.status(response!.statusCode).send(response!.body);
@@ -184,14 +191,14 @@ export function createApp(options: InstrumentationHooks | AppOptions = {}): Fast
 
   app.get("/api/v1/support-cases/:caseId", async (request) => {
     const { caseId } = request.params as { caseId: string };
-    return supportCaseResponse(application.getSupportCase(caseId));
+    return supportCaseResponse(await runWithApplication((service) => service.getSupportCaseDetails(caseId)));
   });
 
   app.post("/api/v1/support-cases/:caseId/evidence", async (request, reply) => {
     const { caseId } = request.params as { caseId: string };
     const response = await withIdempotency(request, idempotencyStore, { caseId, body: request.body ?? null }, async () => {
       const body = validateAttachEvidence(request.body);
-      const evidence = await application.attachEvidence(caseId, body, requestContext(request).correlationId, newCommandId());
+      const evidence = await runWithApplication((service) => service.attachEvidence(caseId, body, requestContext(request).correlationId, newCommandId()));
       return { statusCode: 201, body: { evidenceId: evidence.evidenceId, caseId: evidence.caseId, evidenceType: evidence.evidenceType } };
     });
     return reply.status(response!.statusCode).send(response!.body);
@@ -201,7 +208,7 @@ export function createApp(options: InstrumentationHooks | AppOptions = {}): Fast
     const { caseId } = request.params as { caseId: string };
     return sendIdempotentUpdate(request, reply, idempotencyStore, { caseId, body: request.body ?? null }, () => {
       const body = validateClassify(request.body);
-      return application.classifySupportCase(caseId, body, operatorRef(request), requestContext(request).correlationId, newCommandId());
+      return runWithApplication((service) => service.classifySupportCase(caseId, body, operatorRef(request), requestContext(request).correlationId, newCommandId()));
     });
   });
 
@@ -209,7 +216,7 @@ export function createApp(options: InstrumentationHooks | AppOptions = {}): Fast
     const { caseId } = request.params as { caseId: string };
     return sendIdempotentUpdate(request, reply, idempotencyStore, { caseId, body: request.body ?? null }, () => {
       const body = validateAssign(request.body);
-      return application.assignSupportCase(caseId, body, operatorRef(request), requestContext(request).correlationId, newCommandId());
+      return runWithApplication((service) => service.assignSupportCase(caseId, body, operatorRef(request), requestContext(request).correlationId, newCommandId()));
     });
   });
 
@@ -217,7 +224,7 @@ export function createApp(options: InstrumentationHooks | AppOptions = {}): Fast
     const { caseId } = request.params as { caseId: string };
     return sendIdempotentUpdate(request, reply, idempotencyStore, { caseId, body: request.body ?? null }, () => {
       const body = validateEscalate(request.body);
-      return application.escalateCase(caseId, body, operatorRef(request), requestContext(request).correlationId, newCommandId());
+      return runWithApplication((service) => service.escalateCase(caseId, body, operatorRef(request), requestContext(request).correlationId, newCommandId()));
     });
   });
 
@@ -225,7 +232,7 @@ export function createApp(options: InstrumentationHooks | AppOptions = {}): Fast
     const { caseId } = request.params as { caseId: string };
     return sendIdempotentUpdate(request, reply, idempotencyStore, { caseId, body: request.body ?? null }, () => {
       const body = validateResolve(request.body);
-      return application.resolveCase(caseId, body, operatorRef(request), requestContext(request).correlationId, newCommandId());
+      return runWithApplication((service) => service.resolveCase(caseId, body, operatorRef(request), requestContext(request).correlationId, newCommandId()));
     });
   });
 
@@ -233,7 +240,7 @@ export function createApp(options: InstrumentationHooks | AppOptions = {}): Fast
     const { caseId } = request.params as { caseId: string };
     return sendIdempotentUpdate(request, reply, idempotencyStore, { caseId, body: request.body ?? null }, () => {
       const body = validateClose(request.body);
-      return application.closeCase(caseId, body, operatorRef(request), requestContext(request).correlationId, newCommandId());
+      return runWithApplication((service) => service.closeCase(caseId, body, operatorRef(request), requestContext(request).correlationId, newCommandId()));
     });
   });
 
@@ -241,7 +248,7 @@ export function createApp(options: InstrumentationHooks | AppOptions = {}): Fast
     const { caseId } = request.params as { caseId: string };
     return sendIdempotentUpdate(request, reply, idempotencyStore, { caseId, body: request.body ?? null }, () => {
       const body = validateReopen(request.body);
-      return application.reopenCase(caseId, body, requestContext(request).correlationId, newCommandId());
+      return runWithApplication((service) => service.reopenCase(caseId, body, requestContext(request).correlationId, newCommandId()));
     });
   });
 
@@ -249,7 +256,7 @@ export function createApp(options: InstrumentationHooks | AppOptions = {}): Fast
     const { caseId } = request.params as { caseId: string };
     const response = await withIdempotency(request, idempotencyStore, { caseId, body: request.body ?? null }, async () => {
       const body = validateRequestManualAction(request.body);
-      const action = await application.requestManualAction(caseId, body, requestContext(request).correlationId, newCommandId());
+      const action = await runWithApplication((service) => service.requestManualAction(caseId, body, requestContext(request).correlationId, newCommandId()));
       return { statusCode: 202, body: { manualActionId: action.manualActionId, status: "REQUESTED" } };
     });
     return reply.status(response!.statusCode).send(response!.body);
@@ -569,6 +576,14 @@ function probeBody(probe: ProbeStatus["probe"]): ProbeStatus {
   return { status: health(), probe };
 }
 
+async function readyBody(reply: { status: (statusCode: number) => unknown }, storage: AppStorage | undefined): Promise<ProbeStatus> {
+  if (storage && !await storage.ready()) {
+    reply.status(503);
+    return { status: "not_ready", probe: "ready" };
+  }
+  return probeBody("ready");
+}
+
 function traceContext(request: AppRequest, context: RequestContext = requestContext(request)): RequestTraceContext {
   return {
     ...context,
@@ -594,7 +609,7 @@ const requestContexts = new WeakMap<AppRequest, RequestContext>();
 
 function normalizeOptions(options: InstrumentationHooks | AppOptions): AppOptions {
   const candidate = options as AppOptions;
-  if (candidate.instrumentation !== undefined || candidate.publisher !== undefined || candidate.application !== undefined || candidate.idempotencyStore !== undefined) {
+  if (candidate.instrumentation !== undefined || candidate.publisher !== undefined || candidate.application !== undefined || candidate.idempotencyStore !== undefined || candidate.storage !== undefined) {
     return candidate;
   }
   return { instrumentation: options as InstrumentationHooks };

--- a/services/customer-service/src/application/customer-service.ts
+++ b/services/customer-service/src/application/customer-service.ts
@@ -14,7 +14,8 @@ import {
   type TimelineEntrySnapshot,
 } from "../domain.js";
 import { newCommandId, toEventEnvelope, type EventEnvelope, type EventPublisher } from "./messaging.js";
-import { uuidV7 } from "@trainticket/ts-kit";
+import { OptimisticConcurrencyConflict, uuidV7 } from "@trainticket/ts-kit";
+import { type CustomerServiceRepository } from "./ports/customer-service-repository.js";
 
 export type SupportCaseDetails = SupportCaseSnapshot &
   Readonly<{
@@ -69,7 +70,10 @@ export class CustomerServiceApplication {
   private readonly manualActions = new Map<string, ManualActionRequest>();
   private readonly consumedIntegrationEvents = new Map<string, Readonly<{ source: string; eventType: string; consumedAt: Date; payload: Readonly<Record<string, unknown>> }>>();
 
-  constructor(private readonly publisher: EventPublisher) {}
+  constructor(
+    private readonly publisher: EventPublisher,
+    private readonly repository?: CustomerServiceRepository,
+  ) {}
 
   async openSupportCase(request: OpenSupportCaseRequest, correlationId: string, causationId = newCommandId()): Promise<SupportCaseSnapshot> {
     const openedAt = new Date();
@@ -85,14 +89,27 @@ export class CustomerServiceApplication {
       causationId,
       openedAt,
     });
+    try {
+      await this.repository?.saveNewCase(supportCase.toSnapshot());
+    } catch (error) {
+      if ((error instanceof OptimisticConcurrencyConflict || isUniqueViolation(error)) && this.repository) {
+        const duplicate = await this.repository.findDuplicateOpenCase(supportCase.toSnapshot());
+        if (duplicate) {
+          return duplicate;
+        }
+      }
+      throw error;
+    }
+    const timeline = CaseTimeline.create(supportCase.id);
+    await this.repository?.saveNewTimeline(timeline.toSnapshot());
     this.cases.set(supportCase.id, supportCase);
-    this.timelines.set(supportCase.id, CaseTimeline.create(supportCase.id));
+    this.timelines.set(supportCase.id, timeline);
     await this.publisher.publish(toEventEnvelope(event, causationId));
     return supportCase.toSnapshot();
   }
 
   getSupportCase(caseId: string): SupportCaseDetails {
-    const supportCase = this.requireCase(caseId);
+    const supportCase = this.requireCaseSync(caseId);
     return {
       ...supportCase.toSnapshot(),
       evidence: Object.freeze((this.evidenceByCase.get(caseId) ?? []).map((evidence) => evidence.toSnapshot())),
@@ -100,8 +117,21 @@ export class CustomerServiceApplication {
     };
   }
 
+
+  async getSupportCaseDetails(caseId: string): Promise<SupportCaseDetails> {
+    if (!this.repository) {
+      return this.getSupportCase(caseId);
+    }
+    const supportCase = await this.requireCase(caseId);
+    return {
+      ...supportCase.toSnapshot(),
+      evidence: Object.freeze(await this.repository.evidenceForCase(caseId)),
+      timeline: Object.freeze(((await this.findTimeline(caseId)) ?? CaseTimeline.create(caseId)).entries.map((entry) => ({ ...entry }))),
+    };
+  }
+
   async attachEvidence(caseId: string, request: AttachEvidenceRequest, correlationId: string, causationId = newCommandId()) {
-    this.requireCase(caseId);
+    await this.requireCase(caseId);
     const { evidence, event } = EvidenceRef.attach({
       evidenceId: newEvidenceId(),
       caseId,
@@ -117,12 +147,13 @@ export class CustomerServiceApplication {
     const evidenceRefs = this.evidenceByCase.get(caseId) ?? [];
     evidenceRefs.push(evidence);
     this.evidenceByCase.set(caseId, evidenceRefs);
+    await this.repository?.saveEvidence(evidence.toSnapshot());
     await this.publisher.publish(toEventEnvelope(event, causationId));
     return evidence.toSnapshot();
   }
 
   async classifySupportCase(caseId: string, request: ClassifySupportCaseRequest, operatorRef: string, correlationId?: string, causationId = newCommandId()): Promise<SupportCaseSnapshot> {
-    const current = this.requireCase(caseId);
+    const { aggregate: current, version } = await this.requireVersionedCase(caseId);
     const { case: updated, event } = current.classify({
       caseId,
       classification: request.classification,
@@ -133,12 +164,15 @@ export class CustomerServiceApplication {
       classifiedAt: new Date(),
     });
     this.cases.set(caseId, updated);
+    if (this.repository) {
+      await this.repository.saveCase(updated.toSnapshot(), version ?? 0n);
+    }
     await this.publisher.publish(toEventEnvelope(event, causationId));
     return updated.toSnapshot();
   }
 
   async assignSupportCase(caseId: string, request: AssignSupportCaseRequest, operatorRef: string, correlationId?: string, causationId = newCommandId()): Promise<SupportCaseSnapshot> {
-    const current = this.requireCase(caseId);
+    const { aggregate: current, version } = await this.requireVersionedCase(caseId);
     const { case: updated, event } = current.assign({
       caseId,
       ownerQueue: request.ownerQueue,
@@ -149,12 +183,15 @@ export class CustomerServiceApplication {
       assignedAt: new Date(),
     });
     this.cases.set(caseId, updated);
+    if (this.repository) {
+      await this.repository.saveCase(updated.toSnapshot(), version ?? 0n);
+    }
     await this.publisher.publish(toEventEnvelope(event, causationId));
     return updated.toSnapshot();
   }
 
   async escalateCase(caseId: string, request: EscalateCaseRequest, operatorRef: string, correlationId?: string, causationId = newCommandId()): Promise<SupportCaseSnapshot> {
-    const current = this.requireCase(caseId);
+    const { aggregate: current, version } = await this.requireVersionedCase(caseId);
     const { case: updated, event } = current.escalate({
       caseId,
       targetQueue: request.targetQueue,
@@ -165,12 +202,15 @@ export class CustomerServiceApplication {
       escalatedAt: new Date(),
     });
     this.cases.set(caseId, updated);
+    if (this.repository) {
+      await this.repository.saveCase(updated.toSnapshot(), version ?? 0n);
+    }
     await this.publisher.publish(toEventEnvelope(event, causationId));
     return updated.toSnapshot();
   }
 
   async resolveCase(caseId: string, request: ResolveCaseRequest, operatorRef: string, correlationId?: string, causationId = newCommandId()): Promise<SupportCaseSnapshot> {
-    const current = this.requireCase(caseId);
+    const { aggregate: current, version } = await this.requireVersionedCase(caseId);
     const { case: updated, event } = current.resolve({
       caseId,
       summary: request.summary,
@@ -181,12 +221,15 @@ export class CustomerServiceApplication {
       resolvedAt: new Date(),
     });
     this.cases.set(caseId, updated);
+    if (this.repository) {
+      await this.repository.saveCase(updated.toSnapshot(), version ?? 0n);
+    }
     await this.publisher.publish(toEventEnvelope(event, causationId));
     return updated.toSnapshot();
   }
 
   async closeCase(caseId: string, request: CloseCaseRequest, operatorRef: string, correlationId?: string, causationId = newCommandId()): Promise<SupportCaseSnapshot> {
-    const current = this.requireCase(caseId);
+    const { aggregate: current, version } = await this.requireVersionedCase(caseId);
     const { case: updated, event } = current.close({
       caseId,
       reason: request.reason,
@@ -196,12 +239,15 @@ export class CustomerServiceApplication {
       closedAt: new Date(),
     });
     this.cases.set(caseId, updated);
+    if (this.repository) {
+      await this.repository.saveCase(updated.toSnapshot(), version ?? 0n);
+    }
     await this.publisher.publish(toEventEnvelope(event, causationId));
     return updated.toSnapshot();
   }
 
   async reopenCase(caseId: string, request: ReopenCaseRequest, correlationId?: string, causationId = newCommandId()): Promise<SupportCaseSnapshot> {
-    const current = this.requireCase(caseId);
+    const { aggregate: current, version } = await this.requireVersionedCase(caseId);
     const { case: updated, event } = current.reopen({
       caseId,
       reason: request.reason,
@@ -211,12 +257,15 @@ export class CustomerServiceApplication {
       reopenedAt: new Date(),
     });
     this.cases.set(caseId, updated);
+    if (this.repository) {
+      await this.repository.saveCase(updated.toSnapshot(), version ?? 0n);
+    }
     await this.publisher.publish(toEventEnvelope(event, causationId));
     return updated.toSnapshot();
   }
 
   async requestManualAction(caseId: string, request: RequestManualActionRequest, correlationId: string, causationId = newCommandId()) {
-    this.requireCase(caseId);
+    await this.requireCase(caseId);
     const { action, event } = ManualActionRequest.request({
       manualActionId: newManualActionId(),
       caseId,
@@ -232,6 +281,7 @@ export class CustomerServiceApplication {
       requestedAt: new Date(),
     });
     this.manualActions.set(action.id, action);
+    await this.repository?.saveNewManualAction(action.toSnapshot());
     await this.appendTimelineEntry(caseId, "ManualActionRequested", toEventEnvelope(event, causationId).payload, "INTERNAL_ONLY", event.occurredAt, event.correlationId, event.causationId);
     await this.publisher.publish(toEventEnvelope(event, causationId));
     return action.toSnapshot();
@@ -245,7 +295,7 @@ export class CustomerServiceApplication {
     if (envelope.producer === "admin-audit" && (envelope.eventType === "ManualActionExecuted" || envelope.eventType === "ManualActionRejected")) {
       await this.recordAdminAuditManualActionOutcome(envelope);
     } else {
-      for (const supportCase of this.cases.values()) {
+      for (const supportCase of await this.findCasesReferencingEnvelope(envelope)) {
         if (caseReferencesEnvelope(supportCase.toSnapshot(), envelope)) {
           await this.appendTimelineEntry(
             supportCase.id,
@@ -274,7 +324,8 @@ export class CustomerServiceApplication {
 
   private async recordAdminAuditManualActionOutcome(envelope: EventEnvelope): Promise<void> {
     const manualActionId = requiredPayloadString(envelope.payload, "manualActionId");
-    const action = this.manualActions.get(manualActionId);
+    const versionedAction = await this.findManualAction(manualActionId);
+    const action = versionedAction?.aggregate;
     if (!action) {
       return;
     }
@@ -291,6 +342,9 @@ export class CustomerServiceApplication {
       causationId: envelope.eventId,
     });
     this.manualActions.set(manualActionId, updated);
+    if (this.repository && versionedAction) {
+      await this.repository.saveManualAction(updated.toSnapshot(), versionedAction.version ?? 0n);
+    }
     const eventEnvelope = toEventEnvelope(event, envelope.eventId);
     await this.publisher.publish(eventEnvelope);
     await this.appendTimelineEntry(
@@ -305,7 +359,8 @@ export class CustomerServiceApplication {
   }
 
   private async appendTimelineEntry(caseId: string, eventType: string, payload: Readonly<Record<string, unknown>>, visibility: "CUSTOMER_VISIBLE" | "INTERNAL_ONLY", occurredAt: Date, correlationId: string, causationId?: string): Promise<void> {
-    const current = this.timelines.get(caseId) ?? CaseTimeline.create(caseId);
+    const versionedTimeline = await this.findVersionedTimeline(caseId);
+    const current = versionedTimeline?.aggregate ?? CaseTimeline.create(caseId);
     const { timeline, event } = current.append({
       entryId: newTimelineEntryId(),
       caseId,
@@ -317,20 +372,71 @@ export class CustomerServiceApplication {
       causationId,
     });
     this.timelines.set(caseId, timeline);
+    if (this.repository) {
+      if (versionedTimeline) {
+        await this.repository.saveTimeline(timeline.toSnapshot(), versionedTimeline.version);
+      } else {
+        await this.repository.saveNewTimeline(timeline.toSnapshot());
+      }
+    }
     await this.publisher.publish(toEventEnvelope(event, event.causationId ?? newCommandId()));
   }
 
-  private requireCase(caseId: string): SupportCase {
+  private requireCaseSync(caseId: string): SupportCase {
     const supportCase = this.cases.get(caseId);
     if (!supportCase) {
       throw new NotFoundError(`Support case ${caseId} was not found`);
     }
     return supportCase;
   }
+
+  private async requireCase(caseId: string): Promise<SupportCase> {
+    return (await this.requireVersionedCase(caseId)).aggregate;
+  }
+
+  private async requireVersionedCase(caseId: string): Promise<Readonly<{ aggregate: SupportCase; version: bigint | undefined }>> {
+    const persisted = await this.repository?.findCase(caseId);
+    if (persisted) {
+      return persisted;
+    }
+    const supportCase = this.cases.get(caseId);
+    if (!supportCase) {
+      throw new NotFoundError(`Support case ${caseId} was not found`);
+    }
+    return { aggregate: supportCase, version: undefined };
+  }
+
+  private async findTimeline(caseId: string): Promise<CaseTimeline | undefined> {
+    return (await this.findVersionedTimeline(caseId))?.aggregate;
+  }
+
+  private async findVersionedTimeline(caseId: string): Promise<Readonly<{ aggregate: CaseTimeline; version: bigint }> | undefined> {
+    return await this.repository?.findTimeline(caseId) ?? (this.timelines.has(caseId) ? { aggregate: this.timelines.get(caseId)!, version: 0n } : undefined);
+  }
+
+  private async findManualAction(manualActionId: string): Promise<Readonly<{ aggregate: ManualActionRequest; version: bigint | undefined }> | undefined> {
+    const persisted = await this.repository?.findManualAction(manualActionId);
+    if (persisted) {
+      return persisted;
+    }
+    const action = this.manualActions.get(manualActionId);
+    return action ? { aggregate: action, version: undefined } : undefined;
+  }
+
+  private async findCasesReferencingEnvelope(envelope: EventEnvelope): Promise<SupportCase[]> {
+    if (!this.repository) {
+      return [...this.cases.values()];
+    }
+    return (await this.repository.listCases()).filter((supportCase) => caseReferencesEnvelope(supportCase.toSnapshot(), envelope));
+  }
 }
 
 export function isDomainError(error: unknown): error is DomainError {
   return error instanceof DomainError;
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return typeof error === "object" && error !== null && (error as { code?: unknown }).code === "23505";
 }
 
 function requiredPayloadString(payload: Record<string, unknown>, field: string): string {

--- a/services/customer-service/src/application/ports/customer-service-repository.ts
+++ b/services/customer-service/src/application/ports/customer-service-repository.ts
@@ -1,0 +1,25 @@
+import {
+  CaseTimeline,
+  ManualActionRequest,
+  SupportCase,
+  type CaseTimelineSnapshot,
+  type EvidenceRefSnapshot,
+  type ManualActionRequestSnapshot,
+  type SupportCaseSnapshot,
+} from "../../domain.js";
+
+export interface CustomerServiceRepository {
+  findCase(caseId: string): Promise<Readonly<{ aggregate: SupportCase; version: bigint }> | undefined>;
+  saveNewCase(snapshot: SupportCaseSnapshot): Promise<{ version: bigint }>;
+  saveCase(snapshot: SupportCaseSnapshot, expectedVersion: bigint): Promise<{ version: bigint }>;
+  listCases(): Promise<SupportCase[]>;
+  findDuplicateOpenCase(snapshot: SupportCaseSnapshot): Promise<SupportCaseSnapshot | undefined>;
+  findTimeline(caseId: string): Promise<Readonly<{ aggregate: CaseTimeline; version: bigint }> | undefined>;
+  saveNewTimeline(snapshot: CaseTimelineSnapshot): Promise<{ version: bigint }>;
+  saveTimeline(snapshot: CaseTimelineSnapshot, expectedVersion: bigint): Promise<{ version: bigint }>;
+  evidenceForCase(caseId: string): Promise<EvidenceRefSnapshot[]>;
+  saveEvidence(snapshot: EvidenceRefSnapshot): Promise<void>;
+  findManualAction(manualActionId: string): Promise<Readonly<{ aggregate: ManualActionRequest; version: bigint }> | undefined>;
+  saveNewManualAction(snapshot: ManualActionRequestSnapshot): Promise<{ version: bigint }>;
+  saveManualAction(snapshot: ManualActionRequestSnapshot, expectedVersion: bigint): Promise<{ version: bigint }>;
+}

--- a/services/customer-service/src/bootstrap.ts
+++ b/services/customer-service/src/bootstrap.ts
@@ -3,6 +3,7 @@ import { createApp, opentelemetryInstrumentationFromEnv, type InstrumentationHoo
 import { RedisEventPublisher } from "./adapters/messaging/publisher.js";
 import { uuidV7 } from "@trainticket/ts-kit";
 import { RedisEventSubscriber } from "./adapters/messaging/subscriber.js";
+import { startCustomerServiceStorage } from "./adapters/storage/runtime.js";
 import { CUSTOMER_SERVICE_CONSUMER_GROUP, CUSTOMER_SERVICE_SUBSCRIPTIONS } from "./adapters/messaging/stream-config.js";
 
 export type BootstrapOptions = Readonly<{
@@ -24,6 +25,7 @@ export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): numbe
 }
 
 export async function bootstrap(options: BootstrapOptions = {}) {
+  const storage = process.env.DATABASE_URL ? await startCustomerServiceStorage() : undefined;
   const publisher = new RedisEventPublisher();
   const application = new CustomerServiceApplication(publisher);
   const subscriber = new RedisEventSubscriber();
@@ -31,17 +33,20 @@ export async function bootstrap(options: BootstrapOptions = {}) {
     CUSTOMER_SERVICE_SUBSCRIPTIONS,
     CUSTOMER_SERVICE_CONSUMER_GROUP,
     `${CUSTOMER_SERVICE_CONSUMER_GROUP}-${process.env.HOSTNAME ?? uuidV7()}`,
-    (envelope) => application.handleIntegrationEvent(envelope as never),
+    (envelope) => storage ? storage.handleIntegrationEvent(envelope as never) : application.handleIntegrationEvent(envelope as never),
   );
 
   const app = createApp({
     instrumentation: options.instrumentation ?? opentelemetryInstrumentationFromEnv(),
     publisher,
     application,
+    idempotencyStore: storage?.idempotencyStore,
+    storage,
   });
   app.addHook("onClose", async () => {
     await subscriber.stop();
     await publisher.close();
+    await storage?.stop();
   });
   await app.listen({ host: runtimeHost(options), port: runtimePort(options) });
   return app;

--- a/services/customer-service/src/domain.test.ts
+++ b/services/customer-service/src/domain.test.ts
@@ -685,3 +685,17 @@ describe("Customer Service domain foundation", () => {
     });
   });
 });
+
+describe("customer-service persistence duplicate signature", () => {
+  it("normalizes undefined and null business references to the same duplicate signature", async () => {
+    const { duplicateBusinessRef } = await import("./adapters/storage/customer-service-repository.js");
+    const withoutReference = SupportCase.open(openCommand({ businessReferences: undefined })).case.toSnapshot();
+    const withNullReference = {
+      ...withoutReference,
+      businessReferences: { journeyOrderId: null } as never,
+    };
+
+    assert.equal(duplicateBusinessRef(withoutReference), "__NO_BUSINESS_REF__");
+    assert.equal(duplicateBusinessRef(withNullReference), duplicateBusinessRef(withoutReference));
+  });
+});

--- a/services/customer-service/src/domain.ts
+++ b/services/customer-service/src/domain.ts
@@ -527,6 +527,10 @@ export class SupportCase {
     Object.freeze(this);
   }
 
+  static fromSnapshot(snapshot: SupportCaseSnapshot): SupportCase {
+    return new SupportCase(deepFreeze(cloneForSnapshot(snapshot)));
+  }
+
   static open(command: OpenSupportCase): { case: SupportCase; event: SupportCaseOpened } {
     validateOpenCommand(command);
 
@@ -888,6 +892,10 @@ export class EvidenceRef {
     Object.freeze(this);
   }
 
+  static fromSnapshot(snapshot: EvidenceRefSnapshot): EvidenceRef {
+    return new EvidenceRef(deepFreeze(cloneForSnapshot(snapshot)));
+  }
+
   static attach(command: AttachEvidence): { evidence: EvidenceRef; event: EvidenceAttached } {
     validateAttachEvidenceCommand(command);
 
@@ -962,6 +970,10 @@ export class ManualActionRequest {
   private constructor(private readonly snapshot: ManualActionRequestSnapshot) {
     deepFreeze(this.snapshot);
     Object.freeze(this);
+  }
+
+  static fromSnapshot(snapshot: ManualActionRequestSnapshot): ManualActionRequest {
+    return new ManualActionRequest(deepFreeze(cloneForSnapshot(snapshot)));
   }
 
   static request(command: RequestManualAction): { action: ManualActionRequest; event: ManualActionRequested } {
@@ -1084,6 +1096,10 @@ export class CaseTimeline {
   private constructor(private readonly snapshot: CaseTimelineSnapshot) {
     deepFreeze(this.snapshot);
     Object.freeze(this);
+  }
+
+  static fromSnapshot(snapshot: CaseTimelineSnapshot): CaseTimeline {
+    return new CaseTimeline(deepFreeze(cloneForSnapshot(snapshot)));
   }
 
   static create(caseId: SupportCaseId): CaseTimeline {

--- a/services/offer-management/migrations/001_offer_storage.sql
+++ b/services/offer-management/migrations/001_offer_storage.sql
@@ -1,0 +1,58 @@
+CREATE TABLE IF NOT EXISTS offer_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS offer_snapshots_quote_request_idx
+  ON offer_snapshots ((data->>'quoteRequestId'), updated_at DESC);
+
+
+CREATE TABLE IF NOT EXISTS offer_upstream_itineraries (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS offer_upstream_fare_quotes (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS offer_upstream_travelers (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS outbox (
+  seq          bigserial PRIMARY KEY,
+  event_id     text NOT NULL UNIQUE,
+  stream       text NOT NULL,
+  envelope     jsonb NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  published_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS outbox_unpublished_seq_idx
+  ON outbox (seq)
+  WHERE published_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS processed_events (
+  event_id     text PRIMARY KEY,
+  stream       text,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS idempotency_records (
+  key           text PRIMARY KEY,
+  request_hash  text NOT NULL,
+  status_code   int NOT NULL,
+  response_body jsonb,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);

--- a/services/offer-management/package-lock.json
+++ b/services/offer-management/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@trainticket/ts-kit": "file:../../platform/ts-kit",
+        "@types/pg": "^8.20.0",
         "fastify": "5.9.0",
-        "ioredis": "^5.11.1"
+        "ioredis": "^5.11.1",
+        "pg": "^8.22.0"
       },
       "devDependencies": {
         "@types/node": "^26.0.1",
@@ -156,6 +158,17 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmmirror.com/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/abstract-logging": {
@@ -508,6 +521,95 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmmirror.com/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmmirror.com/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmmirror.com/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmmirror.com/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmmirror.com/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/pino": {
       "version": "10.3.1",
       "resolved": "https://registry.npmmirror.com/pino/-/pino-10.3.1.tgz",
@@ -544,6 +646,45 @@
       "resolved": "https://registry.npmmirror.com/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmmirror.com/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/process-warning": {
       "version": "5.0.0",
@@ -765,6 +906,15 @@
       "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     }
   }
 }

--- a/services/offer-management/package.json
+++ b/services/offer-management/package.json
@@ -9,8 +9,10 @@
   },
   "dependencies": {
     "@trainticket/ts-kit": "file:../../platform/ts-kit",
+    "@types/pg": "^8.20.0",
     "fastify": "5.9.0",
-    "ioredis": "^5.11.1"
+    "ioredis": "^5.11.1",
+    "pg": "^8.22.0"
   },
   "devDependencies": {
     "@types/node": "^26.0.1",

--- a/services/offer-management/src/adapters/storage/offer-repository.ts
+++ b/services/offer-management/src/adapters/storage/offer-repository.ts
@@ -1,0 +1,74 @@
+import { type PoolClient } from "pg";
+
+import { SnapshotRepository, type SnapshotRecord } from "@trainticket/ts-kit";
+
+import { type OfferSnapshot } from "../../domain.js";
+import { type OfferRepository } from "../../application/offers.js";
+
+export class PostgresOfferRepository implements OfferRepository {
+  constructor(private readonly client: PoolClient) {}
+
+  async save(snapshot: OfferSnapshot, expectedVersion?: bigint): Promise<SnapshotRecord<StoredOfferSnapshot>> {
+    return new SnapshotRepository<StoredOfferSnapshot>(this.client, "offer_snapshots").save(snapshot.offerId, serializeOffer(snapshot), expectedVersion);
+  }
+
+  async findById(offerId: string): Promise<OfferSnapshot | undefined> {
+    const record = await new SnapshotRepository<StoredOfferSnapshot>(this.client, "offer_snapshots").get(offerId);
+    return record ? reviveOffer(record.data) : undefined;
+  }
+
+  clear(): void {
+    // PostgreSQL-backed repositories are scoped to the database lifecycle.
+  }
+}
+
+type StoredOfferSnapshot = Omit<OfferSnapshot, "validityWindow" | "items" | "priceSnapshot" | "quotedAt" | "expiredAt"> & Readonly<{
+  validityWindow: Readonly<{ startsAt: string; expiresAt: string }>;
+  items: readonly StoredOfferItem[];
+  priceSnapshot: StoredPriceSnapshot;
+  quotedAt: string;
+  expiredAt?: string;
+}>;
+type StoredOfferItem = Omit<OfferSnapshot["items"][number], "fareSnapshot" | "availabilitySnapshot"> & Readonly<{
+  fareSnapshot: Omit<OfferSnapshot["items"][number]["fareSnapshot"], "capturedAt" | "expiresAt"> & Readonly<{ capturedAt: string; expiresAt: string }>;
+  availabilitySnapshot: Omit<OfferSnapshot["items"][number]["availabilitySnapshot"], "capturedAt" | "expiresAt"> & Readonly<{ capturedAt: string; expiresAt: string }>;
+}>;
+type StoredPriceSnapshot = Omit<OfferSnapshot["priceSnapshot"], "capturedAt" | "expiresAt"> & Readonly<{ capturedAt: string; expiresAt: string }>;
+
+function serializeSnapshot<T>(snapshot: T): T {
+  return JSON.parse(JSON.stringify(snapshot)) as T;
+}
+
+function serializeOffer(snapshot: OfferSnapshot): StoredOfferSnapshot {
+  return serializeSnapshot(snapshot) as unknown as StoredOfferSnapshot;
+}
+
+function reviveOffer(snapshot: StoredOfferSnapshot): OfferSnapshot {
+  return {
+    ...snapshot,
+    validityWindow: {
+      startsAt: new Date(snapshot.validityWindow.startsAt),
+      expiresAt: new Date(snapshot.validityWindow.expiresAt),
+    },
+    items: snapshot.items.map((item) => ({
+      ...item,
+      fareSnapshot: {
+        ...item.fareSnapshot,
+        capturedAt: new Date(item.fareSnapshot.capturedAt),
+        expiresAt: new Date(item.fareSnapshot.expiresAt),
+      },
+      availabilitySnapshot: {
+        ...item.availabilitySnapshot,
+        capturedAt: new Date(item.availabilitySnapshot.capturedAt),
+        expiresAt: new Date(item.availabilitySnapshot.expiresAt),
+      },
+    })),
+    priceSnapshot: {
+      ...snapshot.priceSnapshot,
+      capturedAt: new Date(snapshot.priceSnapshot.capturedAt),
+      expiresAt: new Date(snapshot.priceSnapshot.expiresAt),
+    },
+    quotedAt: new Date(snapshot.quotedAt),
+    expiredAt: snapshot.expiredAt ? new Date(snapshot.expiredAt) : undefined,
+  };
+}

--- a/services/offer-management/src/adapters/storage/runtime.ts
+++ b/services/offer-management/src/adapters/storage/runtime.ts
@@ -1,0 +1,98 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Redis } from "ioredis";
+import {
+  MigrationRunner,
+  OutboxAppender,
+  OutboxRelay,
+  PostgresIdempotencyStore,
+  ProcessedEventsGuard,
+  checkPostgresReadiness,
+  createPostgresPool,
+  streamForProducer,
+  withTransaction,
+  type EventEnvelope,
+} from "@trainticket/ts-kit";
+import { type Pool } from "pg";
+
+import { OfferApplicationService } from "../../application/offers.js";
+import { applyUpstreamEvent, buildQuoteOfferCommand, type UpstreamStateRepository } from "../../application/upstream-state.js";
+import { PostgresOfferRepository } from "./offer-repository.js";
+import { PostgresUpstreamStateRepository } from "./upstream-state-repository.js";
+
+export type OfferStorageRuntime = Readonly<{
+  ready: () => Promise<boolean>;
+  idempotencyStore: PostgresIdempotencyStore;
+  runCommand: <T>(upstreamRepository: UpstreamStateRepository, operation: (application: OfferApplicationService) => Promise<T>) => Promise<T>;
+  handleUpstreamEvent: (envelope: EventEnvelope, stream?: string) => Promise<"ack" | "retry" | "dlq">;
+  stop: () => Promise<void>;
+}>;
+
+export async function startOfferStorage(redisUrl = process.env.REDIS_URL ?? "redis://localhost:6379"): Promise<OfferStorageRuntime> {
+  const pool = createPostgresPool();
+  const migrations = new MigrationRunner(pool, migrationsDirectory());
+  try {
+    await migrations.apply();
+  } catch (error) {
+    console.error(sanitizedErrorForLog(error));
+  }
+
+  const redis = new Redis(redisUrl, { lazyConnect: true });
+  await redis.connect();
+  const relay = new OutboxRelay(pool, redis, {
+    pollIntervalMs: 250,
+    onFailure: (error) => console.error(sanitizedErrorForLog(error)),
+  });
+  relay.start();
+
+  return {
+    ready: () => migrations.isReady ? checkPostgresReadiness(pool) : Promise.resolve(false),
+    idempotencyStore: new PostgresIdempotencyStore(pool),
+    runCommand: (upstreamRepository, operation) => withOfferTransaction(pool, upstreamRepository, operation),
+    handleUpstreamEvent: (envelope, stream) => withTransaction(pool, async (client): Promise<"ack" | "retry" | "dlq"> => {
+      const guard = new ProcessedEventsGuard(client);
+      if (!await guard.tryStart(envelope.eventId, stream)) {
+        return "ack";
+      }
+      await applyUpstreamEvent(new PostgresUpstreamStateRepository(client), envelope);
+      return "ack";
+    }),
+    stop: async () => {
+      await relay.stop();
+      await Promise.allSettled([redis.quit(), pool.end()]);
+    },
+  };
+}
+
+async function withOfferTransaction<T>(pool: Pool, _upstreamRepository: UpstreamStateRepository, operation: (application: OfferApplicationService) => Promise<T>): Promise<T> {
+  return withTransaction(pool, async (client) => {
+    const publisher = new TransactionalOutboxPublisher(new OutboxAppender(client));
+    const persistedUpstreamRepository = new PostgresUpstreamStateRepository(client);
+    const application = new OfferApplicationService(
+      new PostgresOfferRepository(client),
+      publisher,
+      (request) => buildQuoteOfferCommand(persistedUpstreamRepository, request),
+    );
+    return operation(application);
+  });
+}
+
+class TransactionalOutboxPublisher {
+  constructor(private readonly appender: OutboxAppender) {}
+
+  async publish(envelope: EventEnvelope): Promise<void> {
+    await this.appender.append(envelope, streamForProducer(envelope.producer));
+  }
+}
+
+export function migrationsDirectory(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), "../../../migrations");
+}
+
+function sanitizedErrorForLog(error: unknown): Readonly<{ name: string; message: string }> {
+  if (error instanceof Error) {
+    return { name: error.name || "Error", message: error.message || "Storage failed" };
+  }
+  return { name: typeof error, message: "Storage failed" };
+}

--- a/services/offer-management/src/adapters/storage/upstream-state-repository.ts
+++ b/services/offer-management/src/adapters/storage/upstream-state-repository.ts
@@ -1,0 +1,150 @@
+import { type PoolClient, type QueryResult } from "pg";
+
+import {
+  fareQuoteStorageKey,
+  type StoredAvailability,
+  type StoredFareQuote,
+  type StoredItinerary,
+  type StoredTraveler,
+  type UpstreamStateRepository,
+} from "../../application/upstream-state.js";
+import { type OfferItem } from "../../domain.js";
+
+export class PostgresUpstreamStateRepository implements UpstreamStateRepository {
+  constructor(private readonly client: PoolClient) {}
+
+  async saveItinerary(itinerary: StoredItinerary): Promise<void> {
+    await upsertSnapshot(this.client, "offer_upstream_itineraries", itinerary.itineraryRef, serializeItinerary(itinerary));
+  }
+
+  async findItinerary(itineraryRef: string): Promise<StoredItinerary | undefined> {
+    const row = await findSnapshot<StoredItinerarySnapshot>(this.client, "offer_upstream_itineraries", itineraryRef);
+    return row ? reviveItinerary(row) : undefined;
+  }
+
+  async saveFareQuote(fareQuote: StoredFareQuote): Promise<void> {
+    await upsertSnapshot(this.client, "offer_upstream_fare_quotes", fareQuoteStorageKey(fareQuote.inputHash, fareQuote.channelId, fareQuote.travelerRefs), serializeFareQuote(fareQuote));
+  }
+
+  async findFareQuote(inputHash: string, channelId: string, travelerRefs: readonly string[]): Promise<StoredFareQuote | undefined> {
+    const row = await findSnapshot<StoredFareQuoteSnapshot>(this.client, "offer_upstream_fare_quotes", fareQuoteStorageKey(inputHash, channelId, travelerRefs));
+    return row ? reviveFareQuote(row) : undefined;
+  }
+
+  async saveTraveler(traveler: StoredTraveler): Promise<void> {
+    await upsertSnapshot(this.client, "offer_upstream_travelers", traveler.travelerId, serializeTraveler(traveler));
+  }
+
+  async findTraveler(travelerId: string): Promise<StoredTraveler | undefined> {
+    const row = await findSnapshot<StoredTravelerSnapshot>(this.client, "offer_upstream_travelers", travelerId);
+    return row ? reviveTraveler(row) : undefined;
+  }
+
+  async removeTravelerEligibility(travelerId: string, eligibilityId: string): Promise<void> {
+    const existing = await this.findTraveler(travelerId);
+    if (existing?.eligibilityRef?.eligibilityId !== eligibilityId) {
+      return;
+    }
+    await this.saveTraveler({ ...existing, eligibilityRef: undefined });
+  }
+
+  clear(): void {
+    // PostgreSQL-backed repositories are scoped to the database lifecycle.
+  }
+}
+
+type StoredItinerarySnapshot = Omit<StoredItinerary, "modeBySegment" | "availabilityBySegment"> & Readonly<{
+  modeBySegment: readonly (readonly [string, OfferItem["mode"]])[];
+  availabilityBySegment: readonly (readonly [string, StoredAvailabilitySnapshot])[];
+}>;
+
+type StoredAvailabilitySnapshot = Omit<StoredAvailability, "capturedAt" | "expiresAt"> & Readonly<{
+  capturedAt: string;
+  expiresAt: string;
+}>;
+
+type StoredFareQuoteSnapshot = Omit<StoredFareQuote, "validFrom" | "validUntil"> & Readonly<{
+  validFrom: string;
+  validUntil: string;
+}>;
+
+type StoredTravelerSnapshot = StoredTraveler;
+
+async function upsertSnapshot(client: PoolClient, tableName: UpstreamTableName, id: string, data: unknown): Promise<void> {
+  await client.query(
+    `INSERT INTO ${tableName} (id, version, data)
+     VALUES ($1, 1, $2)
+     ON CONFLICT (id)
+     DO UPDATE SET version = ${tableName}.version + 1, data = EXCLUDED.data, updated_at = now()`,
+    [id, data],
+  );
+}
+
+async function findSnapshot<T>(client: PoolClient, tableName: UpstreamTableName, id: string): Promise<T | undefined> {
+  const result = await client.query(
+    `SELECT data FROM ${tableName} WHERE id = $1`,
+    [id],
+  ) as QueryResult<{ data: T }>;
+  return result.rows[0]?.data;
+}
+
+function serializeItinerary(itinerary: StoredItinerary): StoredItinerarySnapshot {
+  return {
+    itineraryRef: itinerary.itineraryRef,
+    itineraryVersion: itinerary.itineraryVersion,
+    segmentRefs: itinerary.segmentRefs,
+    modeBySegment: [...itinerary.modeBySegment.entries()],
+    availabilityBySegment: [...itinerary.availabilityBySegment.entries()].map(([segmentRef, availability]) => [segmentRef, serializeAvailability(availability)] as const),
+    inputHash: itinerary.inputHash,
+  };
+}
+
+function reviveItinerary(snapshot: StoredItinerarySnapshot): StoredItinerary {
+  return {
+    ...snapshot,
+    modeBySegment: new Map(snapshot.modeBySegment),
+    availabilityBySegment: new Map(snapshot.availabilityBySegment.map(([segmentRef, availability]) => [segmentRef, reviveAvailability(availability)] as const)),
+  };
+}
+
+function serializeAvailability(availability: StoredAvailability): StoredAvailabilitySnapshot {
+  return {
+    ...availability,
+    capturedAt: availability.capturedAt.toISOString(),
+    expiresAt: availability.expiresAt.toISOString(),
+  };
+}
+
+function reviveAvailability(snapshot: StoredAvailabilitySnapshot): StoredAvailability {
+  return {
+    ...snapshot,
+    capturedAt: new Date(snapshot.capturedAt),
+    expiresAt: new Date(snapshot.expiresAt),
+  };
+}
+
+function serializeFareQuote(fareQuote: StoredFareQuote): StoredFareQuoteSnapshot {
+  return {
+    ...fareQuote,
+    validFrom: fareQuote.validFrom.toISOString(),
+    validUntil: fareQuote.validUntil.toISOString(),
+  };
+}
+
+function reviveFareQuote(snapshot: StoredFareQuoteSnapshot): StoredFareQuote {
+  return {
+    ...snapshot,
+    validFrom: new Date(snapshot.validFrom),
+    validUntil: new Date(snapshot.validUntil),
+  };
+}
+
+function serializeTraveler(traveler: StoredTraveler): StoredTravelerSnapshot {
+  return JSON.parse(JSON.stringify(traveler)) as StoredTravelerSnapshot;
+}
+
+function reviveTraveler(snapshot: StoredTravelerSnapshot): StoredTraveler {
+  return snapshot;
+}
+
+type UpstreamTableName = "offer_upstream_itineraries" | "offer_upstream_fare_quotes" | "offer_upstream_travelers";

--- a/services/offer-management/src/app.ts
+++ b/services/offer-management/src/app.ts
@@ -35,7 +35,7 @@ export type HealthStatus = Readonly<{
 }>;
 
 export type ProbeStatus = Readonly<{
-  status: "ok";
+  status: "ok" | "not_ready";
   probe: "live" | "ready";
 }>;
 
@@ -143,6 +143,12 @@ type AppDependencies = Readonly<{
   quoteCommandFactory?: (request: QuoteOfferRequest) => QuoteOfferCommand | Promise<QuoteOfferCommand>;
   upstreamRepository?: UpstreamStateRepository;
   idempotencyStore?: IdempotencyStore;
+  storage?: AppStorage;
+}>;
+
+export type AppStorage = Readonly<{
+  ready: () => boolean | Promise<boolean>;
+  runCommand?: <T>(upstreamRepository: UpstreamStateRepository, operation: (application: OfferApplicationService) => Promise<T>) => Promise<T>;
 }>;
 
 const defaultOfferRepository = new InMemoryOfferRepository();
@@ -165,6 +171,7 @@ export function createApp(instrumentation: InstrumentationHooks = {}, dependenci
     dependencies.quoteCommandFactory ?? ((request) => buildQuoteOfferCommand(upstreamRepository, request)),
   );
   const idempotencyStore = dependencies.idempotencyStore ?? defaultIdempotencyStore;
+  const runWithOfferService = dependencies.storage?.runCommand ?? (<T>(_upstream: UpstreamStateRepository, operation: (service: OfferApplicationService) => Promise<T>) => operation(offerService));
   const spans = new WeakMap<FastifyRequest, TraceSpan>();
 
   app.addHook("onRequest", async (request, reply) => {
@@ -191,8 +198,8 @@ export function createApp(instrumentation: InstrumentationHooks = {}, dependenci
   app.get("/metadata", async () => metadata());
   app.get("/live", async () => probeBody("live"));
   app.get("/livez", async () => probeBody("live"));
-  app.get("/ready", async () => probeBody("ready"));
-  app.get("/readyz", async () => probeBody("ready"));
+  app.get("/ready", async (_request, reply) => readyBody(reply, dependencies.storage));
+  app.get("/readyz", async (_request, reply) => readyBody(reply, dependencies.storage));
 
   // -----------------------------------------------------------------------
   // Offer Management API — POST /api/v1/offers
@@ -222,13 +229,13 @@ export function createApp(instrumentation: InstrumentationHooks = {}, dependenci
           }
 
           const { accountId, channelId, itineraryRef, travelerRefs, quoteRequestId } = request.body;
-          const { response: responseBody } = await offerService.quoteOffer({
+          const { response: responseBody } = await runWithOfferService(upstreamRepository, (service) => service.quoteOffer({
             accountId: accountId!,
             channelId: channelId!,
             itineraryRef: itineraryRef!,
             travelerRefs: travelerRefs!,
             quoteRequestId,
-          }, ctx.correlationId);
+          }, ctx.correlationId));
 
           return { statusCode: 201, body: responseBody };
         },
@@ -260,7 +267,7 @@ export function createApp(instrumentation: InstrumentationHooks = {}, dependenci
     const ctx = requestContext(request);
     const { offerId } = request.params;
 
-    const offer = await offerService.getOffer(offerId);
+    const offer = await runWithOfferService(upstreamRepository, (service) => service.getOffer(offerId));
     if (!offer) {
       sendError(reply, 404, "NOT_FOUND", `Offer ${offerId} not found`, ctx);
       return reply;
@@ -319,6 +326,14 @@ function healthBody(): HealthStatus {
 
 function probeBody(probe: ProbeStatus["probe"]): ProbeStatus {
   return { status: health(), probe };
+}
+
+async function readyBody(reply: { status: (statusCode: number) => unknown }, storage: AppStorage | undefined): Promise<ProbeStatus> {
+  if (storage && !await storage.ready()) {
+    reply.status(503);
+    return { status: "not_ready", probe: "ready" };
+  }
+  return probeBody("ready");
 }
 
 function traceContext(request: AppRequest, context: RequestContext = requestContext(request)): RequestTraceContext {

--- a/services/offer-management/src/application/offers.ts
+++ b/services/offer-management/src/application/offers.ts
@@ -55,7 +55,7 @@ type QuoteOfferResult = Readonly<{
 }>;
 
 export interface OfferRepository {
-  save(snapshot: OfferSnapshot): Promise<void>;
+  save(snapshot: OfferSnapshot, expectedVersion?: bigint): Promise<{ version: bigint }> | Promise<void>;
   findById(offerId: string): Promise<OfferSnapshot | undefined>;
   clear(): void;
 }

--- a/services/offer-management/src/application/upstream-state.ts
+++ b/services/offer-management/src/application/upstream-state.ts
@@ -18,7 +18,7 @@ export type QuoteOfferRequest = Readonly<{
 
 type MoneyLike = Readonly<{ currency: string; minorUnits: number }>;
 
-type StoredItinerary = Readonly<{
+export type StoredItinerary = Readonly<{
   itineraryRef: string;
   itineraryVersion: string;
   segmentRefs: readonly string[];
@@ -27,7 +27,7 @@ type StoredItinerary = Readonly<{
   inputHash?: string;
 }>;
 
-type StoredAvailability = Readonly<{
+export type StoredAvailability = Readonly<{
   snapshotId: string;
   snapshotVersion: string;
   capturedAt: Date;
@@ -37,7 +37,7 @@ type StoredAvailability = Readonly<{
   confidence: AvailabilityConfidence;
 }>;
 
-type StoredFareQuote = Readonly<{
+export type StoredFareQuote = Readonly<{
   quoteId: string;
   inputHash: string;
   channelId: string;
@@ -54,7 +54,7 @@ type StoredFareQuote = Readonly<{
   guaranteeLevel: PriceGuaranteeLevel;
 }>;
 
-type StoredTraveler = Readonly<{
+export type StoredTraveler = Readonly<{
   travelerId: string;
   travelerType: TravelerType;
   maskedDocumentRef?: string;
@@ -386,11 +386,15 @@ function availabilitySnapshots(itinerary: Record<string, unknown>, segmentRefs: 
   return bySegment;
 }
 
-function fareQuoteKey(inputHash: string, channelId: string, travelerRefs: readonly string[]): string {
+export function fareQuoteStorageKey(inputHash: string, channelId: string, travelerRefs: readonly string[]): string {
   return `${inputHash}:${channelId}:${travelerSetHash(travelerRefs)}`;
 }
 
-function travelerSetHash(travelerRefs: readonly string[]): string {
+function fareQuoteKey(inputHash: string, channelId: string, travelerRefs: readonly string[]): string {
+  return fareQuoteStorageKey(inputHash, channelId, travelerRefs);
+}
+
+export function travelerSetHash(travelerRefs: readonly string[]): string {
   return [...travelerRefs].sort().join(",");
 }
 

--- a/services/offer-management/src/bootstrap.ts
+++ b/services/offer-management/src/bootstrap.ts
@@ -2,6 +2,7 @@ import { createRedisMessagingAdapters } from "./adapters/messaging/redis.js";
 import { CONSUMER_GROUP, SUBSCRIBED_STREAMS, consumerName } from "./adapters/messaging/stream-config.js";
 import { createApp, opentelemetryInstrumentationFromEnv, type InstrumentationHooks } from "./app.js";
 import { createUpstreamEventHandler, InMemoryUpstreamStateRepository } from "./application/upstream-state.js";
+import { startOfferStorage } from "./adapters/storage/runtime.js";
 
 export type BootstrapOptions = Readonly<{
   host?: string;
@@ -33,10 +34,13 @@ export function runtimeRedisUrl(options: Pick<BootstrapOptions, "redisUrl"> = {}
 
 export async function bootstrap(options: BootstrapOptions = {}) {
   const messaging = await createRedisMessagingAdapters(runtimeRedisUrl(options));
+  const storage = process.env.DATABASE_URL ? await startOfferStorage(runtimeRedisUrl(options)) : undefined;
   const upstreamRepository = new InMemoryUpstreamStateRepository();
   const app = createApp(options.instrumentation ?? opentelemetryInstrumentationFromEnv(), {
     publisher: messaging.publisher,
     upstreamRepository,
+    idempotencyStore: storage?.idempotencyStore,
+    storage,
   });
 
   const abortController = new AbortController();
@@ -44,7 +48,12 @@ export async function bootstrap(options: BootstrapOptions = {}) {
     SUBSCRIBED_STREAMS,
     CONSUMER_GROUP,
     consumerName(options.instanceId ?? process.env.HOSTNAME),
-    createUpstreamEventHandler(upstreamRepository),
+    async (envelope) => {
+      if (storage) {
+        return storage.handleUpstreamEvent(envelope);
+      }
+      return createUpstreamEventHandler(upstreamRepository)(envelope);
+    },
     abortController.signal,
   );
   const subscriptionFailed = new Promise<never>((_, reject) => {
@@ -67,6 +76,7 @@ export async function bootstrap(options: BootstrapOptions = {}) {
     abortController.abort();
     messaging.subscriber.stop();
     await messaging.close();
+    await storage?.stop();
   });
 
   await app.listen({ host: runtimeHost(options), port: runtimePort(options) });


### PR DESCRIPTION
## Summary
- Add Postgres migrations, snapshot repositories, transactional outbox relays, and processed/idempotency storage for account, customer-service, and offer-management.
- Wire readiness to SELECT 1-backed storage health and include migrations in service Dockerfiles.
- Persist account freeze state, support cases/timelines, and offer snapshots with optimistic concurrency.

## Validation
- npm test in services/account
- npm test in services/customer-service
- npm test in services/offer-management
- make check