### PR TITLE
REQ-106 waitlist API and event contracts

### DIFF
--- a/docs/08-contracts/api/waitlist.md
+++ b/docs/08-contracts/api/waitlist.md
@@ -1,0 +1,179 @@
+# Waitlist — HTTP API
+
+Last updated: 2026-07-08
+
+## Overview
+
+Waitlist manages candidate requests for unavailable or insufficient-capacity
+travel segments. This contract is scoped to the first activation wave for the
+future-scope Waitlist domain and is bounded by `docs/02-domains/waitlist.md`.
+
+Activation-wave rulings:
+
+- Fulfillment reuses the normal booking chain. When Waitlist consumes a matching
+  `CapacityReleased` event for the head of the queue, it acts as a client of the
+  existing `POST /api/v1/journey-orders` contract with a deterministic
+  idempotency key derived from the waitlist request and triggering release. The
+  existing journey-order saga owns booking, capacity hold, payment capture, and
+  ticketing. Waitlist then consumes `JourneyOrderConfirmed` and
+  `JourneyOrderCancelled` to move the request to `FULFILLED` or back to
+  `QUEUED`.
+- Direct `AuthorizeWaitlistHold` calls to Capacity & Availability are a future
+  note only in this activation wave. Capacity & Availability contracts are not
+  changed by Waitlist.
+- Payment guarantee is represented by the required reference field
+  `paymentGuaranteeRef`. The value MUST either start with `pay-auth-` or be an
+  existing `paymentIntentId` (`pi-<uuid>`). Real pre-authorization closure is
+  deferred to later wallet-promotion/payment work.
+- Mutual-exclusion invariant: for the same `(travelerRef, intentFingerprint)`,
+  at most one active request may exist. Active statuses are `DRAFT`, `QUEUED`,
+  `MATCHING`, and `SUSPENDED`.
+
+Field shapes reference `docs/08-contracts/shared-primitives.md` for IDs,
+timestamps, event envelope fields, and pagination conventions. All timestamps
+are RFC3339 UTC. JSON fields are camelCase and enum values are
+SCREAMING_SNAKE_CASE.
+
+## Status enum
+
+The wire status enum is the 8-state machine from the Waitlist domain document:
+
+| Status | Meaning | Allowed next statuses |
+|---|---|---|
+| `DRAFT` | User is selecting or confirming the waitlist plan. | `QUEUED`, `CANCELLED` |
+| `QUEUED` | Request is in the waitlist queue. | `MATCHING`, `EXPIRED`, `CANCELLED`, `SUSPENDED` |
+| `MATCHING` | Released capacity was observed and Waitlist is attempting fulfillment through the normal journey-order chain. | `FULFILLED`, `QUEUED` |
+| `FULFILLED` | Request was successfully fulfilled and entered booking through journey-order. | `CLOSED` |
+| `EXPIRED` | Deadline elapsed before fulfillment. | `CLOSED` |
+| `CANCELLED` | User or business cancellation. | `CLOSED` |
+| `SUSPENDED` | Payment guarantee, risk, or data issue paused the request. | `QUEUED`, `CANCELLED` |
+| `CLOSED` | Terminal archival state. | - |
+
+No `FAILED` status is exposed in this contract; a failed matching attempt rolls
+back to `QUEUED` when the associated journey order is cancelled.
+
+## Resource representation
+
+`WaitlistRequest` responses use the following fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `waitlistRequestId` | string | yes | Canonical waitlist request ID (`wlr-<uuid>`). |
+| `travelerRef` | string | yes | Traveler reference (`tvl-<uuid>`). |
+| `segmentRef` | string | yes | Requested service segment reference. |
+| `travelClass` | string | no | Requested travel class/seat class when specified by the candidate plan. |
+| `deadline` | RFC3339 UTC | yes | Latest time the request may be fulfilled. |
+| `paymentGuaranteeRef` | string | yes | Payment guarantee reference; MUST start with `pay-auth-` or be an existing `paymentIntentId` (`pi-<uuid>`). |
+| `intentFingerprint` | string | yes | Stable fingerprint of the mutually exclusive travel intent. Used with `travelerRef` to enforce the active-request invariant. |
+| `status` | enum | yes | One of `DRAFT`, `QUEUED`, `MATCHING`, `FULFILLED`, `EXPIRED`, `CANCELLED`, `SUSPENDED`, `CLOSED`. |
+
+## Endpoints
+
+### Create Waitlist Request
+
+**POST** `/api/v1/waitlist-requests`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header). Replays with the same body
+return the original response. Reusing the same key with a different body returns
+`IDEMPOTENCY_KEY_REUSED`.
+
+The request creates a WaitlistRequest from the user-confirmed candidate plan. In
+this activation wave the service validates `paymentGuaranteeRef` as a reference
+only; it does not call Payment to create or close a real pre-authorization.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `travelerRef` | string | yes | Traveler reference (`tvl-<uuid>`). |
+| `segmentRef` | string | yes | Requested segment reference. |
+| `travelClass` | string | no | Requested travel class/seat class. |
+| `deadline` | RFC3339 UTC | yes | Latest fulfillment time; must be in the future at creation. |
+| `paymentGuaranteeRef` | string | yes | Required guarantee reference; MUST start with `pay-auth-` or be an existing `paymentIntentId` (`pi-<uuid>`). |
+| `intentFingerprint` | string | yes | Stable mutual-exclusion key for the requested travel intent. |
+
+**Response (201):** `WaitlistRequest` resource.
+
+**Domain effects:** emits `WaitlistRequestCreated`, then internally proceeds to
+payment-guarantee reference validation and queueing
+(`WaitlistPaymentAuthorizationRequested`, `WaitlistQueued`) when the request can
+be queued.
+
+**Error codes:** `VALIDATION_FAILED`, `CONFLICT`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+- `CONFLICT` is returned when `(travelerRef, intentFingerprint)` already has an
+  active request (`DRAFT`, `QUEUED`, `MATCHING`, or `SUSPENDED`).
+- `DOMAIN_RULE_VIOLATION` is returned when the deadline or payment guarantee
+  reference violates Waitlist invariants.
+
+### Get Waitlist Request
+
+**GET** `/api/v1/waitlist-requests/{waitlistRequestId}`
+
+**Response (200):** `WaitlistRequest` resource.
+
+**Error codes:** `NOT_FOUND`
+
+### List Waitlist Requests by Traveler
+
+**GET** `/api/v1/waitlist-requests?travelerRef={travelerRef}&limit=20&offset=0`
+
+`travelerRef` is required for list queries. Broad unfiltered listing is not part
+of this activation-wave API.
+
+**Query parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `travelerRef` | string | yes | Traveler reference (`tvl-<uuid>`). |
+| `status` | enum | no | Optional status filter using the 8-state enum above. |
+| `limit` | integer | no | Pagination limit, default 20, max 100. |
+| `offset` | integer | no | Pagination offset, default 0. |
+
+**Response (200):** Paginated response with `items`, `total`, `limit`, and
+`offset`, where each item is a `WaitlistRequest` resource.
+
+**Error codes:** `VALIDATION_FAILED`
+
+### Cancel Waitlist Request
+
+**POST** `/api/v1/waitlist-requests/{waitlistRequestId}/cancel`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header).
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reason` | string | yes | User or business cancellation reason. Do not include unmasked documents or other sensitive personal data. |
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `waitlistRequestId` | string | Waitlist request ID. |
+| `status` | enum | `CANCELLED` |
+| `cancelledAt` | RFC3339 UTC | Cancellation timestamp. |
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`
+
+- `PRECONDITION_FAILED` is returned when the request is already terminal
+  (`FULFILLED`, `EXPIRED`, `CANCELLED`, or `CLOSED`) and cannot be cancelled.
+
+## Bus-only behavior
+
+The following domain commands from `docs/02-domains/waitlist.md` have no public
+HTTP endpoint in this activation wave:
+
+- `AuthorizeWaitlistPayment` — validates/records the required
+  `paymentGuaranteeRef`; no Payment call is made in this wave.
+- `EnqueueWaitlist` — places a valid request into its queue partition.
+- `MatchReleasedCapacity` — triggered by consuming `CapacityReleased` from
+  `events:capacity-availability`.
+- `AuthorizeWaitlistHold` — future note only; direct Capacity command is not
+  implemented in this wave.
+- `FulfillWaitlist` — triggered by consuming `JourneyOrderConfirmed` from
+  `events:journey-order` for the order started by Waitlist.
+- `ExpireWaitlist` — triggered by the request `deadline`.

--- a/docs/08-contracts/events/waitlist.md
+++ b/docs/08-contracts/events/waitlist.md
@@ -1,0 +1,257 @@
+# Waitlist — Events & Commands
+
+Last updated: 2026-07-08
+
+## Scope and activation-wave rulings
+
+This contract enumerates exactly the Waitlist events listed in
+`docs/02-domains/waitlist.md` and does not add extra domain events.
+
+Activation-wave rulings:
+
+- Fulfillment reuses the normal journey-order chain. Waitlist consumes
+  `CapacityReleased` for a matching head-of-queue request, calls the existing
+  `POST /api/v1/journey-orders` API with a deterministic idempotency key, and
+  then consumes `JourneyOrderConfirmed` or `JourneyOrderCancelled` to advance to
+  `FULFILLED` or return to `QUEUED`.
+- `AuthorizeWaitlistHold` and `WaitlistHoldAuthorized` are documented because
+  they are in the domain command/event table, but direct Capacity & Availability
+  hold authorization is future-scope for this activation wave. Capacity &
+  Availability publishes no new Waitlist-specific events and accepts no new
+  Waitlist command in this wave.
+- Payment guarantee is a required reference field, `paymentGuaranteeRef`, whose
+  value starts with `pay-auth-` or is an existing `paymentIntentId` (`pi-<uuid>`).
+  Real pre-authorization closure is deferred to later payment work.
+- Mutual exclusion is enforced by Waitlist: the same
+  `(travelerRef, intentFingerprint)` may have at most one active request in
+  `DRAFT`, `QUEUED`, `MATCHING`, or `SUSPENDED`.
+
+All payload fields are camelCase, all enum values are SCREAMING_SNAKE_CASE, and
+all timestamps are RFC3339 UTC. Envelope fields, including optional trace
+context propagation, follow `docs/08-contracts/messaging.md` and
+`docs/08-contracts/shared-primitives.md`.
+
+## Event identity and idempotency
+
+Waitlist producers MUST assign deterministic event IDs per aggregate transition
+so that retries do not create duplicate facts. The event ID seed is:
+
+```
+waitlist:<eventType>:<waitlistRequestId>:<aggregateVersion>
+```
+
+where `aggregateVersion` is the version after applying the transition. If the
+same command or consumed upstream event is replayed, the same transition emits
+the same `eventId`; if no new transition is applied, no new event is emitted.
+Consumers still deduplicate by envelope `eventId`.
+
+## Status enum
+
+Waitlist event payloads use the same 8-state enum as the HTTP API:
+`DRAFT`, `QUEUED`, `MATCHING`, `FULFILLED`, `EXPIRED`, `CANCELLED`,
+`SUSPENDED`, `CLOSED`.
+
+## Published Events
+
+### WaitlistRequestCreated
+
+| Field | Description |
+|---|---|
+| **Producer** | waitlist |
+| **Consumers** | reporting |
+| **Trigger** | `CreateWaitlistRequest` command accepted for a user-confirmed waitlist candidate plan. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `waitlistRequestId` | string | yes | Canonical waitlist request ID (`wlr-<uuid>`). |
+| `travelerRef` | string | yes | Traveler reference (`tvl-<uuid>`). |
+| `segmentRef` | string | yes | Requested segment reference. |
+| `travelClass` | string | no | Requested travel class/seat class when specified. |
+| `deadline` | RFC3339 UTC | yes | Latest fulfillment time. |
+| `paymentGuaranteeRef` | string | yes | Required guarantee reference (`pay-auth-*` or `pi-<uuid>`). |
+| `intentFingerprint` | string | yes | Stable mutual-exclusion key for the travel intent. |
+| `status` | enum | yes | `DRAFT`. |
+| `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
+
+### WaitlistPaymentAuthorizationRequested
+
+| Field | Description |
+|---|---|
+| **Producer** | waitlist |
+| **Consumers** | reporting |
+| **Trigger** | `AuthorizeWaitlistPayment` command records the required payment guarantee reference. In this activation wave this is reference validation only, not a Payment pre-authorization call. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `waitlistRequestId` | string | yes | Waitlist request ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `paymentGuaranteeRef` | string | yes | Guarantee reference (`pay-auth-*` or `pi-<uuid>`). |
+| `requestedAt` | RFC3339 UTC | yes | Time the guarantee reference was recorded for the request. |
+| `status` | enum | yes | Current request status after recording the reference; normally `DRAFT` before queueing or `SUSPENDED` if validation cannot proceed. |
+
+### WaitlistQueued
+
+| Field | Description |
+|---|---|
+| **Producer** | waitlist |
+| **Consumers** | notification, reporting |
+| **Trigger** | `EnqueueWaitlist` command places a valid request into its queue partition, or a previously matching request returns to the queue after the associated journey order is cancelled. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `waitlistRequestId` | string | yes | Waitlist request ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | yes | Segment whose queue partition contains the request. |
+| `travelClass` | string | no | Requested travel class/seat class when specified. |
+| `intentFingerprint` | string | yes | Mutual-exclusion key. |
+| `queuedAt` | RFC3339 UTC | yes | Time the request entered or re-entered the queue. |
+| `status` | enum | yes | `QUEUED`. |
+| `journeyOrderRef` | string | no | Associated `ord-<uuid>` when re-queueing after `JourneyOrderCancelled`. |
+
+### WaitlistMatchStarted
+
+| Field | Description |
+|---|---|
+| **Producer** | waitlist |
+| **Consumers** | reporting |
+| **Trigger** | `MatchReleasedCapacity` command consumes a matching `CapacityReleased` event for the head of the queue and starts fulfillment through the normal journey-order chain. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `waitlistRequestId` | string | yes | Waitlist request ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | yes | Segment being matched. |
+| `travelClass` | string | no | Requested travel class/seat class when specified. |
+| `matchedCapacityReleaseRef` | string | yes | Envelope `eventId` of the consumed `CapacityReleased` fact that triggered matching. |
+| `journeyOrderIdempotencyKey` | string | yes | Deterministic idempotency key used when Waitlist posts to `POST /api/v1/journey-orders`. |
+| `startedAt` | RFC3339 UTC | yes | Matching start timestamp. |
+| `status` | enum | yes | `MATCHING`. |
+
+### WaitlistHoldAuthorized
+
+| Field | Description |
+|---|---|
+| **Producer** | waitlist |
+| **Consumers** | reporting |
+| **Trigger** | `AuthorizeWaitlistHold` command succeeds. Future-scope in this activation wave; direct Capacity & Availability hold authorization is not produced now. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `waitlistRequestId` | string | yes | Waitlist request ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | yes | Segment for which a waitlist hold was authorized. |
+| `travelClass` | string | no | Requested travel class/seat class when specified. |
+| `authorizedAt` | RFC3339 UTC | yes | Hold authorization timestamp. |
+| `status` | enum | yes | `MATCHING`. |
+
+### WaitlistFulfilled
+
+| Field | Description |
+|---|---|
+| **Producer** | waitlist |
+| **Consumers** | notification, reporting |
+| **Trigger** | `FulfillWaitlist` command consumes `JourneyOrderConfirmed` for the journey order started by Waitlist. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `waitlistRequestId` | string | yes | Waitlist request ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | yes | Fulfilled segment reference. |
+| `travelClass` | string | no | Requested travel class/seat class when specified. |
+| `journeyOrderRef` | string | yes | Confirmed journey order ID (`ord-<uuid>`). |
+| `fulfilledAt` | RFC3339 UTC | yes | Fulfillment timestamp. |
+| `status` | enum | yes | `FULFILLED`. |
+
+Notification consumes this event for the waitlist-success user touchpoint.
+
+### WaitlistCancelled
+
+| Field | Description |
+|---|---|
+| **Producer** | waitlist |
+| **Consumers** | notification, reporting |
+| **Trigger** | `CancelWaitlist` command cancels an active waitlist request. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `waitlistRequestId` | string | yes | Waitlist request ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | yes | Cancelled segment reference. |
+| `travelClass` | string | no | Requested travel class/seat class when specified. |
+| `cancelledAt` | RFC3339 UTC | yes | Cancellation timestamp. |
+| `reason` | string | yes | User or business cancellation reason; do not include unmasked documents or other sensitive personal data. |
+| `status` | enum | yes | `CANCELLED`. |
+
+Notification consumes this event for the waitlist-cancelled user touchpoint.
+
+### WaitlistExpired
+
+| Field | Description |
+|---|---|
+| **Producer** | waitlist |
+| **Consumers** | notification, reporting |
+| **Trigger** | `ExpireWaitlist` command runs when `deadline` is reached before fulfillment. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `waitlistRequestId` | string | yes | Waitlist request ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | yes | Expired segment reference. |
+| `travelClass` | string | no | Requested travel class/seat class when specified. |
+| `deadline` | RFC3339 UTC | yes | Deadline that elapsed. |
+| `expiredAt` | RFC3339 UTC | yes | Expiry processing timestamp. |
+| `status` | enum | yes | `EXPIRED`. |
+
+Notification consumes this event for the waitlist-expired user touchpoint.
+
+## Accepted Commands
+
+The command list is the domain command/event table from
+`docs/02-domains/waitlist.md`.
+
+| Command | Sender / Trigger | Produced event |
+|---|---|---|
+| `CreateWaitlistRequest` | API gateway / UI via `POST /api/v1/waitlist-requests` | `WaitlistRequestCreated` |
+| `AuthorizeWaitlistPayment` | Waitlist application flow after create; reference-only in this wave | `WaitlistPaymentAuthorizationRequested` |
+| `EnqueueWaitlist` | Waitlist application flow after guarantee reference validation, or requeue after `JourneyOrderCancelled` | `WaitlistQueued` |
+| `MatchReleasedCapacity` | Waitlist consumer of `CapacityReleased` from `events:capacity-availability` | `WaitlistMatchStarted` |
+| `AuthorizeWaitlistHold` | Future-scope direct hold authorization | `WaitlistHoldAuthorized` |
+| `FulfillWaitlist` | Waitlist consumer of `JourneyOrderConfirmed` from `events:journey-order` | `WaitlistFulfilled` |
+| `CancelWaitlist` | API gateway / UI via `POST /api/v1/waitlist-requests/{waitlistRequestId}/cancel` or business cancellation | `WaitlistCancelled` |
+| `ExpireWaitlist` | Waitlist scheduler at `deadline` | `WaitlistExpired` |
+
+## Consumed upstream events
+
+| Upstream stream | Event type | Purpose |
+|---|---|---|
+| `events:capacity-availability` | `CapacityReleased` | Find a matching head-of-queue request and start normal journey-order fulfillment. |
+| `events:journey-order` | `JourneyOrderConfirmed` | Mark the matching request `FULFILLED`. |
+| `events:journey-order` | `JourneyOrderCancelled` | Return the matching request to `QUEUED` instead of introducing a new failure event. |
+
+## Notification touchpoints
+
+Notification consumes Waitlist events only for the four touchpoint classes below;
+reporting consumes all Waitlist events for metrics and audit read models.
+
+| Touchpoint class | Event source |
+|---|---|
+| Success | `WaitlistFulfilled` |
+| Failure / unable-to-complete matching | `WaitlistQueued` when re-queued after `JourneyOrderCancelled` |
+| Expired | `WaitlistExpired` |
+| Cancelled | `WaitlistCancelled` |

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -70,6 +70,7 @@ context.
 | 21 | `reporting` | `events:reporting` | MetricDefined, MetricVersionPublished, ReadModelRebuilt |
 | 21b | `legacy-acl` | `events:legacy-acl` | LegacyCommandMapped |
 | 22 | `supplier-catalog` | `events:supplier-catalog` | SupplierRegistered, CarrierRegistered, ContractActivated, ContractSuspended, ProductCapabilityDeclared, ExternalCodeMapped |
+| 23 | `waitlist` | `events:waitlist` | WaitlistRequestCreated, WaitlistPaymentAuthorizationRequested, WaitlistQueued, WaitlistMatchStarted, WaitlistHoldAuthorized, WaitlistFulfilled, WaitlistCancelled, WaitlistExpired |
 
 ### Dead-Letter Streams
 
@@ -269,6 +270,10 @@ plus notification/finance/reporting fan-in.
 | 46 | `events:admin-audit` | `customer-service` | RULING (2026-07-06): ManualActionExecuted/ManualActionRejected outcomes recorded on the support case timeline (ManualActionResultRecorded) |
 | 47 | `events:account` | `journey-order` | RULING (2026-07-06): AccountFrozen/AccountUnfrozen/AccountClosed gate order creation — frozen or closed accounts cannot place orders |
 | 48 | `events:legacy-acl` | `admin-audit` | RULING (2026-07-07): LegacyCommandMapped recorded as audit entries (DR-014 audit reference) |
+| 49 | `events:capacity-availability` | `waitlist` | CapacityReleased starts head-of-queue matching for candidate waitlist requests |
+| 50 | `events:journey-order` | `waitlist` | JourneyOrderConfirmed/JourneyOrderCancelled advance a matching request to FULFILLED or return it to QUEUED |
+| 51 | `events:waitlist` | `notification` | Waitlist success, failure/requeue, expiry, and cancellation user touchpoints |
+| 52 | `events:waitlist` | `reporting` | Waitlist lifecycle metrics and read models |
 
 ### Cross-Cutting Consumers
 
@@ -279,7 +284,7 @@ analytics, and cross-cutting concerns:
 |---|---|---|
 | `reporting` | All `events:*` streams | Business metrics, funnel analysis, operational dashboards |
 | `finance-settlement` | `events:payment`, `events:provider-integration`, `events:booking-orchestration`, `events:post-sales` | Revenue recognition, reconciliation, invoice generation |
-| `notification` | `events:journey-order`, `events:booking-orchestration`, `events:payment`, `events:entitlement-ticketing`, `events:post-sales` | User-facing notification triggers |
+| `notification` | `events:journey-order`, `events:booking-orchestration`, `events:payment`, `events:entitlement-ticketing`, `events:post-sales`, `events:waitlist` | User-facing notification triggers |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add waitlist HTTP API contract for create/get/list/cancel with 8-state enum and activation-wave rulings
- Add waitlist event contract covering the 8 domain events from docs/02-domains/waitlist.md
- Register events:waitlist and waitlist subscriptions in messaging.md

## Validation
- make check