### PR TITLE
REQ-101 propagate event traceparent in Go and Rust kits

### DIFF
--- a/platform/go-kit/messaging/envelope.go
+++ b/platform/go-kit/messaging/envelope.go
@@ -20,12 +20,15 @@ type EventEnvelope struct {
 	CausationID   string          `json:"causationId,omitempty"`
 	Producer      string          `json:"producer"`
 	SchemaVersion int             `json:"schemaVersion"`
+	Traceparent   string          `json:"traceparent,omitempty"`
+	Tracestate    string          `json:"tracestate,omitempty"`
 	Payload       json.RawMessage `json:"payload"`
 }
 
 type EnvelopeOptions struct {
 	Now         time.Time
 	CausationID string
+	Context     context.Context
 }
 
 func NewEventEnvelope(eventType, producer, correlationID string, payload any, options ...EnvelopeOptions) (EventEnvelope, error) {
@@ -42,10 +45,24 @@ func NewEventEnvelope(eventType, producer, correlationID string, payload any, op
 		causationID = options[0].CausationID
 	}
 	envelope := EventEnvelope{EventID: ids.NewEventID(), EventType: strings.TrimSpace(eventType), OccurredAt: now, CorrelationID: ids.CanonicalCorrelationID(correlationID), Producer: strings.TrimSpace(producer), SchemaVersion: SchemaVersion, Payload: body}
+	if len(options) > 0 {
+		if traceparent := traceparentFromContext(options[0].Context); traceparent != "" {
+			envelope.Traceparent = traceparent
+		}
+	}
 	if strings.TrimSpace(causationID) != "" {
 		envelope.CausationID = ids.CanonicalCausationID(causationID)
 	}
 	return envelope, envelope.Validate()
+}
+
+func (e *EventEnvelope) injectTraceContext(ctx context.Context) {
+	if strings.TrimSpace(e.Traceparent) != "" {
+		return
+	}
+	if traceparent := traceparentFromContext(ctx); traceparent != "" {
+		e.Traceparent = traceparent
+	}
 }
 
 func (e EventEnvelope) Validate() error {

--- a/platform/go-kit/messaging/envelope.go
+++ b/platform/go-kit/messaging/envelope.go
@@ -46,8 +46,9 @@ func NewEventEnvelope(eventType, producer, correlationID string, payload any, op
 	}
 	envelope := EventEnvelope{EventID: ids.NewEventID(), EventType: strings.TrimSpace(eventType), OccurredAt: now, CorrelationID: ids.CanonicalCorrelationID(correlationID), Producer: strings.TrimSpace(producer), SchemaVersion: SchemaVersion, Payload: body}
 	if len(options) > 0 {
-		if traceparent := traceparentFromContext(options[0].Context); traceparent != "" {
+		if traceparent, tracestate := traceContextFromContext(options[0].Context); traceparent != "" {
 			envelope.Traceparent = traceparent
+			envelope.Tracestate = tracestate
 		}
 	}
 	if strings.TrimSpace(causationID) != "" {
@@ -60,8 +61,9 @@ func (e *EventEnvelope) injectTraceContext(ctx context.Context) {
 	if strings.TrimSpace(e.Traceparent) != "" {
 		return
 	}
-	if traceparent := traceparentFromContext(ctx); traceparent != "" {
+	if traceparent, tracestate := traceContextFromContext(ctx); traceparent != "" {
 		e.Traceparent = traceparent
+		e.Tracestate = tracestate
 	}
 }
 

--- a/platform/go-kit/messaging/envelope_test.go
+++ b/platform/go-kit/messaging/envelope_test.go
@@ -328,3 +328,22 @@ func mustSpanContext(t *testing.T, traceIDHex, spanIDHex string, sampled bool) t
 	}
 	return spanContext
 }
+
+func TestNewEventEnvelopeCopiesTracestateAlongsideTraceparent(t *testing.T) {
+	traceState, err := trace.ParseTraceState("vendor=value")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spanContext := mustSpanContext(t, "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", true).WithTraceState(traceState)
+	ctx := trace.ContextWithSpanContext(context.Background(), spanContext)
+	envelope, err := NewEventEnvelope("ThingHappened", "test-producer", "0194f2e0-7b3e-7610-0284-5c26e8b0c123", map[string]string{"thingId": "thing-1"}, EnvelopeOptions{Context: ctx})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Traceparent == "" {
+		t.Fatal("traceparent must be injected for an active span context")
+	}
+	if envelope.Tracestate != "vendor=value" {
+		t.Fatalf("tracestate must ride along with traceparent, got %q", envelope.Tracestate)
+	}
+}

--- a/platform/go-kit/messaging/envelope_test.go
+++ b/platform/go-kit/messaging/envelope_test.go
@@ -12,6 +12,7 @@ import (
 
 	miniredis "github.com/alicebob/miniredis/v2"
 	redis "github.com/redis/go-redis/v9"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestNewEventEnvelopeCanonicalShape(t *testing.T) {
@@ -61,6 +62,83 @@ func TestNewEventEnvelopeOmitsOptionalCausationID(t *testing.T) {
 	}
 	if len(fields) != 7 {
 		t.Fatalf("envelope without causationId must have 7 fields, got %d: %s", len(fields), body)
+	}
+}
+
+func TestNewEventEnvelopeInjectsTraceparentFromActiveSpanContext(t *testing.T) {
+	spanContext := mustSpanContext(t, "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", true)
+	ctx := trace.ContextWithSpanContext(context.Background(), spanContext)
+	envelope, err := NewEventEnvelope("ThingHappened", "test-producer", "0194f2e0-7b3e-7610-0284-5c26e8b0c123", map[string]string{"thingId": "thing-1"}, EnvelopeOptions{Context: ctx})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Traceparent != "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" {
+		t.Fatalf("traceparent mismatch: %q", envelope.Traceparent)
+	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), `"traceparent"`) {
+		t.Fatalf("traceparent missing from JSON: %s", body)
+	}
+}
+
+func TestEventEnvelopeUnknownFieldsAreBidirectionallyCompatible(t *testing.T) {
+	envelope, err := NewEventEnvelope("ThingHappened", "test-producer", "0194f2e0-7b3e-7610-0284-5c26e8b0c123", map[string]string{"thingId": "thing-1"}, EnvelopeOptions{Now: time.Date(2026, 7, 5, 10, 30, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		t.Fatal(err)
+	}
+	fields["futureField"] = json.RawMessage(`{"nested":true}`)
+	withUnknown, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded EventEnvelope
+	if err := json.Unmarshal(withUnknown, &decoded); err != nil {
+		t.Fatalf("decode with unknown field: %v", err)
+	}
+	if err := decoded.Validate(); err != nil {
+		t.Fatalf("validate decoded envelope: %v", err)
+	}
+	decodedBody, err := json.Marshal(decoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(decodedBody), "futureField") {
+		t.Fatalf("unknown field should not be re-emitted by Go struct: %s", decodedBody)
+	}
+}
+
+func TestPublishInjectsTraceparentFromPublishContextWhenEnvelopeWasCreatedOutsideSpan(t *testing.T) {
+	spanContext := mustSpanContext(t, "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", true)
+	ctx := trace.ContextWithSpanContext(context.Background(), spanContext)
+	envelope, err := NewEventEnvelope("ThingHappened", "test-producer", "0194f2e0-7b3e-7610-0284-5c26e8b0c123", map[string]string{"thingId": "thing-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Traceparent != "" {
+		t.Fatalf("envelope should start without traceparent, got %q", envelope.Traceparent)
+	}
+
+	bus := NewInMemoryEventBus()
+	if err := bus.Publish(ctx, envelope); err != nil {
+		t.Fatal(err)
+	}
+	published := bus.Published()
+	if len(published) != 1 {
+		t.Fatalf("expected one published envelope, got %d", len(published))
+	}
+	if published[0].Traceparent != "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" {
+		t.Fatalf("traceparent mismatch: %q", published[0].Traceparent)
 	}
 }
 
@@ -228,4 +306,25 @@ func TestRedisSubscriptionDuplicateAckSkipLogs(t *testing.T) {
 	if !strings.Contains(logText, "duplicate event already processed") || !strings.Contains(logText, envelope.EventID) {
 		t.Fatalf("missing duplicate ack-skip log: %s", logText)
 	}
+}
+
+func mustSpanContext(t *testing.T, traceIDHex, spanIDHex string, sampled bool) trace.SpanContext {
+	t.Helper()
+	traceID, err := trace.TraceIDFromHex(traceIDHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spanID, err := trace.SpanIDFromHex(spanIDHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	flags := trace.TraceFlags(0)
+	if sampled {
+		flags = trace.FlagsSampled
+	}
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: spanID, TraceFlags: flags})
+	if !spanContext.IsValid() {
+		t.Fatalf("invalid span context")
+	}
+	return spanContext
 }

--- a/platform/go-kit/messaging/fake.go
+++ b/platform/go-kit/messaging/fake.go
@@ -19,6 +19,7 @@ type fakeSub struct {
 
 func NewInMemoryEventBus() *InMemoryEventBus { return &InMemoryEventBus{} }
 func (b *InMemoryEventBus) Publish(ctx context.Context, envelope EventEnvelope) error {
+	envelope.injectTraceContext(ctx)
 	b.mu.Lock()
 	b.published = append(b.published, envelope)
 	subs := append([]fakeSub(nil), b.subs...)

--- a/platform/go-kit/messaging/observer.go
+++ b/platform/go-kit/messaging/observer.go
@@ -6,6 +6,7 @@ import (
 
 	goruntime "github.com/trainticket/greenfield/platform/go-runtime"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -44,14 +45,18 @@ func ConsumerGroupFromContext(ctx context.Context) string {
 	return value
 }
 
-// ObservedHandler wraps event handling in a consumer span. It does not mutate
-// the event envelope; traceparent propagation is intentionally out-of-band.
+// ObservedHandler wraps event handling in a consumer span. A valid envelope
+// traceparent becomes the remote parent; malformed trace context is ignored so
+// ack/retry/DLQ behavior is unchanged.
 func ObservedHandler(observer Observer, stream, consumerGroup string, next Handler) Handler {
 	if observer == nil {
 		observer = NoopObserver()
 	}
 	return func(ctx context.Context, envelope EventEnvelope) error {
 		ctx = MessageContext(ctx, stream, consumerGroup)
+		if parent, ok := remoteSpanContextFromEnvelope(envelope); ok {
+			ctx = trace.ContextWithRemoteSpanContext(ctx, parent)
+		}
 		operation := strings.TrimSpace(envelope.EventType)
 		if operation == "" {
 			operation = "messaging.consume"
@@ -77,4 +82,25 @@ func SetSpanMessagingAttributes(ctx context.Context, stream, consumerGroup strin
 		attribute.String("eventType", strings.TrimSpace(envelope.EventType)),
 		attribute.String("correlationId", strings.TrimSpace(envelope.CorrelationID)),
 	)
+}
+
+func traceparentFromContext(ctx context.Context) string {
+	carrier := propagation.MapCarrier{}
+	propagation.TraceContext{}.Inject(ctx, carrier)
+	return strings.TrimSpace(carrier.Get("traceparent"))
+}
+
+func remoteSpanContextFromEnvelope(envelope EventEnvelope) (trace.SpanContext, bool) {
+	carrier := propagation.MapCarrier{}
+	if traceparent := strings.TrimSpace(envelope.Traceparent); traceparent != "" {
+		carrier.Set("traceparent", traceparent)
+	}
+	if tracestate := strings.TrimSpace(envelope.Tracestate); tracestate != "" {
+		carrier.Set("tracestate", tracestate)
+	}
+	spanContext := trace.SpanContextFromContext(propagation.TraceContext{}.Extract(context.Background(), carrier))
+	if !spanContext.IsValid() || !spanContext.IsRemote() {
+		return trace.SpanContext{}, false
+	}
+	return spanContext, true
 }

--- a/platform/go-kit/messaging/observer.go
+++ b/platform/go-kit/messaging/observer.go
@@ -84,10 +84,10 @@ func SetSpanMessagingAttributes(ctx context.Context, stream, consumerGroup strin
 	)
 }
 
-func traceparentFromContext(ctx context.Context) string {
+func traceContextFromContext(ctx context.Context) (string, string) {
 	carrier := propagation.MapCarrier{}
 	propagation.TraceContext{}.Inject(ctx, carrier)
-	return strings.TrimSpace(carrier.Get("traceparent"))
+	return strings.TrimSpace(carrier.Get("traceparent")), strings.TrimSpace(carrier.Get("tracestate"))
 }
 
 func remoteSpanContextFromEnvelope(envelope EventEnvelope) (trace.SpanContext, bool) {

--- a/platform/go-kit/messaging/observer_test.go
+++ b/platform/go-kit/messaging/observer_test.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestObservedHandlerNoopWithoutOTelEnv(t *testing.T) {
@@ -32,6 +33,81 @@ func TestObservedHandlerNoopWithoutOTelEnv(t *testing.T) {
 	}
 	if !handled {
 		t.Fatalf("handler was not called")
+	}
+}
+
+func TestObservedHandlerUsesValidTraceparentAsRemoteParent(t *testing.T) {
+	goruntime.ResetOTelForTest()
+	exporter := tracetest.NewInMemoryExporter()
+	shutdown, err := goruntime.InitOTelSDK(goruntime.OTelSDKConfig{ServiceName: "go-kit-test", Exporter: exporter})
+	if err != nil {
+		t.Fatalf("init sdk: %v", err)
+	}
+	defer func() {
+		_ = shutdown(context.Background())
+		goruntime.ResetOTelForTest()
+	}()
+	envelope := testEnvelopeForObserver(t)
+	envelope.Traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+	err = ObservedHandler(goruntime.NewOTelObserver(goruntime.OTelObserverConfig{ServiceName: "go-kit-test", TracerName: "go-kit-test"}), "events:test", "group-a", func(ctx context.Context, _ EventEnvelope) error {
+		parent := trace.SpanFromContext(ctx).(interface{ Parent() trace.SpanContext }).Parent()
+		if got := parent.SpanID().String(); got != "00f067aa0ba902b7" {
+			t.Fatalf("handler parent span id mismatch: %s", got)
+		}
+		if !parent.IsRemote() {
+			t.Fatalf("handler parent should be remote")
+		}
+		return nil
+	})(context.Background(), envelope)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected one span, got %d", len(spans))
+	}
+	if got := spans[0].SpanContext.TraceID().String(); got != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Fatalf("trace id mismatch: %s", got)
+	}
+	if got := spans[0].Parent.SpanID().String(); got != "00f067aa0ba902b7" {
+		t.Fatalf("parent span id mismatch: %s", got)
+	}
+	if !spans[0].Parent.IsRemote() {
+		t.Fatalf("parent should be remote")
+	}
+}
+
+func TestObservedHandlerIgnoresMalformedTraceparent(t *testing.T) {
+	goruntime.ResetOTelForTest()
+	exporter := tracetest.NewInMemoryExporter()
+	shutdown, err := goruntime.InitOTelSDK(goruntime.OTelSDKConfig{ServiceName: "go-kit-test", Exporter: exporter})
+	if err != nil {
+		t.Fatalf("init sdk: %v", err)
+	}
+	defer func() {
+		_ = shutdown(context.Background())
+		goruntime.ResetOTelForTest()
+	}()
+	envelope := testEnvelopeForObserver(t)
+	envelope.Traceparent = "malformed"
+
+	err = ObservedHandler(goruntime.NewOTelObserver(goruntime.OTelObserverConfig{ServiceName: "go-kit-test", TracerName: "go-kit-test"}), "events:test", "group-a", func(ctx context.Context, _ EventEnvelope) error {
+		parent := trace.SpanFromContext(ctx).(interface{ Parent() trace.SpanContext }).Parent()
+		if parent.IsValid() {
+			t.Fatalf("malformed traceparent should not create handler parent: %s", parent.TraceID())
+		}
+		return nil
+	})(context.Background(), envelope)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected one span, got %d", len(spans))
+	}
+	if spans[0].Parent.IsValid() {
+		t.Fatalf("malformed traceparent should not create a parent: %s", spans[0].Parent.TraceID())
 	}
 }
 

--- a/platform/go-kit/messaging/redis.go
+++ b/platform/go-kit/messaging/redis.go
@@ -106,6 +106,7 @@ func (b *RedisEventBus) Close() error {
 }
 
 func (b *RedisEventBus) Publish(ctx context.Context, envelope EventEnvelope) error {
+	envelope.injectTraceContext(ctx)
 	if err := envelope.Validate(); err != nil {
 		return fmt.Errorf("invalid envelope: %w", err)
 	}

--- a/platform/rust-kit/src/messaging.rs
+++ b/platform/rust-kit/src/messaging.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "redis-impl")]
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
 use std::future::Future;
@@ -6,10 +8,22 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use chrono::{SecondsFormat, Utc};
+use opentelemetry::Context as OTelContext;
 #[cfg(feature = "redis-impl")]
-use opentelemetry::trace::{Span as OTelSpanTrait, Tracer};
+use opentelemetry::KeyValue;
+#[cfg(any(test, feature = "redis-impl"))]
+use opentelemetry::global;
 #[cfg(feature = "redis-impl")]
-use opentelemetry::{KeyValue, global};
+use opentelemetry::propagation::Extractor;
+use opentelemetry::propagation::{Injector, TextMapPropagator};
+#[cfg(feature = "redis-impl")]
+use opentelemetry::trace::Span as OTelSpanTrait;
+#[cfg(feature = "redis-impl")]
+use opentelemetry::trace::SpanContext;
+use opentelemetry::trace::TraceContextExt;
+#[cfg(any(test, feature = "redis-impl"))]
+use opentelemetry::trace::Tracer;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -26,6 +40,10 @@ pub struct EventEnvelope {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub causation_id: Option<String>,
     pub correlation_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub traceparent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tracestate: Option<String>,
     pub occurred_at: String,
     pub payload: Value,
 }
@@ -39,6 +57,7 @@ impl EventEnvelope {
         producer: impl Into<String>,
         payload: Value,
     ) -> Result<Self, EnvelopeIdError> {
+        let trace_context = active_trace_context();
         Ok(Self {
             event_id: event_id(),
             event_type: event_type.into(),
@@ -46,6 +65,10 @@ impl EventEnvelope {
             producer: producer.into(),
             causation_id: validate_optional_causation_id(causation_id.map(Into::into))?,
             correlation_id: canonical_correlation_id(correlation_id.into())?,
+            traceparent: trace_context
+                .as_ref()
+                .and_then(|carrier| carrier.traceparent.clone()),
+            tracestate: trace_context.and_then(|carrier| carrier.tracestate),
             occurred_at: occurred_at.into(),
             payload,
         })
@@ -181,6 +204,82 @@ fn validate_optional_causation_id(
 }
 pub fn now_rfc3339_utc() -> String {
     Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+#[derive(Debug, Default)]
+struct TraceContextCarrier {
+    traceparent: Option<String>,
+    tracestate: Option<String>,
+}
+
+impl Injector for TraceContextCarrier {
+    fn set(&mut self, key: &str, value: String) {
+        match key.to_ascii_lowercase().as_str() {
+            "traceparent" => self.traceparent = Some(value),
+            "tracestate" => {
+                if !value.trim().is_empty() {
+                    self.tracestate = Some(value);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(feature = "redis-impl")]
+#[derive(Debug, Default)]
+struct EnvelopeTraceContextExtractor {
+    fields: HashMap<String, String>,
+}
+
+#[cfg(feature = "redis-impl")]
+impl EnvelopeTraceContextExtractor {
+    fn new(envelope: &EventEnvelope) -> Self {
+        let mut fields = HashMap::new();
+        if let Some(traceparent) = envelope.traceparent.as_deref() {
+            fields.insert("traceparent".to_string(), traceparent.trim().to_string());
+        }
+        if let Some(tracestate) = envelope.tracestate.as_deref() {
+            fields.insert("tracestate".to_string(), tracestate.trim().to_string());
+        }
+        Self { fields }
+    }
+}
+
+#[cfg(feature = "redis-impl")]
+impl Extractor for EnvelopeTraceContextExtractor {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.fields
+            .get(&key.to_ascii_lowercase())
+            .map(String::as_str)
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.fields.keys().map(String::as_str).collect()
+    }
+}
+
+fn active_trace_context() -> Option<TraceContextCarrier> {
+    let context = OTelContext::current();
+    if !context.span().span_context().is_valid() {
+        return None;
+    }
+    let mut carrier = TraceContextCarrier::default();
+    TraceContextPropagator::new().inject_context(&context, &mut carrier);
+    carrier.traceparent.as_ref()?;
+    Some(carrier)
+}
+
+#[cfg(feature = "redis-impl")]
+fn remote_parent_context(envelope: &EventEnvelope) -> Option<OTelContext> {
+    let extractor = EnvelopeTraceContextExtractor::new(envelope);
+    let context = TraceContextPropagator::new().extract(&extractor);
+    let span_context: SpanContext = context.span().span_context().clone();
+    if span_context.is_valid() && span_context.is_remote() {
+        Some(context)
+    } else {
+        None
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -888,11 +987,15 @@ pub mod redis_runtime {
                 return ops.ack(&message.stream, group, &message.id).await;
             }
             let tracer = global::tracer("rust-kit.messaging");
-            let mut span = tracer
+            let span_builder = tracer
                 .span_builder(envelope.event_type.clone())
                 .with_kind(opentelemetry::trace::SpanKind::Consumer)
-                .with_attributes(messaging_span_attributes(&message.stream, group, &envelope))
-                .start(&tracer);
+                .with_attributes(messaging_span_attributes(&message.stream, group, &envelope));
+            let mut span = if let Some(parent_context) = remote_parent_context(&envelope) {
+                span_builder.start_with_context(&tracer, &parent_context)
+            } else {
+                span_builder.start(&tracer)
+            };
             match handler(envelope.clone()).await {
                 Ok(()) => {
                     span.end();
@@ -1423,6 +1526,115 @@ pub mod redis_runtime {
         }
 
         #[tokio::test]
+        async fn subscription_processing_uses_valid_traceparent_as_remote_parent() {
+            let _serial = crate::otel::test_serial();
+            let exporter = opentelemetry_sdk::trace::InMemorySpanExporterBuilder::new().build();
+            let exported = exporter.clone();
+            let otel_guard = crate::otel::init_with_exporter("rust-kit-test", exporter);
+            let subscriber = RedisEventSubscriber {
+                client: redis::Client::open("redis://127.0.0.1:0").unwrap(),
+                state: Arc::new(SubscriberState::new()),
+                stop: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            };
+            let mut envelope = EventEnvelope::canonical(
+                "ParentedEvent",
+                correlation_id(),
+                Some(command_id()),
+                "payment",
+                serde_json::json!({"id":"1"}),
+            );
+            envelope.traceparent =
+                Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string());
+            let raw = serde_json::to_string(&envelope).unwrap();
+            let mut ops = FakeStreamOps {
+                read_messages: vec![StreamMessage {
+                    stream: "events:payment".to_string(),
+                    id: "1-0".to_string(),
+                    raw_envelope: raw,
+                    delivery_count: 1,
+                }],
+                ..Default::default()
+            };
+
+            subscriber
+                .subscribe_with_ops(
+                    &mut ops,
+                    vec!["events:payment".to_string()],
+                    "journey-order".to_string(),
+                    "consumer-1".to_string(),
+                    Box::new(|_| Box::pin(async { Ok(()) })),
+                    true,
+                )
+                .await
+                .unwrap();
+
+            otel_guard.force_flush().expect("flush messaging span");
+            let spans = exported.get_finished_spans().expect("finished spans");
+            let span = spans
+                .iter()
+                .find(|span| span.name == "ParentedEvent")
+                .expect("messaging span");
+            assert_eq!(
+                span.span_context.trace_id().to_string(),
+                "4bf92f3577b34da6a3ce929d0e0e4736"
+            );
+            assert_eq!(span.parent_span_id.to_string(), "00f067aa0ba902b7");
+            assert!(span.parent_span_is_remote);
+        }
+
+        #[tokio::test]
+        async fn subscription_processing_ignores_malformed_traceparent() {
+            let _serial = crate::otel::test_serial();
+            let exporter = opentelemetry_sdk::trace::InMemorySpanExporterBuilder::new().build();
+            let exported = exporter.clone();
+            let otel_guard = crate::otel::init_with_exporter("rust-kit-test", exporter);
+            let subscriber = RedisEventSubscriber {
+                client: redis::Client::open("redis://127.0.0.1:0").unwrap(),
+                state: Arc::new(SubscriberState::new()),
+                stop: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            };
+            let mut envelope = EventEnvelope::canonical(
+                "MalformedParentEvent",
+                correlation_id(),
+                Some(command_id()),
+                "payment",
+                serde_json::json!({"id":"1"}),
+            );
+            envelope.traceparent = Some("malformed".to_string());
+            let raw = serde_json::to_string(&envelope).unwrap();
+            let mut ops = FakeStreamOps {
+                read_messages: vec![StreamMessage {
+                    stream: "events:payment".to_string(),
+                    id: "1-0".to_string(),
+                    raw_envelope: raw,
+                    delivery_count: 1,
+                }],
+                ..Default::default()
+            };
+
+            subscriber
+                .subscribe_with_ops(
+                    &mut ops,
+                    vec!["events:payment".to_string()],
+                    "journey-order".to_string(),
+                    "consumer-1".to_string(),
+                    Box::new(|_| Box::pin(async { Ok(()) })),
+                    true,
+                )
+                .await
+                .unwrap();
+
+            otel_guard.force_flush().expect("flush messaging span");
+            let spans = exported.get_finished_spans().expect("finished spans");
+            let span = spans
+                .iter()
+                .find(|span| span.name == "MalformedParentEvent")
+                .expect("messaging span");
+            assert_eq!(span.parent_span_id, opentelemetry::trace::SpanId::INVALID);
+            assert!(!span.parent_span_is_remote);
+        }
+
+        #[tokio::test]
         async fn queued_publisher_parks_failed_events_and_drains_after_recovery() {
             let pending = Arc::new(Mutex::new(std::collections::VecDeque::new()));
             let envelope = EventEnvelope::canonical(
@@ -1481,6 +1693,66 @@ mod tests {
         assert!(envelope.event_id.starts_with("evt-"));
         assert!(envelope.correlation_id.starts_with("corr-"));
         assert!(envelope.occurred_at.ends_with('Z'));
+    }
+
+    #[test]
+    fn envelope_serialization_omits_trace_context_without_active_span() {
+        let envelope = EventEnvelope::canonical(
+            "EntitlementIssued",
+            correlation_id(),
+            Some(command_id()),
+            "entitlement-ticketing",
+            serde_json::json!({"a":1}),
+        );
+        let value = serde_json::to_value(&envelope).unwrap();
+        let object = value.as_object().unwrap();
+        assert!(!object.contains_key("traceparent"));
+        assert!(!object.contains_key("tracestate"));
+        assert_eq!(object.len(), 8);
+    }
+
+    #[test]
+    fn envelope_deserialization_ignores_unknown_fields() {
+        let mut value = serde_json::to_value(EventEnvelope::canonical(
+            "EntitlementIssued",
+            correlation_id(),
+            Some(command_id()),
+            "entitlement-ticketing",
+            serde_json::json!({"a":1}),
+        ))
+        .unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("futureField".to_string(), serde_json::json!({"ok": true}));
+        let decoded: EventEnvelope = serde_json::from_value(value).unwrap();
+        let encoded = serde_json::to_value(decoded).unwrap();
+        assert!(!encoded.as_object().unwrap().contains_key("futureField"));
+    }
+
+    #[test]
+    fn envelope_creation_injects_active_traceparent() {
+        let _serial = crate::otel::test_serial();
+        let exporter = opentelemetry_sdk::trace::InMemorySpanExporterBuilder::new().build();
+        let otel_guard = crate::otel::init_with_exporter("rust-kit-test", exporter);
+        let tracer = global::tracer("rust-kit-test");
+        let span = tracer.start("producer");
+        let _attached = OTelContext::current_with_span(span).attach();
+
+        let envelope = EventEnvelope::canonical(
+            "EntitlementIssued",
+            correlation_id(),
+            Some(command_id()),
+            "entitlement-ticketing",
+            serde_json::json!({"a":1}),
+        );
+
+        let traceparent = envelope.traceparent.expect("traceparent");
+        assert!(traceparent.starts_with("00-"), "{traceparent}");
+        assert_eq!(traceparent.len(), 55);
+        assert!(envelope.tracestate.is_none());
+        drop(_attached);
+        otel_guard.shutdown().expect("shutdown otel");
     }
 
     #[test]

--- a/platform/rust-kit/src/otel.rs
+++ b/platform/rust-kit/src/otel.rs
@@ -127,7 +127,8 @@ fn otlp_endpoint_configured() -> bool {
 #[cfg(test)]
 pub(crate) fn test_serial() -> std::sync::MutexGuard<'static, ()> {
     static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+    LOCK.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 #[cfg(test)]

--- a/platform/shared-kernel-rust/src/lib.rs
+++ b/platform/shared-kernel-rust/src/lib.rs
@@ -498,6 +498,7 @@ pub struct EventEnvelope {
     occurred_at: UnixMillis,
     correlation_id: CorrelationId,
     causation_id: Option<CausationId>,
+    traceparent: Option<String>,
 }
 
 impl EventEnvelope {
@@ -523,6 +524,7 @@ impl EventEnvelope {
             occurred_at,
             correlation_id,
             causation_id,
+            traceparent: None,
         })
     }
 
@@ -548,6 +550,10 @@ impl EventEnvelope {
 
     pub fn causation_id(&self) -> Option<&CausationId> {
         self.causation_id.as_ref()
+    }
+
+    pub fn traceparent(&self) -> Option<&str> {
+        self.traceparent.as_deref()
     }
 }
 

--- a/services/capacity-availability/tests/skeleton.rs
+++ b/services/capacity-availability/tests/skeleton.rs
@@ -307,6 +307,8 @@ async fn api_publisher_envelope_is_properly_formatted() {
         causation_id: None,
         correlation_id: "corr-test".to_string(),
         occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+        traceparent: None,
+        tracestate: None,
         payload: json!({"holdId": "hold-test"}),
     };
     publisher.publish(&envelope).unwrap();
@@ -335,6 +337,8 @@ fn subscriber_deduplicates_duplicate_event_id() {
         causation_id: None,
         correlation_id: "corr-test".to_string(),
         occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+        traceparent: None,
+        tracestate: None,
         payload: json!({"test": true}),
     };
 
@@ -474,6 +478,8 @@ fn subscriber_decision_logic_retries_dlqs_and_dedups() {
         causation_id: None,
         correlation_id: "0194f2e0-7b3e-7610-0284-5c26e8b0cd02".to_string(),
         occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+        traceparent: None,
+        tracestate: None,
         payload: json!({"segmentBookingId": "sb-1"}),
     };
     let transient = ReceivedEvent {
@@ -541,6 +547,8 @@ fn in_memory_segment_reservation_requested_missing_idempotency_key_is_fatal() {
         causation_id: None,
         correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa12".to_string(),
         occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+        traceparent: None,
+        tracestate: None,
         payload: json!({
             "segmentBookingId": "sb-1",
             "journeyOrderId": "ord-1",
@@ -571,6 +579,8 @@ fn in_memory_post_sales_applied_without_hold_pointer_is_acked() {
         causation_id: None,
         correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa22".to_string(),
         occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+        traceparent: None,
+        tracestate: None,
         payload: json!({
             "caseId": "psc-1",
             "orderId": "ord-1",
@@ -604,6 +614,8 @@ async fn postgres_inbound_classifies_known_event_schema_errors_as_fatal() {
             causation_id: None,
             correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa02".to_string(),
             occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+            traceparent: None,
+            tracestate: None,
             payload: json!({"segmentBookingId": "sb-1", "journeyOrderId": "ord-1", "segmentRef": "seg-1", "travelerRef": "traveler-1"}),
         })
         .await;
@@ -636,6 +648,8 @@ async fn postgres_post_sales_applied_without_hold_pointer_is_acked() {
             causation_id: None,
             correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa32".to_string(),
             occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+            traceparent: None,
+            tracestate: None,
             payload: json!({
                 "caseId": "psc-1",
                 "orderId": "ord-1",
@@ -664,6 +678,8 @@ fn in_memory_segment_reservation_confirmed_without_capacity_hold_id_is_acked() {
         causation_id: None,
         correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa42".to_string(),
         occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+        traceparent: None,
+        tracestate: None,
         payload: json!({
             "segmentBookingId": "sb-1",
             "providerReference": "prov-1",
@@ -691,6 +707,8 @@ fn in_memory_segment_reservation_confirmed_missing_segment_booking_id_is_fatal()
         causation_id: None,
         correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa44".to_string(),
         occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+        traceparent: None,
+        tracestate: None,
         payload: json!({"evidence": "confirmed"}),
     });
 
@@ -722,6 +740,8 @@ async fn postgres_segment_reservation_confirmed_missing_segment_booking_id_is_fa
             causation_id: None,
             correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa48".to_string(),
             occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+            traceparent: None,
+            tracestate: None,
             payload: json!({"evidence": "confirmed"}),
         })
         .await;
@@ -748,6 +768,8 @@ fn in_memory_capacity_inbound_event_contract_classification_matrix() {
             causation_id: None,
             correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fb01".to_string(),
             occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+            traceparent: None,
+            tracestate: None,
             payload,
         }
     }
@@ -857,6 +879,8 @@ async fn postgres_capacity_inbound_event_contract_classification_pre_db_matrix()
             causation_id: None,
             correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fb02".to_string(),
             occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+            traceparent: None,
+            tracestate: None,
             payload,
         }
     }
@@ -1136,6 +1160,8 @@ fn subscriber_dlqs_after_fifth_delivery_attempt_from_broker_counter() {
         causation_id: Some("cmd-0194f2e0-7b3e-7610-0284-5c26e8b0cf32".to_string()),
         correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0cf33".to_string(),
         occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+        traceparent: None,
+        tracestate: None,
         payload: json!({"segmentBookingId": "sb-1"}),
     };
     let received = ReceivedEvent {


### PR DESCRIPTION
## Summary
- add optional traceparent/tracestate fields to Go and Rust event envelopes
- inject active W3C trace context on envelope creation/publish paths and use valid traceparent as consumer remote parent
- add compatibility and malformed-traceparent tests; update capacity test fixtures for optional wire fields

## Validation
- (platform/go-kit) go test ./...
- (platform/rust-kit) cargo test
- (platform/rust-kit) cargo test --features redis-impl (run 3x)
- (platform/shared-kernel-rust) cargo test
- make check