### PR TITLE
Hotfix: enable transaction management in merged Java persistence configurations

### DIFF
--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/infrastructure/persistence/AdminAuditPersistenceConfiguration.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/infrastructure/persistence/AdminAuditPersistenceConfiguration.java
@@ -20,8 +20,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
+@EnableTransactionManagement
 @ConditionalOnExpression("'${DATABASE_URL:}' != ''")
 public class AdminAuditPersistenceConfiguration {
     @Bean(destroyMethod = "close")

--- a/services/payment/src/main/java/com/trainticket/payment/infrastructure/persistence/PaymentPersistenceConfiguration.java
+++ b/services/payment/src/main/java/com/trainticket/payment/infrastructure/persistence/PaymentPersistenceConfiguration.java
@@ -21,8 +21,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
+@EnableTransactionManagement
 @ConditionalOnExpression("'${DATABASE_URL:}' != ''")
 public class PaymentPersistenceConfiguration {
     @Bean(destroyMethod = "close")

--- a/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostSalesPersistenceConfiguration.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostSalesPersistenceConfiguration.java
@@ -20,8 +20,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
+@EnableTransactionManagement
 @ConditionalOnExpression("'${DATABASE_URL:}' != ''")
 public class PostSalesPersistenceConfiguration {
     @Bean(destroyMethod = "close")

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/infrastructure/persistence/TravelerProfilePersistenceConfiguration.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/infrastructure/persistence/TravelerProfilePersistenceConfiguration.java
@@ -20,8 +20,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
+@EnableTransactionManagement
 @ConditionalOnExpression("'${DATABASE_URL:}' != ''")
 public class TravelerProfilePersistenceConfiguration {
     @Bean(destroyMethod = "close")


### PR DESCRIPTION
Spring Boot 4 ships transaction auto-configuration in modules these services do not depend on, so `@Transactional` guard-and-dispatch blocks were silently non-transactional (discovered at gate-081A: finance-settlement lost PaymentCaptured events via commit-then-fail ack-skip; verified by handler proxy class inspection). Adds `@EnableTransactionManagement` beside each `PlatformTransactionManager` definition in payment, traveler-profile, post-sales, admin-audit — the REQ-081A trio got the same fix inside #153.

Verified live: images rebuilt+rolled, e2e 01/02/03/09 green (43 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)