### PR TITLE
REQ-088 ack-skip notification triggers without recipients

### DIFF
--- a/services/notification/src/application/notification-service.ts
+++ b/services/notification/src/application/notification-service.ts
@@ -284,21 +284,36 @@ const CONTRACT_FIELDS_BY_EVENT: Readonly<Record<string, readonly RequiredField[]
   ],
   PostSalesEligibilityEvaluated: [
     { name: "caseId", type: "string" },
+    { name: "eligible", type: "boolean" },
+    { name: "reasonCode", type: "string" },
   ],
   PostSalesDecisionQuoted: [
     { name: "caseId", type: "string" },
+    { name: "decisionKind", type: "string" },
+    { name: "eligible", type: "boolean" },
+    { name: "ruleSnapshotRef", type: "string" },
   ],
   PostSalesExecutionStarted: [
     { name: "caseId", type: "string" },
+    { name: "orderedSteps", type: "array" },
+    { name: "approvalRef", type: "string" },
   ],
   PostSalesApplied: [
     { name: "caseId", type: "string" },
+    { name: "orderId", type: "string" },
+    { name: "resultSummary", type: "object" },
   ],
   PostSalesFailed: [
     { name: "caseId", type: "string" },
+    { name: "orderId", type: "string" },
+    { name: "reason", type: "string" },
   ],
   ChangeApplied: [
     { name: "caseId", type: "string" },
+    { name: "orderId", type: "string" },
+    { name: "oldEntitlementRef", type: "string" },
+    { name: "newEntitlementRef", type: "string" },
+    { name: "changeOfferRef", type: "string" },
   ],
 });
 

--- a/services/notification/src/application/notification-service.ts
+++ b/services/notification/src/application/notification-service.ts
@@ -83,7 +83,9 @@ export class NotificationApplicationService {
   async handleExternalTrigger(envelope: EventEnvelope): Promise<ExternalTriggerResult> {
     const command = scheduleCommandFromEnvelope(envelope);
     if (command === undefined) {
-      console.info(`Ignoring unsupported notification trigger ${envelope.eventType} (${envelope.eventId})`);
+      if (mappingFor(envelope.eventType) === undefined) {
+        console.info(`Ignoring unsupported notification trigger ${envelope.eventType} (${envelope.eventId})`);
+      }
       return "ignored";
     }
 
@@ -150,12 +152,13 @@ function scheduleCommandFromEnvelope(envelope: EventEnvelope): ScheduleNotificat
     return undefined;
   }
 
+  validateTriggerContract(envelope);
+
   const payload = envelope.payload;
   const recipientRef = mapping.recipient(payload);
   if (recipientRef === undefined) {
-    throw new NonConformantNotificationTrigger(
-      `Notification trigger ${envelope.eventType} (${envelope.eventId}) does not contain a resolvable recipientRef`,
-    );
+    console.debug(`Skipping notification trigger ${envelope.eventType} (${envelope.eventId}): no resolvable recipientRef`);
+    return undefined;
   }
 
   return {
@@ -187,6 +190,172 @@ function triggerBusinessRef(envelope: EventEnvelope): string | undefined {
     ?? stringValue(payload.postSalesCaseId)
     ?? stringValue(payload.businessRef);
   return businessRef ? `${envelope.eventType}:${businessRef}` : undefined;
+}
+
+type FieldType = "array" | "boolean" | "money" | "object" | "string";
+
+type RequiredField = Readonly<{
+  name: string;
+  type: FieldType;
+}>;
+
+const CONTRACT_FIELDS_BY_EVENT: Readonly<Record<string, readonly RequiredField[]>> = Object.freeze({
+  JourneyOrderCreated: [
+    { name: "orderId", type: "string" },
+    { name: "accountId", type: "string" },
+    { name: "offerId", type: "string" },
+    { name: "monetarySummary", type: "object" },
+    { name: "travelerRefs", type: "array" },
+    { name: "segmentRefs", type: "array" },
+    { name: "createdAt", type: "string" },
+  ],
+  JourneyOrderPendingPayment: [
+    { name: "orderId", type: "string" },
+    { name: "accountId", type: "string" },
+    { name: "paymentPurpose", type: "string" },
+    { name: "monetarySummary", type: "object" },
+  ],
+  JourneyOrderPaymentRecorded: [
+    { name: "orderId", type: "string" },
+    { name: "accountId", type: "string" },
+    { name: "paymentIntentId", type: "string" },
+  ],
+  JourneyOrderConfirmed: [
+    { name: "orderId", type: "string" },
+    { name: "accountId", type: "string" },
+    { name: "monetarySummary", type: "object" },
+    { name: "confirmedAt", type: "string" },
+  ],
+  JourneyOrderCancelled: [
+    { name: "orderId", type: "string" },
+    { name: "accountId", type: "string" },
+    { name: "reason", type: "string" },
+  ],
+  JourneyOrderPostSalesAdjusted: [
+    { name: "orderId", type: "string" },
+    { name: "accountId", type: "string" },
+    { name: "postSalesCaseId", type: "string" },
+    { name: "monetarySummary", type: "object" },
+  ],
+  JourneyOrderAdjusted: [
+    { name: "orderId", type: "string" },
+    { name: "accountId", type: "string" },
+    { name: "postSalesCaseId", type: "string" },
+    { name: "monetarySummary", type: "object" },
+  ],
+  PaymentCaptured: [
+    { name: "paymentIntentId", type: "string" },
+    { name: "businessRef", type: "string" },
+    { name: "capturedAmount", type: "money" },
+    { name: "channel", type: "string" },
+    { name: "channelTransactionId", type: "string" },
+  ],
+  PaymentFailed: [
+    { name: "paymentIntentId", type: "string" },
+    { name: "reasonCode", type: "string" },
+    { name: "retryable", type: "boolean" },
+  ],
+  PaymentIntentFailed: [
+    { name: "paymentIntentId", type: "string" },
+    { name: "reasonCode", type: "string" },
+    { name: "retryable", type: "boolean" },
+  ],
+  PaymentIntentExpired: [
+    { name: "paymentIntentId", type: "string" },
+  ],
+  PaymentExpired: [
+    { name: "paymentIntentId", type: "string" },
+  ],
+  RefundSettled: [
+    { name: "refundId", type: "string" },
+    { name: "paymentIntentId", type: "string" },
+    { name: "amount", type: "money" },
+  ],
+  EntitlementIssued: [
+    { name: "entitlementId", type: "string" },
+    { name: "segmentBookingId", type: "string" },
+    { name: "journeyOrderId", type: "string" },
+    { name: "travelerRef", type: "string" },
+    { name: "segmentRef", type: "string" },
+    { name: "issuePurpose", type: "string" },
+    { name: "credentialNo", type: "string" },
+    { name: "credentialType", type: "string" },
+    { name: "issuedAt", type: "string" },
+  ],
+  PostSalesEligibilityEvaluated: [
+    { name: "caseId", type: "string" },
+  ],
+  PostSalesDecisionQuoted: [
+    { name: "caseId", type: "string" },
+  ],
+  PostSalesExecutionStarted: [
+    { name: "caseId", type: "string" },
+  ],
+  PostSalesApplied: [
+    { name: "caseId", type: "string" },
+  ],
+  PostSalesFailed: [
+    { name: "caseId", type: "string" },
+  ],
+  ChangeApplied: [
+    { name: "caseId", type: "string" },
+  ],
+});
+
+function validateTriggerContract(envelope: EventEnvelope): void {
+  const envelopeViolations = envelopeContractViolations(envelope);
+  const payload = recordValue(envelope.payload);
+  const requiredFields = CONTRACT_FIELDS_BY_EVENT[envelope.eventType] ?? [];
+  const payloadViolations = payload === undefined
+    ? ["payload must be an object"]
+    : requiredFields.flatMap((field) => fieldViolation(payload, field));
+  const violations = [...envelopeViolations, ...payloadViolations];
+
+  if (violations.length > 0) {
+    throw new NonConformantNotificationTrigger(
+      `Notification trigger ${envelope.eventType} (${envelope.eventId}) violates its event contract: ${violations.join(", ")}`,
+    );
+  }
+}
+
+function envelopeContractViolations(envelope: EventEnvelope): string[] {
+  const violations: string[] = [];
+  for (const field of ["eventId", "eventType", "producer", "correlationId", "occurredAt"] as const) {
+    if (stringValue(envelope[field]) === undefined) {
+      violations.push(`${field} must be a non-empty string`);
+    }
+  }
+  if (typeof envelope.schemaVersion !== "number" || !Number.isInteger(envelope.schemaVersion) || envelope.schemaVersion < 1) {
+    violations.push("schemaVersion must be a positive integer");
+  }
+  return violations;
+}
+
+function fieldViolation(payload: Record<string, unknown>, field: RequiredField): string[] {
+  const value = payload[field.name];
+  if (value === undefined || value === null) {
+    return [`payload.${field.name} is required`];
+  }
+  switch (field.type) {
+    case "array":
+      return Array.isArray(value) ? [] : [`payload.${field.name} must be an array`];
+    case "boolean":
+      return typeof value === "boolean" ? [] : [`payload.${field.name} must be a boolean`];
+    case "money":
+      return isMoney(value) ? [] : [`payload.${field.name} must be Money`];
+    case "object":
+      return recordValue(value) === undefined ? [`payload.${field.name} must be an object`] : [];
+    case "string":
+      return stringValue(value) === undefined ? [`payload.${field.name} must be a non-empty string`] : [];
+  }
+}
+
+function isMoney(value: unknown): boolean {
+  const record = recordValue(value);
+  return record !== undefined
+    && stringValue(record.currency) !== undefined
+    && typeof record.minorUnits === "number"
+    && Number.isInteger(record.minorUnits);
 }
 
 function mappingFor(eventType: string): TriggerMapping | undefined {
@@ -324,6 +493,10 @@ function pickStringVariables(payload: Record<string, unknown>, keys: readonly st
     }
   }
   return variables;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
 }
 
 function stringValue(value: unknown): string | undefined {

--- a/services/notification/src/messaging.test.ts
+++ b/services/notification/src/messaging.test.ts
@@ -89,7 +89,14 @@ describe("notification messaging integration surface", () => {
       correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       occurredAt: "2026-07-05T10:00:00.000Z",
-      payload: { recipientRef: "usr-test-001", paymentIntentId: "pi-test-001" },
+      payload: {
+        recipientRef: "usr-test-001",
+        paymentIntentId: "pi-test-001",
+        businessRef: "ord-test-001",
+        capturedAmount: { currency: "CNY", minorUnits: 35000 },
+        channel: "wechat_pay",
+        channelTransactionId: "wx-test-001",
+      },
     };
 
     await service.handleExternalTrigger(upstream);
@@ -120,7 +127,15 @@ describe("notification messaging integration surface", () => {
       correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       occurredAt: "2026-07-05T10:00:00.000Z",
-      payload: { recipientRef: "usr-test-001", paymentIntentId: "pi-test-001", transactionRequired: false },
+      payload: {
+        recipientRef: "usr-test-001",
+        paymentIntentId: "pi-test-001",
+        businessRef: "ord-test-001",
+        capturedAmount: { currency: "CNY", minorUnits: 35000 },
+        channel: "wechat_pay",
+        channelTransactionId: "wx-test-001",
+        transactionRequired: false,
+      },
     };
 
     assert.equal(await service.handleExternalTrigger(upstream), "cancelled");
@@ -142,14 +157,22 @@ describe("notification messaging integration surface", () => {
       correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       occurredAt: "2026-07-05T10:00:00.000Z",
-      payload: { recipientRef: "usr-test-001", paymentIntentId: "pi-test-001", transactionRequired: true },
+      payload: {
+        recipientRef: "usr-test-001",
+        paymentIntentId: "pi-test-001",
+        businessRef: "ord-test-001",
+        capturedAmount: { currency: "CNY", minorUnits: 35000 },
+        channel: "wechat_pay",
+        channelTransactionId: "wx-test-001",
+        transactionRequired: true,
+      },
     };
 
     assert.equal(await service.handleExternalTrigger(upstream), "delivered");
     assert.deepEqual(publisher.envelopes.map((envelope) => envelope.eventType), ["NotificationScheduled", "NotificationDispatched", "NotificationDelivered"]);
   });
 
-  it("rejects conformant trigger events that do not identify a recipient", async () => {
+  it("ack-skips conformant trigger events that do not identify a recipient", async () => {
     const publisher = new InMemoryEventPublisher();
     const service = new NotificationApplicationService(publisher);
     const upstream: EventEnvelope = {
@@ -160,7 +183,54 @@ describe("notification messaging integration surface", () => {
       correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       occurredAt: "2026-07-05T10:00:00.000Z",
-      payload: { paymentIntentId: "pi-test-001" },
+      payload: {
+        paymentIntentId: "pi-test-001",
+        businessRef: "ord-test-001",
+        capturedAmount: { currency: "CNY", minorUnits: 35000 },
+        channel: "wechat_pay",
+        channelTransactionId: "wx-test-001",
+      },
+    };
+
+    assert.equal(await service.handleExternalTrigger(upstream), "ignored");
+    assert.equal(publisher.envelopes.length, 0);
+  });
+
+  it("ack-skips mapped post-sales triggers when no recipient can be derived", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const service = new NotificationApplicationService(publisher);
+    const upstream: EventEnvelope = {
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c224",
+      eventType: "PostSalesExecutionStarted",
+      schemaVersion: 1,
+      producer: "post-sales",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      occurredAt: "2026-07-05T10:00:00.000Z",
+      payload: { caseId: "psc-test-001" },
+    };
+
+    assert.equal(await service.handleExternalTrigger(upstream), "ignored");
+    assert.equal(publisher.envelopes.length, 0);
+  });
+
+  it("rejects trigger events that violate their own event contract", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const service = new NotificationApplicationService(publisher);
+    const upstream: EventEnvelope = {
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      eventType: "PaymentCaptured",
+      schemaVersion: 1,
+      producer: "payment",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      occurredAt: "2026-07-05T10:00:00.000Z",
+      payload: {
+        businessRef: "ord-test-001",
+        capturedAmount: { currency: "CNY", minorUnits: 35000 },
+        channel: "wechat_pay",
+        channelTransactionId: "wx-test-001",
+      },
     };
 
     await assert.rejects(

--- a/services/notification/src/messaging.test.ts
+++ b/services/notification/src/messaging.test.ts
@@ -207,11 +207,32 @@ describe("notification messaging integration surface", () => {
       correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       occurredAt: "2026-07-05T10:00:00.000Z",
-      payload: { caseId: "psc-test-001" },
+      payload: { caseId: "psc-test-001", orderedSteps: ["EXECUTE_REFUND"], approvalRef: "apr-test-001" },
     };
 
     assert.equal(await service.handleExternalTrigger(upstream), "ignored");
     assert.equal(publisher.envelopes.length, 0);
+  });
+
+  it("rejects post-sales triggers that violate their own event contract", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const service = new NotificationApplicationService(publisher);
+    const upstream: EventEnvelope = {
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c225",
+      eventType: "PostSalesExecutionStarted",
+      schemaVersion: 1,
+      producer: "post-sales",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      occurredAt: "2026-07-05T10:00:00.000Z",
+      // Missing contract-required orderedSteps + approvalRef.
+      payload: { caseId: "psc-test-001" },
+    };
+
+    await assert.rejects(
+      async () => service.handleExternalTrigger(upstream),
+      (error: Error) => error.name === "NonConformantNotificationTrigger",
+    );
   });
 
   it("rejects trigger events that violate their own event contract", async () => {

--- a/services/notification/src/storage.test.ts
+++ b/services/notification/src/storage.test.ts
@@ -66,7 +66,14 @@ describe("notification PostgreSQL pilot seams", () => {
       correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       occurredAt: "2026-07-05T10:00:00.000Z",
-      payload: { recipientRef: "usr-test-001", paymentIntentId: "pi-test-001" },
+      payload: {
+        recipientRef: "usr-test-001",
+        paymentIntentId: "pi-test-001",
+        businessRef: "ord-test-001",
+        capturedAmount: { currency: "CNY", minorUnits: 35000 },
+        channel: "wechat_pay",
+        channelTransactionId: "wx-test-001",
+      },
     };
 
     assert.equal(await service.handleExternalTrigger(upstream), "delivered");
@@ -86,7 +93,14 @@ describe("notification PostgreSQL pilot seams", () => {
       correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       occurredAt: "2026-07-05T10:00:00.000Z",
-      payload: { recipientRef: "usr-test-001", paymentIntentId: "pi-test-001" },
+      payload: {
+        recipientRef: "usr-test-001",
+        paymentIntentId: "pi-test-001",
+        businessRef: "ord-test-001",
+        capturedAmount: { currency: "CNY", minorUnits: 35000 },
+        channel: "wechat_pay",
+        channelTransactionId: "wx-test-001",
+      },
     };
     const duplicate = { ...first, eventId: "evt-0194f2e0-7b3f-7c10-8284-5c26e8b0c333" };
 
@@ -105,7 +119,14 @@ describe("notification PostgreSQL pilot seams", () => {
       correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
       occurredAt: "2026-07-05T10:00:00.000Z",
-      payload: { recipientRef: "usr-test-001", paymentIntentId: "pi-test-001" },
+      payload: {
+        recipientRef: "usr-test-001",
+        paymentIntentId: "pi-test-001",
+        businessRef: "ord-test-001",
+        capturedAmount: { currency: "CNY", minorUnits: 35000 },
+        channel: "wechat_pay",
+        channelTransactionId: "wx-test-001",
+      },
     };
     const duplicate = { ...first, eventId: "evt-0194f2e0-7b3f-7c10-8284-5c26e8b0c333" };
     const publisher = new InMemoryEventPublisher();

--- a/services/notification/src/subscriber-resilience.test.ts
+++ b/services/notification/src/subscriber-resilience.test.ts
@@ -53,7 +53,14 @@ function envelope(eventId: string): EventEnvelope {
     causationId: "cmd-test",
     correlationId: "corr-test",
     occurredAt: "2026-07-05T10:00:00.000Z",
-    payload: { recipientRef: "usr-test-001", paymentIntentId: "pi-test-001" },
+    payload: {
+      recipientRef: "usr-test-001",
+      paymentIntentId: "pi-test-001",
+      businessRef: "ord-test-001",
+      capturedAmount: { currency: "CNY", minorUnits: 35000 },
+      channel: "wechat_pay",
+      channelTransactionId: "wx-test-001",
+    },
   };
 }
 

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesMapper.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesMapper.java
@@ -6,6 +6,7 @@ import com.trainticket.postsales.domain.AmountDecisionSnapshot;
 import com.trainticket.postsales.domain.DecisionKind;
 import com.trainticket.postsales.domain.EventMetadata;
 import com.trainticket.postsales.domain.Money;
+import com.trainticket.postsales.domain.ChangeApplied;
 import com.trainticket.postsales.domain.PostSalesApplied;
 import com.trainticket.postsales.domain.PostSalesApproved;
 import com.trainticket.postsales.domain.PostSalesCase;
@@ -16,6 +17,8 @@ import com.trainticket.postsales.domain.PostSalesDecision;
 import com.trainticket.postsales.domain.PostSalesDecisionQuoted;
 import com.trainticket.postsales.domain.PostSalesEligibilityEvaluated;
 import com.trainticket.postsales.domain.PostSalesEvent;
+import com.trainticket.postsales.domain.PostSalesExecutionStarted;
+import com.trainticket.postsales.domain.PostSalesFailed;
 import com.trainticket.postsales.domain.PostSalesRejected;
 import com.trainticket.postsales.domain.PostSalesRequested;
 import java.util.LinkedHashMap;
@@ -152,6 +155,20 @@ public final class PostSalesMapper {
         } else if (event instanceof PostSalesApplied applied) {
             payload.put("orderId", applied.journeyOrderId());
             payload.put("resultSummary", resultSummary(applied));
+        } else if (event instanceof PostSalesExecutionStarted executionStarted) {
+            payload.put("orderedSteps", executionStarted.orderedSteps().stream().map(Enum::name).toList());
+            payload.put("approvalRef", executionStarted.approvalRef());
+        } else if (event instanceof PostSalesFailed failed) {
+            payload.put("orderId", failed.journeyOrderId());
+            payload.put("reason", failed.reason());
+            if (failed.failedStepRef() != null) {
+                payload.put("failedStepRef", failed.failedStepRef());
+            }
+        } else if (event instanceof ChangeApplied changeApplied) {
+            payload.put("orderId", changeApplied.journeyOrderId());
+            payload.put("oldEntitlementRef", changeApplied.oldEntitlementRef());
+            payload.put("newEntitlementRef", changeApplied.newEntitlementRef());
+            payload.put("changeOfferRef", changeApplied.changeOfferRef());
         }
         return payload;
     }


### PR DESCRIPTION
## Summary
- ack-skip mapped notification triggers when their event contract is valid but no recipient can be derived
- validate trigger event envelopes/payloads against required contract fields before treating them as fatal
- update notification tests for conformant PaymentCaptured/PostSalesExecutionStarted no-recipient paths and malformed PaymentCaptured fatal path

## Event × recipient field × handling
| Event family | Recipient derivation fields | No recipient handling |
| --- | --- | --- |
| JourneyOrder* | recipientRef, travelerId, accountId, actorRef, travelerRefs[].recipientRef/travelerId/travelerRef/id | ack-skip when contract-valid and none resolves |
| PaymentCaptured/PaymentFailed/PaymentIntentFailed/PaymentIntentExpired/PaymentExpired | recipientRef, travelerId, accountId, actorRef | ack-skip when contract-valid and none resolves |
| RefundSettled | recipientRef, travelerId, accountId, actorRef | ack-skip when contract-valid and none resolves |
| EntitlementIssued | recipientRef, travelerId, accountId, actorRef, travelerRef | ack-skip when contract-valid and none resolves |
| PostSales* / ChangeApplied | recipientRef, travelerId, accountId, actorRef | ack-skip when contract-valid and none resolves |
| Unsupported event types | no notification mapping | ack-skip |
| Any mapped event violating its own envelope/payload contract | n/a | fatal -> DLQ |

## Validation
- npm test (services/notification): passed
- make check: passed