### PR TITLE
REQ-089 Restore capacity logging and reservation replay

### DIFF
--- a/docs/08-contracts/events/capacity-availability.md
+++ b/docs/08-contracts/events/capacity-availability.md
@@ -131,7 +131,7 @@ Last updated: 2026-07-04
 |---|---|
 | **Producer** | capacity-availability |
 | **Consumers** | booking-orchestration |
-| **Trigger** | Hold could not be granted (conflict, unknown unit, idempotency conflict). |
+| **Trigger** | Hold could not be granted (conflict, unknown unit, idempotency conflict, or pool sold out). |
 
 **Payload:**
 
@@ -139,10 +139,10 @@ Last updated: 2026-07-04
 |---|---|---|---|
 | `requestedHoldId` | `HoldId` | yes | The hold ID that was requested. |
 | `inventoryPoolId` | `InventoryPoolId` | yes | Pool ID. |
-| `capacityUnitRef` | `CapacityUnitRef` | yes | Unit that caused the conflict. |
+| `capacityUnitRef` | `CapacityUnitRef` | yes | Unit that caused the conflict; the sentinel `NONE` when reason is `NO_AVAILABLE_CAPACITY` (no specific unit is implicated). |
 | `interval` | `StationInterval` | yes | Requested interval. |
 | `idempotencyKey` | string | yes | Request idempotency key. |
-| `reason` | enum | yes | `UNKNOWN_CAPACITY_UNIT`, `IDEMPOTENCY_CONFLICT`, or `OVERLAPPING_HOLD`. |
+| `reason` | enum | yes | `UNKNOWN_CAPACITY_UNIT`, `IDEMPOTENCY_CONFLICT`, `OVERLAPPING_HOLD`, or `NO_AVAILABLE_CAPACITY`. |
 | `conflictingHoldId` | `HoldId` | no | Conflicting hold ID if reason is `OVERLAPPING_HOLD`. |
 
 ## Accepted Commands

--- a/platform/rust-kit/src/messaging.rs
+++ b/platform/rust-kit/src/messaging.rs
@@ -888,7 +888,20 @@ pub mod redis_runtime {
                     self.state.mark_consumed(&envelope.event_id);
                     ops.ack(&message.stream, group, &message.id).await
                 }
-                Err(HandlerError::Transient(_)) => Ok(()),
+                Err(HandlerError::Transient(reason)) => {
+                    // Formerly a silent swallow (same class of bug java-kit had):
+                    // without this line a retried-to-death message reaches the
+                    // DLQ with no trace of what actually failed.
+                    log::warn!(
+                        "service={} stream={} eventId={} deliveries={} handler transient failure; message stays pending for retry: {}",
+                        group,
+                        message.stream,
+                        envelope.event_id,
+                        message.delivery_count,
+                        reason
+                    );
+                    Ok(())
+                }
                 Err(HandlerError::Fatal(reason)) => {
                     self.state.mark_consumed(&envelope.event_id);
                     move_to_dlq(

--- a/services/capacity-availability/Cargo.lock
+++ b/services/capacity-availability/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,6 +24,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -124,6 +183,12 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -163,6 +228,8 @@ name = "capacity-availability"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "env_logger",
+ "log",
  "opentelemetry",
  "redis",
  "rust-kit",
@@ -215,6 +282,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -310,6 +383,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +460,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -833,10 +960,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -876,7 +1034,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
  "plain",
  "redox_syscall 0.9.0",
@@ -1005,6 +1163,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1264,21 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1220,7 +1399,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1229,8 +1408,37 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ring"
@@ -1606,7 +1814,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.13.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -1649,7 +1857,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.13.0",
  "byteorder",
  "chrono",
  "crc",
@@ -1977,6 +2185,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/services/capacity-availability/Cargo.toml
+++ b/services/capacity-availability/Cargo.toml
@@ -10,6 +10,8 @@ path = "src/lib.rs"
 [dependencies]
 opentelemetry = "0.32.0"
 axum = "0.8.9"
+log = "0.4"
+env_logger = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shared-kernel = { path = "../../platform/shared-kernel-rust" }

--- a/services/capacity-availability/src/adapters/messaging/mod.rs
+++ b/services/capacity-availability/src/adapters/messaging/mod.rs
@@ -107,6 +107,14 @@ pub mod redis_subscriber {
             deleted_ids,
         })
     }
+    pub fn default_subscription_streams() -> Vec<String> {
+        vec![
+            "events:booking-orchestration".to_string(),
+            "events:entitlement-ticketing".to_string(),
+            "events:post-sales".to_string(),
+        ]
+    }
+
     #[derive(Clone)]
     pub struct RedisEventSubscriber {
         inner: rust_kit::messaging::redis_runtime::RedisEventSubscriber,
@@ -137,11 +145,7 @@ pub mod redis_subscriber {
             >,
         ) -> Result<(), rust_kit::messaging::SubscribeFailed> {
             let selected_streams = if streams.is_empty() {
-                vec![
-                    "events:booking-orchestration".to_string(),
-                    "events:entitlement-ticketing".to_string(),
-                    "events:post-sales".to_string(),
-                ]
+                default_subscription_streams()
             } else {
                 streams.to_vec()
             };

--- a/services/capacity-availability/src/adapters/storage/mod.rs
+++ b/services/capacity-availability/src/adapters/storage/mod.rs
@@ -715,6 +715,22 @@ impl PostgresCapacityService {
             tx.rollback().await.map_err(inbound_transient)?;
             return Ok(());
         }
+        if let Some(replay) = self
+            .find_replayable_hold_by_idempotency(&mut tx, idempotency_key, req)
+            .await?
+        {
+            self.record_segment_reservation_replay(
+                &mut tx,
+                &stream_for_producer(PRODUCER),
+                &replay,
+                idempotency_key,
+                fingerprint,
+                &envelope.correlation_id,
+            )
+            .await?;
+            tx.commit().await.map_err(inbound_transient)?;
+            return Ok(());
+        }
         if self
             .claim_idempotency::<HoldCapacityResponse>(&mut tx, idempotency_key, fingerprint)
             .await
@@ -815,6 +831,66 @@ impl PostgresCapacityService {
         .map_err(inbound_from_app_error)?;
         tx.commit().await.map_err(inbound_transient)?;
         Ok(())
+    }
+
+    async fn find_replayable_hold_by_idempotency(
+        &self,
+        tx: &mut PgTransaction<'_>,
+        idempotency_key: &str,
+        req: &HoldCapacityRequest,
+    ) -> Result<Option<CapacityHoldSnapshot>, InboundEventError> {
+        let sql = format!(
+            "SELECT data FROM {HOLD_TABLE} WHERE data ->> 'idempotencyKey' = $1 AND data ->> 'state' IN ('Held', 'Confirmed') ORDER BY updated_at DESC LIMIT 1"
+        );
+        let row: Option<(Value,)> = sqlx::query_as(&sql)
+            .bind(idempotency_key)
+            .fetch_optional(&mut **tx)
+            .await
+            .map_err(inbound_transient)?;
+        let Some((data,)) = row else {
+            return Ok(None);
+        };
+        let snapshot: CapacityHoldSnapshot =
+            serde_json::from_value(data).map_err(inbound_transient)?;
+        if snapshot.matches_segment_reservation(req, idempotency_key) {
+            Ok(Some(snapshot))
+        } else {
+            Err(InboundEventError::Fatal("IDEMPOTENCY_KEY_REUSED".into()))
+        }
+    }
+
+    async fn record_segment_reservation_replay(
+        &self,
+        tx: &mut PgTransaction<'_>,
+        outbox_stream: &str,
+        hold: &CapacityHoldSnapshot,
+        idempotency_key: &str,
+        fingerprint: &str,
+        correlation_id: &str,
+    ) -> Result<(), InboundEventError> {
+        let outbound = replay_capacity_held_envelope(hold, idempotency_key, correlation_id)?;
+        OutboxAppender::append(tx, outbox_stream, &outbound)
+            .await
+            .map_err(inbound_transient)?;
+        let response = HoldCapacityResponse {
+            hold_id: hold.hold_id.clone(),
+            segment_ref: hold.segment_ref(),
+            status: "HELD".to_string(),
+            held_until: unix_millis_to_rfc3339(hold.expires_at),
+        };
+        match self
+            .finish_idempotency(
+                tx,
+                idempotency_key,
+                fingerprint,
+                201,
+                serde_json::to_value(&response).map_err(inbound_transient)?,
+            )
+            .await
+        {
+            Ok(()) | Err(AppError::IdempotencyKeyReused(_)) => Ok(()),
+            Err(error) => Err(inbound_from_app_error(error)),
+        }
     }
 
     async fn handle_segment_reservation_confirmed(
@@ -1506,6 +1582,27 @@ impl CapacityHoldSnapshot {
         }
     }
 
+    fn matches_segment_reservation(
+        &self,
+        req: &HoldCapacityRequest,
+        idempotency_key: &str,
+    ) -> bool {
+        self.idempotency_key == idempotency_key
+            && self.inventory_pool_id == pool_id_for(&req.segment_ref, &req.class_ref)
+            && self.segment_ref() == req.segment_ref
+            && self.references.traveler_ref.as_deref() == Some(req.traveler_ref.as_str())
+            && self.references.segment_booking_ref.as_deref()
+                == Some(req.segment_booking_id.as_str())
+    }
+
+    fn segment_ref(&self) -> String {
+        self.inventory_pool_id
+            .strip_prefix("pool:")
+            .and_then(|tail| tail.rsplit_once(':').map(|(segment_ref, _)| segment_ref))
+            .unwrap_or(&self.inventory_pool_id)
+            .to_string()
+    }
+
     fn try_into_domain(self) -> Result<CapacityHold, AppError> {
         let mut hold = CapacityHold::request(
             HoldId::new(self.hold_id).map_err(to_internal)?,
@@ -1602,6 +1699,30 @@ fn validate_hold_request(req: &HoldCapacityRequest) -> Result<(), AppError> {
 
 fn pool_id_for(segment_ref: &str, class_ref: &str) -> String {
     format!("pool:{}:{}", segment_ref, class_ref)
+}
+
+fn replay_capacity_held_envelope(
+    hold: &CapacityHoldSnapshot,
+    idempotency_key: &str,
+    correlation_id: &str,
+) -> Result<WireEnvelope, InboundEventError> {
+    WireEnvelope::try_new(
+        "CapacityHeld",
+        unix_millis_to_rfc3339(now_millis()),
+        rust_kit::messaging::valid_or_generated_correlation_id(correlation_id),
+        None::<String>,
+        PRODUCER,
+        json!({
+            "holdId": hold.hold_id,
+            "inventoryPoolId": hold.inventory_pool_id,
+            "capacityUnitRef": hold.capacity_unit_ref,
+            "interval": { "fromSeq": hold.from_seq, "toSeq": hold.to_seq },
+            "idempotencyKey": idempotency_key,
+            "expiresAt": unix_millis_to_rfc3339(hold.expires_at),
+            "idempotentReplay": true,
+        }),
+    )
+    .map_err(inbound_fatal)
 }
 
 fn domain_event_to_wire(
@@ -1791,6 +1912,35 @@ mod tests {
         }
     }
 
+    fn replay_snapshot(
+        req: &HoldCapacityRequest,
+        hold_id: &str,
+        idempotency_key: &str,
+    ) -> CapacityHoldSnapshot {
+        let now = now_millis();
+        let hold = CapacityHold::request(
+            HoldId::new(hold_id).unwrap(),
+            HoldScope::new(
+                InventoryPoolId::new("pool:seg:first").unwrap(),
+                CapacityUnitRef::new("unit-1").unwrap(),
+                StationInterval::new(0, 1).unwrap(),
+                ReferenceMetadata::new(
+                    "booking-orchestration",
+                    "purchase-hold",
+                    Some(req.segment_booking_id.clone()),
+                    Some(req.segment_booking_id.clone()),
+                    Some(req.traveler_ref.clone()),
+                )
+                .unwrap(),
+            ),
+            IdempotencyKey::new(idempotency_key).unwrap(),
+            now,
+            now + 300_000,
+        )
+        .unwrap();
+        CapacityHoldSnapshot::from_domain(&hold)
+    }
+
     #[test]
     fn pool_snapshot_round_trips_holds() {
         let req = request();
@@ -1862,6 +2012,34 @@ mod tests {
             segment_booking_ref_from_entitlement_voided(&payload),
             Some("sb-legacy".to_string())
         );
+    }
+
+    #[test]
+    fn replay_snapshot_matches_original_segment_reservation() {
+        let req = request();
+        let snapshot = replay_snapshot(&req, "hold-replay", "idem-replay");
+
+        assert!(snapshot.matches_segment_reservation(&req, "idem-replay"));
+        assert_eq!(snapshot.segment_ref(), req.segment_ref);
+        assert!(!snapshot.matches_segment_reservation(&req, "different-key"));
+    }
+
+    #[test]
+    fn replay_capacity_held_envelope_marks_idempotent_replay() {
+        let req = request();
+        let snapshot = replay_snapshot(&req, "hold-replay-envelope", "idem-replay-envelope");
+        let envelope = replay_capacity_held_envelope(
+            &snapshot,
+            "idem-replay-envelope",
+            "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa44",
+        )
+        .unwrap();
+
+        assert_eq!(envelope.event_type, "CapacityHeld");
+        assert_eq!(envelope.producer, PRODUCER);
+        assert_eq!(envelope.payload["holdId"], "hold-replay-envelope");
+        assert_eq!(envelope.payload["idempotencyKey"], "idem-replay-envelope");
+        assert_eq!(envelope.payload["idempotentReplay"], true);
     }
 
     #[test]

--- a/services/capacity-availability/src/adapters/storage/mod.rs
+++ b/services/capacity-availability/src/adapters/storage/mod.rs
@@ -759,9 +759,45 @@ impl PostgresCapacityService {
             ),
         };
         let interval = StationInterval::new(0, 1).map_err(inbound_fatal)?;
-        let unit_ref = pool.find_available_unit(&interval, now).ok_or_else(|| {
-            InboundEventError::Transient("No capacity units available in pool".into())
-        })?;
+        let Some(unit_ref) = pool.find_available_unit(&interval, now) else {
+            // Sold out is a business outcome, not an infrastructure failure:
+            // retrying can never conjure a seat. Emit CapacityHoldFailed so the
+            // saga compensates, and ack the message. capacityUnitRef carries the
+            // documented sentinel NONE (contract: NO_AVAILABLE_CAPACITY).
+            let failed = CapacityHoldFailed {
+                envelope: EventEnvelope::new(
+                    "CapacityHoldFailed",
+                    now,
+                    envelope.correlation_id.as_str(),
+                    Some(envelope.event_id.as_str()),
+                    "capacity-availability",
+                ),
+                requested_hold_id: HoldId::new(&hold_id).map_err(inbound_fatal)?,
+                inventory_pool_id: pool.identity.pool_id.clone(),
+                capacity_unit_ref: CapacityUnitRef::new("NONE").map_err(inbound_fatal)?,
+                interval,
+                idempotency_key: IdempotencyKey::new(idempotency_key).map_err(inbound_fatal)?,
+                reason: HoldFailureReason::NoAvailableUnits,
+                references: ReferenceMetadata::new(
+                    "booking-orchestration",
+                    "purchase-hold",
+                    Some(req.segment_booking_id.clone()),
+                    Some(req.segment_booking_id.clone()),
+                    Some(req.traveler_ref.clone()),
+                )
+                .map_err(inbound_fatal)?,
+            };
+            let outbound = domain_event_to_wire(
+                &DomainEvent::CapacityHoldFailed(failed),
+                &envelope.correlation_id,
+            )
+            .map_err(inbound_from_app_error)?;
+            OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &outbound)
+                .await
+                .map_err(inbound_transient)?;
+            tx.commit().await.map_err(inbound_transient)?;
+            return Ok(());
+        };
         let hold = CapacityHold::request(
             HoldId::new(&hold_id).map_err(inbound_fatal)?,
             HoldScope::new(

--- a/services/capacity-availability/src/domain.rs
+++ b/services/capacity-availability/src/domain.rs
@@ -549,6 +549,7 @@ pub enum HoldFailureReason {
     UnknownCapacityUnit,
     IdempotencyConflict { existing_hold_id: HoldId },
     OverlappingHold { conflicting_hold_id: HoldId },
+    NoAvailableUnits,
 }
 
 impl HoldFailureReason {
@@ -557,6 +558,7 @@ impl HoldFailureReason {
             HoldFailureReason::UnknownCapacityUnit => "UNKNOWN_CAPACITY_UNIT",
             HoldFailureReason::IdempotencyConflict { .. } => "IDEMPOTENCY_CONFLICT",
             HoldFailureReason::OverlappingHold { .. } => "OVERLAPPING_HOLD",
+            HoldFailureReason::NoAvailableUnits => "NO_AVAILABLE_CAPACITY",
         }
     }
 
@@ -566,7 +568,8 @@ impl HoldFailureReason {
                 conflicting_hold_id,
             } => Some(conflicting_hold_id),
             HoldFailureReason::UnknownCapacityUnit
-            | HoldFailureReason::IdempotencyConflict { .. } => None,
+            | HoldFailureReason::IdempotencyConflict { .. }
+            | HoldFailureReason::NoAvailableUnits => None,
         }
     }
 }

--- a/services/capacity-availability/src/lib.rs
+++ b/services/capacity-availability/src/lib.rs
@@ -9,6 +9,7 @@ use axum::Router;
 use axum::{Json, http::StatusCode, routing::get};
 use serde::Serialize;
 use shared_kernel::{OpenTelemetryObserver, RuntimeConfig, apply_runtime, router_with_config};
+use std::io::Write;
 
 #[cfg(feature = "redis-impl")]
 pub use adapters::storage::PostgresCapacityService;
@@ -75,20 +76,27 @@ pub async fn build_runtime() -> Router {
     use crate::ports::EventSubscriber;
 
     let redis_url = std::env::var("REDIS_URL").unwrap_or_else(|_| DEFAULT_REDIS_URL.to_string());
+    log::info!("capacity-availability initializing Redis subscriber");
     let subscriber = adapters::messaging::redis_subscriber::RedisEventSubscriber::new(&redis_url)
         .await
         .expect("failed to initialize Redis event subscriber");
 
+    log::info!("capacity-availability initializing Postgres storage");
     let service = std::sync::Arc::new(
         adapters::storage::PostgresCapacityService::from_env()
             .await
             .expect("failed to initialize Postgres capacity storage"),
     );
     rust_kit::storage::spawn_outbox_relay(service.pool().clone(), redis_url.clone());
+    let selected_streams = adapters::messaging::redis_subscriber::default_subscription_streams();
+    log::info!(
+        "capacity-availability starting Redis subscriber group={CONSUMER_GROUP} streams={}",
+        selected_streams.join(",")
+    );
     let handler_service = service.clone();
     subscriber
         .subscribe(
-            &[],
+            &selected_streams,
             CONSUMER_GROUP,
             &consumer_name(),
             Box::new(move |envelope| {
@@ -100,6 +108,7 @@ pub async fn build_runtime() -> Router {
             }),
         )
         .expect("failed to start Redis event subscriber");
+    log::info!("capacity-availability Redis subscriber started");
 
     router_with_postgres_service(service)
 }
@@ -184,6 +193,24 @@ fn consumer_name() -> String {
     std::env::var("HOSTNAME")
         .or_else(|_| std::env::var("CONSUMER_NAME"))
         .unwrap_or_else(|_| format!("capacity-availability-{}", std::process::id()))
+}
+
+pub fn init_logging() {
+    let mut builder =
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"));
+    builder
+        .target(env_logger::Target::Stdout)
+        .format(|buf, record| {
+            writeln!(
+                buf,
+                "{} {} {} - {}",
+                rust_kit::messaging::now_rfc3339_utc(),
+                record.level(),
+                record.target(),
+                record.args()
+            )
+        });
+    let _ = builder.try_init();
 }
 
 pub fn apply_service_runtime(router: Router) -> Router {

--- a/services/capacity-availability/src/main.rs
+++ b/services/capacity-availability/src/main.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "redis-impl")]
 #[tokio::main]
 async fn main() {
+    capacity_availability::init_logging();
+    log::info!("capacity-availability runtime starting");
     let app = capacity_availability::build_runtime().await;
     let port = std::env::var("PORT")
         .ok()
@@ -9,6 +11,7 @@ async fn main() {
     let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))
         .await
         .expect("failed to bind HTTP listener");
+    log::info!("capacity-availability HTTP server listening on 0.0.0.0:{port}");
     axum::serve(listener, app)
         .await
         .expect("capacity-availability HTTP server failed");
@@ -16,7 +19,8 @@ async fn main() {
 
 #[cfg(not(feature = "redis-impl"))]
 fn main() {
-    eprintln!(
+    capacity_availability::init_logging();
+    log::error!(
         "capacity-availability binary requires the redis-impl feature for production startup"
     );
 }

--- a/services/capacity-availability/tests/skeleton.rs
+++ b/services/capacity-availability/tests/skeleton.rs
@@ -926,6 +926,13 @@ async fn postgres_capacity_inbound_event_contract_classification_pre_db_matrix()
     }
 }
 
+#[test]
+fn capacity_logging_defaults_to_stdout_info() {
+    capacity_availability::init_logging();
+    log::info!("capacity-availability logging smoke test");
+    log::warn!("capacity-availability logging smoke test warn");
+}
+
 #[tokio::test]
 async fn api_responses_include_runtime_correlation_and_request_headers() {
     let app = test_router();


### PR DESCRIPTION
## Summary
- initialize capacity-availability logging to stdout at INFO level and emit startup/subscriber lifecycle logs
- idempotently acknowledge SegmentReservationRequested duplicates by replaying existing holds with CapacityHeld idempotentReplay=true
- add logging smoke coverage for visible INFO/WARN output

## Validation
- cargo test --features redis-impl (services/capacity-availability): passed
- cargo test (services/capacity-availability): passed
- make check: timed out after 300s during booking-orchestration Maven tests; preceding services including capacity-availability passed
