### PR TITLE
test: fix envelope component-count assertion (10 since trace context)

### DIFF
--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
@@ -37,7 +37,9 @@ class MessagingTest {
         assertEquals("corr-0194f2e0-7b3e-7610-8284-5c26e8b0e101", envelope.correlationId());
         assertEquals("cmd-0194f2e0-7b3e-7610-8284-5c26e8b0e201", envelope.causationId());
         assertEquals(1, envelope.schemaVersion());
-        assertEquals(8, EventEnvelope.class.getRecordComponents().length);
+        // 8 core fields plus the optional W3C traceparent/tracestate pair
+        // added by the trace-context ruling (docs/08-contracts/messaging.md).
+        assertEquals(10, EventEnvelope.class.getRecordComponents().length);
         assertEquals(1000L, ((Map<?, ?>) ((Map<?, ?>) envelope.payload()).get("amount")).get("minorUnits"));
     }
 


### PR DESCRIPTION
Deterministic failure with a freshly installed java-kit; stale m2 caches had masked it. One-line assertion update with rationale comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)