### PR TITLE
legacy-acl: read domain code from details.domainCode for projection retry

### DIFF
--- a/services/legacy-acl/src/legacy_acl/downstream.py
+++ b/services/legacy-acl/src/legacy_acl/downstream.py
@@ -110,7 +110,12 @@ def _downstream_failure(service: str, raw: str, fallback: str) -> tuple[str, str
         parsed_message = parsed.get("message") or parsed.get("msg") or parsed.get("error")
         if isinstance(parsed_message, str) and parsed_message.strip():
             message = parsed_message.strip()
-        parsed_code = parsed.get("code")
+        # Services wrap the specific domain code in details.domainCode under a
+        # generic top-level code (e.g. DOMAIN_RULE_VIOLATION); prefer the
+        # specific one.
+        details = parsed.get("details")
+        domain_code = details.get("domainCode") if isinstance(details, dict) else None
+        parsed_code = domain_code or parsed.get("code")
         if isinstance(parsed_code, str) and parsed_code.strip():
             code = parsed_code.strip()
     return message, code

--- a/services/legacy-acl/tests/test_skeleton.py
+++ b/services/legacy-acl/tests/test_skeleton.py
@@ -11,3 +11,18 @@ class LegacyAclSkeletonTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def test_downstream_failure_prefers_domain_code() -> None:
+    from legacy_acl.downstream import _downstream_failure
+
+    message, code = _downstream_failure(
+        "offer-management",
+        '{"code": "DOMAIN_RULE_VIOLATION", "message": "No consumed Fare Pricing quote matches", "details": {"domainCode": "MISSING_FARE_QUOTE"}}',
+        "Unprocessable Entity",
+    )
+    assert message == "No consumed Fare Pricing quote matches"
+    assert code == "MISSING_FARE_QUOTE"
+
+    _, generic = _downstream_failure("payment", '{"code": "NOT_FOUND", "message": "missing"}', "Not Found")
+    assert generic == "NOT_FOUND"


### PR DESCRIPTION
#158 的重试从未触发:各服务错误响应顶层 `code` 是泛化的 `DOMAIN_RULE_VIOLATION`,具体域码在 `details.domainCode`。证据:legacy-acl 延迟 p95 仍 ~50ms(重试若触发应 ≥6s),preserve 持续 MISSING_FARE_QUOTE。现在优先取 `details.domainCode`。单测 9/9;已上线观察。

🤖 Generated with [Claude Code](https://claude.com/claude-code)