### PR TITLE
REQ-101B inject trace context into Go service envelopes

### DIFF
--- a/services/fulfillment/internal/application/ports.go
+++ b/services/fulfillment/internal/application/ports.go
@@ -476,7 +476,7 @@ func (s *Service) saveAndPublishPending(ctx context.Context, record *domain.Fulf
 
 func (s *Service) publishEvents(ctx context.Context, events []domain.DomainEvent, meta CommandMetadata) error {
 	for _, event := range events {
-		envelope, err := s.WrapDomainEvent(event, meta)
+		envelope, err := s.WrapDomainEvent(ctx, event, meta)
 		if err != nil {
 			return err
 		}
@@ -487,12 +487,12 @@ func (s *Service) publishEvents(ctx context.Context, events []domain.DomainEvent
 	return nil
 }
 
-func (s *Service) WrapDomainEvent(event domain.DomainEvent, meta CommandMetadata) (EventEnvelope, error) {
+func (s *Service) WrapDomainEvent(ctx context.Context, event domain.DomainEvent, meta CommandMetadata) (EventEnvelope, error) {
 	payload, err := MarshalDomainEventPayload(event)
 	if err != nil {
 		return EventEnvelope{}, err
 	}
-	options := []kitmsg.EnvelopeOptions{{Now: event.OccurredAt().UTC()}}
+	options := []kitmsg.EnvelopeOptions{{Now: event.OccurredAt().UTC(), Context: ctx}}
 	if strings.TrimSpace(meta.CausationID) != "" {
 		options[0].CausationID = meta.CausationID
 	}

--- a/services/fulfillment/internal/application/service_test.go
+++ b/services/fulfillment/internal/application/service_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/trainticket/greenfield/services/fulfillment/internal/domain"
 )
 
@@ -88,6 +90,39 @@ func TestPublisherWrapsDomainEventInCanonicalEnvelope(t *testing.T) {
 	}
 	if payload.FulfillmentRecordID == "" || payload.EntitlementID != "ent-abc123" || payload.SourceEventID != "gate-scan-1" {
 		t.Fatalf("unexpected payload: %#v", payload)
+	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), `"traceparent"`) {
+		t.Fatalf("traceparent must be omitted without span context: %s", body)
+	}
+}
+
+func TestPublisherEnvelopeIncludesTraceparentFromContext(t *testing.T) {
+	publisher := &recordingPublisher{}
+	service := NewService(NewInMemoryRepository(), publisher, NewInMemoryConsumedEventLog(), func(prefix string) string {
+		return prefix + "-00000000-0000-4000-8000-000000000001"
+	}, func() time.Time { return time.Date(2026, 7, 5, 10, 1, 0, 0, time.UTC) })
+
+	seedTicket(t, service, "ent-trace", "sb-trace", "ord-trace", "tvl-trace", "seg-trace")
+	ctx := trace.ContextWithSpanContext(context.Background(), mustSpanContext(t))
+	_, err := service.VerifyBoarding(ctx, VerifyBoardingCommand{
+		EntitlementID:    "ent-trace",
+		SegmentBookingID: "sb-trace",
+		JourneyOrderID:   "ord-trace",
+		TravelerID:       "tvl-trace",
+		SegmentRef:       "seg-trace",
+		Source:           domain.FulfillmentSourceGate,
+		SourceEventID:    "gate-scan-trace",
+		OccurredAt:       time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC),
+	}, CommandMetadata{CorrelationID: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c0aa"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := publisher.envelopes[0].Traceparent; got != wantTraceparent {
+		t.Fatalf("traceparent mismatch: %q", got)
 	}
 }
 
@@ -248,4 +283,23 @@ func TestFulfillmentCompletedPublishesContractEvent(t *testing.T) {
 	if _, ok := payload["segmentRef"]; ok {
 		t.Fatalf("FulfillmentCompleted payload must match contract exactly, got segmentRef")
 	}
+}
+
+const wantTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+func mustSpanContext(t *testing.T) trace.SpanContext {
+	t.Helper()
+	traceID, err := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spanID, err := trace.SpanIDFromHex("00f067aa0ba902b7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: spanID, TraceFlags: trace.FlagsSampled})
+	if !spanContext.IsValid() {
+		t.Fatal("invalid span context")
+	}
+	return spanContext
 }

--- a/services/place-network/internal/adapters/postgres/publisher.go
+++ b/services/place-network/internal/adapters/postgres/publisher.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	kitmessaging "github.com/trainticket/greenfield/platform/go-kit/messaging"
 	"github.com/trainticket/greenfield/platform/go-kit/storage"
@@ -24,9 +26,37 @@ func NewOutboxPublisherWithProvider(db ContextDBProvider) *OutboxPublisher {
 }
 
 func (p *OutboxPublisher) Publish(ctx context.Context, envelope domain.EventEnvelope) error {
-	body, err := json.Marshal(envelope)
+	kitEnvelope, err := toKitEnvelope(ctx, envelope)
+	if err != nil {
+		return err
+	}
+	body, err := json.Marshal(kitEnvelope)
 	if err != nil {
 		return fmt.Errorf("marshal outbox envelope: %w", err)
 	}
-	return storage.NewOutboxAppender(p.db.DBFor(ctx)).Append(ctx, kitmessaging.StreamName(envelope.Producer), envelope.EventID, body)
+	return storage.NewOutboxAppender(p.db.DBFor(ctx)).Append(ctx, kitmessaging.StreamName(kitEnvelope.Producer), kitEnvelope.EventID, body)
+}
+
+func toKitEnvelope(ctx context.Context, envelope domain.EventEnvelope) (kitmessaging.EventEnvelope, error) {
+	payload := envelope.Payload
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	options := kitmessaging.EnvelopeOptions{Context: ctx}
+	if occurredAt, err := time.Parse(time.RFC3339Nano, envelope.OccurredAt); err == nil {
+		options.Now = occurredAt.UTC()
+	}
+	if strings.TrimSpace(envelope.CausationID) != "" {
+		options.CausationID = envelope.CausationID
+	}
+	kitEnvelope, err := kitmessaging.NewEventEnvelope(envelope.EventType, envelope.Producer, envelope.CorrelationID, payload, options)
+	if err != nil {
+		return kitmessaging.EventEnvelope{}, err
+	}
+	kitEnvelope.EventID = envelope.EventID
+	if strings.TrimSpace(envelope.Traceparent) != "" {
+		kitEnvelope.Traceparent = envelope.Traceparent
+		kitEnvelope.Tracestate = envelope.Tracestate
+	}
+	return kitEnvelope, nil
 }

--- a/services/place-network/internal/adapters/postgres/publisher_trace_test.go
+++ b/services/place-network/internal/adapters/postgres/publisher_trace_test.go
@@ -1,0 +1,76 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/trainticket/greenfield/services/place-network/internal/domain"
+)
+
+type captureOutboxDB struct {
+	envelope json.RawMessage
+}
+
+func (d *captureOutboxDB) Exec(_ context.Context, _ string, args ...any) (pgconn.CommandTag, error) {
+	if len(args) >= 3 {
+		d.envelope, _ = json.Marshal(args[2])
+	}
+	return pgconn.NewCommandTag("INSERT 1"), nil
+}
+func (d *captureOutboxDB) Query(context.Context, string, ...any) (pgx.Rows, error) { return nil, nil }
+func (d *captureOutboxDB) QueryRow(context.Context, string, ...any) pgx.Row        { return nil }
+
+func TestOutboxPublisherOmitsTraceparentWithoutSpanContext(t *testing.T) {
+	db := &captureOutboxDB{}
+	envelope := domain.NewEventEnvelope("PlaceRegistered", time.Date(2026, 7, 5, 10, 30, 0, 0, time.UTC), "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c123", "", domain.ProducerPlaceNetwork, domain.PlaceUpdatedEvent{PlaceID: "plc-test"})
+
+	if err := NewOutboxPublisher(db).Publish(context.Background(), envelope); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(db.envelope), `"traceparent"`) {
+		t.Fatalf("traceparent must be omitted without span context: %s", db.envelope)
+	}
+}
+
+func TestOutboxPublisherInjectsTraceparentFromContext(t *testing.T) {
+	db := &captureOutboxDB{}
+	envelope := domain.NewEventEnvelope("PlaceRegistered", time.Date(2026, 7, 5, 10, 30, 0, 0, time.UTC), "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c123", "", domain.ProducerPlaceNetwork, domain.PlaceUpdatedEvent{PlaceID: "plc-test"})
+	ctx := trace.ContextWithSpanContext(context.Background(), mustSpanContext(t))
+
+	if err := NewOutboxPublisher(db).Publish(ctx, envelope); err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(db.envelope, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Trim(string(fields["traceparent"]), `"`); got != wantTraceparent {
+		t.Fatalf("traceparent mismatch: %q in %s", got, db.envelope)
+	}
+}
+
+const wantTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+func mustSpanContext(t *testing.T) trace.SpanContext {
+	t.Helper()
+	traceID, err := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spanID, err := trace.SpanIDFromHex("00f067aa0ba902b7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: spanID, TraceFlags: trace.FlagsSampled})
+	if !spanContext.IsValid() {
+		t.Fatal("invalid span context")
+	}
+	return spanContext
+}

--- a/services/place-network/internal/domain/events.go
+++ b/services/place-network/internal/domain/events.go
@@ -40,6 +40,8 @@ type EventEnvelope struct {
 	CausationID   string `json:"causationId,omitempty"`
 	CorrelationID string `json:"correlationId"`
 	OccurredAt    string `json:"occurredAt"`
+	Traceparent   string `json:"traceparent,omitempty"`
+	Tracestate    string `json:"tracestate,omitempty"`
 	Payload       any    `json:"payload"`
 }
 

--- a/services/place-network/internal/http/handler_test.go
+++ b/services/place-network/internal/http/handler_test.go
@@ -187,6 +187,13 @@ func TestPublisherWrapsEventsInEnvelope(t *testing.T) {
 	if !ok || payload.PlaceID == "" || payload.UpdatedAt != "2026-07-05T10:30:00Z" {
 		t.Fatalf("unexpected payload: %#v", envelope.Payload)
 	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), `"traceparent"`) {
+		t.Fatalf("traceparent must be omitted without span context: %s", body)
+	}
 }
 
 func TestSubscriberHandlerDeduplicatesDuplicateEventID(t *testing.T) {

--- a/services/provider-integration/internal/adapters/postgres/reservations.go
+++ b/services/provider-integration/internal/adapters/postgres/reservations.go
@@ -63,7 +63,7 @@ func (s *ReservationService) RequestReservation(ctx context.Context, cmd applica
 		if s.publisher == nil {
 			return nil
 		}
-		envelope, err := application.NewEventEnvelope("ProviderReservationConfirmed", cmd.CorrelationID, cmd.CausationID, map[string]any{
+		envelope, err := application.NewEventEnvelope(txCtx, "ProviderReservationConfirmed", cmd.CorrelationID, cmd.CausationID, map[string]any{
 			"segmentBookingId":   created.SegmentBookingID,
 			"providerReference":  created.ProviderReference,
 			"normalizedEvidence": created.NormalizedEvidence,

--- a/services/provider-integration/internal/application/events.go
+++ b/services/provider-integration/internal/application/events.go
@@ -41,12 +41,12 @@ type EventSubscriber interface {
 func TransientHandlerError(err error) error { return kitmsg.TransientHandlerError(err) }
 func FatalHandlerError(err error) error     { return kitmsg.FatalHandlerError(err) }
 
-func NewEventEnvelope(eventType, correlationID, causationID string, payload any) (EventEnvelope, error) {
-	options := []kitmsg.EnvelopeOptions{}
+func NewEventEnvelope(ctx context.Context, eventType, correlationID, causationID string, payload any) (EventEnvelope, error) {
+	option := kitmsg.EnvelopeOptions{Context: ctx}
 	if strings.TrimSpace(causationID) != "" {
-		options = append(options, kitmsg.EnvelopeOptions{CausationID: causationID})
+		option.CausationID = causationID
 	}
-	return kitmsg.NewEventEnvelope(eventType, ProducerName, correlationID, payload, options...)
+	return kitmsg.NewEventEnvelope(eventType, ProducerName, correlationID, payload, option)
 }
 
 func canonicalCorrelationID(value string) string { return ids.CanonicalCorrelationID(value) }

--- a/services/provider-integration/internal/application/reservations.go
+++ b/services/provider-integration/internal/application/reservations.go
@@ -157,7 +157,7 @@ func (s *InMemoryReservationService) publish(ctx context.Context, eventType, cor
 	if s.publisher == nil {
 		return nil
 	}
-	envelope, err := NewEventEnvelope(eventType, correlationID, causationID, payload)
+	envelope, err := NewEventEnvelope(ctx, eventType, correlationID, causationID, payload)
 	if err != nil {
 		return err
 	}

--- a/services/provider-integration/internal/http/api_test.go
+++ b/services/provider-integration/internal/http/api_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/trainticket/greenfield/platform/go-kit/idempotency"
 	goruntime "github.com/trainticket/greenfield/platform/go-runtime"
 	"github.com/trainticket/greenfield/services/provider-integration/internal/application"
@@ -271,6 +273,13 @@ func TestPublisherWrapsCorrectEnvelope(t *testing.T) {
 	if envelope.OccurredAt.IsZero() {
 		t.Fatalf("occurredAt is required")
 	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), `"traceparent"`) {
+		t.Fatalf("traceparent must be omitted without span context: %s", body)
+	}
 	var payload map[string]any
 	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
 		t.Fatalf("bad payload JSON: %v", err)
@@ -287,6 +296,21 @@ func TestPublisherWrapsCorrectEnvelope(t *testing.T) {
 		if payload[field] != want {
 			t.Fatalf("payload[%s]=%#v, want %#v (payload %#v)", field, payload[field], want, payload)
 		}
+	}
+}
+
+func TestPublisherEnvelopeIncludesTraceparentFromContext(t *testing.T) {
+	publisher := &fakePublisher{}
+	service := application.NewInMemoryReservationService(publisher)
+	ctx := trace.ContextWithSpanContext(context.Background(), mustSpanContext(t))
+	_, err := service.RequestReservation(ctx, application.RequestProviderReservationCommand{
+		SegmentBookingID: segmentBookingID1, ProviderConfigRef: "cr-rail", ReservationPayload: map[string]any{"seat": "1A"}, CorrelationID: testUUIDv7(3), IdempotencyKey: testUUIDv7(5),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := publisher.envelopes[0].Traceparent; got != wantTraceparent {
+		t.Fatalf("traceparent mismatch: %q", got)
 	}
 }
 
@@ -543,4 +567,23 @@ func TestInboundSegmentBookingCancelledMissingReasonIsFatal(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected missing reason to be fatal")
 	}
+}
+
+const wantTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+func mustSpanContext(t *testing.T) trace.SpanContext {
+	t.Helper()
+	traceID, err := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spanID, err := trace.SpanIDFromHex("00f067aa0ba902b7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: spanID, TraceFlags: trace.FlagsSampled})
+	if !spanContext.IsValid() {
+		t.Fatal("invalid span context")
+	}
+	return spanContext
 }

--- a/services/service-plan/internal/application/events_test.go
+++ b/services/service-plan/internal/application/events_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
+
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/trainticket/greenfield/platform/go-kit/ids"
 )
@@ -99,12 +102,40 @@ func TestPublisherReceivesCorrectServicePlanEnvelope(t *testing.T) {
 	if envelope.OccurredAt.IsZero() {
 		t.Fatalf("missing occurredAt: %#v", envelope)
 	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), `"traceparent"`) {
+		t.Fatalf("traceparent must be omitted without span context: %s", body)
+	}
 	var payload map[string]any
 	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
 		t.Fatalf("payload is not json: %v", err)
 	}
 	if payload["serviceNumber"] != "G1234" || payload["status"] != "ACTIVE" {
 		t.Fatalf("unexpected payload: %#v", payload)
+	}
+}
+
+func TestPublisherEnvelopeIncludesTraceparentFromContext(t *testing.T) {
+	publisher := &recordingPublisher{}
+	service := NewService(publisher)
+	ctx := trace.ContextWithSpanContext(context.Background(), mustSpanContext(t))
+	_, err := service.CreateScheduledService(ctx, CreateScheduledServiceCommand{
+		CarrierID:         "car-0194f2e0-7b3e-7610-0284-5c26e8b0c001",
+		ServiceNumber:     "G1234",
+		DepartureTime:     time.Date(2026, 7, 5, 10, 30, 0, 0, time.UTC),
+		ArrivalTime:       time.Date(2026, 7, 5, 12, 30, 0, 0, time.UTC),
+		OriginNodeID:      "node-a",
+		DestinationNodeID: "node-b",
+		CorrelationID:     "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c444",
+	})
+	if err != nil {
+		t.Fatalf("create scheduled service: %v", err)
+	}
+	if got := publisher.envelopes[0].Traceparent; got != wantTraceparent {
+		t.Fatalf("traceparent mismatch: %q", got)
 	}
 }
 
@@ -256,4 +287,23 @@ func TestCreateServiceSegmentAfterRestartUsesPersistedService(t *testing.T) {
 	if result.ScheduledServiceRef != "ss-0194f2e0-7b3e-7610-0284-5c26e8b0c801" || result.SegmentRef == "" {
 		t.Fatalf("unexpected segment result: %#v", result)
 	}
+}
+
+const wantTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+func mustSpanContext(t *testing.T) trace.SpanContext {
+	t.Helper()
+	traceID, err := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spanID, err := trace.SpanIDFromHex("00f067aa0ba902b7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: spanID, TraceFlags: trace.FlagsSampled})
+	if !spanContext.IsValid() {
+		t.Fatal("invalid span context")
+	}
+	return spanContext
 }

--- a/services/service-plan/internal/application/service.go
+++ b/services/service-plan/internal/application/service.go
@@ -180,7 +180,7 @@ func (s *Service) CreateScheduledService(ctx context.Context, command CreateSche
 		return CreateScheduledServiceResult{}, err
 	}
 
-	envelope := s.newEnvelope("ServicePlanPublished", command.CorrelationID, command.CausationID, payload)
+	envelope := s.newEnvelope(ctx, "ServicePlanPublished", command.CorrelationID, command.CausationID, payload)
 
 	if err := s.within(ctx, func(txCtx context.Context) error {
 		if s.repository != nil {
@@ -377,7 +377,7 @@ func (s *Service) CreateServiceSegment(ctx context.Context, command CreateServic
 	if err != nil {
 		return CreateServiceSegmentResult{}, err
 	}
-	envelope := s.newEnvelope("ServicePlanChanged", command.CorrelationID, command.CausationID, payload)
+	envelope := s.newEnvelope(ctx, "ServicePlanChanged", command.CorrelationID, command.CausationID, payload)
 
 	if err := s.within(ctx, func(txCtx context.Context) error {
 		if s.repository != nil {
@@ -491,8 +491,8 @@ func (s *Service) flushPendingEvents(ctx context.Context) error {
 	}
 }
 
-func (s *Service) newEnvelope(eventType, correlationID, causationID string, payload []byte) EventEnvelope {
-	options := []kitmsg.EnvelopeOptions{{Now: s.now().UTC()}}
+func (s *Service) newEnvelope(ctx context.Context, eventType, correlationID, causationID string, payload []byte) EventEnvelope {
+	options := []kitmsg.EnvelopeOptions{{Now: s.now().UTC(), Context: ctx}}
 	if strings.TrimSpace(causationID) != "" {
 		options[0].CausationID = causationID
 	}

--- a/services/supplier-catalog/internal/application/service.go
+++ b/services/supplier-catalog/internal/application/service.go
@@ -170,7 +170,7 @@ func (s *Service) RegisterSupplier(ctx context.Context, cmd RegisterSupplierComm
 		s.mu.Unlock()
 	}
 
-	envelopes := wrapDomainEvents(events, cmd.CorrelationID, cmd.CausationID)
+	envelopes := wrapDomainEvents(ctx, events, cmd.CorrelationID, cmd.CausationID)
 	if err := s.persistAndPublish(ctx, func(txCtx context.Context) error {
 		if s.repository != nil {
 			return s.repository.SaveSupplier(txCtx, supplier)
@@ -279,7 +279,7 @@ func (s *Service) RegisterCarrier(ctx context.Context, cmd RegisterCarrierComman
 		s.mu.Unlock()
 	}
 
-	envelopes := wrapDomainEvents(events, cmd.CorrelationID, cmd.CausationID)
+	envelopes := wrapDomainEvents(ctx, events, cmd.CorrelationID, cmd.CausationID)
 	if err := s.persistAndPublish(ctx, func(txCtx context.Context) error {
 		if s.repository != nil {
 			return s.repository.SaveCarrier(txCtx, carrier)
@@ -361,7 +361,7 @@ func (s *Service) ActivateContract(ctx context.Context, cmd ActivateContractComm
 		s.mu.Unlock()
 	}
 
-	envelopes := wrapDomainEvents(events, cmd.CorrelationID, cmd.CausationID)
+	envelopes := wrapDomainEvents(ctx, events, cmd.CorrelationID, cmd.CausationID)
 	if err := s.persistAndPublish(ctx, func(txCtx context.Context) error {
 		if s.repository != nil {
 			return s.repository.SaveContract(txCtx, contract)
@@ -441,10 +441,10 @@ func (s *Service) flushPendingEvents(ctx context.Context) error {
 	}
 }
 
-func wrapDomainEvents(events []interface{}, correlationID, causationID string) []EventEnvelope {
+func wrapDomainEvents(ctx context.Context, events []interface{}, correlationID, causationID string) []EventEnvelope {
 	envelopes := make([]EventEnvelope, 0, len(events))
 	for _, event := range events {
-		envelope, err := WrapDomainEvent(event, correlationID, causationID)
+		envelope, err := WrapDomainEvent(ctx, event, correlationID, causationID)
 		if err == nil {
 			envelopes = append(envelopes, envelope)
 		}
@@ -452,12 +452,12 @@ func wrapDomainEvents(events []interface{}, correlationID, causationID string) [
 	return envelopes
 }
 
-func WrapDomainEvent(event interface{}, correlationID, causationID string) (EventEnvelope, error) {
-	options := []kitmsg.EnvelopeOptions{}
+func WrapDomainEvent(ctx context.Context, event interface{}, correlationID, causationID string) (EventEnvelope, error) {
+	option := kitmsg.EnvelopeOptions{Context: ctx}
 	if strings.TrimSpace(causationID) != "" {
-		options = append(options, kitmsg.EnvelopeOptions{CausationID: causationID})
+		option.CausationID = causationID
 	}
-	return kitmsg.NewEventEnvelope(eventType(event), producerName, correlationID, event, options...)
+	return kitmsg.NewEventEnvelope(eventType(event), producerName, correlationID, event, option)
 }
 
 func newUUIDString() string                      { return ids.NewUUIDv7() }

--- a/services/supplier-catalog/internal/application/service_test.go
+++ b/services/supplier-catalog/internal/application/service_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/trainticket/greenfield/services/supplier-catalog/internal/domain"
 )
 
@@ -48,7 +50,7 @@ func (r failingRepository) FindContractByRef(context.Context, string) (domain.Co
 }
 
 func TestWrapDomainEventProducesContractEnvelope(t *testing.T) {
-	envelope, err := WrapDomainEvent(domain.SupplierRegisteredEvent{SupplierID: "sup-1", LegalName: "Legal", BrandName: "Brand", Status: domain.SupplierStatusDraft}, "0194f2e0-7b3e-7610-0284-5c26e8b0c444", "0194f2e0-7b3e-7610-0284-5c26e8b0c555")
+	envelope, err := WrapDomainEvent(context.Background(), domain.SupplierRegisteredEvent{SupplierID: "sup-1", LegalName: "Legal", BrandName: "Brand", Status: domain.SupplierStatusDraft}, "0194f2e0-7b3e-7610-0284-5c26e8b0c444", "0194f2e0-7b3e-7610-0284-5c26e8b0c555")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,6 +68,20 @@ func TestWrapDomainEventProducesContractEnvelope(t *testing.T) {
 	}
 	if len(envelope.Payload) == 0 {
 		t.Fatalf("missing payload")
+	}
+	if envelope.Traceparent != "" {
+		t.Fatalf("traceparent must be absent without span context: %q", envelope.Traceparent)
+	}
+}
+
+func TestWrapDomainEventIncludesTraceparentFromContext(t *testing.T) {
+	ctx := trace.ContextWithSpanContext(context.Background(), mustSpanContext(t))
+	envelope, err := WrapDomainEvent(ctx, domain.SupplierRegisteredEvent{SupplierID: "sup-1", LegalName: "Legal", BrandName: "Brand", Status: domain.SupplierStatusDraft}, "0194f2e0-7b3e-7610-0284-5c26e8b0c444", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Traceparent != wantTraceparent {
+		t.Fatalf("traceparent mismatch: %q", envelope.Traceparent)
 	}
 }
 
@@ -103,4 +119,23 @@ func TestListSuppliersPropagatesRepositoryError(t *testing.T) {
 	if !errors.Is(err, boom) {
 		t.Fatalf("expected repository error, got %v", err)
 	}
+}
+
+const wantTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+func mustSpanContext(t *testing.T) trace.SpanContext {
+	t.Helper()
+	traceID, err := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spanID, err := trace.SpanIDFromHex("00f067aa0ba902b7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: spanID, TraceFlags: trace.FlagsSampled})
+	if !spanContext.IsValid() {
+		t.Fatal("invalid span context")
+	}
+	return spanContext
 }


### PR DESCRIPTION
## Summary
- Thread request/consumer context into Go service envelope creation funnels for fulfillment, provider-integration, service-plan, and supplier-catalog.
- Convert place-network outbox writes through the go-kit envelope with creation-time trace context capture.
- Add per-service positive traceparent tests plus no-span omission assertions.

## Validation
- for d in platform/go-kit services/fulfillment services/place-network services/provider-integration services/service-plan services/supplier-catalog; do (cd $d && go test ./...); done
- make check