### PR TITLE
REQ-109 add Jaeger trace backend

### DIFF
--- a/deploy/k8s/jaeger.yaml
+++ b/deploy/k8s/jaeger.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger
+  namespace: train-ticket
+  labels:
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/part-of: train-ticket
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: jaeger
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: jaeger
+        app.kubernetes.io/part-of: train-ticket
+    spec:
+      containers:
+        - name: jaeger
+          image: jaegertracing/all-in-one:1.57
+          imagePullPolicy: IfNotPresent
+          args:
+            - --memory.max-traces=20000
+          env:
+            - name: COLLECTOR_OTLP_ENABLED
+              value: "true"
+          ports:
+            - name: jaeger-otlp
+              containerPort: 4317
+            - name: ui
+              containerPort: 16686
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: ui
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: ui
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger
+  namespace: train-ticket
+  labels:
+    app.kubernetes.io/name: jaeger
+    app.kubernetes.io/part-of: train-ticket
+spec:
+  type: ClusterIP
+  ports:
+    - name: jaeger-otlp
+      port: 4317
+      targetPort: jaeger-otlp
+    - name: ui
+      port: 16686
+      targetPort: ui
+  selector:
+    app.kubernetes.io/name: jaeger

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - redis.yaml
   - mailpit.yaml
   - otel-collector.yaml
+  - jaeger.yaml
   - services.yaml

--- a/deploy/k8s/otel-collector.yaml
+++ b/deploy/k8s/otel-collector.yaml
@@ -32,6 +32,10 @@ data:
     exporters:
       debug:
         verbosity: basic
+      otlp/jaeger:
+        endpoint: jaeger:4317
+        tls:
+          insecure: true
 
     extensions:
       health_check:
@@ -55,6 +59,7 @@ data:
             - batch
           exporters:
             - debug
+            - otlp/jaeger
         metrics:
           receivers:
             - otlp

--- a/docs/07-observability/README.md
+++ b/docs/07-observability/README.md
@@ -14,10 +14,12 @@ depend on external infrastructure.
 - health extension on `13133`.
 - zPages extension on `55679`.
 - debug exporters for traces, metrics, and logs.
+- Jaeger OTLP exporter for traces, targeting `jaeger:4317`.
 
-The debug exporters are intentional for the greenfield baseline. They make local
-signal flow visible without requiring Jaeger, Prometheus, Loki, ClickHouse, or a
-vendor backend. Production deployment can replace or extend the exporters while
+The debug exporters are retained for local smoke checks and low-level signal
+flow visibility. Traces are also exported to Jaeger all-in-one so local compose
+and kind users can query captured spans without changing the service-side OTLP
+contract. Production deployment can replace or extend the exporters while
 preserving the same service-side OTLP contract.
 
 ## Local Runtime
@@ -46,7 +48,8 @@ Stop the local collector:
 make observability-down
 ```
 
-The compose file lives at `platform/observability/docker-compose.yaml`.
+The compose file lives at `platform/observability/docker-compose.yaml` and starts
+both the OpenTelemetry Collector and Jaeger all-in-one.
 
 ## kind Cluster Deployment
 
@@ -88,6 +91,33 @@ kubectl -n train-ticket logs deploy/otel-collector -f
 Seeing no spans immediately after this infrastructure change is expected: the
 collector and service-side environment contract are present, but service SDK
 exporters are not installed by this task.
+
+## Jaeger Trace Querying
+
+Jaeger all-in-one is included for local, queryable trace storage. It accepts
+collector-exported OTLP/gRPC traces on the in-cluster `jaeger:4317` service port
+and serves the Jaeger UI on port `16686`. The service-side contract does not
+change: services still send OTLP to the collector through the standard `OTEL_*`
+environment variables.
+
+Access the UI from a kind cluster with port-forwarding:
+
+```bash
+kubectl -n train-ticket port-forward svc/jaeger 16686:16686
+```
+
+Open <http://127.0.0.1:16686>, select `journey-order` in the Service field, and
+run a search after generating a purchase flow. The same query can be checked via
+the Jaeger API:
+
+```bash
+curl -fsS 'http://127.0.0.1:16686/api/traces?service=journey-order&limit=5'
+```
+
+A successful purchase-chain sample returns at least one trace in the `data`
+array. Jaeger is configured with in-memory storage and `--memory.max-traces=20000`;
+traces are intentionally non-persistent and disappear when the Jaeger pod or
+compose container is restarted.
 
 ## Service Contract
 

--- a/platform/observability/docker-compose.yaml
+++ b/platform/observability/docker-compose.yaml
@@ -12,4 +12,16 @@ services:
       - "${OTEL_HTTP_PORT:-4318}:4318"
       - "${OTEL_HEALTH_PORT:-13133}:13133"
       - "${OTEL_ZPAGES_PORT:-55679}:55679"
+    depends_on:
+      - jaeger
+    restart: unless-stopped
+
+  jaeger:
+    image: ${JAEGER_IMAGE:-jaegertracing/all-in-one:1.57}
+    command:
+      - --memory.max-traces=20000
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    ports:
+      - "${JAEGER_UI_PORT:-16686}:16686"
     restart: unless-stopped

--- a/platform/observability/otel-collector.yaml
+++ b/platform/observability/otel-collector.yaml
@@ -20,6 +20,10 @@ processors:
 exporters:
   debug:
     verbosity: basic
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
 
 extensions:
   health_check:
@@ -43,6 +47,7 @@ service:
         - batch
       exporters:
         - debug
+        - otlp/jaeger
     metrics:
       receivers:
         - otlp


### PR DESCRIPTION
## Summary
- Add Jaeger all-in-one Deployment/Service to the kind kustomization
- Export collector traces to Jaeger while preserving debug exporter and OTLP receiver contract
- Add Jaeger to local observability compose and document UI/API trace querying

## Validation
- make check
- make observability-config
- kubectl kustomize deploy/k8s
- make observability-validate (blocked: Docker daemon unavailable in sandbox)