### PR TITLE
REQ-110 Fix trip planning snapshot OCC races

### DIFF
--- a/services/trip-planning/src/trip_planning/adapters/storage/postgres.py
+++ b/services/trip-planning/src/trip_planning/adapters/storage/postgres.py
@@ -6,7 +6,7 @@ from contextvars import ContextVar
 from datetime import UTC, datetime
 from typing import Any, Mapping
 
-from train_ticket_platform.storage import OutboxAppender, SnapshotRepository
+from train_ticket_platform.storage import OptimisticConcurrencyError, OutboxAppender, SnapshotRepository
 from trip_planning.domain import AvailabilityHint, Itinerary, LegCandidate, PriceHint
 from trip_planning.events import EventEnvelope
 
@@ -163,10 +163,24 @@ class PostgresPlanStore:
 
     def save_itinerary(self, itinerary: Mapping[str, object]) -> None:
         ref = str(itinerary["itineraryRef"])
+        payload = dict(itinerary)
 
         def write(conn: Any) -> None:
-            snap = self._itineraries.get(conn, ref)
-            self._itineraries.save(conn, ref, dict(itinerary), None if snap is None else int(snap[0]))
+            for _attempt in range(3):
+                snap = self._itineraries.get(conn, ref)
+                if snap is not None and dict(snap[1]) == payload:
+                    return
+                try:
+                    self._itineraries.save(conn, ref, payload, None if snap is None else int(snap[0]))
+                    return
+                except OptimisticConcurrencyError:
+                    # Search writes are durable read-model snapshots keyed by a
+                    # deterministic itinerary id. Concurrent searches can legitimately
+                    # race to persist the same candidate; retry with the winning version
+                    # and fall back to the already-readable snapshot below.
+                    continue
+            if self._itineraries.get(conn, ref) is None:
+                raise OptimisticConcurrencyError(f"concurrent update detected for {ref}")
 
         self.with_connection(write)
 

--- a/services/trip-planning/src/trip_planning/api.py
+++ b/services/trip-planning/src/trip_planning/api.py
@@ -20,7 +20,7 @@ from .domain import AvailabilityHint, Itinerary, LegCandidate, PriceHint, TripIn
 from .application_ports import EventPublisher, EventSubscriber
 from .events import PublishFailed, build_itinerary_proposed_event, new_uuid7
 from train_ticket_platform.idempotency import configure_idempotency_middleware
-from train_ticket_platform.storage import DatabaseConfig, DatabasePool, OutboxRelay, PostgresIdempotencyStore, ReadinessGate, run_migrations
+from train_ticket_platform.storage import DatabaseConfig, DatabasePool, OptimisticConcurrencyError, OutboxRelay, PostgresIdempotencyStore, ReadinessGate, run_migrations
 
 from .runtime import health, profile
 
@@ -581,7 +581,13 @@ def create_app(
                         app.state.itineraries[itinerary["itineraryRef"]] = itinerary
                         save_itinerary = getattr(_active_plan_store, "save_itinerary", None)
                         if callable(save_itinerary):
-                            save_itinerary(itinerary)
+                            try:
+                                save_itinerary(itinerary)
+                            except OptimisticConcurrencyError:
+                                logger.info(
+                                    "itinerary snapshot write lost deterministic-id race",
+                                    extra={"itinerary_ref": itinerary["itineraryRef"]},
+                                )
                 publisher.publish(event)
         except PublishFailed:
             return _canonical_error(503, "UNAVAILABLE", "Event bus is unavailable", correlation_id)

--- a/services/trip-planning/tests/test_concurrent_snapshot_persistence.py
+++ b/services/trip-planning/tests/test_concurrent_snapshot_persistence.py
@@ -1,0 +1,122 @@
+import threading
+import unittest
+
+from train_ticket_platform.storage import OptimisticConcurrencyError
+
+from trip_planning.adapters.storage.postgres import PostgresPlanStore
+
+
+class _FakeConnection:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def transaction(self):
+        return self
+
+
+class _FakePool:
+    def connection(self):
+        return _FakeConnection()
+
+
+class _RacingSnapshotRepository:
+    """Force two writers to read a missing snapshot before either insert."""
+
+    def __init__(self) -> None:
+        self._snapshot: tuple[int, dict[str, object]] | None = None
+        self._lock = threading.Lock()
+        self._first_read_barrier = threading.Barrier(2)
+        self.conflicts = 0
+
+    def get(self, conn: object, aggregate_id: str) -> tuple[int, dict[str, object]] | None:
+        with self._lock:
+            snapshot = self._snapshot
+        if snapshot is None:
+            self._first_read_barrier.wait(timeout=5)
+        return None if snapshot is None else (snapshot[0], dict(snapshot[1]))
+
+    def save(
+        self,
+        conn: object,
+        aggregate_id: str,
+        data: dict[str, object],
+        expected_version: int | None = None,
+    ) -> int:
+        with self._lock:
+            if expected_version is None:
+                if self._snapshot is not None:
+                    self.conflicts += 1
+                    raise OptimisticConcurrencyError(f"snapshot already exists for {aggregate_id}")
+                self._snapshot = (1, dict(data))
+                return 1
+            if self._snapshot is None or self._snapshot[0] != expected_version:
+                self.conflicts += 1
+                raise OptimisticConcurrencyError(f"concurrent update detected for {aggregate_id}")
+            version = expected_version + 1
+            self._snapshot = (version, dict(data))
+            return version
+
+    @property
+    def snapshot(self) -> tuple[int, dict[str, object]] | None:
+        with self._lock:
+            return None if self._snapshot is None else (self._snapshot[0], dict(self._snapshot[1]))
+
+
+class ConcurrentItinerarySnapshotPersistenceTest(unittest.TestCase):
+
+    def test_previous_read_modify_write_pattern_raises_occ_on_concurrent_same_id_write(self) -> None:
+        racing_repository = _RacingSnapshotRepository()
+        itinerary = {"itineraryRef": "itin_4616aaaf830a1f7d", "legs": []}
+        errors: list[BaseException] = []
+
+        def naive_write() -> None:
+            try:
+                snap = racing_repository.get(object(), str(itinerary["itineraryRef"]))
+                racing_repository.save(
+                    object(),
+                    str(itinerary["itineraryRef"]),
+                    itinerary,
+                    None if snap is None else int(snap[0]),
+                )
+            except BaseException as exc:  # captures the historical lost race
+                errors.append(exc)
+
+        threads = [threading.Thread(target=naive_write) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], OptimisticConcurrencyError)
+
+    def test_concurrent_same_itinerary_snapshot_write_is_idempotent(self) -> None:
+        store = PostgresPlanStore(_FakePool())
+        racing_repository = _RacingSnapshotRepository()
+        store._itineraries = racing_repository  # type: ignore[attr-defined]
+        itinerary = {
+            "itineraryRef": "itin_4616aaaf830a1f7d",
+            "legs": [],
+            "priceHint": {"currency": "CNY", "minorUnits": 0},
+            "availabilityHint": {"status": "UNKNOWN", "confidence": 50},
+        }
+        errors: list[BaseException] = []
+
+        def write_itinerary() -> None:
+            try:
+                store.save_itinerary(itinerary)
+            except BaseException as exc:  # pragma: no cover - asserted below for thread failures
+                errors.append(exc)
+
+        threads = [threading.Thread(target=write_itinerary) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+
+        self.assertEqual(errors, [])
+        self.assertEqual(racing_repository.conflicts, 1)
+        self.assertEqual(racing_repository.snapshot, (1, itinerary))

--- a/services/trip-planning/tests/test_event_ports.py
+++ b/services/trip-planning/tests/test_event_ports.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 from trip_planning import create_app
 from trip_planning.adapters.messaging.fake import FakeEventPublisher, FakeEventSubscriber
 from trip_planning.events import EventEnvelope, PublishFailed
+from train_ticket_platform.storage import OptimisticConcurrencyError
 
 
 CAPTURED = datetime(2026, 7, 3, 12, 0, tzinfo=timezone.utc)
@@ -98,6 +99,53 @@ class EventPublisherTest(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(store.saved_inside_transaction)
         self.assertTrue(publisher.published_inside_transaction)
+
+    def test_search_returns_success_when_snapshot_write_loses_occ_race(self) -> None:
+        class ConflictingStore:
+            def transaction(self):
+                class Context:
+                    def __enter__(self):
+                        return self
+
+                    def __exit__(self, exc_type, exc, traceback):
+                        return False
+
+                return Context()
+
+            def candidates(self, origin_ref: str, destination_ref: str, departure_date: str) -> list[object]:
+                return []
+
+            def save_itinerary(self, itinerary: dict[str, object]) -> None:
+                raise OptimisticConcurrencyError("concurrent update detected for itin_4616aaaf830a1f7d")
+
+            def load(self) -> None:
+                return None
+
+        import trip_planning.api as api
+
+        store = ConflictingStore()
+        publisher = FakeEventPublisher()
+        original = api._active_plan_store
+        api._active_plan_store = store
+        try:
+            client = TestClient(create_app(event_publisher=publisher, start_event_subscriber=False))
+            api._active_plan_store = store
+            response = client.post(
+                "/api/v1/itineraries/search",
+                json={
+                    "originRef": "station:A",
+                    "destinationRef": "station:B",
+                    "departureDate": "2026-08-01",
+                    "travelerRefs": ["tvl-1"],
+                    "channel": "WEB",
+                },
+            )
+        finally:
+            api._active_plan_store = original
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()["itineraries"]), 1)
+        self.assertEqual(len(publisher.published), 1)
 
     def test_fake_publisher_records_events(self) -> None:
         publisher = FakeEventPublisher()


### PR DESCRIPTION
## Summary
- add regression coverage for concurrent deterministic itinerary snapshot writes
- retry/reload Postgres itinerary snapshot persistence on optimistic concurrency conflicts
- guard search response path so OCC conflicts never surface as 500 or empty results

## Validation
- cd services/trip-planning && uv run pytest tests/test_event_ports.py tests/test_concurrent_snapshot_persistence.py
- cd services/trip-planning && uv run pytest
- make check

## Notes
- Chose bounded conflict retry plus idempotent skip for identical snapshots, preserving current contracts and response shape.
- Audited trip-planning deterministic snapshot patterns: only itinerary_snapshots use SnapshotRepository/OCC; fare/availability/planning snapshot refs are embedded read-model hint refs, not separately persisted aggregates in trip-planning.