### PR TITLE
REQ-100 propagate trace context in python and ts kits

### DIFF
--- a/platform/python-kit/src/train_ticket_platform/events.py
+++ b/platform/python-kit/src/train_ticket_platform/events.py
@@ -24,7 +24,8 @@ class MalformedEnvelopeError(ValueError):
 class EventEnvelope:
     """Contract EventEnvelope with camelCase attribute aliases.
 
-    Wire JSON uses exactly the eight fields from docs/08-contracts/messaging.md.
+    Wire JSON uses the fields from docs/08-contracts/messaging.md: eight core
+    fields plus the optional ``traceparent``/``tracestate`` trace context.
     ``causationId`` is omitted from JSON only when absent because existing
     service contracts allow no causation for externally triggered facts.
     """

--- a/platform/python-kit/src/train_ticket_platform/events.py
+++ b/platform/python-kit/src/train_ticket_platform/events.py
@@ -37,6 +37,8 @@ class EventEnvelope:
     producer: str = ""
     schemaVersion: int = 1
     payload: Mapping[str, Any] = field(default_factory=dict)
+    traceparent: str | None = None
+    tracestate: str | None = None
 
     def __init__(
         self,
@@ -54,6 +56,8 @@ class EventEnvelope:
         correlation_id: str | None = None,
         causation_id: str | None = None,
         schema_version: int | None = None,
+        traceparent: str | None = None,
+        tracestate: str | None = None,
     ) -> None:
         object.__setattr__(self, "eventId", eventId or event_id or new_prefixed_uuid7("evt"))
         object.__setattr__(self, "eventType", eventType or event_type or "")
@@ -63,6 +67,12 @@ class EventEnvelope:
         object.__setattr__(self, "producer", producer)
         object.__setattr__(self, "schemaVersion", schemaVersion if schema_version is None else schema_version)
         object.__setattr__(self, "payload", payload or {})
+        context_traceparent = traceparent
+        context_tracestate = tracestate
+        if context_traceparent is None:
+            context_traceparent, context_tracestate = _active_trace_context()
+        object.__setattr__(self, "traceparent", context_traceparent)
+        object.__setattr__(self, "tracestate", context_tracestate if context_traceparent else None)
 
     @property
     def event_id(self) -> str:
@@ -109,6 +119,10 @@ class EventEnvelope:
         }
         if self.causationId:
             data["causationId"] = self.causationId
+        if self.traceparent:
+            data["traceparent"] = self.traceparent
+            if self.tracestate:
+                data["tracestate"] = self.tracestate
         return data
 
     def as_dict(self) -> dict[str, Any]:
@@ -121,10 +135,6 @@ class EventEnvelope:
     def from_json_dict(cls, data: Mapping[str, Any]) -> "EventEnvelope":
         if not isinstance(data, Mapping):
             raise MalformedEnvelopeError("event envelope must be a JSON object")
-        allowed = REQUIRED_ENVELOPE_FIELDS
-        unknown = set(data) - allowed
-        if unknown:
-            raise MalformedEnvelopeError(f"event envelope contains unknown fields: {sorted(unknown)}")
         required_without_cause = REQUIRED_ENVELOPE_FIELDS - {"causationId"}
         missing = [field_name for field_name in required_without_cause if field_name not in data]
         if missing:
@@ -160,11 +170,33 @@ class EventEnvelope:
             producer=required_text("producer"),
             schemaVersion=schema_version,
             payload=payload,
+            traceparent=data.get("traceparent") if isinstance(data.get("traceparent"), str) else "",
+            tracestate=data.get("tracestate") if isinstance(data.get("tracestate"), str) else None,
         )
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "EventEnvelope":
         return cls.from_json_dict(data)
+
+
+def _active_trace_context() -> tuple[str | None, str | None]:
+    try:
+        from .observability import otel_tracing_enabled
+
+        if not otel_tracing_enabled():
+            return None, None
+        from opentelemetry import trace
+        from opentelemetry.trace import format_trace_id, format_span_id
+
+        span_context = trace.get_current_span().get_span_context()
+    except Exception:
+        return None, None
+    if not getattr(span_context, "is_valid", False):
+        return None, None
+    flags = int(getattr(span_context, "trace_flags", 0)) & 0xFF
+    traceparent = f"00-{format_trace_id(span_context.trace_id)}-{format_span_id(span_context.span_id)}-{flags:02x}"
+    tracestate = str(getattr(span_context, "trace_state", "") or "")
+    return traceparent, tracestate or None
 
 
 def canonical_correlation_id(value: str | None) -> str:

--- a/platform/python-kit/src/train_ticket_platform/messaging.py
+++ b/platform/python-kit/src/train_ticket_platform/messaging.py
@@ -15,6 +15,7 @@ from typing import Any, Protocol
 from .events import EventEnvelope
 from .observability import otel_tracing_enabled
 
+
 MAXLEN = 100000
 MAX_RETRIES = 3
 RETRY_BACKOFF_SECONDS = (0.1, 0.3, 0.9)
@@ -442,7 +443,7 @@ class RedisEventSubscriber(EventSubscriber):
 def _call_handler_with_span(handler: Callable[[EventEnvelope], Any], envelope: EventEnvelope, stream: str, group: str) -> Any:
     if not otel_tracing_enabled():
         return handler(envelope)
-    from opentelemetry import trace
+    from opentelemetry import context, trace
     from opentelemetry.trace import SpanKind, Status, StatusCode
 
     attributes = {
@@ -457,7 +458,8 @@ def _call_handler_with_span(handler: Callable[[EventEnvelope], Any], envelope: E
         "messaging.train_ticket.correlationId": envelope.correlationId,
     }
     span_name = f"{group} process {envelope.eventType}"
-    with trace.get_tracer(__name__).start_as_current_span(span_name, kind=SpanKind.CONSUMER, attributes=attributes) as span:
+    parent_context = _remote_parent_context(envelope)
+    with trace.get_tracer(__name__).start_as_current_span(span_name, context=parent_context or context.get_current(), kind=SpanKind.CONSUMER, attributes=attributes) as span:
         try:
             result = handler(envelope)
         except Exception as exc:
@@ -467,6 +469,45 @@ def _call_handler_with_span(handler: Callable[[EventEnvelope], Any], envelope: E
         if isinstance(result, HandlerResult) and result.status is not HandlerStatus.SUCCESS:
             span.set_status(Status(StatusCode.ERROR, result.message or result.status.value))
         return result
+
+
+def _remote_parent_context(envelope: EventEnvelope) -> Any | None:
+    traceparent = getattr(envelope, "traceparent", None)
+    if not isinstance(traceparent, str):
+        return None
+    parts = traceparent.split("-")
+    if len(parts) != 4:
+        return None
+    version, trace_id, span_id, flags = parts
+    if version != "00" or len(trace_id) != 32 or len(span_id) != 16 or len(flags) != 2:
+        return None
+    try:
+        trace_id_int = int(trace_id, 16)
+        span_id_int = int(span_id, 16)
+        trace_flags = int(flags, 16)
+    except ValueError:
+        return None
+    if trace_id_int == 0 or span_id_int == 0:
+        return None
+    try:
+        from opentelemetry import context
+        from opentelemetry.trace import SpanContext, TraceFlags, TraceState, set_span_in_context
+        from opentelemetry.trace.span import NonRecordingSpan
+
+        tracestate_value = getattr(envelope, "tracestate", None)
+        trace_state = TraceState.from_header([tracestate_value]) if isinstance(tracestate_value, str) and tracestate_value else TraceState()
+        span_context = SpanContext(
+            trace_id=trace_id_int,
+            span_id=span_id_int,
+            is_remote=True,
+            trace_flags=TraceFlags(trace_flags),
+            trace_state=trace_state,
+        )
+        if not span_context.is_valid:
+            return None
+        return set_span_in_context(NonRecordingSpan(span_context), context.get_current())
+    except Exception:
+        return None
 
 
 class InMemoryEventPublisher(EventPublisher):

--- a/platform/python-kit/src/train_ticket_platform/messaging.py
+++ b/platform/python-kit/src/train_ticket_platform/messaging.py
@@ -481,6 +481,10 @@ def _remote_parent_context(envelope: EventEnvelope) -> Any | None:
     version, trace_id, span_id, flags = parts
     if version != "00" or len(trace_id) != 32 or len(span_id) != 16 or len(flags) != 2:
         return None
+    # W3C trace context is lowercase hex; reject uppercase for parity with
+    # the ts-kit parser so malformed values are ignored identically everywhere.
+    if trace_id != trace_id.lower() or span_id != span_id.lower() or flags != flags.lower():
+        return None
     try:
         trace_id_int = int(trace_id, 16)
         span_id_int = int(span_id, 16)

--- a/platform/python-kit/tests/test_messaging.py
+++ b/platform/python-kit/tests/test_messaging.py
@@ -1,8 +1,10 @@
 import json
 import logging
+from datetime import UTC, datetime
 
 from train_ticket_platform.events import EventEnvelope
 from train_ticket_platform.messaging import FatalHandlerError, HandlerResult, InMemoryEventSubscriber, RedisEventSubscriber, TransientHandlerError, dlq_for_stream
+from train_ticket_platform.observability import init_opentelemetry
 
 
 class FakeRedis:
@@ -164,3 +166,87 @@ def test_otel_enabled_creates_http_server_span(monkeypatch) -> None:
     assert server_spans, f"expected an HTTP server span, got: {[span.name for span in spans]}"
     route_attr = server_spans[0].attributes.get("http.route") or server_spans[0].attributes.get("http.target")
     assert route_attr == "/health"
+
+
+def test_envelope_omits_trace_context_when_otel_disabled(monkeypatch) -> None:
+    monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)
+    envelope = EventEnvelope(
+        eventId="evt-test",
+        eventType="SomethingHappened",
+        occurredAt=datetime(2026, 7, 8, tzinfo=UTC),
+        correlationId="corr-test",
+        causationId="cmd-test",
+        producer="tester",
+        payload={"x": 1},
+    )
+
+    assert envelope.to_json_dict() == {
+        "eventId": "evt-test",
+        "eventType": "SomethingHappened",
+        "occurredAt": "2026-07-08T00:00:00.000Z",
+        "correlationId": "corr-test",
+        "producer": "tester",
+        "schemaVersion": 1,
+        "payload": {"x": 1},
+        "causationId": "cmd-test",
+    }
+
+
+def test_envelope_deserialization_ignores_unknown_fields_and_preserves_trace_context(monkeypatch) -> None:
+    monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)
+    restored = EventEnvelope.from_json_dict({
+        "eventId": "evt-test",
+        "eventType": "SomethingHappened",
+        "occurredAt": "2026-07-08T00:00:00.000Z",
+        "correlationId": "corr-test",
+        "producer": "tester",
+        "schemaVersion": 1,
+        "payload": {},
+        "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        "tracestate": "vendor=value",
+        "futureField": "ignored",
+    })
+
+    assert restored.traceparent == "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    assert restored.tracestate == "vendor=value"
+    assert restored.to_json_dict()["traceparent"] == restored.traceparent
+
+
+def test_otel_enabled_injects_trace_context_and_consumer_uses_remote_parent(monkeypatch) -> None:
+    pytest = __import__("pytest")
+    trace = pytest.importorskip("opentelemetry.trace")
+    exporter_mod = pytest.importorskip("opentelemetry.sdk.trace.export.in_memory_span_exporter")
+
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "otlp")
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "python-kit-trace-test")
+    exporter = exporter_mod.InMemorySpanExporter()
+    provider = init_opentelemetry("python-kit-trace-test", span_exporter=exporter)
+    producer_span = None
+    with trace.get_tracer("python-kit-trace-test").start_as_current_span("producer") as span:
+        producer_span = span
+        envelope = EventEnvelope(eventType="SomethingHappened", producer="tester", payload={})
+    subscriber = InMemoryEventSubscriber([envelope])
+    subscriber.subscribe(["events:tester"], "tester", "tester-consumer", lambda _: HandlerResult.success())
+
+    consumer = next(span for span in exporter.get_finished_spans() if span.name == "in-memory process SomethingHappened")
+    assert envelope.traceparent is not None
+    assert consumer.context.trace_id == producer_span.get_span_context().trace_id
+    assert consumer.parent.span_id == producer_span.get_span_context().span_id
+    provider.shutdown()
+
+
+def test_malformed_traceparent_is_ignored_for_consumer_parent(monkeypatch) -> None:
+    pytest = __import__("pytest")
+    trace = pytest.importorskip("opentelemetry.trace")
+    exporter_mod = pytest.importorskip("opentelemetry.sdk.trace.export.in_memory_span_exporter")
+
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "otlp")
+    exporter = exporter_mod.InMemorySpanExporter()
+    provider = init_opentelemetry("python-kit-trace-test", span_exporter=exporter)
+    envelope = EventEnvelope(eventType="SomethingHappened", producer="tester", payload={}, traceparent="not-valid")
+    subscriber = InMemoryEventSubscriber([envelope])
+    subscriber.subscribe(["events:tester"], "tester", "tester-consumer", lambda _: HandlerResult.success())
+
+    consumer = next(span for span in exporter.get_finished_spans() if span.name == "in-memory process SomethingHappened")
+    assert not consumer.parent or not consumer.parent.is_valid
+    provider.shutdown()

--- a/platform/ts-kit/dist/messaging.d.ts
+++ b/platform/ts-kit/dist/messaging.d.ts
@@ -8,6 +8,8 @@ export type EventEnvelope<TPayload extends Record<string, unknown> = Record<stri
     correlationId: string;
     occurredAt: string;
     payload: TPayload;
+    traceparent?: string;
+    tracestate?: string;
 }>;
 export declare class PublishFailed extends Error {
     constructor(message: string, options?: ErrorOptions);
@@ -65,6 +67,8 @@ export declare class InMemoryEventPublisher implements EventPublisher {
         correlationId: string;
         occurredAt: string;
         payload: Record<string, unknown>;
+        traceparent?: string;
+        tracestate?: string;
     }>[];
     failNext: boolean;
     publish(envelope: EventEnvelope): Promise<void>;

--- a/platform/ts-kit/dist/messaging.js
+++ b/platform/ts-kit/dist/messaging.js
@@ -1,5 +1,5 @@
 import { Redis } from "ioredis";
-import { endSpan, endSpanWithError, markSpanError, startConsumerSpan } from "./observability.js";
+import { activeTraceContext, endSpan, endSpanWithError, markSpanError, remoteTraceContext, startConsumerSpan } from "./observability.js";
 import { canonicalCausationId, canonicalCorrelationId, canonicalEventId, newCommandId, newCorrelationId, newEventId } from "./ids.js";
 export class PublishFailed extends Error {
     constructor(message, options) {
@@ -22,6 +22,7 @@ export class HandlerError extends Error {
     }
 }
 export function createEventEnvelope(input) {
+    const traceContext = activeTraceContext();
     return Object.freeze({
         eventId: input.eventId ? canonicalEventId(input.eventId) : newEventId(),
         eventType: input.eventType,
@@ -31,6 +32,7 @@ export function createEventEnvelope(input) {
         correlationId: input.correlationId ? canonicalCorrelationId(input.correlationId) : newCorrelationId(),
         occurredAt: occurredAt(input.occurredAt),
         payload: Object.freeze(omitUndefined(input.payload)),
+        ...traceContext,
     });
 }
 export async function publishAfterCommit(transaction, publisher, envelopes) {
@@ -314,7 +316,7 @@ export class RedisEventSubscriber {
         }
         let envelope;
         try {
-            envelope = JSON.parse(envelopeJson);
+            envelope = deserializeEventEnvelope(envelopeJson);
         }
         catch (error) {
             await this.deadLetterAndAck(stream, group, consumerName, entry, error, attempts);
@@ -460,6 +462,7 @@ async function handleWithConsumerSpan(handler, envelope, stream, consumerGroup) 
         eventId: envelope.eventId,
         eventType: envelope.eventType,
         correlationId: envelope.correlationId,
+        parentContext: remoteTraceContext(envelope.traceparent, envelope.tracestate),
     });
     try {
         const result = await handler(envelope);
@@ -474,6 +477,10 @@ async function handleWithConsumerSpan(handler, envelope, stream, consumerGroup) 
         endSpanWithError(span, error);
         throw error;
     }
+}
+function deserializeEventEnvelope(envelopeJson) {
+    const raw = JSON.parse(envelopeJson);
+    return Object.freeze({ ...raw, payload: Object.freeze(raw.payload ?? {}) });
 }
 function truncateFailureReason(reason) {
     const text = reason instanceof Error

--- a/platform/ts-kit/dist/observability.d.ts
+++ b/platform/ts-kit/dist/observability.d.ts
@@ -1,4 +1,4 @@
-import { type Span, type Tracer } from "@opentelemetry/api";
+import { type Context, type Span, type Tracer } from "@opentelemetry/api";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { type SpanExporter } from "@opentelemetry/sdk-trace-base";
 export type InitOpenTelemetryOptions = Readonly<{
@@ -8,6 +8,11 @@ export type InitOpenTelemetryOptions = Readonly<{
 export declare function otelTracingEnabled(): boolean;
 export declare function initOpenTelemetry(options?: InitOpenTelemetryOptions): NodeSDK | undefined;
 export declare function getOpenTelemetryTracer(serviceName?: string): Tracer | undefined;
+export declare function activeTraceContext(): Readonly<{
+    traceparent: string;
+    tracestate?: string;
+}> | undefined;
+export declare function remoteTraceContext(traceparent: string | undefined, tracestate?: string): Context | undefined;
 export declare function startConsumerSpan(attributes: MessagingConsumerSpanAttributes): Span | undefined;
 export type MessagingConsumerSpanAttributes = Readonly<{
     stream: string;
@@ -15,6 +20,7 @@ export type MessagingConsumerSpanAttributes = Readonly<{
     eventId: string;
     eventType: string;
     correlationId: string;
+    parentContext?: Context;
 }>;
 export declare function endSpanWithError(span: Span | undefined, error: unknown): void;
 export declare function endSpan(span: Span | undefined): void;

--- a/platform/ts-kit/dist/observability.js
+++ b/platform/ts-kit/dist/observability.js
@@ -1,5 +1,5 @@
 import process from "node:process";
-import { context, SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
+import { context, createTraceState, isSpanContextValid, SpanKind, SpanStatusCode, trace, TraceFlags } from "@opentelemetry/api";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
 import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
 import { FastifyInstrumentation } from "@opentelemetry/instrumentation-fastify";
@@ -42,6 +42,22 @@ export function getOpenTelemetryTracer(serviceName) {
     }
     return trace.getTracer(serviceName ?? process.env.OTEL_SERVICE_NAME ?? "train-ticket-service");
 }
+export function activeTraceContext() {
+    if (!otelTracingEnabled()) {
+        return undefined;
+    }
+    const spanContext = trace.getActiveSpan()?.spanContext();
+    if (!spanContext || !isSpanContextValid(spanContext)) {
+        return undefined;
+    }
+    const traceparent = `00-${spanContext.traceId}-${spanContext.spanId}-${(spanContext.traceFlags & 0xff).toString(16).padStart(2, "0")}`;
+    const tracestate = spanContext.traceState?.serialize();
+    return tracestate ? { traceparent, tracestate } : { traceparent };
+}
+export function remoteTraceContext(traceparent, tracestate) {
+    const spanContext = parseTraceparent(traceparent, tracestate);
+    return spanContext ? trace.setSpanContext(context.active(), spanContext) : undefined;
+}
 export function startConsumerSpan(attributes) {
     if (!otelTracingEnabled()) {
         return undefined;
@@ -61,7 +77,7 @@ export function startConsumerSpan(attributes) {
             "messaging.train_ticket.correlationId": attributes.correlationId,
         },
     };
-    return tracer.startSpan(`${attributes.consumerGroup} process ${attributes.eventType}`, spanOptions, context.active());
+    return tracer.startSpan(`${attributes.consumerGroup} process ${attributes.eventType}`, spanOptions, attributes.parentContext ?? context.active());
 }
 export function endSpanWithError(span, error) {
     if (!span) {
@@ -81,4 +97,28 @@ export function endSpan(span) {
 }
 export function markSpanError(span, message) {
     span?.setStatus({ code: SpanStatusCode.ERROR, message });
+}
+function parseTraceparent(traceparent, tracestate) {
+    if (!traceparent) {
+        return undefined;
+    }
+    const parts = traceparent.split("-");
+    if (parts.length !== 4) {
+        return undefined;
+    }
+    const [version, traceId, spanId, flags] = parts;
+    if (version !== "00" || !/^[0-9a-f]{32}$/.test(traceId) || !/^[0-9a-f]{16}$/.test(spanId) || !/^[0-9a-f]{2}$/.test(flags)) {
+        return undefined;
+    }
+    if (traceId === "00000000000000000000000000000000" || spanId === "0000000000000000") {
+        return undefined;
+    }
+    const spanContext = {
+        traceId,
+        spanId,
+        traceFlags: Number.parseInt(flags, 16) & TraceFlags.SAMPLED,
+        traceState: tracestate ? createTraceState(tracestate) : undefined,
+        isRemote: true,
+    };
+    return isSpanContextValid(spanContext) ? spanContext : undefined;
 }

--- a/platform/ts-kit/src/messaging.test.ts
+++ b/platform/ts-kit/src/messaging.test.ts
@@ -1,8 +1,14 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { createEventEnvelope, HandlerError, RedisEventSubscriber } from "./messaging.js";
+import { context, trace } from "@opentelemetry/api";
+import { InMemorySpanExporter } from "@opentelemetry/sdk-trace-base";
+
+import { createEventEnvelope, HandlerError, InMemoryEventSubscriber, RedisEventSubscriber, type EventEnvelope } from "./messaging.js";
+import { initOpenTelemetry } from "./observability.js";
 import { isPrefixedUuidV7, newCommandId, newCorrelationId, newEventId } from "./ids.js";
+
+const sharedTraceExporter = new InMemorySpanExporter();
 
 describe("EventEnvelope factory", () => {
   it("generates v7-prefixed envelope IDs when callers omit them", () => {
@@ -192,5 +198,122 @@ describe("RedisEventSubscriber retry and ack-skip observability", () => {
     assert.equal(warnings.length, 1);
     assert.equal((warnings[0] as { message?: string }).message, "duplicate event already processed; acking without handler");
     assert.equal((warnings[0] as { eventId?: string }).eventId, envelope.eventId);
+  });
+});
+
+
+async function waitForSpan(exporter: InMemorySpanExporter, name: string) {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const span = exporter.getFinishedSpans().find((candidate) => candidate.name === name);
+    if (span) {
+      return span;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return exporter.getFinishedSpans().find((candidate) => candidate.name === name);
+}
+
+describe("EventEnvelope trace context", () => {
+  it("omits trace context when OpenTelemetry tracing is disabled", () => {
+    const previous = process.env.OTEL_TRACES_EXPORTER;
+    delete process.env.OTEL_TRACES_EXPORTER;
+    try {
+      const envelope = createEventEnvelope({
+        eventId: newEventId(),
+        correlationId: newCorrelationId(),
+        causationId: newCommandId(),
+        eventType: "ExampleCreated",
+        producer: "ts-kit-test",
+        occurredAt: "2026-07-08T00:00:00.000Z",
+        payload: {},
+      });
+      assert.deepEqual(JSON.parse(JSON.stringify(envelope)), envelope);
+      assert.equal("traceparent" in envelope, false);
+      assert.equal("tracestate" in envelope, false);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OTEL_TRACES_EXPORTER;
+      } else {
+        process.env.OTEL_TRACES_EXPORTER = previous;
+      }
+    }
+  });
+
+  it("injects trace context and uses it as the consumer span remote parent", async () => {
+    const previousExporter = process.env.OTEL_TRACES_EXPORTER;
+    const previousService = process.env.OTEL_SERVICE_NAME;
+    process.env.OTEL_TRACES_EXPORTER = "otlp";
+    process.env.OTEL_SERVICE_NAME = "ts-kit-trace-test";
+    const exporter = sharedTraceExporter;
+    exporter.reset();
+    const sdk = initOpenTelemetry({ serviceName: "ts-kit-trace-test", spanExporter: exporter });
+    try {
+      let envelope: EventEnvelope | undefined;
+      let producerTraceId = "";
+      let producerSpanId = "";
+      const producer = trace.getTracer("ts-kit-trace-test").startSpan("producer");
+      await context.with(trace.setSpan(context.active(), producer), async () => {
+        envelope = createEventEnvelope({ eventType: "ExampleCreated", producer: "ts-kit-test", payload: {} });
+        producerTraceId = producer.spanContext().traceId;
+        producerSpanId = producer.spanContext().spanId;
+      });
+      producer.end();
+      assert.ok(envelope?.traceparent);
+
+      const subscriber = new InMemoryEventSubscriber();
+      await subscriber.subscribe(["events:ts-kit-test"], "ts-kit", "consumer-a", () => undefined);
+      assert.equal(await subscriber.simulateEvent(envelope), "ack");
+      await (sdk as unknown as { forceFlush?: () => Promise<void> } | undefined)?.forceFlush?.();
+      const consumer = await waitForSpan(exporter, "in-memory process ExampleCreated");
+      assert.ok(consumer);
+      assert.equal(consumer.spanContext().traceId, producerTraceId);
+      assert.equal((consumer as unknown as { parentSpanId?: string }).parentSpanId, producerSpanId);
+    } finally {
+      if (previousExporter === undefined) {
+        delete process.env.OTEL_TRACES_EXPORTER;
+      } else {
+        process.env.OTEL_TRACES_EXPORTER = previousExporter;
+      }
+      if (previousService === undefined) {
+        delete process.env.OTEL_SERVICE_NAME;
+      } else {
+        process.env.OTEL_SERVICE_NAME = previousService;
+      }
+    }
+  });
+
+  it("deserializes unknown fields and ignores malformed traceparent for parent selection", async () => {
+    const previousExporter = process.env.OTEL_TRACES_EXPORTER;
+    process.env.OTEL_TRACES_EXPORTER = "otlp";
+    const exporter = sharedTraceExporter;
+    exporter.reset();
+    const sdk = initOpenTelemetry({ serviceName: "ts-kit-trace-test", spanExporter: exporter });
+    const xacks: unknown[][] = [];
+    const redis = {
+      xack: async (...args: unknown[]) => { xacks.push(args); return 1; },
+      xadd: async () => { throw new Error("should not DLQ"); },
+    };
+    const subscriber = new RedisEventSubscriber(redis as never);
+    const raw = {
+      ...createEventEnvelope({ eventType: "ExampleCreated", producer: "ts-kit-test", payload: {} }),
+      traceparent: "malformed",
+      futureField: "ignored",
+    };
+    try {
+      await (subscriber as unknown as { processEntry: (stream: string, group: string, consumerName: string, entry: [string, string[]], handler: () => unknown) => Promise<void> })
+        .processEntry("events:ts-kit-test", "ts-kit", "consumer-a", ["1-0", ["envelope", JSON.stringify(raw)]], () => undefined);
+      await (sdk as unknown as { forceFlush?: () => Promise<void> } | undefined)?.forceFlush?.();
+      const consumer = await waitForSpan(exporter, "ts-kit process ExampleCreated");
+      assert.ok(consumer);
+      assert.equal((consumer as unknown as { parentSpanId?: string }).parentSpanId, undefined);
+      assert.equal(xacks.length, 1);
+    } finally {
+      if (previousExporter === undefined) {
+        delete process.env.OTEL_TRACES_EXPORTER;
+      } else {
+        process.env.OTEL_TRACES_EXPORTER = previousExporter;
+      }
+    }
   });
 });

--- a/platform/ts-kit/src/messaging.ts
+++ b/platform/ts-kit/src/messaging.ts
@@ -1,6 +1,6 @@
 import { Redis } from "ioredis";
 
-import { endSpan, endSpanWithError, markSpanError, startConsumerSpan } from "./observability.js";
+import { activeTraceContext, endSpan, endSpanWithError, markSpanError, remoteTraceContext, startConsumerSpan } from "./observability.js";
 import { canonicalCausationId, canonicalCorrelationId, canonicalEventId, newCommandId, newCorrelationId, newEventId } from "./ids.js";
 
 export type EventEnvelope<TPayload extends Record<string, unknown> = Record<string, unknown>> = Readonly<{
@@ -12,6 +12,8 @@ export type EventEnvelope<TPayload extends Record<string, unknown> = Record<stri
   correlationId: string;
   occurredAt: string;
   payload: TPayload;
+  traceparent?: string;
+  tracestate?: string;
 }>;
 
 export class PublishFailed extends Error {
@@ -75,6 +77,7 @@ export type EnvelopeInput<TPayload extends Record<string, unknown>> = Readonly<{
 }>;
 
 export function createEventEnvelope<TPayload extends Record<string, unknown>>(input: EnvelopeInput<TPayload>): EventEnvelope<TPayload> {
+  const traceContext = activeTraceContext();
   return Object.freeze({
     eventId: input.eventId ? canonicalEventId(input.eventId) : newEventId(),
     eventType: input.eventType,
@@ -84,6 +87,7 @@ export function createEventEnvelope<TPayload extends Record<string, unknown>>(in
     correlationId: input.correlationId ? canonicalCorrelationId(input.correlationId) : newCorrelationId(),
     occurredAt: occurredAt(input.occurredAt),
     payload: Object.freeze(omitUndefined(input.payload)) as TPayload,
+    ...traceContext,
   });
 }
 
@@ -424,7 +428,7 @@ export class RedisEventSubscriber implements EventSubscriber {
 
     let envelope: EventEnvelope;
     try {
-      envelope = JSON.parse(envelopeJson) as EventEnvelope;
+      envelope = deserializeEventEnvelope(envelopeJson);
     } catch (error) {
       await this.deadLetterAndAck(stream, group, consumerName, entry, error, attempts);
       return;
@@ -605,6 +609,7 @@ async function handleWithConsumerSpan(handler: EventHandler, envelope: EventEnve
     eventId: envelope.eventId,
     eventType: envelope.eventType,
     correlationId: envelope.correlationId,
+    parentContext: remoteTraceContext(envelope.traceparent, envelope.tracestate),
   });
   try {
     const result = await handler(envelope) as EventHandlerResult | StringHandlerResult | undefined;
@@ -618,6 +623,11 @@ async function handleWithConsumerSpan(handler: EventHandler, envelope: EventEnve
     endSpanWithError(span, error);
     throw error;
   }
+}
+
+function deserializeEventEnvelope(envelopeJson: string): EventEnvelope {
+  const raw = JSON.parse(envelopeJson) as EventEnvelope;
+  return Object.freeze({ ...raw, payload: Object.freeze(raw.payload ?? {}) });
 }
 
 function truncateFailureReason(reason: unknown): string {

--- a/platform/ts-kit/src/observability.ts
+++ b/platform/ts-kit/src/observability.ts
@@ -1,6 +1,6 @@
 import process from "node:process";
 
-import { context, SpanKind, SpanStatusCode, trace, type Span, type SpanOptions, type Tracer } from "@opentelemetry/api";
+import { context, createTraceState, isSpanContextValid, SpanKind, SpanStatusCode, trace, TraceFlags, type Context, type Span, type SpanOptions, type Tracer } from "@opentelemetry/api";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-grpc";
 import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
 import { FastifyInstrumentation } from "@opentelemetry/instrumentation-fastify";
@@ -53,6 +53,24 @@ export function getOpenTelemetryTracer(serviceName?: string): Tracer | undefined
   return trace.getTracer(serviceName ?? process.env.OTEL_SERVICE_NAME ?? "train-ticket-service");
 }
 
+export function activeTraceContext(): Readonly<{ traceparent: string; tracestate?: string }> | undefined {
+  if (!otelTracingEnabled()) {
+    return undefined;
+  }
+  const spanContext = trace.getActiveSpan()?.spanContext();
+  if (!spanContext || !isSpanContextValid(spanContext)) {
+    return undefined;
+  }
+  const traceparent = `00-${spanContext.traceId}-${spanContext.spanId}-${(spanContext.traceFlags & 0xff).toString(16).padStart(2, "0")}`;
+  const tracestate = spanContext.traceState?.serialize();
+  return tracestate ? { traceparent, tracestate } : { traceparent };
+}
+
+export function remoteTraceContext(traceparent: string | undefined, tracestate?: string): Context | undefined {
+  const spanContext = parseTraceparent(traceparent, tracestate);
+  return spanContext ? trace.setSpanContext(context.active(), spanContext) : undefined;
+}
+
 export function startConsumerSpan(attributes: MessagingConsumerSpanAttributes): Span | undefined {
   if (!otelTracingEnabled()) {
     return undefined;
@@ -72,7 +90,7 @@ export function startConsumerSpan(attributes: MessagingConsumerSpanAttributes): 
       "messaging.train_ticket.correlationId": attributes.correlationId,
     },
   };
-  return tracer.startSpan(`${attributes.consumerGroup} process ${attributes.eventType}`, spanOptions, context.active());
+  return tracer.startSpan(`${attributes.consumerGroup} process ${attributes.eventType}`, spanOptions, attributes.parentContext ?? context.active());
 }
 
 export type MessagingConsumerSpanAttributes = Readonly<{
@@ -81,6 +99,7 @@ export type MessagingConsumerSpanAttributes = Readonly<{
   eventId: string;
   eventType: string;
   correlationId: string;
+  parentContext?: Context;
 }>;
 
 export function endSpanWithError(span: Span | undefined, error: unknown): void {
@@ -102,4 +121,29 @@ export function endSpan(span: Span | undefined): void {
 
 export function markSpanError(span: Span | undefined, message: string): void {
   span?.setStatus({ code: SpanStatusCode.ERROR, message });
+}
+
+function parseTraceparent(traceparent: string | undefined, tracestate?: string) {
+  if (!traceparent) {
+    return undefined;
+  }
+  const parts = traceparent.split("-");
+  if (parts.length !== 4) {
+    return undefined;
+  }
+  const [version, traceId, spanId, flags] = parts;
+  if (version !== "00" || !/^[0-9a-f]{32}$/.test(traceId) || !/^[0-9a-f]{16}$/.test(spanId) || !/^[0-9a-f]{2}$/.test(flags)) {
+    return undefined;
+  }
+  if (traceId === "00000000000000000000000000000000" || spanId === "0000000000000000") {
+    return undefined;
+  }
+  const spanContext = {
+    traceId,
+    spanId,
+    traceFlags: Number.parseInt(flags, 16) & TraceFlags.SAMPLED,
+    traceState: tracestate ? createTraceState(tracestate) : undefined,
+    isRemote: true,
+  };
+  return isSpanContextValid(spanContext) ? spanContext : undefined;
 }

--- a/services/fare-pricing/src/fare_pricing/ports/__init__.py
+++ b/services/fare-pricing/src/fare_pricing/ports/__init__.py
@@ -28,6 +28,8 @@ class EventEnvelope(_PlatformEventEnvelope):
             producer=producer,
             schemaVersion=schema_version,
             payload=payload or kwargs.pop("payload", {}),
+            traceparent=kwargs.pop("traceparent", None),
+            tracestate=kwargs.pop("tracestate", None),
         )
 
     @classmethod
@@ -41,6 +43,8 @@ class EventEnvelope(_PlatformEventEnvelope):
             causation_id=restored.causationId or "",
             producer=restored.producer,
             schema_version=restored.schemaVersion,
+            traceparent=restored.traceparent or "",
+            tracestate=restored.tracestate,
             payload=restored.payload,
         )
 

--- a/services/fare-pricing/tests/test_api.py
+++ b/services/fare-pricing/tests/test_api.py
@@ -802,17 +802,17 @@ class FarePricingMessagingTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             EventEnvelope.from_json_dict({})
 
-        with self.assertRaises(ValueError):
-            EventEnvelope.from_json_dict({
-                "eventId": "evt-test-extra",
-                "eventType": "FareRuleSetPublished",
-                "occurredAt": "2026-07-03T12:00:00.000Z",
-                "correlationId": "corr-test",
-                "producer": "fare-pricing",
-                "schemaVersion": 1,
-                "payload": {},
-                "legacyCommandId": "cmd-legacy",
-            })
+        restored = EventEnvelope.from_json_dict({
+            "eventId": "evt-test-extra",
+            "eventType": "FareRuleSetPublished",
+            "occurredAt": "2026-07-03T12:00:00.000Z",
+            "correlationId": "corr-test",
+            "producer": "fare-pricing",
+            "schemaVersion": 1,
+            "payload": {},
+            "legacyCommandId": "cmd-legacy",
+        })
+        self.assertEqual(restored.event_id, "evt-test-extra")
 
         restored = EventEnvelope.from_json_dict({
             "eventId": "evt-test-minimal",

--- a/services/trip-planning/src/trip_planning/events.py
+++ b/services/trip-planning/src/trip_planning/events.py
@@ -44,6 +44,8 @@ class EventEnvelope(_PlatformEventEnvelope):
             occurredAt=restored.occurredAt,
             payload=restored.payload,
             schemaVersion=restored.schemaVersion,
+            traceparent=restored.traceparent or "",
+            tracestate=restored.tracestate,
         )
 
 


### PR DESCRIPTION
## Summary
- inject optional traceparent/tracestate into Python and TypeScript event envelopes when OTel has an active span
- use valid envelope traceparent as the remote parent for consumer spans, ignoring malformed values without changing ack/retry/DLQ behavior
- relax Python envelope deserialization for additive unknown fields and preserve trace context through service wrappers

## Validation
- platform/python-kit: uv run pytest
- platform/ts-kit: npm test
- services/account, customer-service, notification, offer-management: npm test
- services/trip-planning, fare-pricing, risk-compliance, reporting: uv run pytest
- make check