### PR TITLE
REQ-094 improve kit messaging observability

### DIFF
--- a/platform/go-kit/messaging/envelope_test.go
+++ b/platform/go-kit/messaging/envelope_test.go
@@ -142,3 +142,90 @@ func TestRedisSubscriptionFatalHandlerMovesMessageToDLQWithMetadataAndWarnLog(t 
 		t.Fatalf("missing WARN DLQ log: %s", logText)
 	}
 }
+
+func TestRedisSubscriptionTransientHandlerLogsRetryPath(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	bus := NewRedisEventBusWithClient(client, RedisConfig{ReadBlock: 10 * time.Millisecond, RecoveryEvery: time.Hour})
+	defer bus.Close()
+
+	envelope, err := NewEventEnvelope("RetryEvent", "payment", "0194f2e0-7b3e-7610-0284-5c26e8b0c123", map[string]string{"id": "1"}, EnvelopeOptions{Now: time.Date(2026, 7, 5, 10, 30, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var logBuffer bytes.Buffer
+	originalWriter := log.Writer()
+	log.SetOutput(&logBuffer)
+	defer log.SetOutput(originalWriter)
+
+	stream := StreamName("payment")
+	if err := bus.Subscribe(ctx, Subscription{Streams: []string{"payment"}, Group: "journey-order", ConsumerName: "consumer-1"}, func(context.Context, EventEnvelope) error {
+		return TransientHandlerError(errors.New("redis temporarily unavailable"))
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := bus.client.XAdd(ctx, &redis.XAddArgs{Stream: stream, Values: map[string]any{EnvelopeField: string(body)}}).Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !strings.Contains(logBuffer.String(), "handler transient failure") {
+		time.Sleep(10 * time.Millisecond)
+	}
+	logText := logBuffer.String()
+	if !strings.Contains(logText, "handler transient failure") || !strings.Contains(logText, envelope.EventID) || !strings.Contains(logText, "redis temporarily unavailable") {
+		t.Fatalf("missing transient retry log: %s", logText)
+	}
+	if dlq, err := bus.client.XRange(ctx, stream+DeadLetterSuffix, "-", "+").Result(); err != nil || len(dlq) != 0 {
+		t.Fatalf("transient retry should not DLQ: messages=%#v err=%v", dlq, err)
+	}
+}
+
+func TestRedisSubscriptionDuplicateAckSkipLogs(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	bus := NewRedisEventBusWithClient(client, RedisConfig{ReadBlock: 10 * time.Millisecond, RecoveryEvery: time.Hour})
+	defer bus.Close()
+
+	envelope, err := NewEventEnvelope("DuplicateEvent", "payment", "0194f2e0-7b3e-7610-0284-5c26e8b0c123", map[string]string{"id": "1"}, EnvelopeOptions{Now: time.Date(2026, 7, 5, 10, 30, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var logBuffer bytes.Buffer
+	originalWriter := log.Writer()
+	log.SetOutput(&logBuffer)
+	defer log.SetOutput(originalWriter)
+
+	stream := StreamName("payment")
+	if err := bus.Subscribe(ctx, Subscription{Streams: []string{"payment"}, Group: "journey-order", ConsumerName: "consumer-1"}, func(context.Context, EventEnvelope) error {
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		if err := bus.client.XAdd(ctx, &redis.XAddArgs{Stream: stream, Values: map[string]any{EnvelopeField: string(body)}}).Err(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !strings.Contains(logBuffer.String(), "duplicate event already processed") {
+		time.Sleep(10 * time.Millisecond)
+	}
+	logText := logBuffer.String()
+	if !strings.Contains(logText, "duplicate event already processed") || !strings.Contains(logText, envelope.EventID) {
+		t.Fatalf("missing duplicate ack-skip log: %s", logText)
+	}
+}

--- a/platform/go-kit/messaging/redis.go
+++ b/platform/go-kit/messaging/redis.go
@@ -189,6 +189,7 @@ func (b *RedisEventBus) consumeLoop(ctx context.Context, streams []string, group
 			// A non-persistent Redis loses consumer groups on restart:
 			// NOGROUP means "recreate and carry on". Every other error
 			// backs off so a dead connection never hot-spins this loop.
+			log.Printf("WARN service=%s stream=%s eventId=unknown deliveries=0 read failed; recreating group if missing and backing off: %T: %v", group, strings.Join(streams, ","), err, err)
 			if strings.Contains(strings.ToUpper(err.Error()), "NOGROUP") {
 				for _, s := range streams {
 					_ = b.ensureGroup(ctx, s, group)

--- a/platform/go-kit/messaging/redis.go
+++ b/platform/go-kit/messaging/redis.go
@@ -212,7 +212,13 @@ func (b *RedisEventBus) recoverPending(ctx context.Context, stream, group, consu
 	start := "0-0"
 	for {
 		messages, next, err := b.client.XAutoClaim(ctx, &redis.XAutoClaimArgs{Stream: stream, Group: group, Consumer: consumer, MinIdle: b.cfg.RecoveryMinIdle, Start: start, Count: 100}).Result()
-		if err != nil || len(messages) == 0 {
+		if err != nil {
+			if ctx.Err() == nil {
+				log.Printf("WARN service=%s stream=%s eventId=%s deliveries=%d recovery failed: %T: %v", group, stream, "unknown", int64(0), err, err)
+			}
+			return
+		}
+		if len(messages) == 0 {
 			return
 		}
 		for _, m := range messages {
@@ -237,12 +243,15 @@ func (b *RedisEventBus) processMessage(ctx context.Context, stream, group, consu
 		return
 	}
 	if b.dedup != nil && b.dedup.Seen(envelope.EventID) {
+		log.Printf("WARN service=%s stream=%s eventId=%s deliveries=%d duplicate event already processed; acking without handler", group, stream, envelope.EventID, attempts)
 		_ = b.client.XAck(ctx, stream, group, message.ID).Err()
 		return
 	}
 	if err := handler(ctx, envelope); err != nil {
 		if IsFatalHandlerError(err) || attempts >= MaxDeliveryAttempts {
 			b.moveToDLQAndAck(ctx, stream, group, consumer, message.ID, raw, err, attempts)
+		} else {
+			log.Printf("WARN service=%s stream=%s eventId=%s deliveries=%d handler transient failure; message stays pending for retry: %T: %v", group, stream, envelope.EventID, attempts, err, err)
 		}
 		return
 	}
@@ -260,24 +269,30 @@ func (b *RedisEventBus) deliveryAttempts(ctx context.Context, stream, group, id 
 }
 func (b *RedisEventBus) moveToDLQAndAck(ctx context.Context, stream, group, consumer, id, raw string, reason any, attempts int64) {
 	failureReason := truncateFailureReason(reason)
-	log.Printf("WARN service=%s stream=%s eventId=%s failureReason=%s moving message to DLQ", group, stream, eventIDForLog(raw), failureReason)
+	safeAttempts := maxInt64(1, attempts)
+	deadLetteredAt := time.Now().UTC().Format(time.RFC3339Nano)
+	log.Printf("WARN service=%s stream=%s eventId=%s deliveries=%d consumerGroup=%s failureReason=%s attempts=%d deadLetteredAt=%s moving message to DLQ", group, stream, eventIDForLog(raw), safeAttempts, group, failureReason, safeAttempts, deadLetteredAt)
 	_ = b.client.XAdd(ctx, &redis.XAddArgs{
 		Stream: stream + DeadLetterSuffix,
 		MaxLen: MaxLen,
 		Approx: true,
-		Values: dlqFields(raw, group, consumer, failureReason, attempts),
+		Values: dlqFieldsWithTimestamp(raw, group, consumer, failureReason, safeAttempts, deadLetteredAt),
 	}).Err()
 	_ = b.client.XAck(ctx, stream, group, id).Err()
 }
 
 func dlqFields(raw, group, consumer, failureReason string, attempts int64) map[string]any {
+	return dlqFieldsWithTimestamp(raw, group, consumer, failureReason, attempts, time.Now().UTC().Format(time.RFC3339Nano))
+}
+
+func dlqFieldsWithTimestamp(raw, group, consumer, failureReason string, attempts int64, deadLetteredAt string) map[string]any {
 	return map[string]any{
 		EnvelopeField:    raw,
 		"consumerGroup":  group,
 		"consumerName":   consumer,
 		"failureReason":  failureReason,
 		"attempts":       fmt.Sprintf("%d", maxInt64(1, attempts)),
-		"deadLetteredAt": time.Now().UTC().Format(time.RFC3339Nano),
+		"deadLetteredAt": deadLetteredAt,
 	}
 }
 

--- a/platform/python-kit/src/train_ticket_platform/messaging.py
+++ b/platform/python-kit/src/train_ticket_platform/messaging.py
@@ -170,6 +170,16 @@ class RedisEventSubscriber(EventSubscriber):
                     break
                 if isinstance(exc, (TransientHandlerError, FatalHandlerError)):
                     raise
+                LOGGER.warning(
+                    "service=%s stream=%s eventId=%s deliveries=%s subscriber poll/recovery failed: %s: %s",
+                    group,
+                    ",".join(streams_tuple),
+                    "unknown",
+                    0,
+                    exc.__class__.__name__,
+                    exc,
+                    exc_info=True,
+                )
                 # Redis is non-persistent here: a restart drops consumer groups,
                 # so recreate them on NOGROUP instead of spinning on the error.
                 if "NOGROUP" in str(exc):
@@ -259,6 +269,13 @@ class RedisEventSubscriber(EventSubscriber):
             self._xack(stream, group, msg_id_str)
             return
         if self._already_seen(envelope.eventId):
+            LOGGER.warning(
+                "service=%s stream=%s eventId=%s deliveries=%s duplicate event already processed; acking without handler",
+                group,
+                stream,
+                envelope.eventId,
+                self._delivery_count(stream, group, msg_id_str) or 1,
+            )
             self._xack(stream, group, msg_id_str)
             return
         if self._delivery_count(stream, group, msg_id_str) >= MAX_DELIVERY_ATTEMPTS:
@@ -267,19 +284,49 @@ class RedisEventSubscriber(EventSubscriber):
             return
         try:
             result = handler(envelope)
-        except TransientHandlerError:
+        except TransientHandlerError as exc:
+            LOGGER.warning(
+                "service=%s stream=%s eventId=%s deliveries=%s handler transient failure; message stays pending for retry: %s: %s",
+                group,
+                stream,
+                envelope.eventId,
+                self._delivery_count(stream, group, msg_id_str) or 1,
+                exc.__class__.__name__,
+                exc,
+                exc_info=True,
+            )
             return
         except FatalHandlerError as exc:
             self._move_to_dlq(stream, group, consumer_name, envelope_json, exc, self._delivery_count(stream, group, msg_id_str))
             self._xack(stream, group, msg_id_str)
             return
         except Exception as exc:
-            if self._delivery_count(stream, group, msg_id_str) >= MAX_DELIVERY_ATTEMPTS:
-                self._move_to_dlq(stream, group, consumer_name, envelope_json, exc, self._delivery_count(stream, group, msg_id_str))
+            deliveries = self._delivery_count(stream, group, msg_id_str) or 1
+            if deliveries >= MAX_DELIVERY_ATTEMPTS:
+                self._move_to_dlq(stream, group, consumer_name, envelope_json, exc, deliveries)
                 self._xack(stream, group, msg_id_str)
+            else:
+                LOGGER.warning(
+                    "service=%s stream=%s eventId=%s deliveries=%s handler unexpected failure; message stays pending for retry: %s: %s",
+                    group,
+                    stream,
+                    envelope.eventId,
+                    deliveries,
+                    exc.__class__.__name__,
+                    exc,
+                    exc_info=True,
+                )
             return
         if isinstance(result, HandlerResult):
             if result.status is HandlerStatus.TRANSIENT_ERROR:
+                LOGGER.warning(
+                    "service=%s stream=%s eventId=%s deliveries=%s handler transient result; message stays pending for retry: %s",
+                    group,
+                    stream,
+                    envelope.eventId,
+                    self._delivery_count(stream, group, msg_id_str) or 1,
+                    result.message or "HandlerResult.TRANSIENT_ERROR",
+                )
                 return
             if result.status is HandlerStatus.FATAL_ERROR:
                 self._move_to_dlq(stream, group, consumer_name, envelope_json, result.message or "HandlerResult.FATAL_ERROR", self._delivery_count(stream, group, msg_id_str))
@@ -338,12 +385,18 @@ class RedisEventSubscriber(EventSubscriber):
     def _move_to_dlq(self, stream: str, group: str, consumer_name: str, envelope_json: str, reason: object, attempts: int) -> None:
         failure_reason = _truncate_failure_reason(reason)
         event_id = _event_id_for_log(envelope_json)
+        safe_attempts = max(1, attempts)
+        dead_lettered_at = datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
         LOGGER.warning(
-            "service=%s stream=%s eventId=%s failureReason=%s moving message to DLQ",
+            "service=%s stream=%s eventId=%s deliveries=%s consumerGroup=%s failureReason=%s attempts=%s deadLetteredAt=%s moving message to DLQ",
             group,
             stream,
             event_id,
+            safe_attempts,
+            group,
             failure_reason,
+            safe_attempts,
+            dead_lettered_at,
         )
         self._client.xadd(
             dlq_for_stream(stream),
@@ -352,8 +405,8 @@ class RedisEventSubscriber(EventSubscriber):
                 "consumerGroup": group,
                 "consumerName": consumer_name,
                 "failureReason": failure_reason,
-                "attempts": str(max(1, attempts)),
-                "deadLetteredAt": datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+                "attempts": str(safe_attempts),
+                "deadLetteredAt": dead_lettered_at,
             },
             maxlen=MAXLEN,
             approximate=True,

--- a/platform/python-kit/tests/test_messaging.py
+++ b/platform/python-kit/tests/test_messaging.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 from train_ticket_platform.events import EventEnvelope
-from train_ticket_platform.messaging import FatalHandlerError, RedisEventSubscriber, dlq_for_stream
+from train_ticket_platform.messaging import FatalHandlerError, HandlerResult, RedisEventSubscriber, TransientHandlerError, dlq_for_stream
 
 
 class FakeRedis:
@@ -66,3 +66,41 @@ def test_process_entry_uses_supplied_consumer_name_for_max_delivery_dlq() -> Non
 
     dlq_fields = subscriber._client.dlq_entries[0][1]
     assert dlq_fields["consumerName"] == "tester-consumer"
+
+
+def test_transient_handler_exception_logs_retry_path(caplog) -> None:
+    caplog.set_level(logging.WARNING)
+    subscriber = object.__new__(RedisEventSubscriber)
+    subscriber._client = FakeRedis()
+    subscriber._dedup = set()
+    subscriber._dedup_lock = None
+    envelope = EventEnvelope(eventType="SomethingHappened", producer="tester", payload={"x": 1})
+    fields = {"envelope": json.dumps(envelope.to_json_dict())}
+
+    def handler(_: EventEnvelope) -> None:
+        raise TransientHandlerError("redis unavailable")
+
+    subscriber._process_message("events:tester", "tester", "tester-consumer", "1-0", fields, handler)
+
+    assert subscriber._client.acks == []
+    assert subscriber._client.dlq_entries == []
+    assert "handler transient failure" in caplog.text
+    assert "TransientHandlerError" in caplog.text
+    assert envelope.eventId in caplog.text
+
+
+def test_ack_skip_duplicate_logs_ack_path(caplog) -> None:
+    caplog.set_level(logging.WARNING)
+    subscriber = object.__new__(RedisEventSubscriber)
+    subscriber._client = FakeRedis()
+    subscriber._dedup = set()
+    subscriber._dedup_lock = None
+    envelope = EventEnvelope(eventType="SomethingHappened", producer="tester", payload={"x": 1})
+    subscriber._record_seen(envelope.eventId)
+    fields = {"envelope": json.dumps(envelope.to_json_dict())}
+
+    subscriber._process_message("events:tester", "tester", "tester-consumer", "1-0", fields, lambda _: HandlerResult.success())
+
+    assert subscriber._client.acks == [("events:tester", "tester", "1-0")]
+    assert "duplicate event already processed" in caplog.text
+    assert envelope.eventId in caplog.text

--- a/platform/ts-kit/dist/messaging.js
+++ b/platform/ts-kit/dist/messaging.js
@@ -251,6 +251,14 @@ export class RedisEventSubscriber {
             }
             catch (error) {
                 // Non-persistent redis loses consumer groups on restart; recreate then back off so a dead connection never hot-spins.
+                console.warn({
+                    service: group,
+                    stream: streams.join(","),
+                    eventId: "unknown",
+                    deliveries: 0,
+                    error: sanitizedErrorForLog(error),
+                    message: "poll read failed; recreating group if missing and backing off",
+                });
                 if (String(error).includes("NOGROUP")) {
                     await Promise.all(streams.map((stream) => this.createGroup(stream, group)));
                 }
@@ -270,7 +278,21 @@ export class RedisEventSubscriber {
                 return;
             }
             for (const stream of streams) {
-                await this.claimAndProcess(stream, group, consumerName, handler);
+                try {
+                    await this.claimAndProcess(stream, group, consumerName, handler);
+                }
+                catch (error) {
+                    // One stream's XAUTOCLAIM failure must not kill the whole
+                    // recovery loop; log with context and keep recovering.
+                    console.warn({
+                        service: group,
+                        stream,
+                        eventId: "unknown",
+                        deliveries: 0,
+                        error: sanitizedErrorForLog(error),
+                        message: "pending-entry recovery failed; will retry next cycle",
+                    });
+                }
             }
         }
     }

--- a/platform/ts-kit/dist/messaging.js
+++ b/platform/ts-kit/dist/messaging.js
@@ -247,7 +247,7 @@ export class RedisEventSubscriber {
             }
             try {
                 const messages = await read("XREADGROUP", "GROUP", group, consumerName, "BLOCK", READ_BLOCK_MS, "COUNT", READ_COUNT, "STREAMS", ...streams, ...streams.map(() => ">"));
-                await this.processMessages(messages, group, handler);
+                await this.processMessages(messages, group, consumerName, handler);
             }
             catch (error) {
                 // Non-persistent redis loses consumer groups on restart; recreate then back off so a dead connection never hot-spins.
@@ -274,42 +274,55 @@ export class RedisEventSubscriber {
             }
         }
     }
-    async processMessages(messages, group, handler) {
+    async processMessages(messages, group, consumerName, handler) {
         for (const [stream, entries] of messages ?? []) {
             for (const entry of entries) {
-                await this.processEntry(stream, group, entry, handler);
+                await this.processEntry(stream, group, consumerName, entry, handler);
             }
         }
     }
-    async processEntry(stream, group, entry, handler) {
+    async processEntry(stream, group, consumerName, entry, handler, deliveryAttempts = 1) {
         const [entryId, fields] = entry;
+        const attempts = Math.max(1, deliveryAttempts);
         const envelopeJson = fieldValue(fields, "envelope");
         if (!envelopeJson) {
-            await this.deadLetterAndAck(stream, group, entry);
+            await this.deadLetterAndAck(stream, group, consumerName, entry, "MissingEnvelope", attempts);
             return;
         }
         let envelope;
         try {
             envelope = JSON.parse(envelopeJson);
         }
-        catch {
-            await this.deadLetterAndAck(stream, group, entry);
+        catch (error) {
+            await this.deadLetterAndAck(stream, group, consumerName, entry, error, attempts);
             return;
         }
         if (this.consumedEventIds.has(envelope.eventId)) {
+            console.warn({
+                service: group,
+                stream,
+                eventId: envelope.eventId,
+                deliveries: attempts,
+                message: "duplicate event already processed; acking without handler",
+            });
             await this.redis.xack(stream, group, entryId);
             return;
         }
         let result;
+        let failureReason = "HandlerResult.dlq";
         try {
             const rawResult = await handler(envelope);
             result = rawResult === undefined ? "ack" : normalizeHandlerResult(rawResult);
+            failureReason = failureReasonFromHandlerResult(rawResult);
         }
         catch (error) {
-            console.error(sanitizedErrorForLog(error));
             result = error instanceof HandlerError
                 ? (error.kind === "fatal" ? "dlq" : "retry")
                 : (this.options.thrownHandlerErrors === "retry" ? "retry" : "dlq");
+            failureReason = error;
+            if (result === "dlq") {
+                console.error(sanitizedErrorForLog(error));
+            }
         }
         if (result === "ack") {
             this.consumedEventIds.add(envelope.eventId);
@@ -317,8 +330,17 @@ export class RedisEventSubscriber {
             return;
         }
         if (result === "dlq") {
-            await this.deadLetterAndAck(stream, group, entry);
+            await this.deadLetterAndAck(stream, group, consumerName, entry, failureReason, attempts);
+            return;
         }
+        console.warn({
+            service: group,
+            stream,
+            eventId: envelope.eventId,
+            deliveries: attempts,
+            reason: failureReasonForLog(failureReason),
+            message: "handler transient failure; message stays pending for retry",
+        });
     }
     async claimAndProcess(stream, group, consumerName, handler) {
         const claimed = await this.redis.xautoclaim(stream, group, consumerName, CLAIM_MIN_IDLE_MS, "0", "COUNT", 100);
@@ -326,10 +348,10 @@ export class RedisEventSubscriber {
         const deliveryCounts = await this.deliveryCounts(stream, group, entries.map(([entryId]) => entryId));
         for (const entry of entries) {
             if ((deliveryCounts.get(entry[0]) ?? 1) >= MAX_DELIVERIES) {
-                await this.deadLetterAndAck(stream, group, entry);
+                await this.deadLetterAndAck(stream, group, consumerName, entry, "MaxDeliveries", deliveryCounts.get(entry[0]) ?? MAX_DELIVERIES);
             }
             else {
-                await this.processEntry(stream, group, entry, handler);
+                await this.processEntry(stream, group, consumerName, entry, handler, deliveryCounts.get(entry[0]) ?? 1);
             }
         }
     }
@@ -345,9 +367,23 @@ export class RedisEventSubscriber {
         }));
         return counts;
     }
-    async deadLetterAndAck(stream, group, entry) {
+    async deadLetterAndAck(stream, group, consumerName, entry, reason, attempts) {
         const envelopeJson = fieldValue(entry[1], "envelope") ?? JSON.stringify({});
-        await this.redis.xadd(dlqForStream(stream), "MAXLEN", "~", STREAM_MAXLEN, "*", "envelope", envelopeJson);
+        const failureReason = truncateFailureReason(reason);
+        const safeAttempts = Math.max(1, attempts);
+        const deadLetteredAt = new Date().toISOString();
+        console.warn({
+            service: group,
+            stream,
+            eventId: eventIdForLog(envelopeJson),
+            deliveries: safeAttempts,
+            consumerGroup: group,
+            failureReason,
+            attempts: safeAttempts,
+            deadLetteredAt,
+            message: "moving message to DLQ",
+        });
+        await this.redis.xadd(dlqForStream(stream), "MAXLEN", "~", STREAM_MAXLEN, "*", "envelope", envelopeJson, "consumerGroup", group, "consumerName", consumerName, "failureReason", failureReason, "attempts", String(safeAttempts), "deadLetteredAt", deadLetteredAt);
         await this.redis.xack(stream, group, entry[0]);
     }
     async createGroup(stream, group) {
@@ -394,15 +430,36 @@ export function dlqStreamKey(context) {
 export function redisUrl() {
     return process.env.REDIS_URL ?? "redis://localhost:6379";
 }
+function truncateFailureReason(reason) {
+    const text = reason instanceof Error
+        ? `${reason.name || "Error"}: ${reason.message || "Handler failed"}`
+        : String(reason || "unknown");
+    return text.length > 500 ? text.slice(0, 500) : text;
+}
+function eventIdForLog(envelopeJson) {
+    try {
+        const envelope = JSON.parse(envelopeJson);
+        return typeof envelope.eventId === "string" ? envelope.eventId : "unknown";
+    }
+    catch {
+        return "unknown";
+    }
+}
 function isRecoverableRedisReadError(error) {
     const message = String(error);
     return message.includes("NOGROUP") || message.includes("Connection is closed") || message.includes("Connection is not established") || message.includes("ECONNREFUSED") || message.includes("ETIMEDOUT") || message.includes("READONLY") || message.includes("LOADING");
 }
 function sanitizedErrorForLog(error) {
     if (error instanceof Error) {
-        return { name: error.name || "Error", message: error.message || "Handler failed" };
+        return { name: error.name || "Error", message: error.message || "Handler failed", stack: error.stack };
     }
-    return { name: typeof error, message: "Handler failed" };
+    return { name: typeof error, message: String(error || "Handler failed") };
+}
+function failureReasonForLog(reason) {
+    if (reason instanceof Error) {
+        return sanitizedErrorForLog(reason);
+    }
+    return { name: typeof reason, message: String(reason || "HandlerResult.retry") };
 }
 function normalizeHandlerResult(result) {
     if (result === "ack" || result === "retry" || result === "dlq") {
@@ -416,6 +473,18 @@ function normalizeHandlerResult(result) {
 }
 function handlerSucceeded(result) {
     return normalizeHandlerResult(result) === "ack";
+}
+function failureReasonFromHandlerResult(result) {
+    if (result === undefined || result === "ack" || result === "retry") {
+        return "HandlerResult.dlq";
+    }
+    if (result === "dlq") {
+        return "HandlerResult.dlq";
+    }
+    if (!result.ok) {
+        return result.error ?? `HandlerResult.${result.kind ?? result.errorType ?? "transient"}`;
+    }
+    return "HandlerResult.dlq";
 }
 function occurredAt(value) {
     if (value instanceof Date) {

--- a/platform/ts-kit/src/messaging.test.ts
+++ b/platform/ts-kit/src/messaging.test.ts
@@ -133,8 +133,64 @@ describe("RedisEventSubscriber DLQ observability", () => {
       service: "ts-kit",
       stream: "events:ts-kit-test",
       eventId: envelope.eventId,
+      deliveries: 1,
+      consumerGroup: "ts-kit",
       failureReason: "HandlerError: bad payload",
+      attempts: 1,
+      deadLetteredAt: args[16],
       message: "moving message to DLQ",
     });
+  });
+});
+
+describe("RedisEventSubscriber retry and ack-skip observability", () => {
+  it("warns when transient handler errors stay pending for retry", async () => {
+    const redis = {
+      xack: async () => { throw new Error("transient retry should not ack"); },
+      xadd: async () => { throw new Error("transient retry should not DLQ"); },
+    };
+    const subscriber = new RedisEventSubscriber(redis as never);
+    const envelope = createEventEnvelope({ eventType: "Retryable", producer: "ts-kit-test", payload: {} });
+    const entry: [string, string[]] = ["1-0", ["envelope", JSON.stringify(envelope)]];
+    const warnings: unknown[] = [];
+    const originalWarn = console.warn;
+    console.warn = (value?: unknown) => { warnings.push(value); };
+    try {
+      await (subscriber as unknown as { processEntry: (stream: string, group: string, consumerName: string, entry: [string, string[]], handler: () => unknown) => Promise<void> })
+        .processEntry("events:ts-kit-test", "ts-kit", "consumer-a", entry, () => { throw new HandlerError("transient", "redis unavailable"); });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.equal(warnings.length, 1);
+    assert.equal((warnings[0] as { message?: string }).message, "handler transient failure; message stays pending for retry");
+    assert.equal((warnings[0] as { eventId?: string }).eventId, envelope.eventId);
+  });
+
+  it("warns when duplicate events are acked without invoking the handler", async () => {
+    const xacks: unknown[][] = [];
+    const redis = {
+      xack: async (...args: unknown[]) => { xacks.push(args); return 1; },
+      xadd: async () => { throw new Error("duplicate ack skip should not DLQ"); },
+    };
+    const subscriber = new RedisEventSubscriber(redis as never);
+    const envelope = createEventEnvelope({ eventType: "Duplicate", producer: "ts-kit-test", payload: {} });
+    const entry: [string, string[]] = ["1-0", ["envelope", JSON.stringify(envelope)]];
+    const warnings: unknown[] = [];
+    const originalWarn = console.warn;
+    console.warn = (value?: unknown) => { warnings.push(value); };
+    try {
+      await (subscriber as unknown as { processEntry: (stream: string, group: string, consumerName: string, entry: [string, string[]], handler: () => unknown) => Promise<void> })
+        .processEntry("events:ts-kit-test", "ts-kit", "consumer-a", entry, () => undefined);
+      await (subscriber as unknown as { processEntry: (stream: string, group: string, consumerName: string, entry: [string, string[]], handler: () => unknown) => Promise<void> })
+        .processEntry("events:ts-kit-test", "ts-kit", "consumer-a", entry, () => { throw new Error("handler must be skipped"); });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.equal(xacks.length, 2);
+    assert.equal(warnings.length, 1);
+    assert.equal((warnings[0] as { message?: string }).message, "duplicate event already processed; acking without handler");
+    assert.equal((warnings[0] as { eventId?: string }).eventId, envelope.eventId);
   });
 });

--- a/platform/ts-kit/src/messaging.ts
+++ b/platform/ts-kit/src/messaging.ts
@@ -409,6 +409,13 @@ export class RedisEventSubscriber implements EventSubscriber {
     }
 
     if (this.consumedEventIds.has(envelope.eventId)) {
+      console.warn({
+        service: group,
+        stream,
+        eventId: envelope.eventId,
+        deliveries: attempts,
+        message: "duplicate event already processed; acking without handler",
+      });
       await this.redis.xack(stream, group, entryId);
       return;
     }
@@ -424,6 +431,9 @@ export class RedisEventSubscriber implements EventSubscriber {
         ? (error.kind === "fatal" ? "dlq" : "retry")
         : (this.options.thrownHandlerErrors === "retry" ? "retry" : "dlq");
       failureReason = error;
+      if (result === "dlq") {
+        console.error(sanitizedErrorForLog(error));
+      }
     }
 
     if (result === "ack") {
@@ -433,7 +443,16 @@ export class RedisEventSubscriber implements EventSubscriber {
     }
     if (result === "dlq") {
       await this.deadLetterAndAck(stream, group, consumerName, entry, failureReason, attempts);
+      return;
     }
+    console.warn({
+      service: group,
+      stream,
+      eventId: envelope.eventId,
+      deliveries: attempts,
+      reason: failureReasonForLog(failureReason),
+      message: "handler transient failure; message stays pending for retry",
+    });
   }
 
   private async claimAndProcess(stream: string, group: string, consumerName: string, handler: EventHandler): Promise<void> {
@@ -465,11 +484,17 @@ export class RedisEventSubscriber implements EventSubscriber {
   private async deadLetterAndAck(stream: string, group: string, consumerName: string, entry: StreamEntry, reason: unknown, attempts: number): Promise<void> {
     const envelopeJson = fieldValue(entry[1], "envelope") ?? JSON.stringify({});
     const failureReason = truncateFailureReason(reason);
+    const safeAttempts = Math.max(1, attempts);
+    const deadLetteredAt = new Date().toISOString();
     console.warn({
       service: group,
       stream,
       eventId: eventIdForLog(envelopeJson),
+      deliveries: safeAttempts,
+      consumerGroup: group,
       failureReason,
+      attempts: safeAttempts,
+      deadLetteredAt,
       message: "moving message to DLQ",
     });
     await this.redis.xadd(
@@ -487,9 +512,9 @@ export class RedisEventSubscriber implements EventSubscriber {
       "failureReason",
       failureReason,
       "attempts",
-      String(Math.max(1, attempts)),
+      String(safeAttempts),
       "deadLetteredAt",
-      new Date().toISOString(),
+      deadLetteredAt,
     );
     await this.redis.xack(stream, group, entry[0]);
   }
@@ -572,11 +597,18 @@ function isRecoverableRedisReadError(error: unknown): boolean {
   return message.includes("NOGROUP") || message.includes("Connection is closed") || message.includes("Connection is not established") || message.includes("ECONNREFUSED") || message.includes("ETIMEDOUT") || message.includes("READONLY") || message.includes("LOADING");
 }
 
-function sanitizedErrorForLog(error: unknown): Readonly<{ name: string; message: string }> {
+function sanitizedErrorForLog(error: unknown): Readonly<{ name: string; message: string; stack?: string }> {
   if (error instanceof Error) {
-    return { name: error.name || "Error", message: error.message || "Handler failed" };
+    return { name: error.name || "Error", message: error.message || "Handler failed", stack: error.stack };
   }
-  return { name: typeof error, message: "Handler failed" };
+  return { name: typeof error, message: String(error || "Handler failed") };
+}
+
+function failureReasonForLog(reason: unknown): Readonly<{ name: string; message: string; stack?: string }> {
+  if (reason instanceof Error) {
+    return sanitizedErrorForLog(reason);
+  }
+  return { name: typeof reason, message: String(reason || "HandlerResult.retry") };
 }
 
 function normalizeHandlerResult(result: EventHandlerResult | StringHandlerResult): "ack" | "retry" | "dlq" {

--- a/platform/ts-kit/src/messaging.ts
+++ b/platform/ts-kit/src/messaging.ts
@@ -358,6 +358,14 @@ export class RedisEventSubscriber implements EventSubscriber {
         await this.processMessages(messages, group, consumerName, handler);
       } catch (error) {
         // Non-persistent redis loses consumer groups on restart; recreate then back off so a dead connection never hot-spins.
+        console.warn({
+          service: group,
+          stream: streams.join(","),
+          eventId: "unknown",
+          deliveries: 0,
+          error: sanitizedErrorForLog(error),
+          message: "poll read failed; recreating group if missing and backing off",
+        });
         if (String(error).includes("NOGROUP")) {
           await Promise.all(streams.map((stream) => this.createGroup(stream, group)));
         }
@@ -378,7 +386,20 @@ export class RedisEventSubscriber implements EventSubscriber {
         return;
       }
       for (const stream of streams) {
-        await this.claimAndProcess(stream, group, consumerName, handler);
+        try {
+          await this.claimAndProcess(stream, group, consumerName, handler);
+        } catch (error) {
+          // One stream's XAUTOCLAIM failure must not kill the whole
+          // recovery loop; log with context and keep recovering.
+          console.warn({
+            service: group,
+            stream,
+            eventId: "unknown",
+            deliveries: 0,
+            error: sanitizedErrorForLog(error),
+            message: "pending-entry recovery failed; will retry next cycle",
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add structured WARN/ERROR observability for python/ts/go kit retry, DLQ, and duplicate ack-skip paths
- Align DLQ log fields with consumerGroup/failureReason/deadLetteredAt/attempts metadata while preserving existing DLQ entries
- Add retry, fatal-DLQ, and ack-skip log coverage tests across the three kits

## Validation
- uv run pytest -q (platform/python-kit)
- npm test (platform/ts-kit)
- go test ./... (platform/go-kit)
- uv run pytest -q (services/fare-pricing)
- npm test (services/notification)
- go test ./... (services/place-network)
- make check