### PR TITLE
docs: add wallet promotion contracts

### DIFF
--- a/docs/08-contracts/README.md
+++ b/docs/08-contracts/README.md
@@ -36,6 +36,7 @@ docs/08-contracts/
     ├── place-network.md
     ├── waitlist.md
     ├── dispatch.md
+    ├── wallet-promotion.md
     └── finance-settlement-events.md
 ```
 

--- a/docs/08-contracts/api/README.md
+++ b/docs/08-contracts/api/README.md
@@ -149,8 +149,9 @@ correlation IDs.
 | 20 | `customer-service.md` | Customer Service | typescript |
 | 21 | `finance-settlement.md` | Finance & Settlement | java |
 | 22 | `reporting.md` | Reporting | python |
-| 23 | `waitlist.md` | Waitlist | deferred |
-| 24 | `dispatch.md` | Dispatch | deferred |
+| 23 | `waitlist.md` | Waitlist | rust (activated, ADR-0002) |
+| 24 | `dispatch.md` | Dispatch | activation wave in progress |
+| 25 | `wallet-promotion.md` | Wallet / Promotion | activation wave in progress |
 
 ## Open Issues
 

--- a/docs/08-contracts/api/wallet-promotion.md
+++ b/docs/08-contracts/api/wallet-promotion.md
@@ -1,0 +1,371 @@
+# Wallet / Promotion — HTTP API
+
+Last updated: 2026-07-08
+
+## Overview
+
+Wallet / Promotion owns non-cash benefits: promotion instruments, the per-account
+wallet balance ledger, and idempotent benefit redemption. This contract is scoped
+to the ADR-0002 second activation wave and is bounded by
+`docs/02-domains/wallet-promotion.md`.
+
+Activation-wave rulings:
+
+- This wave delivers the full `PromotionInstrument` lifecycle and the per-account
+  `WalletAccount` balance ledger. Points and stored value are represented as
+  balance sub-ledgers with monetary `Money` values (`currency` + integer
+  `minorUnits`); there is no decimal or floating-point money on the wire.
+- `BenefitRedemption` is idempotent. The same benefit and the same
+  `businessReason` MUST NOT produce duplicate redemption effects. A replay of an
+  equivalent redemption returns the original redemption result; a different
+  amount or reference for the same idempotency key returns
+  `IDEMPOTENCY_KEY_REUSED`, and a conflicting same-reason redemption returns
+  `CONFLICT`.
+- Combination payment is not delivered in this wave. Payment contracts are not
+  changed. Future note: a later wave will define the "cash remaining payable"
+  interface between Wallet / Promotion and Payment.
+- Finance Settlement and Notification are event consumers at the contract
+  surface, but their concrete consumption implementations are deferred to a
+  later wave.
+- Issuance sources supported in this wave are `MANUAL_OPS` and
+  `POST_SALES_COMP`. Post-sales compensation is carried by the issuance request
+  as `caseId`; the Post Sales contract is not changed and Wallet / Promotion
+  does not subscribe to a Post Sales stream in this wave.
+
+Field shapes reference `docs/08-contracts/shared-primitives.md` for IDs,
+timestamps, event envelope fields, pagination conventions, and `Money`. All
+timestamps are RFC3339 UTC. JSON fields are camelCase and enum values are
+SCREAMING_SNAKE_CASE.
+
+## Status enum
+
+The wire status enum is the seven-state `PromotionInstrument` state machine from
+the Wallet / Promotion domain document:
+
+| Status | Meaning | Allowed next statuses |
+|---|---|---|
+| `ISSUED` | Benefit has been issued and is available for use. | `RESERVED`, `REDEEMED`, `EXPIRED`, `REVOKED` |
+| `RESERVED` | Benefit value is temporarily frozen for an order, post-sales case, or other business use. | `REDEEMED`, `RELEASED`, `EXPIRED` |
+| `REDEEMED` | Benefit has been consumed. | `REVERSED` |
+| `RELEASED` | A previous reservation was released and value is available again. | `RESERVED`, `REDEEMED`, `EXPIRED` |
+| `EXPIRED` | Validity window elapsed before use. | - |
+| `REVOKED` | Issued benefit was administratively or commercially revoked. | - |
+| `REVERSED` | A previous redemption was reversed by a compensating business action. | - |
+
+`EXPIRED`, `REVOKED`, and `REVERSED` are terminal. `ExpireBenefit` is scheduler
+or domain-policy driven and has no public HTTP endpoint in this wave.
+
+## Wallet balance invariants
+
+A `WalletAccount` is the per-account ledger view for benefit balances.
+
+- Each balance mutation MUST carry a non-empty `businessReason`.
+- Available and reserved/frozen balances MUST never be negative:
+  `availableBalance.minorUnits >= 0` and `reservedBalance.minorUnits >= 0` for
+  every `(accountId, balanceType, currency)` sub-ledger.
+- Money arithmetic MUST reject cross-currency operations at the domain boundary.
+- Every mutation appends a ledger entry and increments the affected aggregate
+  version. Consumers should use the event envelope `eventId` for deduplication.
+
+## Common enums
+
+| Enum | Values |
+|---|---|
+| `benefitType` | `BALANCE`, `COUPON`, `COMPENSATION_CREDIT`, `POINTS` |
+| `balanceType` | `STORED_VALUE`, `POINTS`, `PROMOTION_CREDIT` |
+| `issuanceSource` | `MANUAL_OPS`, `POST_SALES_COMP` |
+| `businessReason.reasonType` | `MANUAL_OPS`, `POST_SALES_COMP`, `ORDER_PURCHASE`, `RESERVATION_TIMEOUT`, `CUSTOMER_SERVICE_ADJUSTMENT`, `SYSTEM_EXPIRY`, `REVERSAL` |
+
+`businessReason` is the cross-command audit reason object:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reasonType` | enum | yes | SCREAMING_SNAKE_CASE reason type from the table above. |
+| `reasonCode` | string | yes | Stable business code such as `GOODWILL_COMP` or `ORDER_BENEFIT_USE`. |
+| `referenceType` | string | no | Referenced object class, for example `ORDER`, `POST_SALES_CASE`, `MANUAL_ACTION`, or `SCHEDULER_JOB`. |
+| `referenceId` | string | no | Referenced aggregate or case ID. Use `caseId` for `POST_SALES_COMP` issuance without changing the Post Sales contract. |
+| `description` | string | no | Human-readable operational reason. Do not include unmasked documents or other sensitive personal data. |
+
+## Resource representations
+
+### PromotionInstrument
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `benefitId` | string | yes | Canonical benefit ID (`ben-<uuid>`). |
+| `accountId` | string | yes | Account that owns the benefit. |
+| `walletAccountId` | string | yes | Wallet account ledger ID (`wac-<uuid>`). |
+| `benefitType` | enum | yes | One of `BALANCE`, `COUPON`, `COMPENSATION_CREDIT`, `POINTS`. |
+| `balanceType` | enum | yes | Ledger bucket affected by this benefit. |
+| `status` | enum | yes | One of the seven statuses above. |
+| `issuedAmount` | Money | yes | Original issued value. |
+| `availableAmount` | Money | yes | Currently available amount; never negative. |
+| `reservedAmount` | Money | yes | Currently frozen amount; never negative. |
+| `redeemedAmount` | Money | yes | Amount already redeemed. |
+| `issuanceSource` | enum | yes | `MANUAL_OPS` or `POST_SALES_COMP`. |
+| `caseId` | string | no | Post-sales case reference when `issuanceSource` is `POST_SALES_COMP`. |
+| `applicableScope` | object | yes | Scope/rules for eligibility. See `ApplicableScope`. |
+| `redemptionRule` | object | yes | Redemption rule such as single-use and maximum amount. See `RedemptionRule`. |
+| `revocationRule` | object | yes | Revocation rule for allowed administrative/business revoke conditions. |
+| `validFrom` | RFC3339 UTC | yes | Start of validity window. |
+| `validUntil` | RFC3339 UTC | yes | End of validity window. |
+| `businessReason` | object | yes | Reason for the latest state or balance change. |
+| `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
+| `updatedAt` | RFC3339 UTC | yes | Last mutation timestamp. |
+| `version` | integer | yes | Aggregate version after the latest mutation. |
+
+`ApplicableScope`:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `scopeType` | enum | yes | `ANY_TRIP`, `ORDER`, `POST_SALES_CASE`, `SERVICE_SEGMENT`, or `PRODUCT_CATEGORY`. |
+| `referenceIds` | array[string] | no | Optional IDs constraining the scope. |
+| `currency` | string | yes | ISO-4217 currency for monetary benefits. |
+
+`RedemptionRule`:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `singleUse` | boolean | yes | If true, the first successful redemption moves the benefit to `REDEEMED`. |
+| `maxRedemptionAmount` | Money | no | Maximum redeemable value for one redemption. |
+| `requiresReservation` | boolean | yes | Whether `ReserveBenefit` must precede redemption. |
+
+### WalletAccount
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `walletAccountId` | string | yes | Wallet account ID (`wac-<uuid>`). |
+| `accountId` | string | yes | Owning Account context ID. |
+| `balances` | array[WalletBalance] | yes | Per `(balanceType, currency)` sub-ledger balances. |
+| `lastLedgerEntryId` | string | no | Last applied ledger entry (`wle-<uuid>`). |
+| `updatedAt` | RFC3339 UTC | yes | Last ledger update timestamp. |
+| `version` | integer | yes | Wallet account aggregate version. |
+
+`WalletBalance`:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `balanceType` | enum | yes | `STORED_VALUE`, `POINTS`, or `PROMOTION_CREDIT`. |
+| `availableBalance` | Money | yes | Available amount; `minorUnits` MUST be non-negative. |
+| `reservedBalance` | Money | yes | Frozen amount; `minorUnits` MUST be non-negative. |
+| `redeemedBalance` | Money | yes | Cumulative redeemed amount. |
+
+## Endpoints
+
+### Issue Benefit
+
+**POST** `/api/v1/benefits`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header). Replays with the same body
+return the original response. Reusing the same key with a different body returns
+`IDEMPOTENCY_KEY_REUSED`.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `accountId` | string | yes | Account receiving the benefit. |
+| `benefitType` | enum | yes | `BALANCE`, `COUPON`, `COMPENSATION_CREDIT`, or `POINTS`. |
+| `balanceType` | enum | yes | Wallet sub-ledger to credit. |
+| `amount` | Money | yes | Issued amount. `minorUnits` must be positive. |
+| `issuanceSource` | enum | yes | `MANUAL_OPS` or `POST_SALES_COMP`. |
+| `caseId` | string | no | Required when `issuanceSource` is `POST_SALES_COMP`; ignored otherwise. |
+| `applicableScope` | object | yes | Eligibility scope. |
+| `redemptionRule` | object | yes | Redemption rule. |
+| `revocationRule` | object | yes | Revocation rule. |
+| `validFrom` | RFC3339 UTC | yes | Start of validity window. |
+| `validUntil` | RFC3339 UTC | yes | End of validity window; must be after `validFrom`. |
+| `businessReason` | object | yes | Business reason for issuance. |
+
+**Response (201):** `PromotionInstrument` resource.
+
+**Domain effects:** creates or updates the account's `WalletAccount`, credits the
+matching available balance, and emits `BenefitIssued`.
+
+**Error codes:** `VALIDATION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Get Benefit
+
+**GET** `/api/v1/benefits/{benefitId}`
+
+**Response (200):** `PromotionInstrument` resource.
+
+**Error codes:** `NOT_FOUND`
+
+### List Benefits by Account
+
+**GET** `/api/v1/benefits?byAccountId={accountId}&limit=20&offset=0`
+
+`byAccountId` is required and contains the owning `accountId`. Broad unfiltered
+listing is not part of this activation-wave API.
+
+**Query parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `byAccountId` | string | yes | Owning account ID used to filter benefits. |
+| `status` | enum | no | Optional seven-state status filter. |
+| `benefitType` | enum | no | Optional benefit type filter. |
+| `limit` | integer | no | Pagination limit, default 20, max 100. |
+| `offset` | integer | no | Pagination offset, default 0. |
+
+**Response (200):** Paginated response with `items`, `total`, `limit`, and
+`offset`, where each item is a `PromotionInstrument` resource.
+
+**Error codes:** `VALIDATION_FAILED`
+
+### Reserve Benefit
+
+**POST** `/api/v1/benefits/{benefitId}/reserve`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header).
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `amount` | Money | yes | Amount to freeze. Must be positive, same currency as the benefit, and not exceed available amount. |
+| `reservationRef` | string | yes | External reservation reference, for example an order or post-sales workflow reference. |
+| `reservationExpiresAt` | RFC3339 UTC | yes | Reservation expiry timestamp. |
+| `businessReason` | object | yes | Business reason for freezing value. |
+
+**Response (200):** `PromotionInstrument` resource with status `RESERVED`.
+
+**Domain effects:** moves amount from available to reserved balance and emits
+`BenefitReserved`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Redeem Benefit
+
+**POST** `/api/v1/benefits/{benefitId}/redeem`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header).
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `amount` | Money | yes | Amount to redeem. Must be positive, same currency as the benefit, and satisfy the redemption rule. |
+| `redemptionRef` | string | yes | Business reference for this redemption, for example `ord-<uuid>` or a post-sales workflow reference. |
+| `reservationRef` | string | no | Reservation being consumed when redemption follows `ReserveBenefit`. |
+| `businessReason` | object | yes | Business reason. The same benefit and the same reason cannot be redeemed twice. |
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `benefit` | PromotionInstrument | Updated benefit resource, normally status `REDEEMED` when the redemption consumes the redeemable amount or the rule is `singleUse=true`. |
+| `redemption` | BenefitRedemption | Idempotent redemption record. |
+
+`BenefitRedemption` fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `redemptionId` | string | yes | Redemption ID (`brd-<uuid>`). |
+| `benefitId` | string | yes | Redeemed benefit. |
+| `accountId` | string | yes | Owning account. |
+| `amount` | Money | yes | Redeemed amount. |
+| `redemptionRef` | string | yes | Business reference supplied in the request. |
+| `businessReason` | object | yes | Idempotency/audit reason. |
+| `redeemedAt` | RFC3339 UTC | yes | Redemption timestamp. |
+
+**Domain effects:** moves amount from reserved or available balance to redeemed
+balance and emits `BenefitRedeemed`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `CONFLICT`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Release Reserved Benefit
+
+**POST** `/api/v1/benefits/{benefitId}/release`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header).
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `amount` | Money | yes | Reserved amount to release. Must be positive, same currency, and not exceed reserved amount. |
+| `reservationRef` | string | yes | Reservation being released. |
+| `businessReason` | object | yes | Business reason, for example timeout or order cancellation. |
+
+**Response (200):** `PromotionInstrument` resource with status `RELEASED`.
+
+**Domain effects:** moves amount from reserved back to available balance and
+emits `BenefitReservationReleased`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Revoke Benefit
+
+**POST** `/api/v1/benefits/{benefitId}/revoke`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header).
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `businessReason` | object | yes | Business reason for revocation. |
+| `effectiveAt` | RFC3339 UTC | no | Revocation effective timestamp; defaults to request processing time. |
+
+**Response (200):** `PromotionInstrument` resource with status `REVOKED`.
+
+**Domain effects:** removes remaining available value from the wallet ledger,
+requires reserved amount to be zero, and emits `BenefitRevoked`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Reverse Redemption
+
+**POST** `/api/v1/benefits/{benefitId}/reverse-redemption`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header).
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `redemptionId` | string | yes | Redemption to reverse. |
+| `amount` | Money | yes | Amount to reverse. Must be positive, same currency, and not exceed the redemption's unreversed amount. |
+| `businessReason` | object | yes | Business reason for reversal. |
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `benefit` | PromotionInstrument | Updated benefit resource with status `REVERSED`. |
+| `reversedRedemptionId` | string | Redemption that was reversed. |
+| `reversedAt` | RFC3339 UTC | Reversal timestamp. |
+
+**Domain effects:** compensates a prior redemption, restores value according to
+policy, and emits `BenefitRedemptionReversed`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Get Wallet Account
+
+**GET** `/api/v1/wallet-accounts/{accountId}`
+
+The path parameter is the Account context `accountId`. The response returns the
+Wallet / Promotion ledger view for that account.
+
+**Response (200):** `WalletAccount` resource.
+
+**Error codes:** `NOT_FOUND`
+
+## Bus-only behavior
+
+The following domain command from `docs/02-domains/wallet-promotion.md` has no
+public HTTP endpoint in this activation wave:
+
+- `ExpireBenefit` — triggered by the benefit `validUntil` scheduler/domain
+  policy. It moves eligible active benefits to `EXPIRED`, zeros their remaining
+  available/reserved ledger exposure without making balances negative, carries a
+  `businessReason.reasonType` of `SYSTEM_EXPIRY`, and emits `BenefitExpired`.

--- a/docs/08-contracts/events/wallet-promotion.md
+++ b/docs/08-contracts/events/wallet-promotion.md
@@ -1,0 +1,304 @@
+# Wallet / Promotion — Events & Commands
+
+Last updated: 2026-07-08
+
+## Scope and activation-wave rulings
+
+This contract enumerates exactly the seven Wallet / Promotion events listed in
+`docs/02-domains/wallet-promotion.md` for the ADR-0002 second activation wave.
+It covers `PromotionInstrument` lifecycle events, the per-account
+`WalletAccount` balance ledger effects of those events, and idempotent
+`BenefitRedemption` records.
+
+Activation-wave rulings:
+
+- Wallet / Promotion produces events in this wave and subscribes to no upstream
+  streams. Issuance from Post Sales compensation is represented by the issuing
+  command's `issuanceSource=POST_SALES_COMP` plus `caseId`; no Post Sales event
+  or API contract changes are introduced.
+- Supported issuance sources are `MANUAL_OPS` and `POST_SALES_COMP` only.
+- Payment contracts are unchanged. Combination payment is not part of this wave;
+  future note: a later wave will define the "cash remaining payable" interface.
+- Finance Settlement and Notification are event consumers at the contract
+  surface, but their concrete consumer implementations are deferred to a later
+  wave. Reporting may consume all events for read models and metrics.
+- Every event payload carries the `businessReason` that caused the state or
+  balance change. Producers MUST NOT include unmasked documents or other
+  sensitive personal data in reason descriptions.
+
+All payload fields are camelCase, all enum values are SCREAMING_SNAKE_CASE, and
+all timestamps are RFC3339 UTC. Envelope fields, including optional trace context
+propagation, follow `docs/08-contracts/messaging.md` and
+`docs/08-contracts/shared-primitives.md`. Monetary values use `Money` as
+`{currency, minorUnits}`.
+
+## Event identity and idempotency
+
+Wallet / Promotion producers MUST assign deterministic event IDs per aggregate
+transition so that retries do not create duplicate facts. The event ID seed is:
+
+```
+wallet-promotion:<eventType>:<benefitId>:<aggregateVersion>
+```
+
+where `aggregateVersion` is the `PromotionInstrument` version after applying the
+transition. If a command replay does not apply a new transition, no new event is
+emitted. Consumers still deduplicate by envelope `eventId`.
+
+`BenefitRedeemed` additionally represents the idempotent `BenefitRedemption`
+record. The same `(benefitId, businessReason.reasonType,
+businessReason.reasonCode, businessReason.referenceType,
+businessReason.referenceId)` MUST NOT be redeemed twice.
+
+## Status enum
+
+Event payloads use the same seven-state enum as the HTTP API: `ISSUED`,
+`RESERVED`, `REDEEMED`, `RELEASED`, `EXPIRED`, `REVOKED`, `REVERSED`.
+
+## Common payload objects
+
+`businessReason` fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reasonType` | enum | yes | `MANUAL_OPS`, `POST_SALES_COMP`, `ORDER_PURCHASE`, `RESERVATION_TIMEOUT`, `CUSTOMER_SERVICE_ADJUSTMENT`, `SYSTEM_EXPIRY`, or `REVERSAL`. |
+| `reasonCode` | string | yes | Stable business reason code. |
+| `referenceType` | string | no | Referenced object class such as `ORDER`, `POST_SALES_CASE`, `MANUAL_ACTION`, or `SCHEDULER_JOB`. |
+| `referenceId` | string | no | Referenced object ID. For post-sales compensation this is the carried `caseId`. |
+| `description` | string | no | Human-readable reason; must not contain unmasked sensitive personal data. |
+
+`walletBalanceDelta` fields used by all balance-changing events:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `walletAccountId` | string | yes | Wallet account ID (`wac-<uuid>`). |
+| `balanceType` | enum | yes | `STORED_VALUE`, `POINTS`, or `PROMOTION_CREDIT`. |
+| `availableDelta` | Money | yes | Change to available balance. May be negative, but resulting balance must not be negative. |
+| `reservedDelta` | Money | yes | Change to reserved/frozen balance. May be negative, but resulting balance must not be negative. |
+| `redeemedDelta` | Money | yes | Change to cumulative redeemed balance. |
+| `availableBalanceAfter` | Money | yes | Available balance after the transition; `minorUnits` must be non-negative. |
+| `reservedBalanceAfter` | Money | yes | Reserved/frozen balance after the transition; `minorUnits` must be non-negative. |
+| `ledgerEntryId` | string | yes | Wallet ledger entry ID (`wle-<uuid>`). |
+
+## Published Events
+
+### BenefitIssued
+
+| Field | Description |
+|---|---|
+| **Producer** | wallet-promotion |
+| **Consumers** | finance-settlement (deferred), notification (deferred), reporting |
+| **Trigger** | `IssueBenefit` command accepted from manual operations or post-sales compensation issuance request. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `benefitId` | string | yes | Issued benefit ID (`ben-<uuid>`). |
+| `accountId` | string | yes | Account receiving the benefit. |
+| `walletAccountId` | string | yes | Wallet account credited by issuance. |
+| `benefitType` | enum | yes | `BALANCE`, `COUPON`, `COMPENSATION_CREDIT`, or `POINTS`. |
+| `balanceType` | enum | yes | Credited wallet sub-ledger. |
+| `issuedAmount` | Money | yes | Original issued value. |
+| `availableAmount` | Money | yes | Available amount after issuance. |
+| `reservedAmount` | Money | yes | Reserved amount after issuance; normally zero. |
+| `issuanceSource` | enum | yes | `MANUAL_OPS` or `POST_SALES_COMP`. |
+| `caseId` | string | no | Post-sales case reference when `issuanceSource` is `POST_SALES_COMP`. |
+| `applicableScope` | object | yes | Benefit eligibility scope. |
+| `redemptionRule` | object | yes | Redemption rule captured at issuance. |
+| `revocationRule` | object | yes | Revocation rule captured at issuance. |
+| `validFrom` | RFC3339 UTC | yes | Start of validity window. |
+| `validUntil` | RFC3339 UTC | yes | End of validity window. |
+| `businessReason` | object | yes | Business reason for issuance. |
+| `walletBalanceDelta` | object | yes | Ledger delta; `availableDelta` equals `issuedAmount`. |
+| `issuedAt` | RFC3339 UTC | yes | Issuance timestamp. |
+| `status` | enum | yes | `ISSUED`. |
+| `aggregateVersion` | integer | yes | Benefit version after issuance. |
+
+### BenefitReserved
+
+| Field | Description |
+|---|---|
+| **Producer** | wallet-promotion |
+| **Consumers** | finance-settlement (deferred), notification (deferred), reporting |
+| **Trigger** | `ReserveBenefit` command freezes available benefit value for an order, post-sales workflow, or other business reference. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `benefitId` | string | yes | Reserved benefit ID. |
+| `accountId` | string | yes | Owning account. |
+| `walletAccountId` | string | yes | Wallet account whose balance was frozen. |
+| `benefitType` | enum | yes | Benefit type. |
+| `balanceType` | enum | yes | Affected wallet sub-ledger. |
+| `reservedAmount` | Money | yes | Amount reserved by this command. |
+| `reservationRef` | string | yes | Business reservation reference. |
+| `reservationExpiresAt` | RFC3339 UTC | yes | Reservation expiry timestamp. |
+| `availableAmount` | Money | yes | Benefit available amount after reservation. |
+| `totalReservedAmount` | Money | yes | Benefit reserved amount after reservation. |
+| `businessReason` | object | yes | Business reason for the freeze. |
+| `walletBalanceDelta` | object | yes | Ledger delta; available decreases and reserved increases by `reservedAmount`. |
+| `reservedAt` | RFC3339 UTC | yes | Reservation timestamp. |
+| `status` | enum | yes | `RESERVED`. |
+| `aggregateVersion` | integer | yes | Benefit version after reservation. |
+
+### BenefitRedeemed
+
+| Field | Description |
+|---|---|
+| **Producer** | wallet-promotion |
+| **Consumers** | finance-settlement (deferred), notification (deferred), reporting |
+| **Trigger** | `RedeemBenefit` command consumes benefit value and creates an idempotent `BenefitRedemption` record. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `benefitId` | string | yes | Redeemed benefit ID. |
+| `redemptionId` | string | yes | Idempotent redemption record ID (`brd-<uuid>`). |
+| `accountId` | string | yes | Owning account. |
+| `walletAccountId` | string | yes | Wallet account debited by redemption. |
+| `benefitType` | enum | yes | Benefit type. |
+| `balanceType` | enum | yes | Affected wallet sub-ledger. |
+| `redeemedAmount` | Money | yes | Amount redeemed by this command. |
+| `redemptionRef` | string | yes | Business reference for redemption. |
+| `reservationRef` | string | no | Consumed reservation reference when redemption was reserved first. |
+| `availableAmount` | Money | yes | Benefit available amount after redemption. |
+| `reservedAmount` | Money | yes | Benefit reserved amount after redemption. |
+| `totalRedeemedAmount` | Money | yes | Benefit cumulative redeemed amount after redemption. |
+| `businessReason` | object | yes | Idempotency/audit reason; same benefit and reason cannot redeem twice. |
+| `walletBalanceDelta` | object | yes | Ledger delta from available or reserved into redeemed. |
+| `redeemedAt` | RFC3339 UTC | yes | Redemption timestamp. |
+| `status` | enum | yes | `REDEEMED` when fully/single-use redeemed; otherwise current lifecycle status after partial redemption. |
+| `aggregateVersion` | integer | yes | Benefit version after redemption. |
+
+### BenefitReservationReleased
+
+| Field | Description |
+|---|---|
+| **Producer** | wallet-promotion |
+| **Consumers** | finance-settlement (deferred), notification (deferred), reporting |
+| **Trigger** | `ReleaseReservedBenefit` command releases a prior reservation because the business use ended or timed out. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `benefitId` | string | yes | Benefit whose reservation was released. |
+| `accountId` | string | yes | Owning account. |
+| `walletAccountId` | string | yes | Wallet account whose frozen value was released. |
+| `benefitType` | enum | yes | Benefit type. |
+| `balanceType` | enum | yes | Affected wallet sub-ledger. |
+| `releasedAmount` | Money | yes | Amount released from reserved value. |
+| `reservationRef` | string | yes | Reservation reference being released. |
+| `availableAmount` | Money | yes | Benefit available amount after release. |
+| `reservedAmount` | Money | yes | Benefit reserved amount after release. |
+| `businessReason` | object | yes | Business reason for release. |
+| `walletBalanceDelta` | object | yes | Ledger delta; reserved decreases and available increases by `releasedAmount`. |
+| `releasedAt` | RFC3339 UTC | yes | Release timestamp. |
+| `status` | enum | yes | `RELEASED`. |
+| `aggregateVersion` | integer | yes | Benefit version after release. |
+
+### BenefitExpired
+
+| Field | Description |
+|---|---|
+| **Producer** | wallet-promotion |
+| **Consumers** | finance-settlement (deferred), notification (deferred), reporting |
+| **Trigger** | `ExpireBenefit` scheduler/domain policy runs when `validUntil` has elapsed before the benefit reaches a terminal state. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `benefitId` | string | yes | Expired benefit ID. |
+| `accountId` | string | yes | Owning account. |
+| `walletAccountId` | string | yes | Wallet account adjusted by expiry. |
+| `benefitType` | enum | yes | Benefit type. |
+| `balanceType` | enum | yes | Affected wallet sub-ledger. |
+| `expiredAmount` | Money | yes | Remaining unredeemed amount removed by expiry. |
+| `validUntil` | RFC3339 UTC | yes | Validity timestamp that elapsed. |
+| `availableAmount` | Money | yes | Benefit available amount after expiry; zero for terminal expiry. |
+| `reservedAmount` | Money | yes | Benefit reserved amount after expiry; zero for terminal expiry. |
+| `businessReason` | object | yes | Expiry reason, normally `reasonType=SYSTEM_EXPIRY`. |
+| `walletBalanceDelta` | object | yes | Ledger delta removing remaining available/reserved exposure without negative balances. |
+| `expiredAt` | RFC3339 UTC | yes | Expiry processing timestamp. |
+| `status` | enum | yes | `EXPIRED`. |
+| `aggregateVersion` | integer | yes | Benefit version after expiry. |
+
+### BenefitRevoked
+
+| Field | Description |
+|---|---|
+| **Producer** | wallet-promotion |
+| **Consumers** | finance-settlement (deferred), notification (deferred), reporting |
+| **Trigger** | `RevokeBenefit` command revokes an issued or released benefit according to its revocation rule. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `benefitId` | string | yes | Revoked benefit ID. |
+| `accountId` | string | yes | Owning account. |
+| `walletAccountId` | string | yes | Wallet account adjusted by revocation. |
+| `benefitType` | enum | yes | Benefit type. |
+| `balanceType` | enum | yes | Affected wallet sub-ledger. |
+| `revokedAmount` | Money | yes | Remaining available amount removed by revocation. |
+| `availableAmount` | Money | yes | Benefit available amount after revocation; zero for terminal revocation. |
+| `reservedAmount` | Money | yes | Benefit reserved amount after revocation; must be zero before revoke succeeds. |
+| `businessReason` | object | yes | Business reason for revocation. |
+| `walletBalanceDelta` | object | yes | Ledger delta removing remaining available value. |
+| `revokedAt` | RFC3339 UTC | yes | Revocation timestamp. |
+| `status` | enum | yes | `REVOKED`. |
+| `aggregateVersion` | integer | yes | Benefit version after revocation. |
+
+### BenefitRedemptionReversed
+
+| Field | Description |
+|---|---|
+| **Producer** | wallet-promotion |
+| **Consumers** | finance-settlement (deferred), notification (deferred), reporting |
+| **Trigger** | `ReverseRedemption` command compensates a prior `BenefitRedeemed` fact. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `benefitId` | string | yes | Benefit whose redemption was reversed. |
+| `redemptionId` | string | yes | Original redemption record being reversed. |
+| `reversalId` | string | yes | Reversal record ID (`brr-<uuid>`). |
+| `accountId` | string | yes | Owning account. |
+| `walletAccountId` | string | yes | Wallet account adjusted by reversal. |
+| `benefitType` | enum | yes | Benefit type. |
+| `balanceType` | enum | yes | Affected wallet sub-ledger. |
+| `reversedAmount` | Money | yes | Amount reversed. |
+| `availableAmount` | Money | yes | Benefit available amount after reversal according to policy. |
+| `reservedAmount` | Money | yes | Benefit reserved amount after reversal. |
+| `totalRedeemedAmount` | Money | yes | Benefit cumulative redeemed amount after reversal. |
+| `businessReason` | object | yes | Business reason for reversal. |
+| `walletBalanceDelta` | object | yes | Ledger delta compensating the redeemed value. |
+| `reversedAt` | RFC3339 UTC | yes | Reversal timestamp. |
+| `status` | enum | yes | `REVERSED`. |
+| `aggregateVersion` | integer | yes | Benefit version after reversal. |
+
+## Accepted Commands
+
+The command list is the domain command/event table from
+`docs/02-domains/wallet-promotion.md`.
+
+| Command | Sender / Trigger | Produced event |
+|---|---|---|
+| `IssueBenefit` | API gateway / operations via `POST /api/v1/benefits`, or post-sales compensation issuance request carrying `caseId` | `BenefitIssued` |
+| `ReserveBenefit` | API gateway or order/post-sales workflow via `POST /api/v1/benefits/{benefitId}/reserve` | `BenefitReserved` |
+| `RedeemBenefit` | API gateway or business workflow via `POST /api/v1/benefits/{benefitId}/redeem` | `BenefitRedeemed` |
+| `ReleaseReservedBenefit` | API gateway or timeout/cancellation workflow via `POST /api/v1/benefits/{benefitId}/release` | `BenefitReservationReleased` |
+| `ExpireBenefit` | Wallet / Promotion scheduler/domain policy at `validUntil` | `BenefitExpired` |
+| `RevokeBenefit` | API gateway / operations via `POST /api/v1/benefits/{benefitId}/revoke` | `BenefitRevoked` |
+| `ReverseRedemption` | API gateway / compensating workflow via `POST /api/v1/benefits/{benefitId}/reverse-redemption` | `BenefitRedemptionReversed` |
+
+## Consumed upstream events
+
+Wallet / Promotion subscribes to no upstream event stream in this activation
+wave. Post-sales compensation issuance is command/request driven with a carried
+`caseId`; this avoids any Post Sales contract change in this wave.

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -72,6 +72,7 @@ context.
 | 22 | `supplier-catalog` | `events:supplier-catalog` | SupplierRegistered, CarrierRegistered, ContractActivated, ContractSuspended, ProductCapabilityDeclared, ExternalCodeMapped |
 | 23 | `waitlist` | `events:waitlist` | WaitlistRequestCreated, WaitlistPaymentAuthorizationRequested, WaitlistQueued, WaitlistMatchStarted, WaitlistHoldAuthorized, WaitlistFulfilled, WaitlistCancelled, WaitlistExpired |
 | 24 | `dispatch` | `events:dispatch` | DispatchRequested, DriverAssigned, DriverEtaUpdated, DriverArrived, RideStarted, RideEnded, DriverCancelled, DispatchUserCancelled, DispatchNoShowRecorded |
+| 25 | `wallet-promotion` | `events:wallet-promotion` | BenefitIssued, BenefitReserved, BenefitRedeemed, BenefitReservationReleased, BenefitExpired, BenefitRevoked, BenefitRedemptionReversed |
 
 ### Dead-Letter Streams
 
@@ -275,6 +276,9 @@ plus notification/finance/reporting fan-in.
 | 50 | `events:journey-order` | `waitlist` | JourneyOrderConfirmed/JourneyOrderCancelled advance a matching request to FULFILLED or return it to QUEUED |
 | 51 | `events:waitlist` | `notification` | Waitlist success, failure/requeue, expiry, and cancellation user touchpoints |
 | 52 | `events:waitlist` | `reporting` | Waitlist lifecycle metrics and read models |
+| 53 | `events:wallet-promotion` | `finance-settlement` | Benefit issuance, reservation, redemption, release, expiry, revocation, and reversal facts for future cost attribution and settlement read models; concrete consumption deferred to a later wave |
+| 54 | `events:wallet-promotion` | `notification` | Benefit arrival, expiry, redemption, revocation, and reversal user touchpoints; concrete consumption deferred to a later wave |
+| 55 | `events:wallet-promotion` | `reporting` | Wallet / Promotion lifecycle metrics and read models |
 
 ### Cross-Cutting Consumers
 
@@ -283,9 +287,9 @@ analytics, and cross-cutting concerns:
 
 | Consumer Group (Context) | Subscribed Streams | Purpose |
 |---|---|---|
-| `reporting` | All active `events:*` streams except `events:dispatch` until Dispatch's deferred-consumer activation wave | Business metrics, funnel analysis, operational dashboards |
-| `finance-settlement` | `events:payment`, `events:provider-integration`, `events:booking-orchestration`, `events:post-sales` | Revenue recognition, reconciliation, invoice generation |
-| `notification` | `events:journey-order`, `events:booking-orchestration`, `events:payment`, `events:entitlement-ticketing`, `events:post-sales`, `events:waitlist` | User-facing notification triggers |
+| `reporting` | All active `events:*` streams except `events:dispatch` and `events:wallet-promotion` until their deferred-consumer activation waves | Business metrics, funnel analysis, operational dashboards |
+| `finance-settlement` | `events:payment`, `events:provider-integration`, `events:booking-orchestration`, `events:post-sales` | Revenue recognition, reconciliation, invoice generation. Wallet / Promotion benefit-cost events are a documented deferred consumer (events/wallet-promotion.md). |
+| `notification` | `events:journey-order`, `events:booking-orchestration`, `events:payment`, `events:entitlement-ticketing`, `events:post-sales`, `events:waitlist` | User-facing notification triggers. Wallet / Promotion benefit touchpoints are a documented deferred consumer. |
 
 ### Deferred Dispatch Subscriptions
 


### PR DESCRIPTION
## Summary
- add Wallet / Promotion HTTP API contract for benefit lifecycle and wallet account ledger
- add seven Wallet / Promotion event contracts with deterministic IDs and deferred consumers
- register wallet-promotion stream and subscription matrix entries

## Validation
- make check
- make contract-lint