### PR TITLE
wallet-promotion: restore live-gate fixes missed by the #198 squash

### DIFF
--- a/services/wallet-promotion/migrations/001_wallet_promotion.sql
+++ b/services/wallet-promotion/migrations/001_wallet_promotion.sql
@@ -1,6 +1,8 @@
 CREATE TABLE IF NOT EXISTS promotion_instrument_snapshots (id text PRIMARY KEY, version bigint NOT NULL, data jsonb NOT NULL, updated_at timestamptz NOT NULL DEFAULT now());
 CREATE INDEX IF NOT EXISTS idx_promotion_account ON promotion_instrument_snapshots ((data->>'accountId'));
-CREATE INDEX IF NOT EXISTS idx_promotion_expiry ON promotion_instrument_snapshots (((data->>'validUntil')::timestamptz)) WHERE data->>'status' IN ('ISSUED','RESERVED','RELEASED');
+-- Text-ordered index: RFC3339 UTC strings sort chronologically, and the
+-- timestamptz cast is not IMMUTABLE in index expressions (REQ-081A ruling).
+CREATE INDEX IF NOT EXISTS idx_promotion_expiry ON promotion_instrument_snapshots ((data->>'validUntil')) WHERE data->>'status' IN ('ISSUED','RESERVED','RELEASED');
 CREATE TABLE IF NOT EXISTS wallet_account_snapshots (id text PRIMARY KEY, version bigint NOT NULL, data jsonb NOT NULL, updated_at timestamptz NOT NULL DEFAULT now());
 CREATE UNIQUE INDEX IF NOT EXISTS idx_wallet_account_account ON wallet_account_snapshots ((data->>'accountId'));
 CREATE TABLE IF NOT EXISTS wallet_ledger_entries (ledger_entry_id text PRIMARY KEY, wallet_account_id text NOT NULL, benefit_id text NOT NULL, data jsonb NOT NULL, created_at timestamptz NOT NULL DEFAULT now());

--- a/services/wallet-promotion/pom.xml
+++ b/services/wallet-promotion/pom.xml
@@ -27,11 +27,6 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-api</artifactId>
-      <version>1.46.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/application/WalletPromotionService.java
+++ b/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/application/WalletPromotionService.java
@@ -29,6 +29,7 @@ public class WalletPromotionService {
     private final PromotionRepository repository;
     private final Clock clock;
 
+    @org.springframework.beans.factory.annotation.Autowired
     public WalletPromotionService(PromotionRepository repository) {
         this(repository, Clock.systemUTC());
     }

--- a/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/infrastructure/persistence/PostgresPromotionRepository.java
+++ b/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/infrastructure/persistence/PostgresPromotionRepository.java
@@ -112,14 +112,16 @@ public class PostgresPromotionRepository implements PromotionRepository {
             SELECT data::text
               FROM promotion_instrument_snapshots
              WHERE data->>'status' IN ('ISSUED', 'RESERVED', 'RELEASED')
-               AND (data->>'validUntil')::timestamptz <= ?
+               AND data->>'validUntil' <= ?
              ORDER BY data->>'validUntil'
              LIMIT ?
             """;
+        // RFC3339 UTC strings compare chronologically as text, matching the
+        // text-expression index (timestamptz casts are not IMMUTABLE there).
         return jdbc.query(
             sql,
             (rs, rowNumber) -> read(rs.getString(1), PromotionInstrument.class),
-            java.sql.Timestamp.from(now),
+            java.time.format.DateTimeFormatter.ISO_INSTANT.format(now.truncatedTo(java.time.temporal.ChronoUnit.SECONDS)),
             limit
         );
     }


### PR DESCRIPTION
Four fixes verified live (constructor wiring, otel version pin removal, IMMUTABLE-safe expiry index+query) that landed on the #195 branch after #198's snapshot. Aligns merged source with the running image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)