### PR TITLE
REQ-099 java-kit trace context propagation

### DIFF
--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/PlatformKitConfiguration.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/PlatformKitConfiguration.java
@@ -1,5 +1,6 @@
 package com.trainticket.platformkit;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trainticket.platformkit.http.CanonicalErrorWriter;
 import com.trainticket.platformkit.http.PlatformKitExceptionHandler;
@@ -22,7 +23,9 @@ public class PlatformKitConfiguration {
     @Bean
     @ConditionalOnMissingBean
     ObjectMapper objectMapper() {
-        return new ObjectMapper().findAndRegisterModules();
+        return new ObjectMapper()
+            .findAndRegisterModules()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
     @Bean

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventEnvelope.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventEnvelope.java
@@ -2,11 +2,14 @@ package com.trainticket.platformkit.messaging;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.trainticket.platformkit.observability.EventTraceContext;
 import java.time.Instant;
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record EventEnvelope(
     String eventId,
     String eventType,
@@ -15,7 +18,9 @@ public record EventEnvelope(
     @JsonInclude(JsonInclude.Include.NON_NULL) String causationId,
     String producer,
     int schemaVersion,
-    Object payload
+    Object payload,
+    @JsonInclude(JsonInclude.Include.NON_NULL) String traceparent,
+    @JsonInclude(JsonInclude.Include.NON_NULL) String tracestate
 ) {
     @JsonCreator
     public EventEnvelope(
@@ -26,7 +31,9 @@ public record EventEnvelope(
         @JsonProperty("causationId") String causationId,
         @JsonProperty("producer") String producer,
         @JsonProperty("schemaVersion") int schemaVersion,
-        @JsonProperty("payload") Object payload
+        @JsonProperty("payload") Object payload,
+        @JsonProperty("traceparent") String traceparent,
+        @JsonProperty("tracestate") String tracestate
     ) {
         PrefixedIds.requireEventId(eventId);
         PrefixedIds.requireCorrelationId(correlationId);
@@ -44,6 +51,47 @@ public record EventEnvelope(
         }
         this.schemaVersion = schemaVersion;
         this.payload = Objects.requireNonNull(payload, "payload is required");
+        this.traceparent = blankToNull(traceparent);
+        this.tracestate = this.traceparent == null ? null : blankToNull(tracestate);
+    }
+
+    public EventEnvelope(
+        String eventId,
+        String eventType,
+        Instant occurredAt,
+        String correlationId,
+        String causationId,
+        String producer,
+        int schemaVersion,
+        Object payload
+    ) {
+        this(eventId, eventType, occurredAt, correlationId, causationId, producer, schemaVersion, payload, currentTraceContext());
+    }
+
+    private EventEnvelope(
+        String eventId,
+        String eventType,
+        Instant occurredAt,
+        String correlationId,
+        String causationId,
+        String producer,
+        int schemaVersion,
+        Object payload,
+        EventTraceContext traceContext
+    ) {
+        this(eventId, eventType, occurredAt, correlationId, causationId, producer, schemaVersion, payload, traceContext.traceparent(), traceContext.tracestate());
+    }
+
+    public EventEnvelope withTraceContext(String traceparent, String tracestate) {
+        return new EventEnvelope(eventId, eventType, occurredAt, correlationId, causationId, producer, schemaVersion, payload, traceparent, tracestate);
+    }
+
+    private static EventTraceContext currentTraceContext() {
+        return EventTraceContext.current();
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value;
     }
 
     private static String requireText(String value, String name) {

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventEnvelopeFactory.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventEnvelopeFactory.java
@@ -1,5 +1,6 @@
 package com.trainticket.platformkit.messaging;
 
+import com.trainticket.platformkit.observability.EventTraceContext;
 import java.time.Clock;
 import java.util.Objects;
 
@@ -25,6 +26,7 @@ public class EventEnvelopeFactory {
         if (causationId != null) {
             PrefixedIds.requireCausationId(causationId);
         }
+        EventTraceContext traceContext = EventTraceContext.current();
         return new EventEnvelope(
             PrefixedIds.newEventId(),
             eventType,
@@ -33,7 +35,9 @@ public class EventEnvelopeFactory {
             causationId,
             producer,
             1,
-            payload
+            payload,
+            traceContext.traceparent(),
+            traceContext.tracestate()
         );
     }
 

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/observability/EventTraceContext.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/observability/EventTraceContext.java
@@ -1,0 +1,48 @@
+package com.trainticket.platformkit.observability;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Captures the W3C trace context associated with the currently active span.
+ * Trace propagation is observability-only; failures or disabled OpenTelemetry
+ * must leave the event wire shape unchanged.
+ */
+public record EventTraceContext(String traceparent, String tracestate) {
+    private static final String TRACEPARENT = "traceparent";
+    private static final String TRACESTATE = "tracestate";
+    private static final TextMapSetter<Map<String, String>> SETTER = (carrier, key, value) -> {
+        if (carrier != null && key != null && value != null) {
+            carrier.put(key, value);
+        }
+    };
+
+    public static EventTraceContext current() {
+        if (!Span.current().getSpanContext().isValid()) {
+            return empty();
+        }
+        Map<String, String> carrier = new LinkedHashMap<>();
+        try {
+            W3CTraceContextPropagator.getInstance().inject(Context.current(), carrier, SETTER);
+        } catch (RuntimeException ignored) {
+            return empty();
+        }
+        String traceparent = blankToNull(carrier.get(TRACEPARENT));
+        if (traceparent == null) {
+            return empty();
+        }
+        return new EventTraceContext(traceparent, blankToNull(carrier.get(TRACESTATE)));
+    }
+
+    public static EventTraceContext empty() {
+        return new EventTraceContext(null, null);
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/observability/GlobalEventConsumerTracer.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/observability/GlobalEventConsumerTracer.java
@@ -12,7 +12,7 @@ public final class GlobalEventConsumerTracer implements EventConsumerTracer {
 
     @Override
     public SpanScope start(String stream, String consumerGroup, EventEnvelope envelope) {
-        return new OtelEventConsumerTracer(GlobalOpenTelemetry.getTracer(instrumentationName))
+        return new OtelEventConsumerTracer(GlobalOpenTelemetry.get(), GlobalOpenTelemetry.getTracer(instrumentationName))
             .start(stream, consumerGroup, envelope);
     }
 }

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/observability/OtelEventConsumerTracer.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/observability/OtelEventConsumerTracer.java
@@ -1,14 +1,38 @@
 package com.trainticket.platformkit.observability;
 
 import com.trainticket.platformkit.messaging.EventEnvelope;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import java.util.List;
 
 public final class OtelEventConsumerTracer implements EventConsumerTracer {
+    private static final TextMapGetter<EventEnvelope> GETTER = new TextMapGetter<>() {
+        @Override
+        public Iterable<String> keys(EventEnvelope carrier) {
+            return carrier.tracestate() == null ? List.of("traceparent") : List.of("traceparent", "tracestate");
+        }
+
+        @Override
+        public String get(EventEnvelope carrier, String key) {
+            if (carrier == null || key == null) {
+                return null;
+            }
+            if ("traceparent".equals(key)) {
+                return carrier.traceparent();
+            }
+            if ("tracestate".equals(key)) {
+                return carrier.tracestate();
+            }
+            return null;
+        }
+    };
     private static final AttributeKey<String> MESSAGING_SYSTEM = AttributeKey.stringKey("messaging.system");
     private static final AttributeKey<String> MESSAGING_OPERATION = AttributeKey.stringKey("messaging.operation");
     private static final AttributeKey<String> MESSAGING_DESTINATION = AttributeKey.stringKey("messaging.destination.name");
@@ -19,15 +43,22 @@ public final class OtelEventConsumerTracer implements EventConsumerTracer {
     private static final AttributeKey<String> CORRELATION_ID = AttributeKey.stringKey("messaging.correlation_id");
     private static final AttributeKey<String> CAUSATION_ID = AttributeKey.stringKey("messaging.causation_id");
 
+    private final OpenTelemetry openTelemetry;
     private final Tracer tracer;
 
-    public OtelEventConsumerTracer(Tracer tracer) {
+    public OtelEventConsumerTracer(OpenTelemetry openTelemetry, Tracer tracer) {
+        this.openTelemetry = openTelemetry;
         this.tracer = tracer;
+    }
+
+    public OtelEventConsumerTracer(Tracer tracer) {
+        this(OpenTelemetry.noop(), tracer);
     }
 
     @Override
     public SpanScope start(String stream, String consumerGroup, EventEnvelope envelope) {
         Span span = tracer.spanBuilder(envelope.eventType() + " process")
+            .setParent(parentContext(envelope))
             .setSpanKind(SpanKind.CONSUMER)
             .setAttribute(MESSAGING_SYSTEM, "redis")
             .setAttribute(MESSAGING_OPERATION, "process")
@@ -42,6 +73,20 @@ public final class OtelEventConsumerTracer implements EventConsumerTracer {
             span.setAttribute(CAUSATION_ID, envelope.causationId());
         }
         return new OtelSpanScope(span, span.makeCurrent());
+    }
+
+    private Context parentContext(EventEnvelope envelope) {
+        if (envelope.traceparent() == null || envelope.traceparent().isBlank()) {
+            return Context.current();
+        }
+        try {
+            Context extracted = openTelemetry.getPropagators()
+                .getTextMapPropagator()
+                .extract(Context.current(), envelope, GETTER);
+            return Span.fromContext(extracted).getSpanContext().isValid() ? extracted : Context.current();
+        } catch (RuntimeException ignored) {
+            return Context.current();
+        }
     }
 
     private static final class OtelSpanScope extends SpanScope {

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/observability/PlatformOpenTelemetryConfiguration.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/observability/PlatformOpenTelemetryConfiguration.java
@@ -70,8 +70,8 @@ public class PlatformOpenTelemetryConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    EventConsumerTracer eventConsumerTracer(Tracer tracer) {
-        return new OtelEventConsumerTracer(tracer);
+    EventConsumerTracer eventConsumerTracer(OpenTelemetry openTelemetry, Tracer tracer) {
+        return new OtelEventConsumerTracer(openTelemetry, tracer);
     }
 
     @Bean

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/EventEnvelopeTraceContextTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/EventEnvelopeTraceContextTest.java
@@ -1,0 +1,264 @@
+package com.trainticket.platformkit.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.trainticket.platformkit.observability.OtelEventConsumerTracer;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class EventEnvelopeTraceContextTest {
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @AfterEach
+    void resetGlobalOpenTelemetry() {
+        GlobalOpenTelemetry.resetForTest();
+    }
+
+    @Test
+    void absentOpenTelemetryLeavesSerializationByteForByteUnchanged() throws Exception {
+        EventEnvelope envelope = factory().create("PaymentCaptured", correlationId(), causationId(), Map.of("paymentIntentId", "pi-1"));
+
+        assertThat(envelope.traceparent()).isNull();
+        assertThat(envelope.tracestate()).isNull();
+        assertThat(objectMapper.writeValueAsString(envelope)).isEqualTo(
+            "{\"eventId\":\"" + envelope.eventId() + "\","
+                + "\"eventType\":\"PaymentCaptured\","
+                + "\"occurredAt\":\"2026-07-05T10:30:00Z\","
+                + "\"correlationId\":\"" + envelope.correlationId() + "\","
+                + "\"causationId\":\"" + envelope.causationId() + "\","
+                + "\"producer\":\"payment\","
+                + "\"schemaVersion\":1,"
+                + "\"payload\":{\"paymentIntentId\":\"pi-1\"}}"
+        );
+    }
+
+    @Test
+    void injectsTraceContextWhenOpenTelemetrySpanIsCurrent() {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        OpenTelemetry openTelemetry = openTelemetry(exporter);
+        GlobalOpenTelemetry.set(openTelemetry);
+        Span producerSpan = tracer(openTelemetry).spanBuilder("POST /payments").setSpanKind(SpanKind.SERVER).startSpan();
+
+        EventEnvelope envelope;
+        try (Scope ignored = producerSpan.makeCurrent()) {
+            envelope = factory().create("PaymentCaptured", correlationId(), causationId(), Map.of("paymentIntentId", "pi-1"));
+        } finally {
+            producerSpan.end();
+        }
+
+        assertThat(envelope.traceparent()).startsWith("00-" + producerSpan.getSpanContext().getTraceId() + "-");
+        assertThat(envelope.tracestate()).isNull();
+    }
+
+    @Test
+    void deserializeNewEnvelopeWithTraceContextAndOldEnvelopeWithoutIt() throws Exception {
+        String newEnvelopeJson = "{"
+            + "\"eventId\":\"evt-0194f2e0-7b3e-7610-8284-5c26e8b0c222\","
+            + "\"eventType\":\"PaymentCaptured\","
+            + "\"occurredAt\":\"2026-07-05T10:30:00Z\","
+            + "\"correlationId\":\"corr-0194f2e0-7b3e-7610-8284-5c26e8b0c444\","
+            + "\"causationId\":\"cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c555\","
+            + "\"producer\":\"payment\","
+            + "\"schemaVersion\":1,"
+            + "\"payload\":{},"
+            + "\"traceparent\":\"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01\","
+            + "\"tracestate\":\"vendor=value\","
+            + "\"futureField\":\"ignored\""
+            + "}";
+        EventEnvelope newEnvelope = objectMapper.readValue(newEnvelopeJson, EventEnvelope.class);
+        EventEnvelope oldEnvelope = objectMapper.readValue(
+            newEnvelopeJson.replace(",\"traceparent\":\"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01\",\"tracestate\":\"vendor=value\",\"futureField\":\"ignored\"", ""),
+            EventEnvelope.class
+        );
+
+        assertThat(newEnvelope.traceparent()).isEqualTo("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01");
+        assertThat(newEnvelope.tracestate()).isEqualTo("vendor=value");
+        assertThat(oldEnvelope.traceparent()).isNull();
+        assertThat(oldEnvelope.tracestate()).isNull();
+    }
+
+    @Test
+    void consumerSpanUsesEnvelopeTraceparentAsRemoteParent() {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        OpenTelemetry openTelemetry = openTelemetry(exporter);
+        Tracer tracer = tracer(openTelemetry);
+        Span producerSpan = tracer.spanBuilder("POST /payments").setSpanKind(SpanKind.SERVER).startSpan();
+        EventEnvelope envelope;
+        try (Scope ignored = producerSpan.makeCurrent()) {
+            GlobalOpenTelemetry.set(openTelemetry);
+            envelope = factory().create("PaymentCaptured", correlationId(), causationId(), Map.of("paymentIntentId", "pi-1"));
+        } finally {
+            producerSpan.end();
+        }
+
+        try (var ignored = new OtelEventConsumerTracer(openTelemetry, tracer).start("events:payment", "journey-order", envelope)) {
+            // closing the scope ends the consumer span
+        }
+
+        var consumerSpan = exporter.getFinishedSpanItems().stream()
+            .filter(span -> span.getName().equals("PaymentCaptured process"))
+            .findFirst()
+            .orElseThrow();
+        assertThat(consumerSpan.getTraceId()).isEqualTo(producerSpan.getSpanContext().getTraceId());
+        assertThat(consumerSpan.getParentSpanContext().isRemote()).isTrue();
+        assertThat(consumerSpan.getParentSpanContext().getSpanId()).isEqualTo(producerSpan.getSpanContext().getSpanId());
+    }
+
+    @Test
+    void redisSubscriberConsumerSpanUsesEnvelopeTraceparentAsRemoteParent() throws Exception {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        OpenTelemetry openTelemetry = openTelemetry(exporter);
+        Tracer tracer = tracer(openTelemetry);
+        Span producerSpan = tracer.spanBuilder("POST /payments").setSpanKind(SpanKind.SERVER).startSpan();
+        EventEnvelope envelope;
+        try (Scope ignored = producerSpan.makeCurrent()) {
+            GlobalOpenTelemetry.set(openTelemetry);
+            envelope = factory().create("PaymentCaptured", correlationId(), causationId(), Map.of("paymentIntentId", "pi-1"));
+        } finally {
+            producerSpan.end();
+        }
+        CapturingStreams streams = new CapturingStreams(objectMapper.writeValueAsString(envelope));
+        RedisEventSubscriber subscriber = new RedisEventSubscriber(
+            streams,
+            objectMapper,
+            null,
+            new InMemoryConsumedEventStore(),
+            new OtelEventConsumerTracer(openTelemetry, tracer)
+        );
+        CountDownLatch handled = new CountDownLatch(1);
+
+        try {
+            subscriber.subscribe(List.of("events:payment"), "journey-order", "consumer-1", event -> {
+                handled.countDown();
+                return HandlerResult.SUCCESS;
+            });
+            assertThat(handled.await(2, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            subscriber.close();
+        }
+
+        assertThat(streams.acked).containsExactly("1-0");
+        var consumerSpan = exporter.getFinishedSpanItems().stream()
+            .filter(span -> span.getName().equals("PaymentCaptured process"))
+            .findFirst()
+            .orElseThrow();
+        assertThat(consumerSpan.getTraceId()).isEqualTo(producerSpan.getSpanContext().getTraceId());
+        assertThat(consumerSpan.getParentSpanContext().isRemote()).isTrue();
+        assertThat(consumerSpan.getParentSpanContext().getSpanId()).isEqualTo(producerSpan.getSpanContext().getSpanId());
+    }
+
+    @Test
+    void malformedTraceparentIsIgnoredAndDoesNotAffectConsumerSpanCreation() {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        OpenTelemetry openTelemetry = openTelemetry(exporter);
+        Tracer tracer = tracer(openTelemetry);
+        EventEnvelope envelope = factory()
+            .create("PaymentCaptured", correlationId(), causationId(), Map.of("paymentIntentId", "pi-1"))
+            .withTraceContext("malformed", null);
+
+        try (var ignored = new OtelEventConsumerTracer(openTelemetry, tracer).start("events:payment", "journey-order", envelope)) {
+            // closing the scope ends the consumer span
+        }
+
+        var consumerSpan = exporter.getFinishedSpanItems().stream()
+            .filter(span -> span.getName().equals("PaymentCaptured process"))
+            .findFirst()
+            .orElseThrow();
+        assertThat(consumerSpan.getParentSpanContext().isValid()).isFalse();
+    }
+
+    private static final class CapturingStreams implements RedisStreamOperations {
+        private final String envelopeJson;
+        private final List<String> acked = new ArrayList<>();
+        private boolean delivered;
+
+        private CapturingStreams(String envelopeJson) {
+            this.envelopeJson = envelopeJson;
+        }
+
+        @Override
+        public void createGroup(String stream, String group) {
+        }
+
+        @Override
+        public String publish(String stream, String envelopeJson) {
+            return "1-0";
+        }
+
+        @Override
+        public synchronized List<StreamEntry> readGroup(String stream, String group, String consumerName) {
+            if (delivered) {
+                return List.of();
+            }
+            delivered = true;
+            return List.of(new StreamEntry("1-0", envelopeJson));
+        }
+
+        @Override
+        public List<StreamEntry> autoClaim(String stream, String group, String consumerName) {
+            return List.of();
+        }
+
+        @Override
+        public int deliveryCount(String stream, String group, String messageId) {
+            return 1;
+        }
+
+        @Override
+        public void ack(String stream, String group, String messageId) {
+            acked.add(messageId);
+        }
+
+        @Override
+        public void moveToDlq(String stream, String envelopeJson, DlqMetadata metadata) {
+        }
+    }
+
+    private static EventEnvelopeFactory factory() {
+        return new EventEnvelopeFactory("payment", Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), ZoneOffset.UTC));
+    }
+
+    private static OpenTelemetry openTelemetry(InMemorySpanExporter exporter) {
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+            .build();
+        return OpenTelemetrySdk.builder()
+            .setTracerProvider(tracerProvider)
+            .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+            .build();
+    }
+
+    private static Tracer tracer(OpenTelemetry openTelemetry) {
+        return openTelemetry.getTracer("trace-test");
+    }
+
+    private static String correlationId() {
+        return "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c444";
+    }
+
+    private static String causationId() {
+        return "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c555";
+    }
+}


### PR DESCRIPTION
## Summary
- add optional traceparent/tracestate support to Java EventEnvelope with W3C injection at creation time
- use envelope trace context as remote parent for Redis consumer spans while ignoring malformed values
- add compatibility and in-memory tracing tests for injection/extraction round-trips

## Validation
- (platform/java-kit) mvn -q test
- Java services mvn -q test: admin-audit, booking-orchestration, finance-settlement, journey-order, payment, post-sales, traveler-profile, wallet-promotion
- make check