### PR TITLE
REQ-092 ack-skip late provider terminal events

### DIFF
--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
@@ -156,7 +156,7 @@ public class BookingOrchestrationService {
             case "PaymentCaptured" -> handlePaymentCaptured(payload, envelope.correlationId(), envelope.eventId());
             case "PaymentIntentFailed", "PaymentFailed", "PaymentExpired", "PaymentIntentExpired" -> handlePaymentFailure(payload, envelope.correlationId(), envelope.eventId());
             case "ProviderReservationConfirmed" -> handleProviderReservationConfirmed(payload, envelope.correlationId(), envelope.eventId());
-            case "ProviderReservationFailed", "ProviderReservationTimedOut" -> handleProviderReservationFailed(payload, envelope.correlationId(), envelope.eventId());
+            case "ProviderReservationFailed", "ProviderReservationTimedOut" -> handleProviderReservationFailed(envelope.eventType(), payload, envelope.correlationId(), envelope.eventId());
             case "EntitlementIssued" -> handleEntitlementIssued(payload, envelope.correlationId(), envelope.eventId());
             case "EntitlementIssueFailed" -> handleEntitlementIssueFailed(payload, envelope.correlationId(), envelope.eventId());
             case "EntitlementVoided" -> handleEntitlementVoided(payload, envelope.correlationId(), envelope.eventId());
@@ -321,28 +321,40 @@ public class BookingOrchestrationService {
     }
 
     private void handleProviderReservationConfirmed(Map<String, Object> payload, String correlationId, String causationId) {
-        SegmentBooking booking = bySegmentBookingId(payload);
+        validateProviderReservationConfirmedContract(payload);
+        String segmentBookingId = segmentBookingReference(payload);
+        SegmentBooking booking = bySegmentBookingId(segmentBookingId);
         if (booking == null) {
             throw new IllegalArgumentException("ProviderReservationConfirmed payload references an unknown segment booking");
         }
         ProviderReference reference = providerReference(payload.get("providerReference"));
         String evidence = firstText(payload, "normalizedEvidence", "evidence");
+        if (isTerminal(booking)) {
+            booking.registerLateProviderConfirmation(reference);
+            saveAndPublish(booking, correlationId, causationId);
+            warnProviderAckSkip("ProviderReservationConfirmed", booking);
+            return;
+        }
         booking.confirmFromProvider(new ProviderReservationConfirmed(
-            booking.segmentBookingId(), reference, evidence == null ? "provider-confirmed" : evidence, Map.of()));
-        segmentBookings.save(booking, sagaIdForSegmentBooking(booking.segmentBookingId()).orElseThrow());
-        publishEvents(booking.pullEvents(), correlationId, causationId);
+            booking.segmentBookingId(), reference, evidence, Map.of()));
+        saveAndPublish(booking, correlationId, causationId);
         markSagaStepSucceeded("ProviderReservationConfirmed", booking.segmentBookingId(), correlationId, causationId);
     }
 
-    private void handleProviderReservationFailed(Map<String, Object> payload, String correlationId, String causationId) {
-        SegmentBooking booking = bySegmentBookingId(payload);
+    private void handleProviderReservationFailed(String eventType, Map<String, Object> payload, String correlationId, String causationId) {
+        validateProviderReservationFailedContract(eventType, payload);
+        String segmentBookingId = segmentBookingReference(payload);
+        SegmentBooking booking = bySegmentBookingId(segmentBookingId);
         if (booking == null) {
             throw new IllegalArgumentException("provider failure payload references an unknown segment booking");
         }
+        if (isTerminal(booking)) {
+            warnProviderAckSkip("ProviderReservationFailed", booking);
+            return;
+        }
         String reason = firstText(payload, "errorMessage", "reason", "errorType");
         booking.failReservation(reason == null ? "provider reservation failed" : reason);
-        segmentBookings.save(booking, sagaIdForSegmentBooking(booking.segmentBookingId()).orElseThrow());
-        publishEvents(booking.pullEvents(), correlationId, causationId);
+        saveAndPublish(booking, correlationId, causationId);
     }
 
     private void handleEntitlementIssued(Map<String, Object> payload, String correlationId, String causationId) {
@@ -556,7 +568,10 @@ public class BookingOrchestrationService {
             case SegmentBookingEvent.ProviderReservationTimedOut ignored -> Optional.empty();
             case SegmentBookingEvent.SegmentBookingCancelRequested ignored -> Optional.empty();
             case SegmentBookingEvent.ProviderConfirmationReceivedAfterCancellation ignored -> Optional.empty();
-            case SegmentBookingEvent.ProviderCancellationRequired ignored -> Optional.empty();
+            case SegmentBookingEvent.ProviderCancellationRequired cancellation -> Optional.of(new ContractEvent(
+                "SegmentBookingCancelled",
+                new SegmentBookingCancelledPayload(cancellation.aggregateId(), cancellation.reason(),
+                    holdIdForSegmentBooking(cancellation.aggregateId()))));
         };
     }
 
@@ -569,8 +584,14 @@ public class BookingOrchestrationService {
     }
 
     private SegmentBooking bySegmentBookingId(Map<String, Object> payload) {
-        String segmentBookingId = segmentBookingReference(payload);
-        return segmentBookingId == null ? null : segmentBookings.findById(segmentBookingId).map(SegmentBookingRepository.SegmentBookingRecord::booking).orElse(null);
+        return bySegmentBookingId(segmentBookingReference(payload));
+    }
+
+    private SegmentBooking bySegmentBookingId(String segmentBookingId) {
+        return segmentBookingId == null ? null
+            : segmentBookings.findById(segmentBookingId)
+                .map(SegmentBookingRepository.SegmentBookingRecord::booking)
+                .orElse(null);
     }
 
     private String segmentBookingReference(Map<String, Object> payload) {
@@ -603,7 +624,26 @@ public class BookingOrchestrationService {
         requirePayloadObject(eventType, payload, "interval");
     }
 
-    private void requirePayloadText(String eventType, Map<String, Object> payload, String... fields) {
+    private void validateProviderReservationConfirmedContract(Map<String, Object> payload) {
+        requirePayloadText("ProviderReservationConfirmed", payload, "segmentBookingId", "normalizedEvidence");
+        if (payload.get("providerReference") instanceof Map<?, ?> providerReference) {
+            requirePayloadText("ProviderReservationConfirmed.providerReference", providerReference,
+                "providerId", "reservationId", "displayReference");
+            return;
+        }
+        requirePayloadText("ProviderReservationConfirmed", payload, "providerReference");
+    }
+
+    private void validateProviderReservationFailedContract(String eventType, Map<String, Object> payload) {
+        requirePayloadText(eventType, payload, "segmentBookingId");
+        if ("ProviderReservationTimedOut".equals(eventType)) {
+            requirePayloadText(eventType, payload, "reason");
+        } else {
+            requirePayloadText(eventType, payload, "errorType");
+        }
+    }
+
+    private void requirePayloadText(String eventType, Map<?, ?> payload, String... fields) {
         for (String field : fields) {
             if (text(payload.get(field)) == null) {
                 throw new IllegalArgumentException(eventType + " payload requires " + field);
@@ -628,6 +668,29 @@ public class BookingOrchestrationService {
             case REQUESTED, HOLDING, CANCEL_REQUESTED -> true;
             case CONFIRMED, TICKETED, IN_FULFILLMENT, COMPLETED, CANCELLED, CHANGE_REQUESTED, CHANGED, FAILED -> false;
         };
+    }
+
+    private boolean isTerminal(SegmentBooking booking) {
+        return switch (booking.status()) {
+            case FAILED, CANCELLED -> true;
+            case REQUESTED, HOLDING, CONFIRMED, TICKETED, IN_FULFILLMENT, COMPLETED, CANCEL_REQUESTED,
+                 CHANGE_REQUESTED, CHANGED -> false;
+        };
+    }
+
+    private void saveAndPublish(SegmentBooking booking, String correlationId, String causationId) {
+        String sagaId = sagaIdForSegmentBooking(booking.segmentBookingId()).orElseThrow();
+        segmentBookings.save(booking, sagaId);
+        publishEvents(booking.pullEvents(), correlationId, causationId);
+    }
+
+    private void warnProviderAckSkip(String eventType, SegmentBooking booking) {
+        LOGGER.warn(
+            "Ack-skipping {} from provider-integration: segmentBookingId={}, status={}, failureReason={}",
+            eventType,
+            booking.segmentBookingId(),
+            booking.status(),
+            booking.failureReason().orElse(null));
     }
 
     private void warnCapacityAckSkip(String eventType, String reason) {

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/SegmentBooking.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/SegmentBooking.java
@@ -151,12 +151,8 @@ public final class SegmentBooking {
         if (!segmentBookingId.equals(confirmation.segmentBookingId())) {
             throw new IllegalArgumentException("provider confirmation belongs to a different segment booking");
         }
-        if (status == SegmentBookingStatus.CANCEL_REQUESTED || status == SegmentBookingStatus.CANCELLED) {
-            attachSameProviderReferenceOrThrow(confirmation.providerReference());
-            record(new ProviderConfirmationReceivedAfterCancellation(nextEventId(), segmentBookingId, now(),
-                confirmation.providerReference(), "provider confirmed after cancellation"));
-            record(new ProviderCancellationRequired(nextEventId(), segmentBookingId, now(),
-                confirmation.providerReference(), "cancel late provider confirmation"));
+        if (isTerminalOrCancelling()) {
+            registerLateProviderConfirmation(confirmation.providerReference());
             return;
         }
         confirmReservation(Optional.of(confirmation.providerReference()), confirmation.normalizedEvidence());
@@ -169,6 +165,20 @@ public final class SegmentBooking {
     public void markProviderReservationTimeout(String reason) {
         requireStatus(SegmentBookingStatus.REQUESTED, SegmentBookingStatus.HOLDING);
         record(new ProviderReservationTimedOut(nextEventId(), segmentBookingId, now(), requireText(reason, "reason")));
+    }
+
+    public void registerLateProviderConfirmation(ProviderReference requestedProviderReference) {
+        if (providerReference != null) {
+            return;
+        }
+        attachSameProviderReferenceOrThrow(requestedProviderReference);
+        if (hasProviderCancellationRequiredEvent()) {
+            return;
+        }
+        record(new ProviderConfirmationReceivedAfterCancellation(nextEventId(), segmentBookingId, now(),
+            requestedProviderReference, "provider confirmed after booking terminal"));
+        record(new ProviderCancellationRequired(nextEventId(), segmentBookingId, now(),
+            requestedProviderReference, "cancel late provider confirmation"));
     }
 
     public void failReservation(String reason) {
@@ -221,6 +231,17 @@ public final class SegmentBooking {
 
     public List<DomainEvent> peekEvents() {
         return eventRecorder.peekEvents();
+    }
+
+    private boolean isTerminalOrCancelling() {
+        return status == SegmentBookingStatus.CANCEL_REQUESTED
+            || status == SegmentBookingStatus.CANCELLED
+            || status == SegmentBookingStatus.FAILED;
+    }
+
+    private boolean hasProviderCancellationRequiredEvent() {
+        return eventRecorder.peekEvents().stream()
+            .anyMatch(ProviderCancellationRequired.class::isInstance);
     }
 
     private void confirmReservation(Optional<ProviderReference> maybeProviderReference, String evidence) {

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/application/BookingOrchestrationServicePayloadContractTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/application/BookingOrchestrationServicePayloadContractTest.java
@@ -331,7 +331,7 @@ class BookingOrchestrationServicePayloadContractTest {
             "idem-reservation-provider-failure", "corr-start");
         published.clear();
 
-        assertInstanceOf(HandlerResult.Success.class, service.handleUpstreamEvent(new EventEnvelope("evt-0194f2e0-7b3e-7610-8284-5c26e8b0c402", "ProviderReservationFailed", Instant.parse("2026-07-05T10:05:00Z"), "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c404", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c403", "provider-integration", 1, Map.of("segmentBookingId", "sb-0194f2e0-7b3e-7610-8284-5c26e8b0c401", "reason", "provider-unavailable"))));
+        assertInstanceOf(HandlerResult.Success.class, service.handleUpstreamEvent(new EventEnvelope("evt-0194f2e0-7b3e-7610-8284-5c26e8b0c402", "ProviderReservationFailed", Instant.parse("2026-07-05T10:05:00Z"), "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c404", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c403", "provider-integration", 1, Map.of("segmentBookingId", "sb-0194f2e0-7b3e-7610-8284-5c26e8b0c401", "errorType", "NON_RETRYABLE_TECHNICAL_ERROR", "errorMessage", "provider-unavailable"))));
 
         assertTrue(published.getPublished().stream().anyMatch(envelope ->
             envelope.eventType().equals("SegmentReservationFailed")
@@ -383,6 +383,144 @@ class BookingOrchestrationServicePayloadContractTest {
                 "failureMessage", "provider timeout",
                 "failedAt", "2026-07-05T10:07:00Z"))));
 
+        assertTrue(published.getPublished().isEmpty());
+    }
+
+    @Test
+    void failedBookingProviderConfirmationIsAckSkippedAndRequestsProviderCancellationOnce(CapturedOutput output) {
+        var published = new TestEventPublisher();
+        var service = new BookingOrchestrationService(
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), published);
+        var start = service.startSaga(new BookingOrchestrationService.StartSagaCommand(
+            "ord-provider-late-confirmed", "acc-123", "off-123", List.of("tvl-123"), List.of("seg-001")),
+            "idem-start-provider-late-confirmed", "corr-start");
+        service.requestReservation(start.sagaId(), new BookingOrchestrationService.RequestReservationCommand(
+            "seg-001", "tvl-123", "sb-0194f2e0-7b3e-7610-8284-5c26e8b0d101"),
+            "idem-reservation-provider-late-confirmed", "corr-start");
+        assertInstanceOf(HandlerResult.Success.class, service.handleUpstreamEvent(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d102", "CapacityHoldFailed",
+            Instant.parse("2026-07-05T10:01:00Z"), "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d501", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d502",
+            "capacity-availability", 1, Map.of(
+                "segmentBookingId", "sb-0194f2e0-7b3e-7610-8284-5c26e8b0d101",
+                "failureCode", "NO_AVAILABLE_CAPACITY"))));
+        published.clear();
+
+        var firstResult = service.handleUpstreamEvent(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d103", "ProviderReservationConfirmed",
+            Instant.parse("2026-07-05T10:02:00Z"), "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d503", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d504",
+            "provider-integration", 1, Map.of(
+                "segmentBookingId", "sb-0194f2e0-7b3e-7610-8284-5c26e8b0d101",
+                "providerReference", Map.of("providerId", "provider-1", "reservationId", "res-1", "displayReference", "PNR1"),
+                "normalizedEvidence", "provider confirmed")));
+        var secondResult = service.handleUpstreamEvent(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d104", "ProviderReservationConfirmed",
+            Instant.parse("2026-07-05T10:03:00Z"), "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d503", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d504",
+            "provider-integration", 1, Map.of(
+                "segmentBookingId", "sb-0194f2e0-7b3e-7610-8284-5c26e8b0d101",
+                "providerReference", Map.of("providerId", "provider-1", "reservationId", "res-1", "displayReference", "PNR1"),
+                "normalizedEvidence", "provider confirmed")));
+
+        assertInstanceOf(HandlerResult.Success.class, firstResult);
+        assertInstanceOf(HandlerResult.Success.class, secondResult);
+        assertEquals(1, published.getPublished().stream()
+            .filter(envelope -> envelope.eventType().equals("SegmentBookingCancelled"))
+            .count());
+        String log = output.getOut() + output.getErr();
+        assertTrue(log.contains("Ack-skipping ProviderReservationConfirmed"));
+        assertTrue(log.contains("segmentBookingId=sb-0194f2e0-7b3e-7610-8284-5c26e8b0d101"));
+        assertTrue(log.contains("status=FAILED"));
+        assertTrue(log.contains("failureReason=NO_AVAILABLE_CAPACITY"));
+    }
+
+    @Test
+    void cancelledBookingProviderFailureIsAckSkipped(CapturedOutput output) {
+        var published = new TestEventPublisher();
+        var service = new BookingOrchestrationService(
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), published);
+        var start = service.startSaga(new BookingOrchestrationService.StartSagaCommand(
+            "ord-provider-late-failed", "acc-123", "off-123", List.of("tvl-123"), List.of("seg-001")),
+            "idem-start-provider-late-failed", "corr-start");
+        service.requestReservation(start.sagaId(), new BookingOrchestrationService.RequestReservationCommand(
+            "seg-001", "tvl-123", "sb-0194f2e0-7b3e-7610-8284-5c26e8b0d201"),
+            "idem-reservation-provider-late-failed", "corr-start");
+        assertInstanceOf(HandlerResult.Success.class, service.handleUpstreamEvent(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d202", "CapacityHeld",
+            Instant.parse("2026-07-05T10:01:00Z"), "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d505", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d506",
+            "capacity-availability", 1, Map.of(
+                "holdId", "hold-0194f2e0-7b3e-7610-8284-5c26e8b0d203",
+                "inventoryPoolId", "pool-123",
+                "capacityUnitRef", "cu-123",
+                "interval", Map.of("fromStationRef", "BJP", "toStationRef", "SHH"),
+                "idempotencyKey", "ord-provider-late-failed:seg-001:tvl-123:purchase",
+                "expiresAt", "2026-07-05T10:08:00Z",
+                "idempotentReplay", false))));
+        assertInstanceOf(HandlerResult.Success.class, service.handleUpstreamEvent(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d204", "CapacityReleased",
+            Instant.parse("2026-07-05T10:02:00Z"), "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d507", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d508",
+            "capacity-availability", 1, Map.of(
+                "holdId", "hold-0194f2e0-7b3e-7610-8284-5c26e8b0d203",
+                "inventoryPoolId", "pool-123",
+                "capacityUnitRef", "cu-123",
+                "interval", Map.of("fromStationRef", "BJP", "toStationRef", "SHH"),
+                "releasedAt", "2026-07-05T10:02:00Z",
+                "releaseReason", "customer-cancelled"))));
+        published.clear();
+
+        var result = service.handleUpstreamEvent(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d205", "ProviderReservationFailed",
+            Instant.parse("2026-07-05T10:03:00Z"), "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d509", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d510",
+            "provider-integration", 1, Map.of(
+                "segmentBookingId", "sb-0194f2e0-7b3e-7610-8284-5c26e8b0d201",
+                "errorType", "BUSINESS_REJECTED",
+                "errorMessage", "provider rejected")));
+
+        assertInstanceOf(HandlerResult.Success.class, result);
+        assertTrue(published.getPublished().isEmpty());
+        assertTrue((output.getOut() + output.getErr()).contains("Ack-skipping ProviderReservationFailed"));
+    }
+
+    @Test
+    void requestedBookingProviderConfirmationFollowsMainPath() {
+        var published = new TestEventPublisher();
+        var service = new BookingOrchestrationService(
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), published);
+        var start = service.startSaga(new BookingOrchestrationService.StartSagaCommand(
+            "ord-provider-confirmed", "acc-123", "off-123", List.of("tvl-123"), List.of("seg-001")),
+            "idem-start-provider-confirmed", "corr-start");
+        service.requestReservation(start.sagaId(), new BookingOrchestrationService.RequestReservationCommand(
+            "seg-001", "tvl-123", "sb-0194f2e0-7b3e-7610-8284-5c26e8b0d301"),
+            "idem-reservation-provider-confirmed", "corr-start");
+        published.clear();
+
+        var result = service.handleUpstreamEvent(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d302", "ProviderReservationConfirmed",
+            Instant.parse("2026-07-05T10:02:00Z"), "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d503", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d504",
+            "provider-integration", 1, Map.of(
+                "segmentBookingId", "sb-0194f2e0-7b3e-7610-8284-5c26e8b0d301",
+                "providerReference", Map.of("providerId", "provider-1", "reservationId", "res-1", "displayReference", "PNR1"),
+                "normalizedEvidence", "provider confirmed")));
+
+        assertInstanceOf(HandlerResult.Success.class, result);
+        assertTrue(published.getPublished().stream().anyMatch(envelope -> envelope.eventType().equals("SegmentReservationConfirmed")));
+        assertTrue(published.getPublished().stream().noneMatch(envelope -> envelope.eventType().equals("SegmentReservationFailed")));
+        assertTrue(published.getPublished().stream().noneMatch(envelope -> envelope.eventType().equals("SegmentBookingCancelled")));
+        assertEquals("WAITING_PAYMENT", service.getSaga(start.sagaId()).orElseThrow().status());
+    }
+
+    @Test
+    void malformedProviderReservationConfirmedMissingEvidenceIsFatal() {
+        var published = new TestEventPublisher();
+        var service = new BookingOrchestrationService(
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), published);
+
+        var result = service.handleUpstreamEvent(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d401", "ProviderReservationConfirmed",
+            Instant.parse("2026-07-05T10:02:00Z"), "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d503", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d504",
+            "provider-integration", 1, Map.of(
+                "segmentBookingId", "sb-0194f2e0-7b3e-7610-8284-5c26e8b0d402",
+                "providerReference", Map.of("providerId", "provider-1", "reservationId", "res-1", "displayReference", "PNR1"))));
+
+        assertInstanceOf(HandlerResult.FatalError.class, result);
         assertTrue(published.getPublished().isEmpty());
     }
 

--- a/services/provider-integration/internal/application/inbound_events.go
+++ b/services/provider-integration/internal/application/inbound_events.go
@@ -3,11 +3,15 @@ package application
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 )
 
-const segmentReservationRequested = "SegmentReservationRequested"
+const (
+	segmentReservationRequested = "SegmentReservationRequested"
+	segmentBookingCancelled     = "SegmentBookingCancelled"
+)
 
 type SegmentReservationRequestedPayload struct {
 	SegmentBookingID string `json:"segmentBookingId"`
@@ -22,6 +26,8 @@ func NewInboundEventHandler(reservations ProviderReservationService) EventHandle
 		switch envelope.EventType {
 		case segmentReservationRequested:
 			return handleSegmentReservationRequested(ctx, reservations, envelope)
+		case segmentBookingCancelled:
+			return handleSegmentBookingCancelled(ctx, reservations, envelope)
 		default:
 			return nil
 		}
@@ -55,6 +61,47 @@ func handleSegmentReservationRequested(ctx context.Context, reservations Provide
 		return TransientHandlerError(err)
 	}
 	return nil
+}
+
+type SegmentBookingCancelledPayload struct {
+	SegmentBookingID string `json:"segmentBookingId"`
+	Reason           string `json:"reason"`
+}
+
+func handleSegmentBookingCancelled(ctx context.Context, reservations ProviderReservationService, envelope EventEnvelope) error {
+	if reservations == nil {
+		return TransientHandlerError(fmt.Errorf("reservation service is not configured"))
+	}
+	var payload SegmentBookingCancelledPayload
+	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
+		return FatalHandlerError(fmt.Errorf("invalid SegmentBookingCancelled payload: %w", err))
+	}
+	if err := validateSegmentBookingCancelledPayload(payload); err != nil {
+		return FatalHandlerError(err)
+	}
+	cmd := CancelProviderReservationCommand{
+		SegmentBookingID: strings.TrimSpace(payload.SegmentBookingID),
+		CorrelationID:    envelope.CorrelationID,
+		CausationID:      envelope.EventID,
+		IdempotencyKey:   envelope.EventID,
+	}
+	if _, err := reservations.CancelReservation(ctx, cmd); err != nil {
+		// Most segment bookings are cancelled before any provider
+		// reservation exists (e.g. capacity failed first); nothing to
+		// compensate, so the event is consumed as a no-op.
+		if errors.Is(err, ErrNotFound) {
+			return nil
+		}
+		return TransientHandlerError(err)
+	}
+	return nil
+}
+
+func validateSegmentBookingCancelledPayload(payload SegmentBookingCancelledPayload) error {
+	if err := ValidateSegmentBookingID(payload.SegmentBookingID); err != nil {
+		return fmt.Errorf("invalid SegmentBookingCancelled segmentBookingId: %w", err)
+	}
+	return validateRequiredToken("reason", payload.Reason)
 }
 
 func validateSegmentReservationRequestedPayload(payload SegmentReservationRequestedPayload) error {

--- a/services/provider-integration/internal/http/api_test.go
+++ b/services/provider-integration/internal/http/api_test.go
@@ -448,3 +448,99 @@ func post(router http.Handler, path, body, idempotencyKey string) *httptest.Resp
 	router.ServeHTTP(recorder, request)
 	return recorder
 }
+
+func TestInboundSegmentBookingCancelledCancelsExistingReservation(t *testing.T) {
+	publisher := &fakePublisher{}
+	service := application.NewInMemoryReservationService(publisher)
+	handler := application.NewInboundEventHandler(service)
+	requested := validSegmentReservationRequestedPayload()
+	requestedBytes, err := json.Marshal(requested)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := handler(context.Background(), application.EventEnvelope{
+		EventID:       "evt-" + testUUIDv7(80),
+		EventType:     "SegmentReservationRequested",
+		OccurredAt:    time.Date(2026, 7, 8, 0, 0, 0, 0, time.UTC),
+		CorrelationID: "corr-" + testUUIDv7(81),
+		CausationID:   "cmd-" + testUUIDv7(82),
+		Producer:      "booking-orchestration",
+		SchemaVersion: 1,
+		Payload:       requestedBytes,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cancelled, err := json.Marshal(map[string]any{
+		"segmentBookingId": requested["segmentBookingId"],
+		"reason":           "cancel late provider confirmation",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope := application.EventEnvelope{
+		EventID:       "evt-" + testUUIDv7(83),
+		EventType:     "SegmentBookingCancelled",
+		OccurredAt:    time.Date(2026, 7, 8, 0, 1, 0, 0, time.UTC),
+		CorrelationID: "corr-" + testUUIDv7(81),
+		CausationID:   "evt-" + testUUIDv7(80),
+		Producer:      "booking-orchestration",
+		SchemaVersion: 1,
+		Payload:       cancelled,
+	}
+	if err := handler(context.Background(), envelope); err != nil {
+		t.Fatalf("expected cancellation of existing reservation to ack, got %v", err)
+	}
+	if err := handler(context.Background(), envelope); err != nil {
+		t.Fatalf("expected duplicate cancellation to stay idempotent, got %v", err)
+	}
+}
+
+func TestInboundSegmentBookingCancelledWithoutReservationAcksAsNoOp(t *testing.T) {
+	publisher := &fakePublisher{}
+	service := application.NewInMemoryReservationService(publisher)
+	handler := application.NewInboundEventHandler(service)
+	payloadBytes, err := json.Marshal(map[string]any{
+		"segmentBookingId": "sb-" + testUUIDv7(84),
+		"reason":           "capacity failed before provider reservation",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := handler(context.Background(), application.EventEnvelope{
+		EventID:       "evt-" + testUUIDv7(85),
+		EventType:     "SegmentBookingCancelled",
+		OccurredAt:    time.Date(2026, 7, 8, 0, 2, 0, 0, time.UTC),
+		CorrelationID: "corr-" + testUUIDv7(86),
+		CausationID:   "evt-" + testUUIDv7(87),
+		Producer:      "booking-orchestration",
+		SchemaVersion: 1,
+		Payload:       payloadBytes,
+	}); err != nil {
+		t.Fatalf("expected no-reservation cancellation to ack as no-op, got %v", err)
+	}
+}
+
+func TestInboundSegmentBookingCancelledMissingReasonIsFatal(t *testing.T) {
+	publisher := &fakePublisher{}
+	service := application.NewInMemoryReservationService(publisher)
+	handler := application.NewInboundEventHandler(service)
+	payloadBytes, err := json.Marshal(map[string]any{
+		"segmentBookingId": "sb-" + testUUIDv7(88),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = handler(context.Background(), application.EventEnvelope{
+		EventID:       "evt-" + testUUIDv7(89),
+		EventType:     "SegmentBookingCancelled",
+		OccurredAt:    time.Date(2026, 7, 8, 0, 3, 0, 0, time.UTC),
+		CorrelationID: "corr-" + testUUIDv7(90),
+		CausationID:   "evt-" + testUUIDv7(91),
+		Producer:      "booking-orchestration",
+		SchemaVersion: 1,
+		Payload:       payloadBytes,
+	})
+	if err == nil {
+		t.Fatal("expected missing reason to be fatal")
+	}
+}


### PR DESCRIPTION
## Summary
- ACK-skip conformant provider confirmed/failed facts when local segment booking is FAILED/CANCELLED, with WARN context
- emit contract-supported SegmentBookingCancelled compensation for late provider confirmations against terminal bookings, idempotently
- add provider event contract validation and application tests for terminal, normal, and malformed payload paths

## Validation
- services/booking-orchestration: mvn test -q
- make check