### PR TITLE
REQ-093 Fix finance post-sales refund lag handling

### DIFF
--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/DomainEventEnvelopeMapper.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/DomainEventEnvelopeMapper.java
@@ -51,6 +51,7 @@ public final class DomainEventEnvelopeMapper {
         payload.put("amount", moneyPayload(event.amount()));
         payload.put("recognitionPolicyVersion", event.recognitionPolicyVersion());
         payload.put("sourceEventId", event.sourceEventId());
+        payload.put("metadata", metadataPayload(event));
         return payload;
     }
 
@@ -63,6 +64,7 @@ public final class DomainEventEnvelopeMapper {
         payload.put("amount", moneyPayload(event.amount()));
         payload.put("reversalReason", event.reversalReason());
         payload.put("sourceEventId", event.sourceEventId());
+        payload.put("metadata", metadataPayload(event));
         return payload;
     }
 
@@ -75,6 +77,7 @@ public final class DomainEventEnvelopeMapper {
         payload.put("expectedAmount", moneyPayload(event.expectedAmount()));
         payload.put("actualAmount", moneyPayload(event.actualAmount()));
         payload.put("description", event.description());
+        payload.put("metadata", metadataPayload(event));
         return payload;
     }
 
@@ -83,6 +86,7 @@ public final class DomainEventEnvelopeMapper {
         payload.put("reconciliationCaseId", event.reconciliationCaseId());
         payload.put("resolution", event.resolution());
         payload.put("resolutionNote", event.resolutionNote());
+        payload.put("metadata", metadataPayload(event));
         return payload;
     }
 
@@ -96,6 +100,7 @@ public final class DomainEventEnvelopeMapper {
         payload.put("actualAmount", moneyPayload(event.actualAmount()));
         payload.put("matchedRevenueRecognitionIds", event.matchedRevenueRecognitionIds());
         payload.put("sourceEventIds", event.sourceEventIds());
+        payload.put("metadata", metadataPayload(event));
         return payload;
     }
 
@@ -107,6 +112,7 @@ public final class DomainEventEnvelopeMapper {
         payload.put("totalAmount", moneyPayload(event.totalAmount()));
         payload.put("revenueRecognitionIds", event.revenueRecognitionIds());
         payload.put("generatedAt", event.generatedAt().toString());
+        payload.put("metadata", metadataPayload(event));
         return payload;
     }
 
@@ -115,7 +121,20 @@ public final class DomainEventEnvelopeMapper {
         payload.put("settlementViewId", event.settlementViewId());
         payload.put("viewType", event.viewType());
         payload.put("eventCount", event.eventCount());
+        payload.put("metadata", metadataPayload(event));
         return payload;
+    }
+
+    private static Map<String, Object> metadataPayload(FinanceSettlementEvent event) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("eventId", event.eventId());
+        metadata.put("occurredAt", event.occurredAt().toString());
+        metadata.put("sourceCommandId", event.sourceCommandId());
+        metadata.put("causationId", event.causationId());
+        metadata.put("correlationId", event.correlationId());
+        metadata.put("schemaVersion", event.schemaVersion());
+        metadata.put("attributes", event.attributes());
+        return metadata;
     }
 
     public static Map<String, Object> moneyPayload(Money money) {

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
@@ -14,11 +14,14 @@ import java.util.Currency;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.interceptor.TransactionAspectSupport;
 
 public class FinanceSettlementEventHandler implements EventSubscriber.EventHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(FinanceSettlementEventHandler.class);
+    private static final int ZERO_REFUND_WARNING_SAMPLE_RATE = 100;
+    private static final AtomicInteger ZERO_REFUND_WARNING_SEQUENCE = new AtomicInteger();
     private final ConsumedEventLogRepository consumedEvents;
     private final PaymentIntentOrderReferenceRepository paymentIntentOrderReferences;
     private final SegmentBookingOrderReferenceRepository segmentBookingOrderReferences;
@@ -104,13 +107,13 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
             }
             return HandlerResult.SUCCESS;
         } catch (PublishFailedException | OutOfOrderEventException ex) {
-            LOGGER.warn("service=finance-settlement eventId={} eventType={} transient handling failure",
-                envelope.eventId(), envelope.eventType(), ex);
+            LOGGER.warn("service=finance-settlement eventId={} eventType={} exceptionClass={} exceptionMessage={} transient handling failure",
+                envelope.eventId(), envelope.eventType(), ex.getClass().getName(), ex.getMessage(), ex);
             rollbackCurrentTransactionIfActive();
             return HandlerResult.TRANSIENT_FAILURE;
         } catch (DomainRuleViolation | IllegalArgumentException ex) {
-            LOGGER.warn("service=finance-settlement eventId={} eventType={} fatal handling failure",
-                envelope.eventId(), envelope.eventType(), ex);
+            LOGGER.warn("service=finance-settlement eventId={} eventType={} exceptionClass={} exceptionMessage={} fatal handling failure",
+                envelope.eventId(), envelope.eventType(), ex.getClass().getName(), ex.getMessage(), ex);
             rollbackCurrentTransactionIfActive();
             return HandlerResult.FATAL_FAILURE;
         }
@@ -253,7 +256,9 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
         }
         Object approvedActions = payload.get("approvedActions");
         if (approvedActions instanceof Map<?, ?> actions && actions.get("refund") instanceof Map<?, ?> refund) {
-            projections.saveApprovedRefund(caseId, money(((Map<?, ?>) refund).get("amount"), "approvedActions.refund.amount"));
+            Money refundAmount = money(((Map<?, ?>) refund).get("amount"), "approvedActions.refund.amount");
+            projections.saveApprovedRefund(caseId, refundAmount);
+            optionalText(payload, "orderId").ifPresent(orderId -> projections.saveApprovedRefund(orderId, refundAmount));
         }
     }
 
@@ -263,14 +268,23 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
         Money refund = projections.findApprovedRefund(caseId)
             .or(() -> projections.findApprovedRefund(orderId))
             .orElseThrow(() -> new OutOfOrderEventException("PostSalesApplied received before PostSalesApproved refund amount"));
+        if (refund.isZero()) {
+            if (shouldLogZeroRefundWarning()) {
+                LOGGER.warn("service=finance-settlement eventId={} eventType={} orderId={} caseId={} zero refund amount; skipping revenue reversal",
+                    envelope.eventId(), envelope.eventType(), orderId, caseId);
+            }
+            return;
+        }
+        PaymentCaptureFact capture = projections.findCapture(orderId).orElse(null);
         Optional<RevenueRecognition> matchingRecognition = serviceRevenue(orderId).stream()
             .filter(recognition -> !recognition.reversed())
+            .filter(recognition -> sameCurrency(recognition.amount(), refund))
             .filter(recognition -> sameMoney(recognition.amount(), refund) || recognition.amount().compareTo(refund) >= 0)
             .findFirst();
         if (matchingRecognition.isEmpty()) {
             ReconciliationCase open = ReconciliationCase.open(
                 orderId,
-                "",
+                capture == null ? "" : capture.paymentIntentId(),
                 "refund-lag",
                 refund.negate(),
                 Money.zero(refund.currency()),
@@ -294,7 +308,6 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
             envelope.correlationId()
         );
         service.saveAndPublish(originalRecognition, firstUnpublishedEventIndex);
-        PaymentCaptureFact capture = projections.findCapture(orderId).orElse(null);
         Money expected = capture == null ? refund.negate() : capture.amount().minus(refund);
         service.publishReconciliationCompleted(
             orderId,
@@ -319,7 +332,16 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
     }
 
     private static boolean sameMoney(Money left, Money right) {
-        return left.currency().equals(right.currency()) && left.compareTo(right) == 0;
+        return sameCurrency(left, right) && left.compareTo(right) == 0;
+    }
+
+    private static boolean shouldLogZeroRefundWarning() {
+        int sequence = ZERO_REFUND_WARNING_SEQUENCE.incrementAndGet();
+        return sequence == 1 || sequence % ZERO_REFUND_WARNING_SAMPLE_RATE == 0;
+    }
+
+    private static boolean sameCurrency(Money left, Money right) {
+        return left.currency().equals(right.currency());
     }
 
     private static String orderItemReference(Map<String, Object> payload, String orderId) {

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
@@ -232,6 +232,100 @@ class MessagingTest {
         assertFalse(publisher.published.stream().anyMatch(e -> "RevenueRecognitionReversed".equals(e.eventType())));
     }
 
+
+    @Test
+    void postSalesAppliedCurrencyMismatchOpensRefundLagCaseInsteadOfFatal() {
+        InMemoryConsumedEventLogRepository consumedEvents = new InMemoryConsumedEventLogRepository();
+        RecordingPublisher publisher = new RecordingPublisher();
+        FinanceSettlementApplicationService service = new FinanceSettlementApplicationService(
+            new InMemoryRevenueRepository(), new InMemoryReconciliationRepository(), publisher, new DomainEventEnvelopeMapper());
+        FinanceSettlementEventHandler handler = new FinanceSettlementEventHandler(
+            consumedEvents, new InMemoryPaymentIntentOrderReferenceRepository(),
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), service);
+
+        handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e113", "PaymentCaptured", Instant.parse("2026-07-03T10:30:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e113", null, "payment", 1, Map.of(
+                "paymentIntentId", "pi-currency-mismatch",
+                "businessRef", "ord-currency-mismatch",
+                "capturedAmount", Map.of("currency", "USD", "minorUnits", 10750),
+                "channel", "card",
+                "channelTransactionId", "card-currency-mismatch")));
+        handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e114", "PostSalesApproved", Instant.parse("2026-07-03T10:31:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e113", null, "post-sales", 1, Map.of(
+                "caseId", "psc-currency-mismatch",
+                "orderId", "ord-currency-mismatch",
+                "approvedActions", Map.of(
+                    "decisionKind", "REFUND",
+                    "approvalRef", "approval-currency-mismatch",
+                    "refund", Map.of("orderId", "ord-currency-mismatch", "amount", Map.of("currency", "CNY", "minorUnits", 8750)),
+                    "steps", List.of()))));
+
+        HandlerResult applied = handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e115", "PostSalesApplied", Instant.parse("2026-07-03T10:32:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e113", null, "post-sales", 1, Map.of(
+                "caseId", "psc-currency-mismatch",
+                "orderId", "ord-currency-mismatch",
+                "resultSummary", Map.of("description", "applied"))));
+
+        assertEquals(HandlerResult.SUCCESS, applied);
+        EventEnvelope opened = publisher.published.stream().filter(e -> "ReconciliationCaseOpened".equals(e.eventType())).findFirst().orElseThrow();
+        assertEquals("refund-lag", ((Map<?, ?>) opened.payload()).get("differenceType"));
+        assertEquals("pi-currency-mismatch", ((Map<?, ?>) opened.payload()).get("paymentIntentId"));
+        assertEquals(-8750L, ((Map<?, ?>) ((Map<?, ?>) opened.payload()).get("expectedAmount")).get("minorUnits"));
+    }
+
+    @Test
+    void postSalesAppliedDlqSampleZeroRefundChangeIsNoOpAndConsumesEvent() {
+        InMemoryConsumedEventLogRepository consumedEvents = new InMemoryConsumedEventLogRepository();
+        RecordingPublisher publisher = new RecordingPublisher();
+        FinanceSettlementApplicationService service = new FinanceSettlementApplicationService(
+            new InMemoryRevenueRepository(), new InMemoryReconciliationRepository(), publisher, new DomainEventEnvelopeMapper());
+        FinanceSettlementEventHandler handler = new FinanceSettlementEventHandler(
+            consumedEvents, new InMemoryPaymentIntentOrderReferenceRepository(),
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), service);
+
+        handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e120", "PaymentCaptured", Instant.parse("2026-07-03T10:30:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e120", null, "payment", 1, Map.of(
+                "paymentIntentId", "pi-019f4186-340a-7f86-a2f0-4a10c63c1bc8",
+                "businessRef", "ord-019f4186-340a-7f86-a2f0-4a10c63c1bc8",
+                "capturedAmount", Map.of("currency", "CNY", "minorUnits", 10750),
+                "channel", "wechat_pay",
+                "channelTransactionId", "wx-019f4186-340a-7f86-a2f0-4a10c63c1bc8")));
+        publisher.published.clear();
+
+        handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e121", "PostSalesApproved", Instant.parse("2026-07-03T10:31:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e120", null, "post-sales", 1, Map.of(
+                "caseId", "psc-019f4186-340a-7f86-a2f0-4a10c63c1bc8",
+                "orderId", "ord-019f4186-340a-7f86-a2f0-4a10c63c1bc8",
+                "approvedActions", Map.of(
+                    "decisionKind", "CHANGE",
+                    "approvalRef", "approval-019f4186-340a-7f86-a2f0-4a10c63c1bc8",
+                    "refund", Map.of(
+                        "orderId", "ord-019f4186-340a-7f86-a2f0-4a10c63c1bc8",
+                        "amount", Map.of("currency", "CNY", "minorUnits", 0)),
+                    "steps", List.of()))));
+
+        HandlerResult applied = handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e109", "PostSalesApplied", Instant.parse("2026-07-03T10:32:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e120", null, "post-sales", 1, Map.of(
+                "caseId", "psc-019f4186-340a-7f86-a2f0-4a10c63c1bc8",
+                "orderId", "ord-019f4186-340a-7f86-a2f0-4a10c63c1bc8",
+                "resultSummary", Map.of(
+                    "description", "change applied",
+                    "caseId", "psc-019f4186-340a-7f86-a2f0-4a10c63c1bc8",
+                    "orderId", "ord-019f4186-340a-7f86-a2f0-4a10c63c1bc8"))));
+
+        assertEquals(HandlerResult.SUCCESS, applied);
+        assertEquals(3, consumedEvents.saveCount);
+        assertFalse(publisher.published.stream().anyMatch(e -> "RevenueRecognitionReversed".equals(e.eventType())));
+        assertFalse(publisher.published.stream().anyMatch(e -> "ReconciliationCaseOpened".equals(e.eventType())));
+        assertFalse(publisher.published.stream().anyMatch(e -> "ReconciliationCompleted".equals(e.eventType())));
+    }
+
     @Test
     void operationalFactUsesSegmentReservationRequestedIndexForOrderReference() {
         InMemoryConsumedEventLogRepository consumedEvents = new InMemoryConsumedEventLogRepository();


### PR DESCRIPTION
## Summary
- Make PostSalesApplied zero-refund decisions no-op with sampled WARN logging.
- Avoid refund-lag fallback self-fatal by carrying the payment intent when available and opening a valid reconciliation case.
- Include exception class and message in transient/fatal handler WARN logs.
- Include finance event metadata in produced payloads to match finance-settlement event contracts.

## Handling matrix
| Situation | Handling | Result |
|---|---|---|
| Approved refund is zero | Sampled WARN, skip reversal/case/completion | SUCCESS consumed |
| Matching same-currency unreversed revenue exists and covers refund | Reverse revenue and publish ReconciliationCompleted | SUCCESS consumed |
| No matching same-currency revenue exists | Open refund-lag ReconciliationCase with available paymentIntentId | SUCCESS consumed |
| Approved refund not observed yet | OutOfOrderEventException | TRANSIENT_FAILURE, rollback |
| Malformed contract payload / true domain invariant violation | IllegalArgumentException/DomainRuleViolation | FATAL_FAILURE, rollback with exception details logged |

## Validation
- services/finance-settlement: mvn -q test
- make check
