### PR TITLE
REQ-102 Fix trip-planning lifecycle flake and add observability smoke

### DIFF
--- a/deploy/e2e/13-observability.sh
+++ b/deploy/e2e/13-observability.sh
@@ -20,21 +20,9 @@ api_req() {
   RESP=$(echo "$out" | sed '$d')
 }
 
-tracez_contains_span_signal() {
-  printf '%s' "$RESP" | python3 -c '
-import re
-import sys
-body = sys.stdin.read()
-if "POST /api/v1/itineraries/search" in body or "/api/v1/itineraries/search" in body:
-    sys.exit(0)
-for match in re.finditer(r"(?:Spans|Span Count|Total Spans|Error Spans)</td>\s*<td[^>]*>\s*([0-9]+)", body, re.IGNORECASE):
-    if int(match.group(1)) > 0:
-        sys.exit(0)
-for match in re.finditer(r">([1-9][0-9]*)</td>", body):
-    if int(match.group(1)) > 0:
-        sys.exit(0)
-sys.exit(1)
-'
+accepted_spans_total() {
+  # Sum of otelcol_receiver_accepted_spans across transports; empty on error.
+  printf '%s' "$RESP" | awk '/^otelcol_receiver_accepted_spans/ { sum += $NF } END { if (NR > 0) printf "%.0f", sum }'
 }
 
 echo "== 1. otel collector health"
@@ -46,19 +34,24 @@ curl_raw http://otel-collector:55679/debug/tracez
 if [ "$LAST_CODE" = "200" ]; then ok "zpages tracez HTTP 200"; else bad "zpages tracez HTTP got $LAST_CODE"; fi
 if [ -n "$RESP" ]; then ok "zpages tracez body non-empty"; else bad "zpages tracez body is empty"; fi
 
-echo "== 3. trigger trip-planning request"
+echo "== 3. span flow: receiver counter must grow after real traffic"
+curl_raw http://otel-collector:8888/metrics
+BEFORE=$(accepted_spans_total)
+if [ "$LAST_CODE" = "200" ] && [ -n "$BEFORE" ]; then ok "collector metrics endpoint reports accepted spans ($BEFORE)"; else bad "collector metrics endpoint unavailable (HTTP $LAST_CODE)"; BEFORE=0; fi
+
 api_req POST trip-planning /api/v1/itineraries/search '{"originRef":"obs-origin","destinationRef":"obs-destination","departureDate":"2026-08-01","travelerRefs":["obs-traveler"],"channel":"WEB"}'
 check_code 200 "search itineraries for trace smoke"
 
 SPAN_FOUND=0
-for attempt in 1 2 3 4 5 6; do
+for attempt in 1 2 3 4 5 6 7 8; do
   sleep 2
-  curl_raw http://otel-collector:55679/debug/tracez
-  if [ "$LAST_CODE" = "200" ] && [ -n "$RESP" ] && tracez_contains_span_signal; then
+  curl_raw http://otel-collector:8888/metrics
+  AFTER=$(accepted_spans_total)
+  if [ "$LAST_CODE" = "200" ] && [ -n "$AFTER" ] && [ "$AFTER" -gt "$BEFORE" ] 2>/dev/null; then
     SPAN_FOUND=1
     break
   fi
 done
-if [ "$SPAN_FOUND" = "1" ]; then ok "zpages tracez shows span activity"; else bad "zpages tracez did not show span activity after search"; fi
+if [ "$SPAN_FOUND" = "1" ]; then ok "accepted-span counter grew after search ($BEFORE -> $AFTER)"; else bad "accepted-span counter did not grow after search (before=$BEFORE after=${AFTER:-n/a})"; fi
 
 summary

--- a/deploy/e2e/13-observability.sh
+++ b/deploy/e2e/13-observability.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Observability smoke test: collector health, zpages, and coarse span visibility.
+cd "$(dirname "$0")" && . ./lib.sh
+ensure_curl_pod
+
+curl_raw() {
+  local url=$1 out
+  out=$(k exec -i e2e-curl -- curl -sS --connect-timeout 2 --max-time 5 -w $'\n%{http_code}' "$url" 2>/dev/null || printf '\n000')
+  LAST_CODE=$(echo "$out" | tail -1)
+  RESP=$(echo "$out" | sed '$d')
+}
+
+api_req() {
+  local method=$1 service=$2 path=$3 body=${4:-} out
+  out=$(k exec -i e2e-curl -- curl -sS --connect-timeout 2 --max-time 10 -w $'\n%{http_code}' -X "$method" "http://$service:8080$path" \
+    -H 'Content-Type: application/json' \
+    -H "Idempotency-Key: $(uuid7)" \
+    ${body:+-d "$body"} 2>/dev/null || printf '\n000')
+  LAST_CODE=$(echo "$out" | tail -1)
+  RESP=$(echo "$out" | sed '$d')
+}
+
+tracez_contains_span_signal() {
+  printf '%s' "$RESP" | python3 -c '
+import re
+import sys
+body = sys.stdin.read()
+if "POST /api/v1/itineraries/search" in body or "/api/v1/itineraries/search" in body:
+    sys.exit(0)
+for match in re.finditer(r"(?:Spans|Span Count|Total Spans|Error Spans)</td>\s*<td[^>]*>\s*([0-9]+)", body, re.IGNORECASE):
+    if int(match.group(1)) > 0:
+        sys.exit(0)
+for match in re.finditer(r">([1-9][0-9]*)</td>", body):
+    if int(match.group(1)) > 0:
+        sys.exit(0)
+sys.exit(1)
+'
+}
+
+echo "== 1. otel collector health"
+curl_raw http://otel-collector:13133/
+if [ "$LAST_CODE" = "200" ]; then ok "otel-collector health HTTP 200"; else bad "otel-collector health HTTP got $LAST_CODE"; fi
+
+echo "== 2. zpages tracez reachable"
+curl_raw http://otel-collector:55679/debug/tracez
+if [ "$LAST_CODE" = "200" ]; then ok "zpages tracez HTTP 200"; else bad "zpages tracez HTTP got $LAST_CODE"; fi
+if [ -n "$RESP" ]; then ok "zpages tracez body non-empty"; else bad "zpages tracez body is empty"; fi
+
+echo "== 3. trigger trip-planning request"
+api_req POST trip-planning /api/v1/itineraries/search '{"originRef":"obs-origin","destinationRef":"obs-destination","departureDate":"2026-08-01","travelerRefs":["obs-traveler"],"channel":"WEB"}'
+check_code 200 "search itineraries for trace smoke"
+
+SPAN_FOUND=0
+for attempt in 1 2 3 4 5 6; do
+  sleep 2
+  curl_raw http://otel-collector:55679/debug/tracez
+  if [ "$LAST_CODE" = "200" ] && [ -n "$RESP" ] && tracez_contains_span_signal; then
+    SPAN_FOUND=1
+    break
+  fi
+done
+if [ "$SPAN_FOUND" = "1" ]; then ok "zpages tracez shows span activity"; else bad "zpages tracez did not show span activity after search"; fi
+
+summary

--- a/deploy/k8s/otel-collector.yaml
+++ b/deploy/k8s/otel-collector.yaml
@@ -106,6 +106,8 @@ spec:
               containerPort: 13133
             - name: zpages
               containerPort: 55679
+            - name: metrics
+              containerPort: 8888
           resources:
             requests:
               cpu: 50m
@@ -158,6 +160,9 @@ spec:
     - name: health
       port: 13133
       targetPort: health
+    - name: metrics
+      port: 8888
+      targetPort: metrics
     - name: zpages
       port: 55679
       targetPort: zpages

--- a/deploy/k8s/otel-collector.yaml
+++ b/deploy/k8s/otel-collector.yaml
@@ -158,5 +158,8 @@ spec:
     - name: health
       port: 13133
       targetPort: health
+    - name: zpages
+      port: 55679
+      targetPort: zpages
   selector:
     app.kubernetes.io/name: otel-collector

--- a/services/trip-planning/tests/test_lifecycle.py
+++ b/services/trip-planning/tests/test_lifecycle.py
@@ -1,3 +1,4 @@
+import time
 import unittest
 
 from fastapi.testclient import TestClient
@@ -5,6 +6,14 @@ from fastapi.testclient import TestClient
 from trip_planning import create_app
 from trip_planning.adapters.messaging.fake import FakeEventPublisher, FakeEventSubscriber
 from trip_planning.events import EventEnvelope
+
+
+def wait_for_handlers(subscriber: FakeEventSubscriber, expected_count: int = 1, timeout_seconds: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if len(subscriber.handlers) >= expected_count:
+            return
+        time.sleep(0.01)
 
 
 class ProductionMessagingWiringTest(unittest.TestCase):
@@ -31,6 +40,7 @@ class ProductionMessagingWiringTest(unittest.TestCase):
         subscriber = FakeEventSubscriber()
         app = create_app(event_publisher=publisher, event_subscriber=subscriber)
         with TestClient(app):
+            wait_for_handlers(subscriber)
             self.assertEqual(len(subscriber.handlers), 1)
             streams, group, consumer_name, _handler = subscriber.handlers[0]
             self.assertEqual(streams, ["events:place-network", "events:service-plan", "events:capacity-availability"])
@@ -54,6 +64,7 @@ class ProductionMessagingWiringTest(unittest.TestCase):
             api._default_subscriber = lambda: subscriber  # type: ignore[assignment]
             app = create_app(event_publisher=publisher)
             with TestClient(app):
+                wait_for_handlers(subscriber)
                 self.assertEqual(len(subscriber.handlers), 1)
         finally:
             api._default_subscriber = original  # type: ignore[assignment]


### PR DESCRIPTION
## Summary
- Add bounded polling in trip-planning lifecycle tests so subscriber handler registration no longer races the supervisor thread.
- Add deploy/e2e/13-observability.sh smoke script for collector health, zpages, and coarse span visibility after a real trip-planning request.
- Expose the collector zpages port on the Kubernetes service for in-cluster e2e access.

## Validation
- bash -n deploy/e2e/13-observability.sh
- cd services/trip-planning && for i in 1 2 3 4 5; do uv run python -m unittest discover -s tests; done
- make check

Note: live kind context kind-arl-test was not configured in this sandbox, so cluster e2e runs were not available locally.