### PR TITLE
REQ-115 disruption recovery contracts

### DIFF
--- a/docs/08-contracts/api/README.md
+++ b/docs/08-contracts/api/README.md
@@ -152,6 +152,7 @@ correlation IDs.
 | 23 | `waitlist.md` | Waitlist | rust (activated, ADR-0002) |
 | 24 | `dispatch.md` | Dispatch | activation wave in progress |
 | 25 | `wallet-promotion.md` | Wallet / Promotion | activation wave in progress |
+| 26 | `disruption-recovery.md` | Disruption Recovery | activation wave in progress |
 
 ## Open Issues
 

--- a/docs/08-contracts/api/disruption-recovery.md
+++ b/docs/08-contracts/api/disruption-recovery.md
@@ -69,7 +69,7 @@ The wire status enum is the 10-state domain state machine:
 | `OPTIONS_GENERATED` | A recovery option set exists and can either auto-select or wait for choice. | `EXECUTING_RECOVERY`, `AWAITING_USER_CHOICE`, `MANUAL_REVIEW` |
 | `AWAITING_USER_CHOICE` | User or customer service must choose an unexpired option. | `EXECUTING_RECOVERY`, `MANUAL_REVIEW`, `DECLINED` |
 | `EXECUTING_RECOVERY` | The selected option is executing locally or in a downstream context. | `RECOVERED`, `OPTIONS_GENERATED`, `MANUAL_REVIEW`, `FAILED` |
-| `MANUAL_REVIEW` | Automatic decision or execution cannot proceed safely. | `EXECUTING_RECOVERY`, `RECOVERED`, `FAILED`, `CLOSED` |
+| `MANUAL_REVIEW` | Automatic decision or execution cannot proceed safely. | `EXECUTING_RECOVERY`, `RECOVERED`, `FAILED` |
 | `RECOVERED` | Recovery completed by wait, refund, compensation, or an explicit manual outcome. | `CLOSED` |
 | `DECLINED` | User declined available recovery or chose to self-handle. | `CLOSED` |
 | `FAILED` | Execution failed and no automatic recovery path remains. | `CLOSED` |

--- a/docs/08-contracts/api/disruption-recovery.md
+++ b/docs/08-contracts/api/disruption-recovery.md
@@ -1,0 +1,393 @@
+# Disruption Recovery — HTTP API
+
+Last updated: 2026-07-09
+
+## Overview
+
+Disruption Recovery receives operational disruption reports, merges them into
+incidents, opens one recovery case per affected journey order, generates the
+activation-wave recovery options, and orchestrates selected executions. This
+contract is scoped to the ADR-0002 third activation wave and is bounded by
+`docs/02-domains/disruption-recovery.md`.
+
+Activation-wave rulings:
+
+- The only disruption signal source in this wave is **operations reporting** via
+  `POST /api/v1/disruptions`. The request represents the Customer
+  Service/Admin manual rows from the upstream table and MUST carry
+  `disruptionType`, `scheduledServiceRef` and/or `segmentRef`, `serviceDate`,
+  `evidence`, and explicit `affectedOrderIds`. Automatic `segmentRef` to order
+  fan-out is deferred because Journey Order has no by-segment query contract.
+- Service Plan, Provider Integration, Fulfillment, and Transfer Management event
+  sources are deferred. Most of those events are not in production today;
+  Transfer Management is wave 18.
+- An `Incident` is opened or merged by the same report. This wave merges by
+  `(scheduledServiceRef, serviceDate)` when `scheduledServiceRef` is present;
+  otherwise the report opens a distinct incident for its supplied scope.
+- `ServiceAlert` is event-only in this wave. Disruption Recovery publishes
+  `ServiceAlertPublished`; the ServiceAlert read model is deferred.
+- The `RecoveryCase` state machine is exactly the 10-state machine from the
+  domain document (`OPENED` through `CLOSED`) and follows the transition table
+  below. One `RecoveryCase` is opened for each `affectedOrderId` supplied in the
+  report.
+- `RecoveryOptionSet` supports four option types in this wave: `WAIT`, `REFUND`,
+  `COMPENSATION`, and `MANUAL`. `REACCOMMODATION` is deferred until wave 18 after
+  Transfer Management activation.
+- Automatic selection rules may only select `WAIT`, which completes immediately
+  as `RECOVERED` without a downstream call. `REFUND`, `COMPENSATION`, and
+  `MANUAL` move the case to `AWAITING_USER_CHOICE` and require
+  `POST /api/v1/recovery-cases/{caseId}/select-option` by the user or customer
+  service.
+
+Field shapes reference `docs/08-contracts/shared-primitives.md` for IDs,
+timestamps, event envelope fields, pagination conventions, and Money
+(`{currency, minorUnits}`). All timestamps are RFC3339 UTC. JSON fields are
+camelCase and enum values are SCREAMING_SNAKE_CASE.
+
+## Common enums
+
+| Enum | Values |
+|---|---|
+| `disruptionType` | `SERVICE_DELAY`, `SERVICE_CANCELLED`, `SERVICE_SUSPENDED`, `SAILING_SUSPENDED`, `ROAD_CLOSED`, `WEATHER`, `OPERATION_RESTRICTION`, `SUPPLIER_FAILURE`, `DRIVER_CANCELLED`, `DISPATCH_FAILED`, `STOP_CHANGED`, `PORT_CALL_CHANGED`, `BATCH_SYSTEM_EVENT`, `CONNECTION_MISSED` |
+| `incidentStatus` | `DETECTED`, `CONFIRMED`, `BATCH_PROCESSING`, `MONITORING`, `RESOLVED`, `CLOSED` |
+| `recoveryCaseStatus` | `OPENED`, `ASSESSING_IMPACT`, `OPTIONS_GENERATED`, `AWAITING_USER_CHOICE`, `EXECUTING_RECOVERY`, `MANUAL_REVIEW`, `RECOVERED`, `DECLINED`, `FAILED`, `CLOSED` |
+| `recoveryOptionType` | `WAIT`, `REFUND`, `COMPENSATION`, `MANUAL` |
+| `actorType` | `USER`, `CUSTOMER_SERVICE`, `OPERATIONS`, `SYSTEM` |
+| `executionTarget` | `NONE`, `POST_SALES`, `WALLET_PROMOTION`, `MANUAL_QUEUE` |
+
+`REACCOMMODATION` is intentionally absent from the active option-type enum in
+this wave. It remains a domain capability but is deferred until wave 18.
+
+## RecoveryCase state machine
+
+The wire status enum is the 10-state domain state machine:
+
+| Status | Meaning | Allowed next statuses |
+|---|---|---|
+| `OPENED` | A supplied affected order was confirmed as impacted by an incident/disruption report. | `ASSESSING_IMPACT`, `MANUAL_REVIEW` |
+| `ASSESSING_IMPACT` | Disruption Recovery is binding affected scope, responsibility, protection, and waiver candidates. | `OPTIONS_GENERATED`, `MANUAL_REVIEW` |
+| `OPTIONS_GENERATED` | A recovery option set exists and can either auto-select or wait for choice. | `EXECUTING_RECOVERY`, `AWAITING_USER_CHOICE`, `MANUAL_REVIEW` |
+| `AWAITING_USER_CHOICE` | User or customer service must choose an unexpired option. | `EXECUTING_RECOVERY`, `MANUAL_REVIEW`, `DECLINED` |
+| `EXECUTING_RECOVERY` | The selected option is executing locally or in a downstream context. | `RECOVERED`, `OPTIONS_GENERATED`, `MANUAL_REVIEW`, `FAILED` |
+| `MANUAL_REVIEW` | Automatic decision or execution cannot proceed safely. | `EXECUTING_RECOVERY`, `RECOVERED`, `FAILED`, `CLOSED` |
+| `RECOVERED` | Recovery completed by wait, refund, compensation, or an explicit manual outcome. | `CLOSED` |
+| `DECLINED` | User declined available recovery or chose to self-handle. | `CLOSED` |
+| `FAILED` | Execution failed and no automatic recovery path remains. | `CLOSED` |
+| `CLOSED` | Case is archived; no further execution occurs on this case. | - |
+
+Key transitions from the domain document are enforced with this wave's narrower
+option set:
+
+| Current status | Trigger | Target status | Rule |
+|---|---|---|---|
+| `OPENED` | `AssessRecoveryImpact` | `ASSESSING_IMPACT` | Case has `affectedScope` and source `evidenceRef`. |
+| `ASSESSING_IMPACT` | `RecoveryImpactAssessed` | `OPTIONS_GENERATED` | Responsibility, protection, and waiver candidates were assessed for the supplied order. |
+| `OPTIONS_GENERATED` | Automatic `WAIT` rule | `EXECUTING_RECOVERY` then `RECOVERED` | Only `WAIT` may be auto-selected; no downstream call is made. |
+| `OPTIONS_GENERATED` | Non-`WAIT` option set generated | `AWAITING_USER_CHOICE` | `REFUND`, `COMPENSATION`, and `MANUAL` require user or customer-service selection. |
+| `AWAITING_USER_CHOICE` | `RecoveryOptionSelected` | `EXECUTING_RECOVERY` | Option exists, is unexpired, belongs to the current option set, and actor is authorized. |
+| `EXECUTING_RECOVERY` | Downstream execution succeeded or `WAIT` completed | `RECOVERED` | Required downstream convergence has been observed. |
+| `EXECUTING_RECOVERY` | Recoverable execution failure | `OPTIONS_GENERATED` or `MANUAL_REVIEW` | The service may refresh options or require manual review. |
+| Any non-terminal status | High risk, rule conflict, invalid evidence, or selected `MANUAL` | `MANUAL_REVIEW` | Case is placed in the operations/customer-service manual queue. |
+| `RECOVERED`, `DECLINED`, `FAILED` | `CloseRecoveryCase` | `CLOSED` | Closed cases are audit-only. |
+
+## Resource representations
+
+### DisruptionReport
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `disruptionId` | string | yes | Canonical disruption report ID (`drp-<uuid>`). |
+| `disruptionType` | enum | yes | Normalized disruption type from the enum above. |
+| `scheduledServiceRef` | string | no | Scheduled service reference for merge and impact scope. Required when `segmentRef` is absent. |
+| `segmentRef` | string | no | Segment reference from the order/service plan. Required when `scheduledServiceRef` is absent. |
+| `serviceDate` | string | yes | Service operating date in ISO `YYYY-MM-DD`; used with `scheduledServiceRef` for incident merge. |
+| `evidence` | object | yes | Operational evidence object. See `Evidence`. |
+| `affectedOrderIds` | array[string] | yes | Explicit affected journey order IDs (`ord-<uuid>`). Must be non-empty; no automatic segment-to-order fan-out in this wave. |
+| `reportedBy` | object | yes | Reporting actor. See `ActorRef`. |
+| `reportedAt` | RFC3339 UTC | yes | Report timestamp. |
+| `incidentId` | string | yes | Opened or merged incident ID (`inc-<uuid>`). |
+
+### Evidence
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `evidenceRef` | string | yes | Reference to the admin/customer-service evidence record or uploaded artifact. |
+| `sourceSystem` | enum | yes | `CUSTOMER_SERVICE` or `ADMIN`. Other upstream source systems are deferred. |
+| `sourceRecordId` | string | yes | Upstream manual-row identifier. |
+| `summary` | string | yes | Operational summary; MUST NOT include unmasked documents or other sensitive personal data. |
+| `occurredAt` | RFC3339 UTC | no | When the disruption was observed, if known. |
+
+### ActorRef
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `actorType` | enum | yes | `USER`, `CUSTOMER_SERVICE`, `OPERATIONS`, or `SYSTEM`. |
+| `actorId` | string | yes | Account, operator, or service actor reference. |
+
+### Incident
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `incidentId` | string | yes | Incident ID (`inc-<uuid>`). |
+| `status` | enum | yes | Incident status. Newly accepted reports produce `CONFIRMED` incidents in this wave. |
+| `disruptionType` | enum | yes | Dominant normalized type for the incident. |
+| `scheduledServiceRef` | string | no | Service reference used for merge when present. |
+| `segmentRefs` | array[string] | no | Segment refs reported for this incident. |
+| `serviceDate` | string | yes | Service operating date. |
+| `evidenceRefs` | array[string] | yes | Evidence references that opened or merged into the incident. |
+| `affectedOrderCount` | integer | yes | Count of distinct explicit affected orders accepted for this incident. |
+| `openedAt` | RFC3339 UTC | yes | Incident open timestamp. |
+| `updatedAt` | RFC3339 UTC | yes | Last merge or state-change timestamp. |
+
+### RecoveryCase
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | string | yes | Recovery case ID (`rcv-<uuid>`). |
+| `incidentId` | string | yes | Parent incident. |
+| `journeyOrderId` | string | yes | Affected order (`ord-<uuid>`). |
+| `affectedScope` | object | yes | Scope used for recovery. See `AffectedScope`. |
+| `status` | enum | yes | Recovery case status. |
+| `optionSet` | RecoveryOptionSet | no | Current generated option set when available. |
+| `selectedOptionId` | string | no | Selected option ID when a choice has been made. |
+| `execution` | object | no | Current or final execution tracking. See `RecoveryExecution`. |
+| `openedAt` | RFC3339 UTC | yes | Open timestamp. |
+| `updatedAt` | RFC3339 UTC | yes | Last mutation timestamp. |
+
+### AffectedScope
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `journeyOrderId` | string | yes | Affected order ID. |
+| `scheduledServiceRef` | string | no | Scheduled service reference copied from the report when supplied. |
+| `segmentRef` | string | no | Segment reference copied from the report when supplied. |
+| `serviceDate` | string | yes | Service operating date. |
+| `disruptionType` | enum | yes | Normalized disruption type. |
+| `evidenceRef` | string | yes | Evidence reference that supports opening the case. |
+
+### RecoveryOptionSet
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `optionSetId` | string | yes | Option set ID (`ros-<uuid>`). |
+| `caseId` | string | yes | Owning recovery case. |
+| `options` | array[RecoveryOption] | yes | Active options. This wave supports `WAIT`, `REFUND`, `COMPENSATION`, and `MANUAL`. |
+| `generatedAt` | RFC3339 UTC | yes | Generation timestamp. |
+| `expiresAt` | RFC3339 UTC | no | Choice deadline when user choice is required. |
+| `requiresUserChoice` | boolean | yes | `false` only when the generated set contains an auto-selected `WAIT` path. |
+
+### RecoveryOption
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `optionId` | string | yes | Option ID (`rop-<uuid>`). |
+| `optionType` | enum | yes | `WAIT`, `REFUND`, `COMPENSATION`, or `MANUAL`. |
+| `title` | string | yes | User/customer-service display title. |
+| `description` | string | yes | Explanation of the recovery path; must not include sensitive personal data. |
+| `executionTarget` | enum | yes | `NONE`, `POST_SALES`, `WALLET_PROMOTION`, or `MANUAL_QUEUE`. |
+| `refund` | object | for `REFUND` | Refund execution parameters. See `RefundOption`. |
+| `compensation` | object | for `COMPENSATION` | Wallet benefit execution parameters. See `CompensationOption`. |
+| `manualReason` | string | for `MANUAL` | Reason the case should enter manual review. |
+| `expiresAt` | RFC3339 UTC | no | Option-specific expiry. |
+
+### RefundOption
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reasonCode` | string | yes | Post Sales reason code, normally `DISRUPTION_REFUND`. |
+| `scope` | object | yes | Post Sales scope object for the affected order/items/segments. |
+| `waiverRef` | string | no | Frozen waiver policy snapshot reference when a waiver applies. |
+
+Selecting this option starts execution by calling the existing Post Sales
+contract: `POST /api/v1/post-sales-cases` with `caseType=REFUND`, the option's
+`scope`, the option `reasonCode`, and a deterministic idempotency key seeded as
+`disruption-recovery:refund:<caseId>:<optionId>`. Disruption Recovery then
+tracks `PostSalesApplied` from `events:post-sales` to converge the case to
+`RECOVERED`.
+
+### CompensationOption
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `amount` | Money | yes | Wallet benefit amount using `{currency, minorUnits}`. |
+| `benefitType` | enum | yes | Wallet / Promotion benefit type, normally `COMPENSATION_CREDIT`. |
+| `balanceType` | enum | yes | Wallet / Promotion balance type, normally `PROMOTION_CREDIT`. |
+| `validUntil` | RFC3339 UTC | yes | Benefit expiry. |
+| `reasonCode` | string | yes | Wallet business reason code, normally `DISRUPTION_COMP`. |
+
+Selecting this option starts execution by calling Wallet / Promotion
+`POST /api/v1/benefits` with a deterministic idempotency key seeded as
+`disruption-recovery:compensation:<caseId>:<optionId>` and
+`issuanceSource=DISRUPTION_COMP`. `DISRUPTION_COMP` is an additive Wallet /
+Promotion issuance-source enum value introduced by this activation wave.
+
+### RecoveryExecution
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `executionId` | string | yes | Execution tracking ID (`rex-<uuid>`). |
+| `target` | enum | yes | `NONE`, `POST_SALES`, `WALLET_PROMOTION`, or `MANUAL_QUEUE`. |
+| `idempotencyKey` | string | no | Deterministic downstream idempotency key when a downstream HTTP command is used. |
+| `externalRef` | string | no | Downstream case/benefit/manual-queue reference. |
+| `startedAt` | RFC3339 UTC | yes | Execution start timestamp. |
+| `completedAt` | RFC3339 UTC | no | Completion timestamp. |
+| `failureReason` | string | no | Failure reason; do not include unmasked documents or sensitive personal data. |
+
+## Endpoints
+
+### Report Disruption
+
+**POST** `/api/v1/disruptions`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header). Replays with the same body
+return the original response. Reusing the same key with a different body returns
+`IDEMPOTENCY_KEY_REUSED`.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `disruptionType` | enum | yes | Normalized disruption type. |
+| `scheduledServiceRef` | string | no | Scheduled service reference. Required when `segmentRef` is absent. |
+| `segmentRef` | string | no | Segment reference. Required when `scheduledServiceRef` is absent. |
+| `serviceDate` | string | yes | ISO `YYYY-MM-DD` operating date; used with `scheduledServiceRef` for incident merge. |
+| `evidence` | object | yes | Evidence object with `sourceSystem` of `CUSTOMER_SERVICE` or `ADMIN`. |
+| `affectedOrderIds` | array[string] | yes | Explicit affected `ord-<uuid>` IDs. Must be non-empty. |
+| `reportedBy` | object | yes | Reporting actor; normally `CUSTOMER_SERVICE` or `OPERATIONS`. |
+
+**Response (202):**
+
+| Field | Type | Description |
+|---|---|---|
+| `disruption` | DisruptionReport | Accepted report. |
+| `incident` | Incident | Opened or merged incident. |
+| `recoveryCases` | array[RecoveryCase] | One case per distinct `affectedOrderIds` entry. |
+
+**Domain effects:** emits `DisruptionReported`, `IncidentOpened` when a new
+incident is opened, `RecoveryCaseOpened` for each affected order, optionally
+`RecoveryOptionsGenerated`, and `ServiceAlertPublished` for the incident alert
+fact. A repeated report for an already known `(scheduledServiceRef, serviceDate)`
+merges into the existing incident and does not duplicate active cases for the
+same `(incidentId, journeyOrderId)`.
+
+**Error codes:** `VALIDATION_FAILED`, `CONFLICT`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+- `DOMAIN_RULE_VIOLATION` is returned when neither `scheduledServiceRef` nor
+  `segmentRef` is provided, evidence is missing, or `affectedOrderIds` is empty.
+- `CONFLICT` is returned when the same idempotent operation attempts to open a
+  duplicate active case with incompatible scope.
+
+### Get Incident
+
+**GET** `/api/v1/incidents/{incidentId}`
+
+**Response (200):** `Incident` resource.
+
+**Error codes:** `NOT_FOUND`
+
+### Get Recovery Case
+
+**GET** `/api/v1/recovery-cases/{caseId}`
+
+**Response (200):** `RecoveryCase` resource.
+
+**Error codes:** `NOT_FOUND`
+
+### List Recovery Cases by Incident
+
+**GET** `/api/v1/recovery-cases?incidentId={incidentId}&limit=20&offset=0`
+
+`incidentId` is required for list queries. Broad unfiltered listing is not part
+of this activation-wave API.
+
+**Query parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `incidentId` | string | yes | Parent incident ID. |
+| `status` | enum | no | Optional recovery-case status filter. |
+| `limit` | integer | no | Pagination limit, default 20, max 100. |
+| `offset` | integer | no | Pagination offset, default 0. |
+
+**Response (200):** Paginated response with `items`, `total`, `limit`, and
+`offset`, where each item is a `RecoveryCase` resource.
+
+**Error codes:** `VALIDATION_FAILED`
+
+### Select Recovery Option
+
+**POST** `/api/v1/recovery-cases/{caseId}/select-option`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header). Replays with the same body
+return the original response. Reusing the same key with a different body returns
+`IDEMPOTENCY_KEY_REUSED`.
+
+This endpoint is used by users or customer-service agents when a case is in
+`AWAITING_USER_CHOICE`. `WAIT` normally auto-selects before reaching this state;
+if exposed for an already waiting case, selecting `WAIT` still performs no
+downstream call and completes as `RECOVERED`.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `optionId` | string | yes | Option being selected from the current `optionSet`. |
+| `selectedBy` | object | yes | Selecting actor. `actorType` MUST be `USER` or `CUSTOMER_SERVICE`. |
+| `selectionReason` | string | no | Optional reason. Must not include unmasked documents or other sensitive personal data. |
+
+**Response (200):** `RecoveryCase` resource after selection and any synchronous
+state advancement.
+
+**Domain effects:** emits `RecoveryOptionSelected` and
+`RecoveryExecutionStarted` for executable options. `WAIT` emits
+`RecoveryCompleted` immediately and moves to `RECOVERED`. `REFUND` opens a Post
+Sales `REFUND` case and waits for `PostSalesApplied`. `COMPENSATION` issues a
+Wallet / Promotion benefit with `issuanceSource=DISRUPTION_COMP`. `MANUAL` moves
+to `MANUAL_REVIEW` and is handled by operations/customer service outside this
+public API.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+- `PRECONDITION_FAILED` is returned when the case is not in
+  `AWAITING_USER_CHOICE`, the option set is expired, or the option has already
+  been selected.
+
+### Close Recovery Case
+
+**POST** `/api/v1/recovery-cases/{caseId}/close`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header).
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `closedBy` | object | yes | Closing actor; normally `CUSTOMER_SERVICE`, `OPERATIONS`, or `SYSTEM`. |
+| `closeReason` | string | yes | Closure reason. Must not include unmasked documents or sensitive personal data. |
+
+**Response (200):** `RecoveryCase` resource in `CLOSED` status.
+
+**Domain effects:** emits `RecoveryCaseClosed`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`
+
+## Bus-only behavior
+
+The following domain commands have no public HTTP endpoint in this activation
+wave:
+
+- `AssessRecoveryImpact` — runs after a report opens a case using the explicit
+  order scope supplied by operations.
+- `GenerateRecoveryOptions` — creates this wave's option set (`WAIT`, `REFUND`,
+  `COMPENSATION`, `MANUAL`); `REACCOMMODATION` generation is deferred.
+- `ApplyRecoveryDecision` / execution convergence — driven internally after
+  selection and by consuming `PostSalesApplied` from `events:post-sales`.
+- `PublishServiceAlert` — publishes the event-only `ServiceAlertPublished` fact;
+  the ServiceAlert read model is deferred.
+
+Deferred signal sources remain out of this wave: Service Plan, Provider
+Integration, Fulfillment, and Transfer Management events do not open incidents
+or cases until their activation waves.

--- a/docs/08-contracts/api/wallet-promotion.md
+++ b/docs/08-contracts/api/wallet-promotion.md
@@ -27,10 +27,12 @@ Activation-wave rulings:
 - Finance Settlement and Notification are event consumers at the contract
   surface, but their concrete consumption implementations are deferred to a
   later wave.
-- Issuance sources supported in this wave are `MANUAL_OPS` and
-  `POST_SALES_COMP`. Post-sales compensation is carried by the issuance request
-  as `caseId`; the Post Sales contract is not changed and Wallet / Promotion
-  does not subscribe to a Post Sales stream in this wave.
+- Issuance sources supported in this wave are `MANUAL_OPS`,
+  `POST_SALES_COMP`, and the additive Disruption Recovery value
+  `DISRUPTION_COMP`. Post-sales compensation is carried by the issuance request
+  as `caseId`; Disruption Recovery compensation is carried as a recovery
+  `caseId`/business reason. Wallet / Promotion does not subscribe to Post Sales
+  or Disruption Recovery streams in this wave.
 
 Field shapes reference `docs/08-contracts/shared-primitives.md` for IDs,
 timestamps, event envelope fields, pagination conventions, and `Money`. All
@@ -73,8 +75,8 @@ A `WalletAccount` is the per-account ledger view for benefit balances.
 |---|---|
 | `benefitType` | `BALANCE`, `COUPON`, `COMPENSATION_CREDIT`, `POINTS` |
 | `balanceType` | `STORED_VALUE`, `POINTS`, `PROMOTION_CREDIT` |
-| `issuanceSource` | `MANUAL_OPS`, `POST_SALES_COMP` |
-| `businessReason.reasonType` | `MANUAL_OPS`, `POST_SALES_COMP`, `ORDER_PURCHASE`, `RESERVATION_TIMEOUT`, `CUSTOMER_SERVICE_ADJUSTMENT`, `SYSTEM_EXPIRY`, `REVERSAL` |
+| `issuanceSource` | `MANUAL_OPS`, `POST_SALES_COMP`, `DISRUPTION_COMP` |
+| `businessReason.reasonType` | `MANUAL_OPS`, `POST_SALES_COMP`, `DISRUPTION_COMP`, `ORDER_PURCHASE`, `RESERVATION_TIMEOUT`, `CUSTOMER_SERVICE_ADJUSTMENT`, `SYSTEM_EXPIRY`, `REVERSAL` |
 
 `businessReason` is the cross-command audit reason object:
 
@@ -102,8 +104,8 @@ A `WalletAccount` is the per-account ledger view for benefit balances.
 | `availableAmount` | Money | yes | Currently available amount; never negative. |
 | `reservedAmount` | Money | yes | Currently frozen amount; never negative. |
 | `redeemedAmount` | Money | yes | Amount already redeemed. |
-| `issuanceSource` | enum | yes | `MANUAL_OPS` or `POST_SALES_COMP`. |
-| `caseId` | string | no | Post-sales case reference when `issuanceSource` is `POST_SALES_COMP`. |
+| `issuanceSource` | enum | yes | `MANUAL_OPS`, `POST_SALES_COMP`, or `DISRUPTION_COMP`. |
+| `caseId` | string | no | Post-sales case reference when `issuanceSource` is `POST_SALES_COMP`, or Disruption Recovery case reference when `issuanceSource` is `DISRUPTION_COMP`. |
 | `applicableScope` | object | yes | Scope/rules for eligibility. See `ApplicableScope`. |
 | `redemptionRule` | object | yes | Redemption rule such as single-use and maximum amount. See `RedemptionRule`. |
 | `revocationRule` | object | yes | Revocation rule for allowed administrative/business revoke conditions. |
@@ -168,8 +170,8 @@ return the original response. Reusing the same key with a different body returns
 | `benefitType` | enum | yes | `BALANCE`, `COUPON`, `COMPENSATION_CREDIT`, or `POINTS`. |
 | `balanceType` | enum | yes | Wallet sub-ledger to credit. |
 | `amount` | Money | yes | Issued amount. `minorUnits` must be positive. |
-| `issuanceSource` | enum | yes | `MANUAL_OPS` or `POST_SALES_COMP`. |
-| `caseId` | string | no | Required when `issuanceSource` is `POST_SALES_COMP`; ignored otherwise. |
+| `issuanceSource` | enum | yes | `MANUAL_OPS`, `POST_SALES_COMP`, or `DISRUPTION_COMP`. |
+| `caseId` | string | no | Required when `issuanceSource` is `POST_SALES_COMP` or `DISRUPTION_COMP`; ignored otherwise. |
 | `applicableScope` | object | yes | Eligibility scope. |
 | `redemptionRule` | object | yes | Redemption rule. |
 | `revocationRule` | object | yes | Revocation rule. |

--- a/docs/08-contracts/events/disruption-recovery.md
+++ b/docs/08-contracts/events/disruption-recovery.md
@@ -1,0 +1,364 @@
+# Disruption Recovery — Events & Commands
+
+Last updated: 2026-07-09
+
+## Scope and activation-wave rulings
+
+This contract lists the Disruption Recovery events active in the ADR-0002 third
+activation wave. It is bounded by `docs/02-domains/disruption-recovery.md` and
+by the activation rulings in `docs/08-contracts/api/disruption-recovery.md`.
+
+Activation-wave rulings:
+
+- The only signal source is the operations HTTP command
+  `POST /api/v1/disruptions`. It represents Customer Service/Admin manual rows
+  and carries a normalized `disruptionType`, `scheduledServiceRef` and/or
+  `segmentRef`, `evidence`, and explicit `affectedOrderIds`.
+- Automatic `segmentRef` to orders fan-out is deferred because Journey Order has
+  no by-segment query contract. Service Plan, Provider Integration,
+  Fulfillment, and Transfer Management signal events are also deferred; Transfer
+  belongs to wave 18.
+- The report opens or merges an `Incident`; merge key is
+  `(scheduledServiceRef, serviceDate)` when `scheduledServiceRef` is present.
+  `ServiceAlert` is event-only in this wave: `ServiceAlertPublished` is
+  published, but the ServiceAlert read model is deferred.
+- One `RecoveryCase` is opened per explicit `affectedOrderId`. Event payload
+  statuses use the exact 10-state domain machine: `OPENED`, `ASSESSING_IMPACT`,
+  `OPTIONS_GENERATED`, `AWAITING_USER_CHOICE`, `EXECUTING_RECOVERY`,
+  `MANUAL_REVIEW`, `RECOVERED`, `DECLINED`, `FAILED`, `CLOSED`.
+- `RecoveryOptionSet` supports `WAIT`, `REFUND`, `COMPENSATION`, and `MANUAL`.
+  `REACCOMMODATION` is deferred until wave 18 after Transfer Management.
+- Automatic rules may select only `WAIT`. `WAIT` completes as `RECOVERED` with
+  no downstream command. `REFUND` calls the existing Post Sales HTTP contract
+  using a deterministic idempotency key and converges on `PostSalesApplied`.
+  `COMPENSATION` calls Wallet / Promotion `POST /api/v1/benefits` with
+  `issuanceSource=DISRUPTION_COMP`. `MANUAL` moves the case to manual review.
+- Consumers of Disruption Recovery events are deferred for Notification and
+  Reporting in this wave. The only active inbound subscription is
+  `events:post-sales` `PostSalesApplied` for REFUND execution convergence.
+
+All payload fields are camelCase, all enum values are SCREAMING_SNAKE_CASE, and
+all timestamps are RFC3339 UTC. Envelope fields, including optional trace context
+propagation, follow `docs/08-contracts/messaging.md` and
+`docs/08-contracts/shared-primitives.md`. Monetary values use `Money` as
+`{currency, minorUnits}`.
+
+## Event identity and idempotency
+
+Disruption Recovery producers MUST assign deterministic event IDs per aggregate
+transition. The event ID seed is:
+
+```
+disruption-recovery:<eventType>:<aggregateId>:<aggregateVersion>
+```
+
+where `aggregateId` is `incidentId` for incident and alert events,
+`disruptionId` for `DisruptionReported`, and `caseId` for recovery-case events.
+If the same command or consumed upstream event is replayed and no new transition
+is applied, no new event is emitted. Consumers still deduplicate by envelope
+`eventId`.
+
+Downstream HTTP commands use deterministic idempotency keys:
+
+| Option type | Downstream command | Idempotency-key seed |
+|---|---|---|
+| `REFUND` | `POST /api/v1/post-sales-cases` with `caseType=REFUND` | `disruption-recovery:refund:<caseId>:<optionId>` |
+| `COMPENSATION` | `POST /api/v1/benefits` with `issuanceSource=DISRUPTION_COMP` | `disruption-recovery:compensation:<caseId>:<optionId>` |
+
+## Common payload objects
+
+### Evidence
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `evidenceRef` | string | yes | Reference to the customer-service/admin evidence record. |
+| `sourceSystem` | enum | yes | `CUSTOMER_SERVICE` or `ADMIN`; all other sources are deferred. |
+| `sourceRecordId` | string | yes | Upstream manual-row identifier. |
+| `summary` | string | yes | Operational summary; must not include unmasked documents or sensitive personal data. |
+| `occurredAt` | RFC3339 UTC | no | Observation time if known. |
+
+### ActorRef
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `actorType` | enum | yes | `USER`, `CUSTOMER_SERVICE`, `OPERATIONS`, or `SYSTEM`. |
+| `actorId` | string | yes | Account, operator, or service actor reference. |
+
+### AffectedScope
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `journeyOrderId` | string | yes | Affected `ord-<uuid>`. |
+| `scheduledServiceRef` | string | no | Scheduled service reference from the report. |
+| `segmentRef` | string | no | Segment reference from the report. |
+| `serviceDate` | string | yes | ISO `YYYY-MM-DD` service date. |
+| `disruptionType` | enum | yes | Normalized disruption type. |
+| `evidenceRef` | string | yes | Supporting evidence reference. |
+
+### RecoveryOption
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `optionId` | string | yes | Option ID (`rop-<uuid>`). |
+| `optionType` | enum | yes | `WAIT`, `REFUND`, `COMPENSATION`, or `MANUAL`. |
+| `title` | string | yes | Display title. |
+| `description` | string | yes | Explanation; must not include sensitive personal data. |
+| `executionTarget` | enum | yes | `NONE`, `POST_SALES`, `WALLET_PROMOTION`, or `MANUAL_QUEUE`. |
+| `refund` | object | for `REFUND` | `{reasonCode, scope, waiverRef?}` for the Post Sales REFUND case. |
+| `compensation` | object | for `COMPENSATION` | `{amount: Money, benefitType, balanceType, validUntil, reasonCode}` for Wallet / Promotion. |
+| `manualReason` | string | for `MANUAL` | Reason the case requires manual review. |
+| `expiresAt` | RFC3339 UTC | no | Option-specific expiry. |
+
+## Published Events
+
+### DisruptionReported
+
+| Field | Description |
+|---|---|
+| **Producer** | disruption-recovery |
+| **Consumers** | deferred: reporting |
+| **Trigger** | Operations report accepted from `POST /api/v1/disruptions`. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `disruptionId` | string | yes | Disruption report ID (`drp-<uuid>`). |
+| `disruptionType` | enum | yes | Normalized type from the HTTP contract enum. |
+| `scheduledServiceRef` | string | no | Scheduled service reference. |
+| `segmentRef` | string | no | Segment reference. |
+| `serviceDate` | string | yes | ISO `YYYY-MM-DD` service date. |
+| `evidence` | object | yes | Evidence object. |
+| `affectedOrderIds` | array[string] | yes | Explicit affected orders supplied by operations. |
+| `reportedBy` | object | yes | Reporting actor. |
+| `reportedAt` | RFC3339 UTC | yes | Report timestamp. |
+
+### IncidentOpened
+
+| Field | Description |
+|---|---|
+| **Producer** | disruption-recovery |
+| **Consumers** | deferred: notification, reporting |
+| **Trigger** | Accepted report opens a new incident instead of merging into an existing one. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `incidentId` | string | yes | Incident ID (`inc-<uuid>`). |
+| `disruptionId` | string | yes | Report that opened the incident. |
+| `disruptionType` | enum | yes | Dominant normalized disruption type. |
+| `scheduledServiceRef` | string | no | Service reference used for merge when present. |
+| `segmentRefs` | array[string] | no | Segment refs in the incident scope. |
+| `serviceDate` | string | yes | ISO `YYYY-MM-DD` service date. |
+| `evidenceRefs` | array[string] | yes | Evidence references attached at open. |
+| `affectedOrderIds` | array[string] | yes | Explicit affected orders at open. |
+| `status` | enum | yes | `CONFIRMED` in this wave. |
+| `openedAt` | RFC3339 UTC | yes | Open timestamp. |
+
+### RecoveryCaseOpened
+
+| Field | Description |
+|---|---|
+| **Producer** | disruption-recovery |
+| **Consumers** | deferred: notification, reporting |
+| **Trigger** | A report opens a recovery case for one explicit `affectedOrderId`. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | string | yes | Recovery case ID (`rcv-<uuid>`). |
+| `incidentId` | string | yes | Parent incident. |
+| `disruptionId` | string | yes | Source report. |
+| `journeyOrderId` | string | yes | Affected order (`ord-<uuid>`). |
+| `affectedScope` | object | yes | Affected scope object. |
+| `openedAt` | RFC3339 UTC | yes | Case open timestamp. |
+| `status` | enum | yes | `OPENED`. |
+
+### RecoveryOptionsGenerated
+
+| Field | Description |
+|---|---|
+| **Producer** | disruption-recovery |
+| **Consumers** | deferred: notification, reporting |
+| **Trigger** | `GenerateRecoveryOptions` creates this wave's option set for a case. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | string | yes | Recovery case ID. |
+| `incidentId` | string | yes | Parent incident. |
+| `journeyOrderId` | string | yes | Affected order. |
+| `optionSetId` | string | yes | Option set ID (`ros-<uuid>`). |
+| `options` | array[RecoveryOption] | yes | Options; active enum is `WAIT`, `REFUND`, `COMPENSATION`, or `MANUAL`. |
+| `requiresUserChoice` | boolean | yes | `false` only for auto-selectable `WAIT`. |
+| `generatedAt` | RFC3339 UTC | yes | Generation timestamp. |
+| `expiresAt` | RFC3339 UTC | no | Choice deadline. |
+| `status` | enum | yes | `OPTIONS_GENERATED` or `AWAITING_USER_CHOICE` after generation flow. |
+
+### RecoveryOptionSelected
+
+| Field | Description |
+|---|---|
+| **Producer** | disruption-recovery |
+| **Consumers** | deferred: notification, reporting |
+| **Trigger** | Automatic `WAIT` selection or user/customer-service `select-option` command. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | string | yes | Recovery case ID. |
+| `incidentId` | string | yes | Parent incident. |
+| `journeyOrderId` | string | yes | Affected order. |
+| `optionSetId` | string | yes | Option set containing the selected option. |
+| `optionId` | string | yes | Selected option. |
+| `optionType` | enum | yes | `WAIT`, `REFUND`, `COMPENSATION`, or `MANUAL`. |
+| `selectedBy` | object | yes | Actor that selected the option; `SYSTEM` is allowed only for `WAIT`. |
+| `selectedAt` | RFC3339 UTC | yes | Selection timestamp. |
+| `status` | enum | yes | `EXECUTING_RECOVERY` for executable options, or `MANUAL_REVIEW` for `MANUAL`. |
+
+### RecoveryExecutionStarted
+
+| Field | Description |
+|---|---|
+| **Producer** | disruption-recovery |
+| **Consumers** | deferred: reporting |
+| **Trigger** | Selected option starts local execution or a downstream HTTP command. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | string | yes | Recovery case ID. |
+| `incidentId` | string | yes | Parent incident. |
+| `journeyOrderId` | string | yes | Affected order. |
+| `optionId` | string | yes | Selected option. |
+| `optionType` | enum | yes | Selected option type. |
+| `executionId` | string | yes | Execution ID (`rex-<uuid>`). |
+| `executionTarget` | enum | yes | `NONE`, `POST_SALES`, `WALLET_PROMOTION`, or `MANUAL_QUEUE`. |
+| `idempotencyKey` | string | no | Deterministic downstream idempotency key for `REFUND` or `COMPENSATION`. |
+| `downstreamRequest` | object | no | Sanitized downstream request summary. For `REFUND`, includes `caseType=REFUND`; for `COMPENSATION`, includes `issuanceSource=DISRUPTION_COMP`. |
+| `startedAt` | RFC3339 UTC | yes | Execution start timestamp. |
+| `status` | enum | yes | `EXECUTING_RECOVERY` or `MANUAL_REVIEW`. |
+
+### RecoveryCompleted
+
+| Field | Description |
+|---|---|
+| **Producer** | disruption-recovery |
+| **Consumers** | deferred: notification, reporting |
+| **Trigger** | `WAIT` completes locally, Wallet / Promotion benefit issuance succeeds, or consumed `PostSalesApplied` converges a REFUND execution. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | string | yes | Recovery case ID. |
+| `incidentId` | string | yes | Parent incident. |
+| `journeyOrderId` | string | yes | Affected order. |
+| `optionId` | string | yes | Selected option. |
+| `optionType` | enum | yes | Completed option type. |
+| `executionId` | string | yes | Execution ID. |
+| `completedAt` | RFC3339 UTC | yes | Completion timestamp. |
+| `externalRef` | string | no | Post Sales case ID, Wallet benefit ID, or manual reference when applicable. |
+| `status` | enum | yes | `RECOVERED`. |
+
+### RecoveryFailed
+
+| Field | Description |
+|---|---|
+| **Producer** | disruption-recovery |
+| **Consumers** | deferred: notification, reporting |
+| **Trigger** | A selected option fails and cannot automatically converge. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | string | yes | Recovery case ID. |
+| `incidentId` | string | yes | Parent incident. |
+| `journeyOrderId` | string | yes | Affected order. |
+| `optionId` | string | no | Selected option, if any. |
+| `executionId` | string | no | Execution that failed, if any. |
+| `failedAt` | RFC3339 UTC | yes | Failure timestamp. |
+| `reason` | string | yes | Failure reason; must not include sensitive personal data. |
+| `nextStatus` | enum | yes | `OPTIONS_GENERATED`, `MANUAL_REVIEW`, or `FAILED`. |
+
+### RecoveryCaseClosed
+
+| Field | Description |
+|---|---|
+| **Producer** | disruption-recovery |
+| **Consumers** | deferred: reporting |
+| **Trigger** | `CloseRecoveryCase` archives a terminal or manually resolved case. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | string | yes | Recovery case ID. |
+| `incidentId` | string | yes | Parent incident. |
+| `journeyOrderId` | string | yes | Affected order. |
+| `previousStatus` | enum | yes | `RECOVERED`, `DECLINED`, `FAILED`, or `MANUAL_REVIEW` when manually closed. |
+| `closedBy` | object | yes | Closing actor. |
+| `closeReason` | string | yes | Closure reason; must not include sensitive personal data. |
+| `closedAt` | RFC3339 UTC | yes | Closure timestamp. |
+| `status` | enum | yes | `CLOSED`. |
+
+### ServiceAlertPublished
+
+| Field | Description |
+|---|---|
+| **Producer** | disruption-recovery |
+| **Consumers** | deferred: notification, reporting |
+| **Trigger** | Incident alert fact is published for affected users, customer service, or operations. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `serviceAlertId` | string | yes | Service alert ID (`sal-<uuid>`). |
+| `incidentId` | string | yes | Parent incident. |
+| `disruptionType` | enum | yes | Normalized disruption type. |
+| `scheduledServiceRef` | string | no | Scheduled service reference. |
+| `segmentRef` | string | no | Segment reference. |
+| `serviceDate` | string | yes | ISO `YYYY-MM-DD` service date. |
+| `audience` | enum | yes | `AFFECTED_ORDERS`, `CUSTOMER_SERVICE`, or `OPERATIONS`. |
+| `affectedOrderIds` | array[string] | no | Explicit affected orders when audience is `AFFECTED_ORDERS`. |
+| `messageSummary` | string | yes | Alert summary; must not include unmasked documents or sensitive personal data. |
+| `publishedAt` | RFC3339 UTC | yes | Publish timestamp. |
+
+## Accepted Commands
+
+| Command | Sender / Trigger | Produced event |
+|---|---|---|
+| `ReportDisruption` | Operations HTTP `POST /api/v1/disruptions` | `DisruptionReported` |
+| `OpenIncident` | Application flow after report, or merge lookup miss | `IncidentOpened` |
+| `OpenRecoveryCase` | Application flow for each explicit `affectedOrderId` | `RecoveryCaseOpened` |
+| `GenerateRecoveryOptions` | Application flow after impact assessment | `RecoveryOptionsGenerated` |
+| `SelectRecoveryOption` | Automatic `WAIT`, or HTTP `POST /api/v1/recovery-cases/{caseId}/select-option` | `RecoveryOptionSelected` |
+| `ApplyRecoveryDecision` | Internal execution start after selection | `RecoveryExecutionStarted` |
+| `RecordRecoveryExecutionResult` | Local wait completion, Wallet issuance result, or consumed `PostSalesApplied` | `RecoveryCompleted` or `RecoveryFailed` |
+| `CloseRecoveryCase` | HTTP `POST /api/v1/recovery-cases/{caseId}/close` or manual closure | `RecoveryCaseClosed` |
+| `PublishServiceAlert` | Application flow after incident open/merge | `ServiceAlertPublished` |
+
+## Consumed upstream events
+
+| Upstream stream | Event type | Purpose |
+|---|---|---|
+| `events:post-sales` | `PostSalesApplied` | Converge a selected `REFUND` option when the downstream Post Sales case reaches `APPLIED`. |
+
+No other upstream event subscription is active in this wave. Service Plan,
+Provider Integration, Fulfillment, and Transfer Management disruption sources
+are deferred.
+
+## Deferred downstream touchpoints
+
+| Downstream context | Deferred events | Purpose when activated |
+|---|---|---|
+| Notification | `ServiceAlertPublished`, `RecoveryOptionsGenerated`, `RecoveryOptionSelected`, `RecoveryCompleted`, `RecoveryFailed` | User-facing alert, option, decision, and progress notifications. |
+| Reporting | all Disruption Recovery events | Disruption metrics, waiver/compensation cost attribution, and operational read models. |
+| Journey Order | recovery summary events | Order-detail disruption and recovery display. |

--- a/docs/08-contracts/events/disruption-recovery.md
+++ b/docs/08-contracts/events/disruption-recovery.md
@@ -302,7 +302,7 @@ Downstream HTTP commands use deterministic idempotency keys:
 | `caseId` | string | yes | Recovery case ID. |
 | `incidentId` | string | yes | Parent incident. |
 | `journeyOrderId` | string | yes | Affected order. |
-| `previousStatus` | enum | yes | `RECOVERED`, `DECLINED`, `FAILED`, or `MANUAL_REVIEW` when manually closed. |
+| `previousStatus` | enum | yes | `RECOVERED`, `DECLINED`, or `FAILED` — the only states `CloseRecoveryCase` accepts (domain key-transition table). |
 | `closedBy` | object | yes | Closing actor. |
 | `closeReason` | string | yes | Closure reason; must not include sensitive personal data. |
 | `closedAt` | RFC3339 UTC | yes | Closure timestamp. |

--- a/docs/08-contracts/events/wallet-promotion.md
+++ b/docs/08-contracts/events/wallet-promotion.md
@@ -14,9 +14,12 @@ Activation-wave rulings:
 
 - Wallet / Promotion produces events in this wave and subscribes to no upstream
   streams. Issuance from Post Sales compensation is represented by the issuing
-  command's `issuanceSource=POST_SALES_COMP` plus `caseId`; no Post Sales event
-  or API contract changes are introduced.
-- Supported issuance sources are `MANUAL_OPS` and `POST_SALES_COMP` only.
+  command's `issuanceSource=POST_SALES_COMP` plus `caseId`; Disruption Recovery
+  compensation is represented by `issuanceSource=DISRUPTION_COMP` plus the
+  recovery `caseId`. Wallet / Promotion does not subscribe to either upstream
+  stream in this wave.
+- Supported issuance sources are `MANUAL_OPS`, `POST_SALES_COMP`, and
+  `DISRUPTION_COMP`.
 - Payment contracts are unchanged. Combination payment is not part of this wave;
   future note: a later wave will define the "cash remaining payable" interface.
 - Finance Settlement and Notification are event consumers at the contract
@@ -61,10 +64,10 @@ Event payloads use the same seven-state enum as the HTTP API: `ISSUED`,
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `reasonType` | enum | yes | `MANUAL_OPS`, `POST_SALES_COMP`, `ORDER_PURCHASE`, `RESERVATION_TIMEOUT`, `CUSTOMER_SERVICE_ADJUSTMENT`, `SYSTEM_EXPIRY`, or `REVERSAL`. |
+| `reasonType` | enum | yes | `MANUAL_OPS`, `POST_SALES_COMP`, `DISRUPTION_COMP`, `ORDER_PURCHASE`, `RESERVATION_TIMEOUT`, `CUSTOMER_SERVICE_ADJUSTMENT`, `SYSTEM_EXPIRY`, or `REVERSAL`. |
 | `reasonCode` | string | yes | Stable business reason code. |
 | `referenceType` | string | no | Referenced object class such as `ORDER`, `POST_SALES_CASE`, `MANUAL_ACTION`, or `SCHEDULER_JOB`. |
-| `referenceId` | string | no | Referenced object ID. For post-sales compensation this is the carried `caseId`. |
+| `referenceId` | string | no | Referenced object ID. For post-sales or disruption compensation this is the carried `caseId`. |
 | `description` | string | no | Human-readable reason; must not contain unmasked sensitive personal data. |
 
 `walletBalanceDelta` fields used by all balance-changing events:
@@ -102,8 +105,8 @@ Event payloads use the same seven-state enum as the HTTP API: `ISSUED`,
 | `issuedAmount` | Money | yes | Original issued value. |
 | `availableAmount` | Money | yes | Available amount after issuance. |
 | `reservedAmount` | Money | yes | Reserved amount after issuance; normally zero. |
-| `issuanceSource` | enum | yes | `MANUAL_OPS` or `POST_SALES_COMP`. |
-| `caseId` | string | no | Post-sales case reference when `issuanceSource` is `POST_SALES_COMP`. |
+| `issuanceSource` | enum | yes | `MANUAL_OPS`, `POST_SALES_COMP`, or `DISRUPTION_COMP`. |
+| `caseId` | string | no | Post-sales case reference when `issuanceSource` is `POST_SALES_COMP`, or Disruption Recovery case reference when `issuanceSource` is `DISRUPTION_COMP`. |
 | `applicableScope` | object | yes | Benefit eligibility scope. |
 | `redemptionRule` | object | yes | Redemption rule captured at issuance. |
 | `revocationRule` | object | yes | Revocation rule captured at issuance. |

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -73,6 +73,7 @@ context.
 | 23 | `waitlist` | `events:waitlist` | WaitlistRequestCreated, WaitlistPaymentAuthorizationRequested, WaitlistQueued, WaitlistMatchStarted, WaitlistHoldAuthorized, WaitlistFulfilled, WaitlistCancelled, WaitlistExpired |
 | 24 | `dispatch` | `events:dispatch` | DispatchRequested, DriverAssigned, DriverEtaUpdated, DriverArrived, RideStarted, RideEnded, DriverCancelled, DispatchUserCancelled, DispatchNoShowRecorded, DispatchFailed |
 | 25 | `wallet-promotion` | `events:wallet-promotion` | BenefitIssued, BenefitReserved, BenefitRedeemed, BenefitReservationReleased, BenefitExpired, BenefitRevoked, BenefitRedemptionReversed |
+| 26 | `disruption-recovery` | `events:disruption-recovery` | DisruptionReported, IncidentOpened, RecoveryCaseOpened, RecoveryOptionsGenerated, RecoveryOptionSelected, RecoveryExecutionStarted, RecoveryCompleted, RecoveryFailed, RecoveryCaseClosed, ServiceAlertPublished |
 
 ### Dead-Letter Streams
 
@@ -257,8 +258,8 @@ plus notification/finance/reporting fan-in.
 | 31 | `events:post-sales` | `entitlement-ticketing` | PostSalesApproved to void entitlement |
 | 32 | `events:post-sales` | `journey-order` | PostSalesApplied to adjust order |
 | 33 | `events:post-sales` | `notification` | Post-sales events for user notifications |
-| 34 | `events:transfer-management` | `disruption-recovery` | Connection risk events for recovery planning |
-| 35 | `events:disruption-recovery` | `post-sales` | RecoveryOptionAccepted to trigger post-sales |
+| 34 | `events:transfer-management` | *(none for disruption-recovery in this wave)* | Transfer risk/recovery signals are deferred to wave 18 |
+| 35 | `events:disruption-recovery` | *(none — downstream consumers deferred)* | Disruption recovery notification/reporting/order touchpoints are documented in `events/disruption-recovery.md` but not active in this wave |
 | 36 | `events:notification` | *(none — notification owns its stream)* | Notification events are not consumed by other business contexts in phase 1 |
 | 37 | `events:traveler-profile` | `offer-management` | Profile changes for eligibility checks |
 | 38 | `events:traveler-profile` | `journey-order` | Profile changes affecting existing orders |
@@ -279,6 +280,7 @@ plus notification/finance/reporting fan-in.
 | 53 | `events:wallet-promotion` | `finance-settlement` | Benefit issuance, reservation, redemption, release, expiry, revocation, and reversal facts for future cost attribution and settlement read models; concrete consumption deferred to a later wave |
 | 54 | `events:wallet-promotion` | `notification` | Benefit arrival, expiry, redemption, revocation, and reversal user touchpoints; concrete consumption deferred to a later wave |
 | 55 | `events:wallet-promotion` | `reporting` | Wallet / Promotion lifecycle metrics and read models |
+| 56 | `events:post-sales` | `disruption-recovery` | PostSalesApplied converges REFUND recovery execution |
 
 ### Cross-Cutting Consumers
 
@@ -287,9 +289,20 @@ analytics, and cross-cutting concerns:
 
 | Consumer Group (Context) | Subscribed Streams | Purpose |
 |---|---|---|
-| `reporting` | All active `events:*` streams except `events:dispatch` and `events:wallet-promotion` until their deferred-consumer activation waves | Business metrics, funnel analysis, operational dashboards |
+| `reporting` | All active `events:*` streams except `events:dispatch`, `events:wallet-promotion`, and `events:disruption-recovery` until their deferred-consumer activation waves | Business metrics, funnel analysis, operational dashboards |
 | `finance-settlement` | `events:payment`, `events:provider-integration`, `events:booking-orchestration`, `events:post-sales` | Revenue recognition, reconciliation, invoice generation. Wallet / Promotion benefit-cost events are a documented deferred consumer (events/wallet-promotion.md). |
 | `notification` | `events:journey-order`, `events:booking-orchestration`, `events:payment`, `events:entitlement-ticketing`, `events:post-sales`, `events:waitlist` | User-facing notification triggers. Wallet / Promotion benefit touchpoints are a documented deferred consumer. |
+
+### Disruption Recovery subscriptions
+
+`events:disruption-recovery` is registered as a produced stream in this
+contract, but Notification, Reporting, Journey Order, and Customer Service
+consumption of its lifecycle and alert facts is deferred in this activation
+wave. Disruption Recovery has one active inbound subscription: it consumes
+`PostSalesApplied` from `events:post-sales` to converge selected `REFUND`
+recovery options after the downstream Post Sales case reaches `APPLIED`.
+Service Plan, Provider Integration, Fulfillment, and Transfer Management signal
+sources are deferred; Transfer Management belongs to wave 18.
 
 ### Deferred Dispatch Subscriptions
 


### PR DESCRIPTION
## Summary\n- Add Disruption Recovery HTTP and event contracts for ADR-0002 third activation wave.\n- Register disruption-recovery messaging stream and PostSalesApplied inbound subscription.\n- Add Wallet / Promotion DISRUPTION_COMP issuance source enum increment.\n\n## Validation\n- make check