### PR TITLE
REQ-090 ack-skip stale capacity events

### DIFF
--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
@@ -142,8 +142,8 @@ public class BookingOrchestrationService {
         Map<String, Object> payload = payloadMap(envelope.payload());
         switch (envelope.eventType()) {
             case "JourneyOrderCreated" -> handleJourneyOrderCreated(payload, envelope.correlationId(), envelope.eventId());
-            case "CapacityHeld", "CapacityHoldConfirmed" -> handleCapacityHeld(payload, envelope.correlationId(), envelope.eventId());
-            case "CapacityReleased", "CapacityHoldExpired" -> handleCapacityReleased(payload, envelope.correlationId(), envelope.eventId());
+            case "CapacityHeld", "CapacityHoldConfirmed" -> handleCapacityHeld(envelope.eventType(), payload, envelope.correlationId(), envelope.eventId());
+            case "CapacityReleased", "CapacityHoldExpired" -> handleCapacityReleased(envelope.eventType(), payload, envelope.correlationId(), envelope.eventId());
             case "CapacityHoldFailed" -> handleCapacityHoldFailed(payload, envelope.correlationId(), envelope.eventId());
             case "PaymentIntentCreated" -> handlePaymentIntentCreated(payload);
             case "PaymentCaptured" -> handlePaymentCaptured(payload, envelope.correlationId(), envelope.eventId());
@@ -187,7 +187,8 @@ public class BookingOrchestrationService {
         publishEvents(saga.pullEvents(), correlationId, causationId);
     }
 
-    private void handleCapacityHeld(Map<String, Object> payload, String correlationId, String causationId) {
+    private void handleCapacityHeld(String eventType, Map<String, Object> payload, String correlationId, String causationId) {
+        validateCapacityHeldContract(eventType, payload);
         String holdId = firstText(payload, "holdId", "capacityHoldId");
         String idempotencyKey = text(payload.get("idempotencyKey"));
         SegmentBooking booking = null;
@@ -196,19 +197,20 @@ public class BookingOrchestrationService {
                 .map(SegmentBookingRepository.SegmentBookingRecord::booking)
                 .orElse(null);
         }
-        if (booking == null && holdId != null) {
+        if (booking == null) {
             booking = byHoldId(holdId);
         }
         if (booking == null) {
             booking = bySegmentBookingId(payload);
         }
-        if (booking == null || holdId == null) {
-            throw new IllegalArgumentException("CapacityHeld/CapacityHoldConfirmed payload requires holdId and a known segment booking reference");
+        if (booking == null) {
+            warnCapacityAckSkip(eventType, "unknown segment booking reference");
+            return;
         }
         booking.markCapacityHolding(holdId);
         segmentBookings.save(booking, sagaIdForSegmentBooking(booking.segmentBookingId()).orElseThrow());
         publishEvents(booking.pullEvents(), correlationId, causationId);
-        markSagaStepSucceeded(booking.segmentBookingId(), correlationId, causationId);
+        markSagaStepSucceeded(eventType, booking.segmentBookingId(), correlationId, causationId);
     }
 
     private void handleCapacityHoldFailed(Map<String, Object> payload, String correlationId, String causationId) {
@@ -241,18 +243,25 @@ public class BookingOrchestrationService {
         }
     }
 
-    private void handleCapacityReleased(Map<String, Object> payload, String correlationId, String causationId) {
+    private void handleCapacityReleased(String eventType, Map<String, Object> payload, String correlationId, String causationId) {
+        validateCapacityReleasedContract(eventType, payload);
         String holdId = firstText(payload, "holdId", "capacityHoldId");
-        SegmentBooking booking = holdId == null ? null : byHoldId(holdId);
+        SegmentBooking booking = byHoldId(holdId);
         if (booking == null) {
             booking = bySegmentBookingId(payload);
         }
-        if (booking != null) {
-            String reason = firstText(payload, "releaseReason", "reason");
-            booking.markCancelled(reason == null ? "capacity hold released" : reason);
-            segmentBookings.save(booking, sagaIdForSegmentBooking(booking.segmentBookingId()).orElseThrow());
-            publishEvents(booking.pullEvents(), correlationId, causationId);
+        if (booking == null) {
+            warnCapacityAckSkip(eventType, "unknown segment booking reference");
+            return;
         }
+        if (!canApplyCapacityRelease(booking)) {
+            warnCapacityAckSkip(eventType, "segment booking already processed or status advanced");
+            return;
+        }
+        String reason = firstText(payload, "releaseReason", "reason");
+        booking.markCancelled(reason == null ? "capacity hold released" : reason);
+        segmentBookings.save(booking, sagaIdForSegmentBooking(booking.segmentBookingId()).orElseThrow());
+        publishEvents(booking.pullEvents(), correlationId, causationId);
     }
 
     private void handlePaymentIntentCreated(Map<String, Object> payload) {
@@ -304,7 +313,7 @@ public class BookingOrchestrationService {
             booking.segmentBookingId(), reference, evidence == null ? "provider-confirmed" : evidence, Map.of()));
         segmentBookings.save(booking, sagaIdForSegmentBooking(booking.segmentBookingId()).orElseThrow());
         publishEvents(booking.pullEvents(), correlationId, causationId);
-        markSagaStepSucceeded(booking.segmentBookingId(), correlationId, causationId);
+        markSagaStepSucceeded("ProviderReservationConfirmed", booking.segmentBookingId(), correlationId, causationId);
     }
 
     private void handleProviderReservationFailed(Map<String, Object> payload, String correlationId, String causationId) {
@@ -394,12 +403,18 @@ public class BookingOrchestrationService {
         return BookingSaga.start(sagaId, journeyOrderId, "1", "purchase", plan, clock);
     }
 
-    private void markSagaStepSucceeded(String segmentBookingId, String correlationId, String causationId) {
+    private void markSagaStepSucceeded(String eventType, String segmentBookingId, String correlationId, String causationId) {
         SegmentBookingRepository.SegmentBookingRecord record = segmentBookings.findById(segmentBookingId).orElse(null);
         SegmentBooking booking = record == null ? null : record.booking();
         String sagaId = record == null ? null : record.sagaId();
         BookingSaga saga = sagaId == null ? null : sagas.findById(sagaId).orElse(null);
         if (booking == null || saga == null) {
+            return;
+        }
+        if (saga.status() != BookingSagaStatus.RESERVING) {
+            if (eventType.startsWith("Capacity")) {
+                warnCapacityAckSkip(eventType, "saga already processed capacity step");
+            }
             return;
         }
         String stepKey = sagaId + ":" + booking.segmentRef();
@@ -493,8 +508,69 @@ public class BookingOrchestrationService {
     }
 
     private SegmentBooking bySegmentBookingId(Map<String, Object> payload) {
-        String segmentBookingId = text(payload.get("segmentBookingId"));
+        String segmentBookingId = segmentBookingReference(payload);
         return segmentBookingId == null ? null : segmentBookings.findById(segmentBookingId).map(SegmentBookingRepository.SegmentBookingRecord::booking).orElse(null);
+    }
+
+    private String segmentBookingReference(Map<String, Object> payload) {
+        String direct = firstText(payload, "segmentBookingId", "segmentBookingRef");
+        if (direct != null) {
+            return direct;
+        }
+        if (payload.get("references") instanceof Map<?, ?> references) {
+            return firstText(references, "segmentBookingRef", "segmentBookingId");
+        }
+        return null;
+    }
+
+    private void validateCapacityHeldContract(String eventType, Map<String, Object> payload) {
+        if ("CapacityHoldConfirmed".equals(eventType)) {
+            requirePayloadText(eventType, payload, "holdId", "inventoryPoolId", "capacityUnitRef", "confirmedAt");
+        } else {
+            requirePayloadText(eventType, payload, "holdId", "inventoryPoolId", "capacityUnitRef", "idempotencyKey", "expiresAt");
+            requirePayloadBoolean(eventType, payload, "idempotentReplay");
+        }
+        requirePayloadObject(eventType, payload, "interval");
+    }
+
+    private void validateCapacityReleasedContract(String eventType, Map<String, Object> payload) {
+        if ("CapacityHoldExpired".equals(eventType)) {
+            requirePayloadText(eventType, payload, "holdId", "inventoryPoolId", "capacityUnitRef", "expiredAt");
+        } else {
+            requirePayloadText(eventType, payload, "holdId", "inventoryPoolId", "capacityUnitRef", "releasedAt", "releaseReason");
+        }
+        requirePayloadObject(eventType, payload, "interval");
+    }
+
+    private void requirePayloadText(String eventType, Map<String, Object> payload, String... fields) {
+        for (String field : fields) {
+            if (text(payload.get(field)) == null) {
+                throw new IllegalArgumentException(eventType + " payload requires " + field);
+            }
+        }
+    }
+
+    private void requirePayloadBoolean(String eventType, Map<String, Object> payload, String field) {
+        if (!(payload.get(field) instanceof Boolean)) {
+            throw new IllegalArgumentException(eventType + " payload requires " + field);
+        }
+    }
+
+    private void requirePayloadObject(String eventType, Map<String, Object> payload, String field) {
+        if (!(payload.get(field) instanceof Map<?, ?>)) {
+            throw new IllegalArgumentException(eventType + " payload requires " + field);
+        }
+    }
+
+    private boolean canApplyCapacityRelease(SegmentBooking booking) {
+        return switch (booking.status()) {
+            case REQUESTED, HOLDING, CANCEL_REQUESTED -> true;
+            case CONFIRMED, TICKETED, IN_FULFILLMENT, COMPLETED, CANCELLED, CHANGE_REQUESTED, CHANGED, FAILED -> false;
+        };
+    }
+
+    private void warnCapacityAckSkip(String eventType, String reason) {
+        LOGGER.warn("Ack-skipping {} from capacity-availability: {}", eventType, reason);
     }
 
     private BookingSaga sagaByCorrelationId(String correlationId) {

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
@@ -130,6 +130,13 @@ public class BookingOrchestrationService {
         }
     }
 
+    /** Deliberately outside the FATAL classification: maps to TransientError. */
+    private static final class RetryLaterException extends RuntimeException {
+        RetryLaterException(String message) {
+            super(message);
+        }
+    }
+
     private static void rollbackCurrentTransactionIfActive() {
         try {
             TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
@@ -351,6 +358,29 @@ public class BookingOrchestrationService {
             // an unknown local ref is an ack-skip, not a poison pill.
             LOGGER.warn("Ack-skipping EntitlementIssued from entitlement-ticketing: unknown segment booking {}", segmentBookingId);
             return;
+        }
+        SegmentBooking existing = segmentBookings.findById(segmentBookingId)
+            .map(SegmentBookingRepository.SegmentBookingRecord::booking).orElse(null);
+        if (existing != null) {
+            String bookingStatus = existing.status().name();
+            if (bookingStatus.equals("FAILED") || bookingStatus.equals("CANCELLED")) {
+                // e.g. capacity sold out failed the booking but the legacy
+                // facade still drove ticket issuance; nothing to mark here.
+                LOGGER.warn("Ack-skipping EntitlementIssued from entitlement-ticketing: segment booking already terminal");
+                return;
+            }
+            if (bookingStatus.equals("TICKETED")
+                && !existing.entitlementId().map(entitlementId::equals).orElse(false)) {
+                // Change flow reissued a replacement entitlement for a booking
+                // this saga already ticketed; entitlement context owns the truth.
+                LOGGER.warn("Ack-skipping EntitlementIssued from entitlement-ticketing: booking already ticketed with a different entitlement");
+                return;
+            }
+            if (bookingStatus.equals("REQUESTED") || bookingStatus.equals("HOLDING")) {
+                // Entitlement can outrun the provider confirmation; this is a
+                // genuine ordering race, so retry rather than skip or poison.
+                throw new RetryLaterException("EntitlementIssued arrived before reservation confirmation");
+            }
         }
         markTicketed(sagaId, new MarkTicketedCommand(segmentBookingId, entitlementId),
             "event:" + causationId + ":" + segmentBookingId, correlationId);

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
@@ -229,7 +229,18 @@ public class BookingOrchestrationService {
             return;
         }
         String reason = firstText(payload, "reason", "failureMessage", "failureCode");
-        booking.failReservation(reason == null ? "capacity hold failed" : reason);
+        if (booking.status().name().equals("FAILED") || booking.status().name().equals("CANCELLED")) {
+            warnCapacityAckSkip("CapacityHoldFailed", "segment booking already terminal");
+            return;
+        }
+        try {
+            booking.failReservation(reason == null ? "capacity hold failed" : reason);
+        } catch (IllegalStateException ex) {
+            // Redelivered or late hold failure racing a booking that already
+            // advanced; the event is conformant, so skip instead of poisoning.
+            warnCapacityAckSkip("CapacityHoldFailed", "segment booking state already advanced");
+            return;
+        }
         String sagaId = sagaIdForSegmentBooking(booking.segmentBookingId()).orElse(null);
         if (sagaId != null) {
             segmentBookings.save(booking, sagaId);
@@ -376,11 +387,25 @@ public class BookingOrchestrationService {
         }
         String reason = firstText(payload, "reason", "failureMessage", "failureCode");
         String cancellationReason = reason == null ? "entitlement voided" : reason;
+        if (booking.status().name().equals("FAILED") || booking.status().name().equals("CANCELLED")) {
+            LOGGER.warn("Ack-skipping EntitlementVoided from entitlement-ticketing: segment booking already terminal");
+            return;
+        }
+        String sagaId = sagaIdForSegmentBooking(booking.segmentBookingId()).orElse(null);
+        if (sagaId == null) {
+            LOGGER.warn("Ack-skipping EntitlementVoided from entitlement-ticketing: unknown saga for segment booking");
+            return;
+        }
         // A voided entitlement after ticketing is a cancellation (refund flow):
         // emit SegmentBookingCancelled so capacity releases the hold.
-        booking.requestCancellation(cancellationReason);
-        booking.markCancelled(cancellationReason);
-        segmentBookings.save(booking, sagaIdForSegmentBooking(booking.segmentBookingId()).orElseThrow());
+        try {
+            booking.requestCancellation(cancellationReason);
+            booking.markCancelled(cancellationReason);
+        } catch (IllegalStateException ex) {
+            LOGGER.warn("Ack-skipping EntitlementVoided from entitlement-ticketing: booking state already advanced");
+            return;
+        }
+        segmentBookings.save(booking, sagaId);
         publishEvents(booking.pullEvents(), correlationId, causationId);
     }
 

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
@@ -333,8 +333,14 @@ public class BookingOrchestrationService {
         if (segmentBookingId == null || entitlementId == null) {
             throw new IllegalArgumentException("EntitlementIssued payload requires segmentBookingId and entitlementId");
         }
-        String sagaId = sagaIdForSegmentBooking(segmentBookingId)
-            .orElseThrow(() -> new IllegalArgumentException("EntitlementIssued references an unknown segment booking"));
+        String sagaId = sagaIdForSegmentBooking(segmentBookingId).orElse(null);
+        if (sagaId == null) {
+            // Post-sales CHANGE issues replacement entitlements against segment
+            // bookings this saga never orchestrated. The event is conformant;
+            // an unknown local ref is an ack-skip, not a poison pill.
+            LOGGER.warn("Ack-skipping EntitlementIssued from entitlement-ticketing: unknown segment booking {}", segmentBookingId);
+            return;
+        }
         markTicketed(sagaId, new MarkTicketedCommand(segmentBookingId, entitlementId),
             "event:" + causationId + ":" + segmentBookingId, correlationId);
         BookingSaga saga = sagas.findById(sagaId).orElse(null);

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/application/BookingOrchestrationServicePayloadContractTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/application/BookingOrchestrationServicePayloadContractTest.java
@@ -22,7 +22,11 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(OutputCaptureExtension.class)
 class BookingOrchestrationServicePayloadContractTest {
 
     private BookingOrchestrationService service;
@@ -239,6 +243,80 @@ class BookingOrchestrationServicePayloadContractTest {
 
         assertTrue(published.getPublished().stream().anyMatch(envelope -> envelope.eventType().equals("SegmentBookingCancelled")));
     }
+
+    @Test
+    void duplicateCapacityHeldAfterSagaAdvancedIsAcknowledgedWithoutPublishing() {
+        var published = new TestEventPublisher();
+        var service = new BookingOrchestrationService(
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), published);
+        var start = service.startSaga(new BookingOrchestrationService.StartSagaCommand(
+            "ord-capacity-duplicate", "acc-123", "off-123", List.of("tvl-123"), List.of("seg-001")),
+            "idem-start-capacity-duplicate", "corr-start");
+        service.requestReservation(start.sagaId(), new BookingOrchestrationService.RequestReservationCommand(
+            "seg-001", "tvl-123", "sb-0194f2e0-7b3e-7610-8284-5c26e8b0c701"),
+            "idem-reservation-capacity-duplicate", "corr-start");
+
+        assertInstanceOf(HandlerResult.Success.class, service.handleUpstreamEvent(new EventEnvelope("evt-0194f2e0-7b3e-7610-8284-5c26e8b0c702", "CapacityHeld", Instant.parse("2026-07-05T10:03:00Z"), "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c707", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c703", "capacity-availability", 1, Map.of(
+            "holdId", "hold-0194f2e0-7b3e-7610-8284-5c26e8b0c704",
+            "inventoryPoolId", "pool-123",
+            "capacityUnitRef", "cu-123",
+            "interval", Map.of("fromStationRef", "BJP", "toStationRef", "SHH"),
+            "idempotencyKey", "ord-capacity-duplicate:seg-001:tvl-123:purchase",
+            "expiresAt", "2026-07-05T10:08:00Z",
+            "idempotentReplay", false))));
+        published.clear();
+
+        assertInstanceOf(HandlerResult.Success.class, service.handleUpstreamEvent(new EventEnvelope("evt-0194f2e0-7b3e-7610-8284-5c26e8b0c705", "CapacityHeld", Instant.parse("2026-07-05T10:04:00Z"), "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c707", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c706", "capacity-availability", 1, Map.of(
+            "holdId", "hold-0194f2e0-7b3e-7610-8284-5c26e8b0c704",
+            "inventoryPoolId", "pool-123",
+            "capacityUnitRef", "cu-123",
+            "interval", Map.of("fromStationRef", "BJP", "toStationRef", "SHH"),
+            "idempotencyKey", "ord-capacity-duplicate:seg-001:tvl-123:purchase",
+            "expiresAt", "2026-07-05T10:09:00Z",
+            "idempotentReplay", true))));
+
+        assertTrue(published.getPublished().isEmpty());
+        assertEquals("WAITING_PAYMENT", service.getSaga(start.sagaId()).orElseThrow().status());
+    }
+
+    @Test
+    void unknownSegmentBookingRefCapacityReleasedIsAcknowledgedAndWarns(CapturedOutput output) {
+        var published = new TestEventPublisher();
+        var service = new BookingOrchestrationService(
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), published);
+
+        var result = service.handleUpstreamEvent(new EventEnvelope("evt-0194f2e0-7b3e-7610-8284-5c26e8b0c801", "CapacityReleased", Instant.parse("2026-07-05T10:04:00Z"), "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c804", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c802", "capacity-availability", 1, Map.of(
+            "holdId", "hold-0194f2e0-7b3e-7610-8284-5c26e8b0c803",
+            "inventoryPoolId", "pool-123",
+            "capacityUnitRef", "cu-123",
+            "interval", Map.of("fromStationRef", "BJP", "toStationRef", "SHH"),
+            "releasedAt", "2026-07-05T10:04:00Z",
+            "releaseReason", "entitlement-voided",
+            "references", Map.of("segmentBookingRef", "sb-unknown", "orderRef", "ord-unknown", "travelerRef", "tvl-123"))));
+
+        assertInstanceOf(HandlerResult.Success.class, result);
+        assertTrue(published.getPublished().isEmpty());
+        assertTrue(output.getOut().contains("Ack-skipping CapacityReleased") || output.getErr().contains("Ack-skipping CapacityReleased"));
+    }
+
+    @Test
+    void malformedCapacityHeldMissingRequiredFieldIsFatal() {
+        var published = new TestEventPublisher();
+        var service = new BookingOrchestrationService(
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), published);
+
+        var result = service.handleUpstreamEvent(new EventEnvelope("evt-0194f2e0-7b3e-7610-8284-5c26e8b0c901", "CapacityHeld", Instant.parse("2026-07-05T10:03:00Z"), "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c904", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c902", "capacity-availability", 1, Map.of(
+            "holdId", "hold-0194f2e0-7b3e-7610-8284-5c26e8b0c903",
+            "inventoryPoolId", "pool-123",
+            "interval", Map.of("fromStationRef", "BJP", "toStationRef", "SHH"),
+            "idempotencyKey", "ord-capacity-malformed:seg-001:tvl-123:purchase",
+            "expiresAt", "2026-07-05T10:08:00Z",
+            "idempotentReplay", false)));
+
+        assertInstanceOf(HandlerResult.FatalError.class, result);
+        assertTrue(published.getPublished().isEmpty());
+    }
+
 
     @Test
     void failurePathsPropagateConsumedEnvelopeCorrelationId() {


### PR DESCRIPTION
## Summary
- validate CapacityHeld/CapacityReleased contracts before handling
- ack-skip unknown, duplicate, or already-advanced capacity facts with WARN logs instead of FATAL/DLQ
- add unit coverage for duplicate CapacityHeld ack, unknown CapacityReleased WARN ack, and malformed CapacityHeld fatal

## Validation
- cd services/booking-orchestration && mvn test
- make check

## Event classification
| Event | Situation | Result |
|---|---|---|
| CapacityHeld/CapacityHoldConfirmed | Missing required payload fields | FATAL |
| CapacityHeld/CapacityHoldConfirmed | Unknown segment booking/idempotency/hold reference | ACK skip + WARN |
| CapacityHeld/CapacityHoldConfirmed | Saga already advanced past reserving/step already processed | ACK skip + WARN |
| CapacityHeld/CapacityHoldConfirmed | Matching saga waiting for hold confirmation | ACK and normal saga progression |
| CapacityReleased/CapacityHoldExpired | Missing required payload fields | FATAL |
| CapacityReleased/CapacityHoldExpired | Unknown segment booking/hold reference | ACK skip + WARN |
| CapacityReleased/CapacityHoldExpired | Segment already confirmed/ticketed/cancelled/failed or otherwise past release-application state | ACK skip + WARN |
| CapacityReleased/CapacityHoldExpired | Matching segment still releasable | ACK and cancel segment |
| Any capacity event | Runtime infrastructure failure | RETRY |