### PR TITLE
REQ-113 Dispatch contracts

### DIFF
--- a/docs/08-contracts/README.md
+++ b/docs/08-contracts/README.md
@@ -34,6 +34,8 @@ docs/08-contracts/
     ├── notification.md
     ├── traveler-profile.md
     ├── place-network.md
+    ├── waitlist.md
+    ├── dispatch.md
     └── finance-settlement-events.md
 ```
 

--- a/docs/08-contracts/api/README.md
+++ b/docs/08-contracts/api/README.md
@@ -149,6 +149,8 @@ correlation IDs.
 | 20 | `customer-service.md` | Customer Service | typescript |
 | 21 | `finance-settlement.md` | Finance & Settlement | java |
 | 22 | `reporting.md` | Reporting | python |
+| 23 | `waitlist.md` | Waitlist | deferred |
+| 24 | `dispatch.md` | Dispatch | deferred |
 
 ## Open Issues
 

--- a/docs/08-contracts/api/dispatch.md
+++ b/docs/08-contracts/api/dispatch.md
@@ -1,0 +1,317 @@
+# Dispatch — HTTP API
+
+Last updated: 2026-07-08
+
+## Overview
+
+Dispatch manages immediate ride dispatch for non-scheduled ground transport. This
+contract is scoped to the first activation wave for the future-scope Dispatch
+domain and is bounded by `docs/02-domains/dispatch.md`.
+
+Activation-wave rulings:
+
+- Immediate external supply (driver, vehicle, ETA, and provider lifecycle) is a
+  **simulation boundary** in this wave. Driver assignment and state advancement
+  are driven by internal ops HTTP commands, similar to simulated payment
+  operations in Payment. `provider-integration` has no contract or
+  implementation change in this wave. Future provider-platform integration will
+  replace the ops-driving adapter without changing the Dispatch aggregate
+  invariants.
+- Dispatch produces the Fulfillment handoff facts `DriverArrived`, `RideStarted`,
+  and `RideEnded` according to the event contract. Fulfillment consumption is
+  deferred and is not registered as an active subscription in
+  `docs/08-contracts/messaging.md` for this wave.
+- Post Sales and Notification consumption of Dispatch events is also deferred;
+  this wave documents the event payloads but registers no Dispatch subscribers.
+- Mutual-exclusion invariant: for the same
+  `(riderAccountId, intentFingerprint)`, at most one active dispatch may exist.
+  Active statuses are `REQUESTED`, `MATCHING`, `ASSIGNED`, `DRIVER_ARRIVING`,
+  `DRIVER_ARRIVED`, `PICKED_UP`, and the transient `DRIVER_CANCELLED` status
+  before automatic re-match.
+
+Field shapes reference `docs/08-contracts/shared-primitives.md` for IDs,
+timestamps, event envelope fields, pagination conventions, and Money
+(`{currency, minorUnits}`) if a referenced fare snapshot is expanded by a future
+read model. All timestamps are RFC3339 UTC. JSON fields are camelCase and enum
+values are SCREAMING_SNAKE_CASE.
+
+## Status enum
+
+The wire status enum is the 10-state machine from the Dispatch domain document:
+
+| Status | Meaning | Allowed next statuses |
+|---|---|---|
+| `REQUESTED` | Dispatch request was accepted. | `MATCHING`, `USER_CANCELLED`, failure closure |
+| `MATCHING` | Dispatch is matching driver supply. | `ASSIGNED`, `USER_CANCELLED`, failure closure |
+| `ASSIGNED` | Driver and vehicle have been assigned. | `DRIVER_ARRIVING`, `DRIVER_CANCELLED`, `USER_CANCELLED` |
+| `DRIVER_ARRIVING` | Driver is en route to the pickup point. | `DRIVER_ARRIVED`, `DRIVER_CANCELLED`, `USER_CANCELLED` |
+| `DRIVER_ARRIVED` | Driver has arrived and is waiting for the rider. | `PICKED_UP`, `NO_SHOW`, `USER_CANCELLED` |
+| `PICKED_UP` | Rider is on board and the ride has started. | `COMPLETED` |
+| `DRIVER_CANCELLED` | Driver cancelled the active assignment. | `MATCHING`, failure closure |
+| `USER_CANCELLED` | Rider/user cancelled the dispatch. | Terminal for this API wave |
+| `NO_SHOW` | Rider did not appear at pickup. | Terminal for this API wave |
+| `COMPLETED` | Dispatch lifecycle completed after ride end. | Terminal for this API wave |
+
+`DRIVER_CANCELLED` is an observable transition fact only briefly. The Dispatch
+application MUST automatically return the request to `MATCHING` for re-dispatch
+unless the request is closed by an explicit failure policy outside this wave.
+
+## Resource representation
+
+`RideRequest` responses use the following fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `rideRequestId` | string | yes | Canonical ride request ID (`rrq-<uuid>`). |
+| `riderAccountId` | string | yes | Account that owns the dispatch request. |
+| `travelerRef` | string | yes | Traveler reference (`tvl-<uuid>` or the shared structured TravelerRef). |
+| `pickupRef` | string | yes | Pickup place/location reference captured from Trip Planning or the UI. |
+| `dropoffRef` | string | yes | Drop-off place/location reference captured from Trip Planning or the UI. |
+| `timeWindow` | object | yes | Requested pickup window; see [TimeWindow](#timewindow). |
+| `estimatedFareRef` | string | no | Optional Fare & Pricing estimate reference. The estimate itself remains owned by Fare & Pricing. |
+| `intentFingerprint` | string | yes | Stable fingerprint of the mutually exclusive dispatch intent. |
+| `status` | enum | yes | One of the 10 statuses above. |
+| `assignment` | object | no | Current active assignment when a driver is assigned; see [RideAssignment](#rideassignment). |
+| `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
+| `updatedAt` | RFC3339 UTC | yes | Last state-change timestamp. |
+
+### TimeWindow
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `startAt` | RFC3339 UTC | yes | Earliest acceptable pickup time. |
+| `endAt` | RFC3339 UTC | yes | Latest acceptable pickup time; must be after `startAt`. |
+
+### RideAssignment
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `rideAssignmentId` | string | yes | Canonical assignment ID (`ras-<uuid>`). |
+| `driverRef` | string | yes | Simulated or future provider driver reference. |
+| `vehicleRef` | string | yes | Simulated or future provider vehicle reference. |
+| `etaSeconds` | integer | yes | Current ETA to pickup in seconds; must be non-negative. |
+| `assignedAt` | RFC3339 UTC | yes | Assignment timestamp. |
+| `arrivedAt` | RFC3339 UTC | no | Driver arrival timestamp after `driver-arrived`. |
+| `startedAt` | RFC3339 UTC | no | Ride start timestamp after `start`. |
+| `endedAt` | RFC3339 UTC | no | Ride end timestamp after `complete`. |
+
+## Endpoints
+
+### Create Ride Request
+
+**POST** `/api/v1/ride-requests`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header). Replays with the same body
+return the original response. Reusing the same key with a different body returns
+`IDEMPOTENCY_KEY_REUSED`.
+
+The request creates a `RideRequest` from a user-confirmed immediate-ride intent.
+In this activation wave the request enters the simulated matching flow; Dispatch
+does not call Provider Integration.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `pickupRef` | string | yes | Pickup place/location reference. |
+| `dropoffRef` | string | yes | Drop-off place/location reference. |
+| `timeWindow` | object | yes | Requested pickup window with `startAt` and `endAt` RFC3339 UTC fields. |
+| `riderAccountId` | string | yes | Account that owns the dispatch request. |
+| `travelerRef` | string | yes | Traveler reference (`tvl-<uuid>` or shared structured TravelerRef). |
+| `estimatedFareRef` | string | no | Optional Fare & Pricing estimate reference. |
+| `intentFingerprint` | string | yes | Stable mutual-exclusion key for the ride intent. |
+
+**Response (201):** `RideRequest` resource.
+
+**Domain effects:** emits `DispatchRequested`; the application may immediately
+advance the request to `MATCHING` as part of the simulated matching workflow.
+
+**Error codes:** `VALIDATION_FAILED`, `CONFLICT`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+- `CONFLICT` is returned when `(riderAccountId, intentFingerprint)` already has
+  an active dispatch.
+- `DOMAIN_RULE_VIOLATION` is returned when pickup/dropoff, time window, traveler,
+  or account references violate Dispatch invariants.
+
+### Get Ride Request
+
+**GET** `/api/v1/ride-requests/{rideRequestId}`
+
+**Response (200):** `RideRequest` resource.
+
+**Error codes:** `NOT_FOUND`
+
+### List Ride Requests by Rider Account
+
+**GET** `/api/v1/ride-requests?riderAccountId={riderAccountId}&limit=20&offset=0`
+
+`riderAccountId` is required for list queries. Broad unfiltered listing is not
+part of this activation-wave API.
+
+**Query parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `riderAccountId` | string | yes | Account that owns the dispatch requests. |
+| `status` | enum | no | Optional status filter using the 10-state enum above. |
+| `limit` | integer | no | Pagination limit, default 20, max 100. |
+| `offset` | integer | no | Pagination offset, default 0. |
+
+**Response (200):** Paginated response with `items`, `total`, `limit`, and
+`offset`, where each item is a `RideRequest` resource.
+
+**Error codes:** `VALIDATION_FAILED`
+
+## Internal ops command endpoints
+
+The following state-changing endpoints are internal ops commands for the
+simulation boundary. They MUST NOT be exposed as public rider APIs. Every ops
+POST requires `Idempotency-Key` and follows the replay/reuse behavior described
+above.
+
+### Assign Driver
+
+**POST** `/api/v1/ride-requests/{rideRequestId}/assign`
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `driverRef` | string | yes | Simulated or future provider driver reference. |
+| `vehicleRef` | string | yes | Simulated or future provider vehicle reference. |
+| `etaSeconds` | integer | yes | ETA to pickup in seconds; must be non-negative. |
+
+**Response (200):** `RideRequest` resource in `ASSIGNED` or
+`DRIVER_ARRIVING` status with `assignment` populated.
+
+**Domain effects:** command `AssignDriver`; emits `DriverAssigned`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`
+
+### Update ETA
+
+**POST** `/api/v1/ride-requests/{rideRequestId}/eta`
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `etaSeconds` | integer | yes | New ETA to pickup in seconds; must be non-negative. |
+
+**Response (200):** `RideRequest` resource with updated `assignment.etaSeconds`.
+
+**Domain effects:** command `UpdateEta`; emits `DriverEtaUpdated`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`
+
+### Mark Driver Arrived
+
+**POST** `/api/v1/ride-requests/{rideRequestId}/driver-arrived`
+
+**Request:** empty JSON object (`{}`).
+
+**Response (200):** `RideRequest` resource in `DRIVER_ARRIVED` status.
+
+**Domain effects:** command `MarkDriverArrived`; emits `DriverArrived` for the
+Fulfillment handoff contract. Fulfillment consumption is deferred in this wave.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`
+
+### Start Ride
+
+**POST** `/api/v1/ride-requests/{rideRequestId}/start`
+
+**Request:** empty JSON object (`{}`).
+
+**Response (200):** `RideRequest` resource in `PICKED_UP` status.
+
+**Domain effects:** command `StartRide`; emits `RideStarted` for the Fulfillment
+handoff contract. Fulfillment consumption is deferred in this wave.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`
+
+### Complete Dispatch
+
+**POST** `/api/v1/ride-requests/{rideRequestId}/complete`
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `finalFareRef` | string | no | Optional Fare & Pricing final-fare or adjustment reference. Dispatch records the reference only. |
+
+**Response (200):** `RideRequest` resource in `COMPLETED` status.
+
+**Domain effects:** command `CompleteDispatch`; emits `RideEnded` as the
+cross-context wire event for the domain completion transition. The domain table
+labels the completion fact `DispatchCompleted`; this contract uses `RideEnded`
+for the Fulfillment handoff named in the Dispatch upstream/downstream table.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`
+
+### Driver Cancel
+
+**POST** `/api/v1/ride-requests/{rideRequestId}/driver-cancel`
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reason` | string | yes | Driver/provider cancellation reason. Do not include unmasked documents or other sensitive personal data. |
+
+**Response (200):** `RideRequest` resource after cancellation processing. The
+resource may already be back in `MATCHING` because `DRIVER_CANCELLED`
+automatically re-dispatches.
+
+**Domain effects:** command `CancelByDriver`; emits `DriverCancelled`, then the
+application automatically returns the request to `MATCHING` for re-assignment
+unless a future failure policy closes it.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`
+
+### User Cancel
+
+**POST** `/api/v1/ride-requests/{rideRequestId}/user-cancel`
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reason` | string | yes | User cancellation reason. Do not include unmasked documents or other sensitive personal data. |
+
+**Response (200):** `RideRequest` resource in `USER_CANCELLED` status.
+
+**Domain effects:** command `CancelByUser`; emits `DispatchUserCancelled`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`
+
+### Record No Show
+
+**POST** `/api/v1/ride-requests/{rideRequestId}/no-show`
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reason` | string | no | Operational reason or policy reference. Do not include unmasked documents or other sensitive personal data. |
+
+**Response (200):** `RideRequest` resource in `NO_SHOW` status.
+
+**Domain effects:** command `RecordNoShow`; emits `DispatchNoShowRecorded`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`
+
+## Bus-only behavior
+
+No Dispatch command is bus-only in this activation wave. Upstream provider
+callbacks are intentionally absent because provider integration is deferred; ops
+HTTP commands simulate assignment and provider lifecycle facts.

--- a/docs/08-contracts/events/dispatch.md
+++ b/docs/08-contracts/events/dispatch.md
@@ -1,0 +1,312 @@
+# Dispatch — Events & Commands
+
+Last updated: 2026-07-08
+
+## Scope and activation-wave rulings
+
+This contract enumerates exactly the Dispatch command/event lifecycle from
+`docs/02-domains/dispatch.md`: `RideRequest` and `RideAssignment`, the 10-state
+machine, nine commands, and nine produced lifecycle facts. The completion fact is
+published on the wire as `RideEnded` so Fulfillment can consume the handoff event
+named in the Dispatch downstream table; it is the wire contract for the domain
+`DispatchCompleted` transition.
+
+Activation-wave rulings:
+
+- Immediate driver/vehicle/ETA supply is a **simulation boundary**. Driver
+  assignment and lifecycle advancement are driven by internal ops HTTP commands
+  under `/api/v1/ride-requests/{rideRequestId}/...`. Dispatch does not consume
+  provider-platform events and `provider-integration` has no contract change in
+  this wave. Future external platform integration may replace the ops driver
+  without changing these event payloads.
+- Dispatch produces `DriverArrived`, `RideStarted`, and `RideEnded` as
+  Fulfillment handoff facts. Fulfillment consumption is deferred in this wave.
+- Post Sales and Notification consumption is also deferred. The events below
+  identify intended touchpoints, but `docs/08-contracts/messaging.md` registers
+  no active Dispatch subscribers for this activation wave.
+- Mutual exclusion is enforced by Dispatch: the same
+  `(riderAccountId, intentFingerprint)` may have at most one active dispatch in
+  `REQUESTED`, `MATCHING`, `ASSIGNED`, `DRIVER_ARRIVING`, `DRIVER_ARRIVED`,
+  `PICKED_UP`, or transient `DRIVER_CANCELLED` before automatic re-match.
+
+All payload fields are camelCase, all enum values are SCREAMING_SNAKE_CASE, and
+all timestamps are RFC3339 UTC. Envelope fields, including optional trace context
+propagation, follow `docs/08-contracts/messaging.md` and
+`docs/08-contracts/shared-primitives.md`.
+
+## Event identity and idempotency
+
+Dispatch producers MUST assign deterministic event IDs per aggregate transition
+so retries do not create duplicate facts. The event ID seed is:
+
+```
+dispatch:<eventType>:<rideRequestId>:<aggregateVersion>
+```
+
+where `aggregateVersion` is the version after applying the transition. If the
+same command is replayed, the same transition emits the same `eventId`; if no new
+transition is applied, no new event is emitted. Consumers still deduplicate by
+envelope `eventId`.
+
+## Status enum
+
+Dispatch event payloads use the same 10-state enum as the HTTP API:
+`REQUESTED`, `MATCHING`, `ASSIGNED`, `DRIVER_ARRIVING`, `DRIVER_ARRIVED`,
+`PICKED_UP`, `DRIVER_CANCELLED`, `USER_CANCELLED`, `NO_SHOW`, `COMPLETED`.
+
+`DRIVER_CANCELLED` MUST be followed by automatic return to `MATCHING` for
+re-dispatch unless a future explicit failure policy closes the request.
+
+## Published Events
+
+### DispatchRequested
+
+| Field | Description |
+|---|---|
+| **Producer** | dispatch |
+| **Consumers** | deferred: notification, reporting |
+| **Trigger** | `RequestDispatch` command accepted from `POST /api/v1/ride-requests`. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `rideRequestId` | string | yes | Canonical ride request ID (`rrq-<uuid>`). |
+| `riderAccountId` | string | yes | Account that owns the dispatch request. |
+| `travelerRef` | string | yes | Traveler reference (`tvl-<uuid>` or shared structured TravelerRef). |
+| `pickupRef` | string | yes | Pickup place/location reference. |
+| `dropoffRef` | string | yes | Drop-off place/location reference. |
+| `timeWindow` | object | yes | Requested pickup window with `startAt` and `endAt` RFC3339 UTC fields. |
+| `estimatedFareRef` | string | no | Fare & Pricing estimate reference, if supplied. |
+| `intentFingerprint` | string | yes | Stable mutual-exclusion key for the ride intent. |
+| `status` | enum | yes | `REQUESTED`. |
+| `requestedAt` | RFC3339 UTC | yes | Request creation timestamp. |
+
+### DriverAssigned
+
+| Field | Description |
+|---|---|
+| **Producer** | dispatch |
+| **Consumers** | deferred: notification, reporting |
+| **Trigger** | `AssignDriver` ops command binds a driver/vehicle assignment. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `rideRequestId` | string | yes | Ride request ID. |
+| `rideAssignmentId` | string | yes | Active assignment ID (`ras-<uuid>`). |
+| `riderAccountId` | string | yes | Account that owns the dispatch request. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `pickupRef` | string | yes | Pickup place/location reference. |
+| `dropoffRef` | string | yes | Drop-off place/location reference. |
+| `driverRef` | string | yes | Simulated or future provider driver reference. |
+| `vehicleRef` | string | yes | Simulated or future provider vehicle reference. |
+| `etaSeconds` | integer | yes | ETA to pickup in seconds; non-negative. |
+| `assignedAt` | RFC3339 UTC | yes | Assignment timestamp. |
+| `status` | enum | yes | `ASSIGNED` or `DRIVER_ARRIVING` when the implementation immediately marks the driver en route. |
+
+### DriverEtaUpdated
+
+| Field | Description |
+|---|---|
+| **Producer** | dispatch |
+| **Consumers** | deferred: notification, reporting |
+| **Trigger** | `UpdateEta` ops command updates the active assignment ETA. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `rideRequestId` | string | yes | Ride request ID. |
+| `rideAssignmentId` | string | yes | Active assignment ID. |
+| `riderAccountId` | string | yes | Account that owns the dispatch request. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `driverRef` | string | yes | Driver reference. |
+| `vehicleRef` | string | yes | Vehicle reference. |
+| `etaSeconds` | integer | yes | Updated ETA to pickup in seconds; non-negative. |
+| `updatedAt` | RFC3339 UTC | yes | ETA update timestamp. |
+| `status` | enum | yes | Current status, normally `DRIVER_ARRIVING` or `ASSIGNED`. |
+
+### DriverArrived
+
+| Field | Description |
+|---|---|
+| **Producer** | dispatch |
+| **Consumers** | deferred: fulfillment, notification, reporting |
+| **Trigger** | `MarkDriverArrived` ops command records driver arrival at pickup. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `rideRequestId` | string | yes | Ride request ID. |
+| `rideAssignmentId` | string | yes | Active assignment ID. |
+| `riderAccountId` | string | yes | Account that owns the dispatch request. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `pickupRef` | string | yes | Pickup place/location reference. |
+| `dropoffRef` | string | yes | Drop-off place/location reference. |
+| `driverRef` | string | yes | Driver reference. |
+| `vehicleRef` | string | yes | Vehicle reference. |
+| `arrivedAt` | RFC3339 UTC | yes | Driver arrival timestamp. |
+| `status` | enum | yes | `DRIVER_ARRIVED`. |
+
+This event is the first Fulfillment handoff fact, but Fulfillment consumption is
+deferred in this wave.
+
+### RideStarted
+
+| Field | Description |
+|---|---|
+| **Producer** | dispatch |
+| **Consumers** | deferred: fulfillment, notification, reporting |
+| **Trigger** | `StartRide` ops command records rider pickup / ride start. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `rideRequestId` | string | yes | Ride request ID. |
+| `rideAssignmentId` | string | yes | Active assignment ID. |
+| `riderAccountId` | string | yes | Account that owns the dispatch request. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `pickupRef` | string | yes | Pickup place/location reference. |
+| `dropoffRef` | string | yes | Drop-off place/location reference. |
+| `driverRef` | string | yes | Driver reference. |
+| `vehicleRef` | string | yes | Vehicle reference. |
+| `startedAt` | RFC3339 UTC | yes | Ride start timestamp. |
+| `status` | enum | yes | `PICKED_UP`. |
+
+This event is a Fulfillment handoff fact, but Fulfillment consumption is deferred
+in this wave.
+
+### RideEnded
+
+| Field | Description |
+|---|---|
+| **Producer** | dispatch |
+| **Consumers** | deferred: fulfillment, post-sales, notification, reporting |
+| **Trigger** | `CompleteDispatch` ops command records ride completion. This is the wire event for the domain `DispatchCompleted` fact. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `rideRequestId` | string | yes | Ride request ID. |
+| `rideAssignmentId` | string | yes | Completed assignment ID. |
+| `riderAccountId` | string | yes | Account that owns the dispatch request. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `pickupRef` | string | yes | Pickup place/location reference. |
+| `dropoffRef` | string | yes | Drop-off place/location reference. |
+| `driverRef` | string | yes | Driver reference. |
+| `vehicleRef` | string | yes | Vehicle reference. |
+| `startedAt` | RFC3339 UTC | yes | Ride start timestamp. |
+| `endedAt` | RFC3339 UTC | yes | Ride end timestamp. |
+| `finalFareRef` | string | no | Optional final fare or adjustment reference recorded by Dispatch. |
+| `status` | enum | yes | `COMPLETED`. |
+
+This event is the final Fulfillment handoff fact. Fulfillment and Post Sales
+consumption is deferred in this wave.
+
+### DriverCancelled
+
+| Field | Description |
+|---|---|
+| **Producer** | dispatch |
+| **Consumers** | deferred: notification, reporting |
+| **Trigger** | `CancelByDriver` ops command records driver/provider cancellation of the active assignment. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `rideRequestId` | string | yes | Ride request ID. |
+| `rideAssignmentId` | string | yes | Cancelled assignment ID. |
+| `riderAccountId` | string | yes | Account that owns the dispatch request. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `driverRef` | string | yes | Driver reference. |
+| `vehicleRef` | string | yes | Vehicle reference. |
+| `cancelledAt` | RFC3339 UTC | yes | Cancellation timestamp. |
+| `reason` | string | yes | Cancellation reason; do not include unmasked documents or other sensitive personal data. |
+| `status` | enum | yes | `DRIVER_CANCELLED`. |
+| `nextStatus` | enum | yes | `MATCHING`, because this wave automatically re-dispatches after driver cancellation. |
+
+Dispatch MUST clear the cancelled active assignment and re-enter `MATCHING` after
+publishing this fact unless a future failure policy closes the request.
+
+### DispatchUserCancelled
+
+| Field | Description |
+|---|---|
+| **Producer** | dispatch |
+| **Consumers** | deferred: post-sales, notification, reporting |
+| **Trigger** | `CancelByUser` command cancels an active dispatch. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `rideRequestId` | string | yes | Ride request ID. |
+| `rideAssignmentId` | string | no | Active assignment ID at the time of cancellation, if any. |
+| `riderAccountId` | string | yes | Account that owns the dispatch request. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `pickupRef` | string | yes | Pickup place/location reference. |
+| `dropoffRef` | string | yes | Drop-off place/location reference. |
+| `cancelledAt` | RFC3339 UTC | yes | Cancellation timestamp. |
+| `reason` | string | yes | User cancellation reason; do not include unmasked documents or other sensitive personal data. |
+| `status` | enum | yes | `USER_CANCELLED`. |
+
+### DispatchNoShowRecorded
+
+| Field | Description |
+|---|---|
+| **Producer** | dispatch |
+| **Consumers** | deferred: post-sales, notification, reporting |
+| **Trigger** | `RecordNoShow` ops command records that the rider did not appear after driver arrival. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `rideRequestId` | string | yes | Ride request ID. |
+| `rideAssignmentId` | string | yes | Active assignment ID. |
+| `riderAccountId` | string | yes | Account that owns the dispatch request. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `pickupRef` | string | yes | Pickup place/location reference. |
+| `dropoffRef` | string | yes | Drop-off place/location reference. |
+| `driverRef` | string | yes | Driver reference. |
+| `vehicleRef` | string | yes | Vehicle reference. |
+| `recordedAt` | RFC3339 UTC | yes | No-show recording timestamp. |
+| `reason` | string | no | Operational reason or policy reference; do not include unmasked documents or other sensitive personal data. |
+| `status` | enum | yes | `NO_SHOW`. |
+
+## Accepted Commands
+
+The command list follows the Dispatch domain command/event table. `RideEnded` is
+the wire event name used for the domain `DispatchCompleted` completion fact.
+
+| Command | Sender / Trigger | Produced event |
+|---|---|---|
+| `RequestDispatch` | API gateway / UI via `POST /api/v1/ride-requests` | `DispatchRequested` |
+| `AssignDriver` | Internal ops simulation via `/assign` | `DriverAssigned` |
+| `UpdateEta` | Internal ops simulation via `/eta` | `DriverEtaUpdated` |
+| `MarkDriverArrived` | Internal ops simulation via `/driver-arrived` | `DriverArrived` |
+| `StartRide` | Internal ops simulation via `/start` | `RideStarted` |
+| `CompleteDispatch` | Internal ops simulation via `/complete` | `RideEnded` (`DispatchCompleted` domain fact) |
+| `CancelByDriver` | Internal ops simulation via `/driver-cancel` | `DriverCancelled` |
+| `CancelByUser` | API gateway / UI or ops via `/user-cancel` | `DispatchUserCancelled` |
+| `RecordNoShow` | Internal ops simulation via `/no-show` | `DispatchNoShowRecorded` |
+
+## Consumed upstream events
+
+Dispatch registers no upstream event subscriptions in this activation wave.
+External provider-platform events are deferred by the simulation-boundary ruling.
+
+## Deferred downstream touchpoints
+
+| Downstream context | Deferred events | Purpose when activated |
+|---|---|---|
+| Fulfillment | `DriverArrived`, `RideStarted`, `RideEnded` | Ride arrival/start/end facts for fulfillment evidence and lifecycle. |
+| Notification | `DispatchRequested`, `DriverAssigned`, `DriverEtaUpdated`, `DriverArrived`, `DriverCancelled`, `DispatchUserCancelled`, `DispatchNoShowRecorded`, `RideEnded` | User-facing dispatch lifecycle notifications. |
+| Post Sales | `DispatchUserCancelled`, `DispatchNoShowRecorded`, `RideEnded` | Cancellation, waiting-fee, no-show, and final-charge dispute handling. |
+| Reporting | all Dispatch events | Dispatch lifecycle metrics and operational read models. |

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -71,6 +71,7 @@ context.
 | 21b | `legacy-acl` | `events:legacy-acl` | LegacyCommandMapped |
 | 22 | `supplier-catalog` | `events:supplier-catalog` | SupplierRegistered, CarrierRegistered, ContractActivated, ContractSuspended, ProductCapabilityDeclared, ExternalCodeMapped |
 | 23 | `waitlist` | `events:waitlist` | WaitlistRequestCreated, WaitlistPaymentAuthorizationRequested, WaitlistQueued, WaitlistMatchStarted, WaitlistHoldAuthorized, WaitlistFulfilled, WaitlistCancelled, WaitlistExpired |
+| 24 | `dispatch` | `events:dispatch` | DispatchRequested, DriverAssigned, DriverEtaUpdated, DriverArrived, RideStarted, RideEnded, DriverCancelled, DispatchUserCancelled, DispatchNoShowRecorded |
 
 ### Dead-Letter Streams
 
@@ -282,9 +283,19 @@ analytics, and cross-cutting concerns:
 
 | Consumer Group (Context) | Subscribed Streams | Purpose |
 |---|---|---|
-| `reporting` | All `events:*` streams | Business metrics, funnel analysis, operational dashboards |
+| `reporting` | All active `events:*` streams except `events:dispatch` until Dispatch's deferred-consumer activation wave | Business metrics, funnel analysis, operational dashboards |
 | `finance-settlement` | `events:payment`, `events:provider-integration`, `events:booking-orchestration`, `events:post-sales` | Revenue recognition, reconciliation, invoice generation |
 | `notification` | `events:journey-order`, `events:booking-orchestration`, `events:payment`, `events:entitlement-ticketing`, `events:post-sales`, `events:waitlist` | User-facing notification triggers |
+
+### Deferred Dispatch Subscriptions
+
+`events:dispatch` is registered as a produced stream in this contract, but has no
+required consumer groups in this activation wave. Immediate driver/vehicle/ETA
+supply is simulated through internal Dispatch ops HTTP commands, so
+`provider-integration` does not subscribe or publish Dispatch provider events.
+Fulfillment handoff consumption of `DriverArrived`, `RideStarted`, and
+`RideEnded` is deferred; Post Sales, Notification, and Reporting subscriptions to
+Dispatch lifecycle events are likewise deferred until their implementation waves.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add Dispatch HTTP API contract for ride requests and internal ops lifecycle commands
- Add Dispatch event contract covering nine lifecycle events and deferred consumers
- Register events:dispatch stream and document deferred subscriptions

## Validation
- make check