### PR TITLE
REQ-116 ancillary service contracts

### DIFF
--- a/docs/08-contracts/api/README.md
+++ b/docs/08-contracts/api/README.md
@@ -153,6 +153,7 @@ correlation IDs.
 | 24 | `dispatch.md` | Dispatch | activation wave in progress |
 | 25 | `wallet-promotion.md` | Wallet / Promotion | activation wave in progress |
 | 26 | `disruption-recovery.md` | Disruption Recovery | activation wave in progress |
+| 27 | `ancillary-service.md` | Ancillary Service | activation wave in progress |
 
 ## Open Issues
 

--- a/docs/08-contracts/api/ancillary-service.md
+++ b/docs/08-contracts/api/ancillary-service.md
@@ -1,0 +1,573 @@
+# Ancillary Service — HTTP API
+
+Last updated: 2026-07-09
+
+## Overview
+
+Ancillary Service owns the commercial and fulfillment lifecycle for non-primary
+transport services such as insurance, meals, baggage/consign, seat selection,
+transfer pickup, lounge, fast track, and bundles. This contract is scoped to the
+ADR-0002 third activation wave and is bounded by
+`docs/02-domains/ancillary-service.md`.
+
+Activation-wave rulings:
+
+- This wave activates exactly three aggregate roots:
+  `AncillaryCatalogItem`, `AncillaryOffer`, and `AncillaryOrderItem`.
+  `ServiceFulfillmentRecord` is not a separate aggregate on the wire; fulfillment
+  records are facts embedded under `AncillaryOrderItem` and published as
+  fulfillment-fact events.
+- Pricing is static catalog pricing in this wave. Each catalog item carries a
+  `price` Money value. Fare & Pricing `PriceQuote`, `RuleSnapshot`, and
+  `FeeAssessment` integration remains deferred; future references are carried as
+  optional informational refs only.
+- Ancillary order items reference `journeyOrderId`, `travelerRef`, and optional
+  `segmentRef`; this contract does not change Journey Order HTTP or event
+  contracts. Payment integration is deferred; the resource carries informational
+  `payableAmount` and `refundableAmount` only.
+- Eligibility is the minimum rule set for this wave: primary-ticket status via a
+  read-only entitlement lookup or caller-supplied `entitlementRef`, purchase time
+  window before departure, and mandatory `segmentRef` for segment-bound services.
+  Traveler age/documents, supplier capacity, fare-rule eligibility, provider
+  availability, and other dimensions are deferred.
+- All state-changing HTTP endpoints require `Idempotency-Key` and follow the
+  standard replay/reuse behavior in `docs/08-contracts/api/README.md`.
+- Finance Settlement, Notification, and Post Sales consumers are contract-surface
+  touchpoints only; concrete consumer behavior is deferred to later waves.
+- Ancillary Service consumes `JourneyOrderCancelled` from `events:journey-order`
+  in this wave and automatically cancels associated non-terminal order items.
+
+Field shapes reference `docs/08-contracts/shared-primitives.md` for IDs,
+timestamps, event envelope fields, pagination conventions, and `Money`
+(`{currency, minorUnits}`). All timestamps are RFC3339 UTC. JSON fields are
+camelCase and enum values are SCREAMING_SNAKE_CASE.
+
+## Common enums
+
+| Enum | Values |
+|---|---|
+| `serviceType` | `INSURANCE`, `MEAL`, `BAGGAGE`, `CONSIGN`, `SEAT_SELECTION`, `TRANSFER_PICKUP`, `LOUNGE`, `FAST_TRACK`, `BUNDLE` |
+| `attachmentScope` | `JOURNEY`, `SEGMENT`, `TRAVELER`, `ENTITLEMENT`, `PLACE`, `TRANSFER` |
+| `catalogStatus` | `DRAFT`, `PUBLISHED`, `SUSPENDED`, `SUPERSEDED`, `EXPIRED` |
+| `offerStatus` | `DRAFTING`, `QUOTED`, `SELECTED`, `EXPIRED`, `INELIGIBLE`, `FAILED` |
+| `orderItemStatus` | `SELECTED`, `PENDING_CONFIRMATION`, `CONFIRMED`, `FULFILLMENT_READY`, `FULFILLED`, `FAILED`, `CANCELLED`, `REFUND_PENDING`, `REFUNDED` |
+| `factType` | `MEAL_ISSUED`, `BAGGAGE_CHECKED`, `CONSIGN_ACCEPTED`, `CONSIGN_DELIVERED`, `SEAT_ASSIGNED`, `LOUNGE_REDEEMED`, `FAST_TRACK_USED`, `PICKUP_COMPLETED`, `INSURANCE_ACTIVATED`, `INSURANCE_VOIDED`, `SERVICE_VOUCHER_ISSUED`, `SERVICE_VOUCHER_REDEEMED`, `PROVIDER_FULFILLMENT_FAILED` |
+| `eligibilityStatus` | `ELIGIBLE`, `INELIGIBLE`, `UNKNOWN` |
+| `primaryTicketStatus` | `ISSUED`, `CONFIRMED`, `PENDING`, `CANCELLED`, `VOIDED`, `UNKNOWN` |
+| `refundRecommendation` | `FULL_REFUND`, `PARTIAL_REFUND`, `NO_REFUND`, `MANUAL_REVIEW` |
+
+## State machines
+
+### AncillaryCatalogItem status
+
+| Status | Meaning | Allowed next statuses |
+|---|---|---|
+| `DRAFT` | Operations are configuring the catalog item. | `PUBLISHED`, `SUSPENDED` |
+| `PUBLISHED` | Item is eligible for quoting. | `SUSPENDED`, `SUPERSEDED`, `EXPIRED` |
+| `SUSPENDED` | Sales are paused for supplier, compliance, inventory, or operations reasons. | `PUBLISHED`, `SUPERSEDED` |
+| `SUPERSEDED` | A newer catalog item version replaces this version. | Terminal |
+| `EXPIRED` | Sale or service validity elapsed. | Terminal |
+
+Published items MUST NOT be edited in place for price, eligibility rule, or
+fulfillment-rule changes; publish a superseding version instead.
+
+### AncillaryOffer status
+
+The wire offer status follows the domain document status table:
+
+| Status | Meaning | Allowed next statuses |
+|---|---|---|
+| `DRAFTING` | Eligibility, static catalog price, and availability inputs are being collected. | `QUOTED`, `INELIGIBLE`, `FAILED` |
+| `QUOTED` | Offer may be selected until expiry. | `SELECTED`, `EXPIRED`, `INELIGIBLE` |
+| `SELECTED` | Offer has been selected for order-item creation. | `EXPIRED` |
+| `EXPIRED` | Validity window elapsed. | Terminal for this quote; create a new quote to reprice. |
+| `INELIGIBLE` | Minimum eligibility checks failed. | Terminal for this quote; create a new quote with new inputs. |
+| `FAILED` | Catalog, supplier, or rule input failed. | Terminal for this quote. |
+
+### AncillaryOrderItem status
+
+This wave uses the nine-state lifecycle from the domain document and excludes the
+future `COMPENSATED` closure from the wire contract.
+
+| Status | Meaning | Allowed next statuses |
+|---|---|---|
+| `SELECTED` | User selected the item but it is not yet confirmed. | `PENDING_CONFIRMATION`, `CANCELLED` |
+| `PENDING_CONFIRMATION` | Waiting for supplier, voucher, seat, entitlement, or primary-ticket condition. | `CONFIRMED`, `FAILED`, `CANCELLED` |
+| `CONFIRMED` | Service is confirmed but not yet in the fulfillment window. | `FULFILLMENT_READY`, `CANCELLED`, `REFUND_PENDING` |
+| `FULFILLMENT_READY` | Voucher, seat, consign, or service window is ready. | `FULFILLED`, `FAILED`, `CANCELLED` |
+| `FULFILLED` | Service was redeemed or completed. | Terminal for this wave |
+| `FAILED` | Confirmation or fulfillment failed. | `CANCELLED`, `REFUND_PENDING` |
+| `CANCELLED` | User, system, main-journey cancellation, or supplier cancelled the item. | `REFUND_PENDING`, terminal |
+| `REFUND_PENDING` | Refund/retain decision exists and awaits Payment execution outside this domain. | `REFUNDED` |
+| `REFUNDED` | Payment/refund result was recorded for the ancillary item. | Terminal |
+
+## Resource representations
+
+### AncillaryCatalogItem
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `catalogItemId` | string | yes | Catalog item ID (`aci-<uuid>`). |
+| `version` | integer | yes | Monotonically increasing catalog version. |
+| `serviceType` | enum | yes | Ancillary service type. |
+| `displayName` | string | yes | User/ops display name. |
+| `attachmentScope` | enum | yes | Binding scope for the item. |
+| `modalities` | string[] | yes | Applicable transport modes such as `TRAIN`, `AIR`, `BUS`, `FERRY`, or `TRANSFER`. |
+| `supplierRef` | string | no | Normalized supplier capability reference. |
+| `price` | Money | yes | Static catalog price for this wave. |
+| `currency` | string | yes | ISO-4217 currency matching `price.currency`; included for search/filter convenience. |
+| `salesWindow` | object | yes | `startAt` and `endAt` RFC3339 UTC timestamps. |
+| `serviceWindow` | object | no | Optional service-validity `startAt` and `endAt` timestamps. |
+| `purchaseCutoffHoursBeforeDeparture` | integer | yes | Minimum whole hours before departure required to purchase. |
+| `eligibilityRuleVersion` | string | yes | Version label for the minimum eligibility rule snapshot. |
+| `requiresEntitlementRef` | boolean | yes | Whether a primary entitlement reference/assertion is required. |
+| `requiresSegmentRef` | boolean | yes | Must be true for `SEGMENT` attachment scope and segment-bound service types. |
+| `fulfillmentMethod` | enum | yes | `VOUCHER`, `PROVIDER_CONFIRMATION`, `MANUAL_OPS`, `NONE`. |
+| `status` | enum | yes | Catalog status. |
+| `supersededByCatalogItemId` | string | no | Replacement catalog item when status is `SUPERSEDED`. |
+| `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
+| `updatedAt` | RFC3339 UTC | yes | Last update timestamp. |
+
+### AncillaryOffer
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ancillaryOfferId` | string | yes | Offer ID (`aof-<uuid>`). |
+| `offerVersion` | integer | yes | Offer version. |
+| `status` | enum | yes | Offer status. |
+| `journeyOrderId` | string | no | Journey order association for post-ticket add-ons, when known. |
+| `offerRef` | string | no | Optional Offer Management offer reference for bundle display; no contract change is required upstream. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | no | Segment reference; required for segment-bound services. |
+| `entitlementRef` | string | no | Caller-supplied entitlement proof or read-only entitlement lookup reference. |
+| `catalogItemId` | string | yes | Quoted catalog item. |
+| `catalogItemVersion` | integer | yes | Catalog version used by the quote. |
+| `serviceType` | enum | yes | Service type copied from the catalog snapshot. |
+| `attachmentScope` | enum | yes | Attachment scope copied from the catalog snapshot. |
+| `quantity` | integer | yes | Positive quantity. |
+| `unitPrice` | Money | yes | Static catalog unit price. |
+| `totalPrice` | Money | yes | `unitPrice * quantity` in minor units. |
+| `eligibility` | object | yes | Minimum eligibility result. See `EligibilityResult`. |
+| `validFrom` | RFC3339 UTC | yes | Quote validity start. |
+| `expiresAt` | RFC3339 UTC | yes | Quote expiry. |
+| `ruleSummary` | string | no | Human-readable rule summary; do not include sensitive personal data. |
+| `futurePricingRefs` | object | no | Optional informational refs reserved for deferred Fare & Pricing integration. |
+| `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
+| `updatedAt` | RFC3339 UTC | yes | Last update timestamp. |
+
+`EligibilityResult` fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `status` | enum | yes | `ELIGIBLE`, `INELIGIBLE`, or `UNKNOWN`. |
+| `primaryTicketStatus` | enum | yes | Primary ticket/entitlement status supplied or read. |
+| `entitlementRef` | string | no | Entitlement proof used for this result. |
+| `departureAt` | RFC3339 UTC | yes | Departure time used for the cutoff calculation. |
+| `evaluatedAt` | RFC3339 UTC | yes | Eligibility evaluation timestamp. |
+| `purchaseCutoffHoursBeforeDeparture` | integer | yes | Cutoff hours enforced. |
+| `segmentRefRequired` | boolean | yes | Whether a segment reference was required. |
+| `segmentRefPresent` | boolean | yes | Whether the request supplied a segment reference. |
+| `reasons` | array[object] | yes | Reason objects with `code` and `message`; messages must not include unmasked documents. |
+
+### AncillaryOrderItem
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ancillaryOrderItemId` | string | yes | Order item ID (`aoi-<uuid>`). |
+| `journeyOrderId` | string | yes | Owning Journey Order reference; Journey Order contract is unchanged. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | no | Segment binding where applicable. |
+| `entitlementRef` | string | no | Entitlement proof or service entitlement/voucher reference. |
+| `ancillaryOfferId` | string | yes | Selected offer. |
+| `offerVersion` | integer | yes | Selected offer version. |
+| `catalogItemId` | string | yes | Catalog item snapshot used. |
+| `catalogItemVersion` | integer | yes | Catalog version snapshot used. |
+| `serviceType` | enum | yes | Service type. |
+| `attachmentScope` | enum | yes | Attachment scope. |
+| `quantity` | integer | yes | Positive quantity. |
+| `payableAmount` | Money | yes | Informational amount due for Payment/Journey Order coordination. |
+| `refundableAmount` | Money | yes | Informational amount currently recommended as refundable. |
+| `refundRecommendation` | enum | no | Latest refund suggestion, if evaluated. |
+| `refundReason` | string | no | Stable reason code or summary; no unmasked sensitive personal data. |
+| `status` | enum | yes | Nine-state order-item status. |
+| `statusReason` | string | no | Reason for latest transition. |
+| `fulfillmentFacts` | array[object] | yes | Embedded service fulfillment facts. See `FulfillmentFact`. |
+| `selectedAt` | RFC3339 UTC | yes | Selection timestamp. |
+| `updatedAt` | RFC3339 UTC | yes | Last transition timestamp. |
+
+`FulfillmentFact` fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fulfillmentFactId` | string | yes | Fact ID (`aff-<uuid>`). |
+| `factType` | enum | yes | Fulfillment fact type. |
+| `providerRef` | string | no | Normalized provider reference, voucher, seat, baggage, policy, or pickup reference. |
+| `placeRef` | string | no | Place where the fact happened. |
+| `occurredAt` | RFC3339 UTC | yes | Fact occurrence time. |
+| `recordedAt` | RFC3339 UTC | yes | Time Ancillary Service recorded the fact. |
+| `performedBy` | enum | yes | `SYSTEM`, `PROVIDER`, `OPS`, `CUSTOMER_SERVICE`. |
+| `idempotencyRef` | string | yes | Provider event, voucher redemption, or ops command reference used for deduplication. |
+| `compensable` | boolean | yes | Whether a failed fact can be compensated in a later wave. |
+| `notes` | string | no | Operational notes; must not contain unmasked sensitive personal data. |
+
+## Endpoints
+
+### Create Catalog Item
+
+**POST** `/api/v1/ancillary-catalog-items`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header).
+
+**Request:** catalog fields needed to create a draft item: `serviceType`,
+`displayName`, `attachmentScope`, `modalities`, `supplierRef`, `price`,
+`salesWindow`, optional `serviceWindow`, `purchaseCutoffHoursBeforeDeparture`,
+`eligibilityRuleVersion`, `requiresEntitlementRef`, `requiresSegmentRef`, and
+`fulfillmentMethod`.
+
+**Response (201):** `AncillaryCatalogItem` with status `DRAFT`.
+
+**Error codes:** `VALIDATION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Update Draft Catalog Item
+
+**PUT** `/api/v1/ancillary-catalog-items/{catalogItemId}`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header). Only `DRAFT` items may be
+updated. Published rule, price, or fulfillment changes require supersession.
+
+**Request:** same mutable catalog fields as create, plus `expectedVersion`.
+
+**Response (200):** updated `AncillaryCatalogItem`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Delete Draft Catalog Item
+
+**DELETE** `/api/v1/ancillary-catalog-items/{catalogItemId}`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header). Only `DRAFT` items may be
+deleted. Published, suspended, superseded, or expired items remain in the audit
+trail and must use lifecycle transitions instead.
+
+**Response (204):** empty body.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Publish Catalog Item
+
+**POST** `/api/v1/ancillary-catalog-items/{catalogItemId}/publish`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header).
+
+**Request fields:** `approvalRef` (string, required), `effectiveAt` (RFC3339 UTC,
+optional), `expectedVersion` (integer, required).
+
+**Response (200):** `AncillaryCatalogItem` with status `PUBLISHED`.
+
+**Domain effects:** emits `AncillaryCatalogItemPublished`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Suspend Catalog Item
+
+**POST** `/api/v1/ancillary-catalog-items/{catalogItemId}/suspend`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header).
+
+**Request fields:** `reasonCode` (string, required), `effectiveAt` (RFC3339 UTC,
+optional), `expectedVersion` (integer, required).
+
+**Response (200):** `AncillaryCatalogItem` with status `SUSPENDED`.
+
+**Domain effects:** emits `AncillaryCatalogItemSuspended`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Supersede Catalog Item
+
+**POST** `/api/v1/ancillary-catalog-items/{catalogItemId}/supersede`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header).
+
+**Request fields:** `replacementCatalogItemId` (string, required), `reasonCode`
+(string, required), `effectiveAt` (RFC3339 UTC, optional), `expectedVersion`
+(integer, required).
+
+**Response (200):** `AncillaryCatalogItem` with status `SUPERSEDED`.
+
+**Domain effects:** emits `AncillaryCatalogItemSuperseded`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Expire Catalog Item
+
+**POST** `/api/v1/ancillary-catalog-items/{catalogItemId}/expire`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header). Used by operations or a
+scheduler when sale/service validity has elapsed.
+
+**Request fields:** `reasonCode` (string, required), `expiredAt` (RFC3339 UTC,
+required), `expectedVersion` (integer, required).
+
+**Response (200):** `AncillaryCatalogItem` with status `EXPIRED`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Get Catalog Item
+
+**GET** `/api/v1/ancillary-catalog-items/{catalogItemId}`
+
+**Response (200):** `AncillaryCatalogItem`.
+
+**Error codes:** `NOT_FOUND`
+
+### List Catalog Items
+
+**GET** `/api/v1/ancillary-catalog-items?status=PUBLISHED&serviceType=MEAL&limit=20&offset=0`
+
+**Query parameters:** optional `status`, optional `serviceType`, optional
+`attachmentScope`, plus pagination.
+
+**Response (200):** paginated response with `items`, `total`, `limit`, and
+`offset`, where each item is an `AncillaryCatalogItem`.
+
+**Error codes:** `VALIDATION_FAILED`
+
+### Draft Ancillary Offer
+
+**POST** `/api/v1/ancillary-offers`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header).
+
+**Request fields:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `catalogItemId` | string | yes | Published catalog item to quote. |
+| `journeyOrderId` | string | no | Existing Journey Order for add-on purchases, if any. |
+| `offerRef` | string | no | Optional Offer Management reference for bundle display. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | conditional | Required when the catalog item requires segment binding. |
+| `entitlementRef` | string | no | Caller-supplied entitlement proof. If absent and required, the service may perform a read-only entitlement lookup. |
+| `primaryTicketStatus` | enum | no | Caller-supplied status assertion when no entitlement lookup is used. |
+| `departureAt` | RFC3339 UTC | yes | Departure time for purchase cutoff evaluation. |
+| `quantity` | integer | yes | Positive quantity. |
+
+**Response (201):** `AncillaryOffer` in `DRAFTING`, `INELIGIBLE`, or `FAILED`
+status after minimum eligibility collection.
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Quote Ancillary Offer
+
+**POST** `/api/v1/ancillary-offers/{ancillaryOfferId}/quote`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header). Uses static catalog pricing
+for this wave.
+
+**Request fields:** `expectedVersion` (integer, required), optional
+`validitySeconds` (integer), and optional `clientRequestId` (string).
+
+**Response (200):** `AncillaryOffer` with status `QUOTED`, `INELIGIBLE`, or
+`FAILED`.
+
+**Domain effects:** emits `AncillaryOfferQuoted` when quoted.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Select Ancillary Offer
+
+**POST** `/api/v1/ancillary-offers/{ancillaryOfferId}/select`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header). The offer must be `QUOTED`,
+not expired, and still eligible.
+
+**Request fields:** `journeyOrderId` (string, required), `expectedVersion`
+(integer, required), and optional `clientRequestId` (string).
+
+**Response (201):** `AncillaryOrderItem` with status `SELECTED`.
+
+**Domain effects:** moves the offer to `SELECTED` and emits
+`AncillaryOrderItemSelected`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Get Ancillary Offer
+
+**GET** `/api/v1/ancillary-offers/{ancillaryOfferId}`
+
+**Response (200):** `AncillaryOffer`.
+
+**Error codes:** `NOT_FOUND`
+
+### Confirm Ancillary Order Item
+
+**POST** `/api/v1/ancillary-order-items/{ancillaryOrderItemId}/confirm`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header).
+
+**Request fields:** `confirmationRef` (string, optional), `entitlementRef`
+(string, optional), `expectedStatus` (enum, optional), and `reasonCode` (string,
+optional).
+
+**Response (200):** `AncillaryOrderItem` in `PENDING_CONFIRMATION` or
+`CONFIRMED` according to the confirmation stage.
+
+**Domain effects:** emits `AncillaryOrderItemPendingConfirmation` or
+`AncillaryOrderItemConfirmed`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Mark Fulfillment Ready
+
+**POST** `/api/v1/ancillary-order-items/{ancillaryOrderItemId}/fulfillment-ready`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header).
+
+**Request fields:** optional `providerRef`, optional `entitlementRef`, optional
+`reasonCode`, and optional `readyAt` RFC3339 UTC.
+
+**Response (200):** `AncillaryOrderItem` with status `FULFILLMENT_READY`.
+
+**Domain effects:** emits `AncillaryOrderItemFulfillmentReady`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Cancel Ancillary Order Item
+
+**POST** `/api/v1/ancillary-order-items/{ancillaryOrderItemId}/cancel`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header).
+
+**Request fields:** `reasonCode` (string, required), `source` (enum `USER`,
+`OPS`, `SYSTEM`, `JOURNEY_ORDER_CANCELLED`, required), optional `sourceEventId`,
+optional `cancelledAt` RFC3339 UTC, and optional `expectedStatus`.
+
+**Response (200):** `AncillaryOrderItem` with status `CANCELLED`.
+
+**Domain effects:** emits `AncillaryOrderItemCancelled`. When triggered by the
+`JourneyOrderCancelled` subscription, `source` is `JOURNEY_ORDER_CANCELLED` and
+`sourceEventId` is the consumed Journey Order event ID.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Suggest Ancillary Refund
+
+**POST** `/api/v1/ancillary-order-items/{ancillaryOrderItemId}/refund-suggestions`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header). This endpoint does not call
+Payment and does not settle funds.
+
+**Request fields:** `reasonCode` (string, required), optional `postSalesCaseId`,
+optional `waiverRef`, optional `requestedAt` RFC3339 UTC.
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `ancillaryOrderItem` | AncillaryOrderItem | Updated item, normally `REFUND_PENDING` when a refund is due. |
+| `recommendation` | enum | `FULL_REFUND`, `PARTIAL_REFUND`, `NO_REFUND`, or `MANUAL_REVIEW`. |
+| `refundableAmount` | Money | Suggested refundable amount. |
+| `reasonCode` | string | Stable refund reason code. |
+
+**Domain effects:** emits `AncillaryOrderItemRefundPending` when a refund is due.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Record Ancillary Refunded
+
+**POST** `/api/v1/ancillary-order-items/{ancillaryOrderItemId}/refunded`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header). Records an external Payment
+or operations outcome; Ancillary Service does not execute the refund.
+
+**Request fields:** `refundRef` (string, required), `refundedAmount` (Money,
+required), `refundedAt` (RFC3339 UTC, required), optional `reasonCode`.
+
+**Response (200):** `AncillaryOrderItem` with status `REFUNDED`.
+
+**Domain effects:** emits `AncillaryOrderItemRefunded`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Record Fulfillment Fact
+
+**POST** `/api/v1/ancillary-order-items/{ancillaryOrderItemId}/fulfillment-facts`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` header). Duplicate provider or ops
+facts are idempotent on `factType` plus `idempotencyRef`.
+
+**Request fields:** `factType` (enum, required), optional `providerRef`, optional
+`placeRef`, `occurredAt` (RFC3339 UTC, required), `performedBy` (enum, required),
+`idempotencyRef` (string, required), optional `compensable` (boolean, default
+false), and optional `notes`.
+
+**Response (200):** `AncillaryOrderItem` with the appended `fulfillmentFacts`
+entry. If the fact completes the service, status may become `FULFILLED`; if it
+records provider failure, status may become `FAILED`.
+
+**Domain effects:** emits `AncillaryFulfillmentFactRecorded` and, when the state
+changes, the corresponding order-item lifecycle event.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Get Ancillary Order Item
+
+**GET** `/api/v1/ancillary-order-items/{ancillaryOrderItemId}`
+
+**Response (200):** `AncillaryOrderItem`.
+
+**Error codes:** `NOT_FOUND`
+
+### List Ancillary Order Items by Journey Order
+
+**GET** `/api/v1/ancillary-order-items?journeyOrderId={journeyOrderId}&limit=20&offset=0`
+
+`journeyOrderId` is required. Broad unfiltered listing is not part of this wave.
+
+**Query parameters:** required `journeyOrderId`, optional `status`, optional
+`travelerRef`, optional `segmentRef`, plus pagination.
+
+**Response (200):** paginated response with `items`, `total`, `limit`, and
+`offset`, where each item is an `AncillaryOrderItem`.
+
+**Error codes:** `VALIDATION_FAILED`
+
+## Bus-only behavior
+
+The following behaviors have no public HTTP endpoint in this activation wave:
+
+- `ExpireAncillaryOffer` — scheduler/domain policy moves elapsed quoted offers to
+  `EXPIRED` and emits `AncillaryOfferExpired`.
+- `HandleJourneyOrderCancelled` — event consumer for `JourneyOrderCancelled` from
+  `events:journey-order`; cancels associated non-terminal ancillary order items
+  and emits `AncillaryOrderItemCancelled` with source `JOURNEY_ORDER_CANCELLED`.
+
+## Deferred integrations and explicit non-changes
+
+- Journey Order contracts are not modified by this wave. Ancillary references are
+  stored and listed by this service; any Journey Order projection is future work.
+- Payment contracts are not modified. `payableAmount` and `refundableAmount` are
+  information fields for future orchestration and external refund-result
+  recording.
+- Fare & Pricing integration is deferred. Static catalog `price` is the only
+  authoritative price source in this wave; `futurePricingRefs` is non-normative.
+- Additional eligibility dimensions from the domain document remain deferred:
+  traveler age/documents, special needs, supplier slot capacity, provider status,
+  fare-rule refundability, and bundle split rules.

--- a/docs/08-contracts/events/ancillary-service.md
+++ b/docs/08-contracts/events/ancillary-service.md
@@ -1,0 +1,489 @@
+# Ancillary Service — Events & Commands
+
+Last updated: 2026-07-09
+
+## Scope and activation-wave rulings
+
+This contract enumerates the Ancillary Service events for the ADR-0002 third
+activation wave. It is bounded by `docs/02-domains/ancillary-service.md` and the
+HTTP contract in `docs/08-contracts/api/ancillary-service.md`.
+
+Activation-wave rulings:
+
+- This wave activates the three aggregate roots `AncillaryCatalogItem`,
+  `AncillaryOffer`, and `AncillaryOrderItem`. The domain's former
+  `ServiceFulfillmentRecord` concept is represented as embedded
+  `fulfillmentFacts` on `AncillaryOrderItem` and as
+  `AncillaryFulfillmentFactRecorded` events.
+- Catalog pricing is authoritative for this wave. Event payloads use `Money`
+  fields copied from the catalog/offer/order snapshots. Fare & Pricing quote,
+  fee assessment, and dynamic price-rule integrations are deferred.
+- Ancillary Service does not modify Journey Order, Payment, Fare & Pricing, or
+  Entitlement contracts. Cross-context references are carried as strings such as
+  `journeyOrderId`, `travelerRef`, `segmentRef`, `entitlementRef`, and optional
+  future refs.
+- Minimum eligibility is limited to primary-ticket status, purchase cutoff before
+  departure, and mandatory segment binding for segment-bound services. Other
+  eligibility dimensions in the domain document are deferred.
+- Ancillary Service subscribes only to `JourneyOrderCancelled` from
+  `events:journey-order` in this wave. It cancels associated non-terminal order
+  items idempotently and emits normal cancellation lifecycle facts.
+- Finance Settlement, Notification, and Post Sales are intended consumers for the
+  published event surface, but concrete consumer implementations are deferred to
+  later waves. Reporting may consume events for read models and metrics.
+
+All payload fields are camelCase, all enum values are SCREAMING_SNAKE_CASE, and
+all timestamps are RFC3339 UTC. Envelope fields, including optional trace context
+propagation, follow `docs/08-contracts/messaging.md` and
+`docs/08-contracts/shared-primitives.md`. Monetary values use `Money` as
+`{currency, minorUnits}`.
+
+## Event identity and idempotency
+
+Ancillary Service producers MUST assign deterministic event IDs per aggregate
+transition so retries do not create duplicate facts. The event ID seed is:
+
+```
+ancillary-service:<eventType>:<aggregateId>:<aggregateVersion>
+```
+
+where `aggregateId` is `catalogItemId`, `ancillaryOfferId`, or
+`ancillaryOrderItemId`, and `aggregateVersion` is the version after applying the
+transition. Fulfillment facts use:
+
+```
+ancillary-service:AncillaryFulfillmentFactRecorded:<ancillaryOrderItemId>:<fulfillmentFactId>
+```
+
+If a command replay does not apply a new transition or append a new fulfillment
+fact, no new event is emitted. Consumers still deduplicate by envelope `eventId`.
+
+## Shared payload objects
+
+### Money
+
+All monetary values use the shared `Money` shape: `currency` plus integer
+`minorUnits`. No decimal strings or floating-point amounts are used.
+
+### EligibilityResult
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `status` | enum | yes | `ELIGIBLE`, `INELIGIBLE`, or `UNKNOWN`. |
+| `primaryTicketStatus` | enum | yes | `ISSUED`, `CONFIRMED`, `PENDING`, `CANCELLED`, `VOIDED`, or `UNKNOWN`. |
+| `entitlementRef` | string | no | Entitlement proof used for this result. |
+| `departureAt` | RFC3339 UTC | yes | Departure time used for cutoff evaluation. |
+| `evaluatedAt` | RFC3339 UTC | yes | Eligibility evaluation time. |
+| `purchaseCutoffHoursBeforeDeparture` | integer | yes | Cutoff hours enforced. |
+| `segmentRefRequired` | boolean | yes | Whether segment binding was required. |
+| `segmentRefPresent` | boolean | yes | Whether the request supplied `segmentRef`. |
+| `reasons` | array[object] | yes | Reason objects with `code` and `message`; messages must not include unmasked sensitive personal data. |
+
+### CatalogSnapshot
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `catalogItemId` | string | yes | Catalog item ID (`aci-<uuid>`). |
+| `catalogItemVersion` | integer | yes | Catalog version. |
+| `serviceType` | enum | yes | `INSURANCE`, `MEAL`, `BAGGAGE`, `CONSIGN`, `SEAT_SELECTION`, `TRANSFER_PICKUP`, `LOUNGE`, `FAST_TRACK`, or `BUNDLE`. |
+| `attachmentScope` | enum | yes | `JOURNEY`, `SEGMENT`, `TRAVELER`, `ENTITLEMENT`, `PLACE`, or `TRANSFER`. |
+| `displayName` | string | yes | Display name captured at quote/order time. |
+| `unitPrice` | Money | yes | Static catalog unit price. |
+| `purchaseCutoffHoursBeforeDeparture` | integer | yes | Minimum cutoff used by eligibility. |
+| `eligibilityRuleVersion` | string | yes | Eligibility rule snapshot version. |
+| `fulfillmentMethod` | enum | yes | `VOUCHER`, `PROVIDER_CONFIRMATION`, `MANUAL_OPS`, or `NONE`. |
+
+### FulfillmentFact
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fulfillmentFactId` | string | yes | Fact ID (`aff-<uuid>`). |
+| `factType` | enum | yes | One of the fulfillment fact types listed below. |
+| `providerRef` | string | no | Normalized provider/voucher/seat/baggage/policy/pickup reference. |
+| `placeRef` | string | no | Place reference for the fact. |
+| `occurredAt` | RFC3339 UTC | yes | When the fact happened. |
+| `recordedAt` | RFC3339 UTC | yes | When Ancillary Service recorded it. |
+| `performedBy` | enum | yes | `SYSTEM`, `PROVIDER`, `OPS`, or `CUSTOMER_SERVICE`. |
+| `idempotencyRef` | string | yes | Provider event, voucher redemption, or ops command reference used for deduplication. |
+| `compensable` | boolean | yes | Whether this fact can be compensated in a later wave. |
+| `notes` | string | no | Operational notes; must not contain unmasked sensitive personal data. |
+
+`factType` values are `MEAL_ISSUED`, `BAGGAGE_CHECKED`, `CONSIGN_ACCEPTED`,
+`CONSIGN_DELIVERED`, `SEAT_ASSIGNED`, `LOUNGE_REDEEMED`, `FAST_TRACK_USED`,
+`PICKUP_COMPLETED`, `INSURANCE_ACTIVATED`, `INSURANCE_VOIDED`,
+`SERVICE_VOUCHER_ISSUED`, `SERVICE_VOUCHER_REDEEMED`, and
+`PROVIDER_FULFILLMENT_FAILED`.
+
+## Published Events
+
+### AncillaryCatalogItemPublished
+
+| Field | Description |
+|---|---|
+| **Producer** | ancillary-service |
+| **Consumers** | deferred: offer-management, notification, reporting |
+| **Trigger** | `PublishCatalogItem` command publishes a configured catalog item. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `catalogItemId` | string | yes | Catalog item ID. |
+| `version` | integer | yes | Published version. |
+| `serviceType` | enum | yes | Ancillary service type. |
+| `displayName` | string | yes | Display name. |
+| `attachmentScope` | enum | yes | Binding scope. |
+| `modalities` | string[] | yes | Applicable transport modalities. |
+| `supplierRef` | string | no | Normalized supplier capability reference. |
+| `price` | Money | yes | Static catalog price. |
+| `salesWindow` | object | yes | Sale `startAt` and `endAt` timestamps. |
+| `serviceWindow` | object | no | Service `startAt` and `endAt` timestamps when applicable. |
+| `purchaseCutoffHoursBeforeDeparture` | integer | yes | Purchase cutoff. |
+| `eligibilityRuleVersion` | string | yes | Eligibility rule version. |
+| `requiresEntitlementRef` | boolean | yes | Whether entitlement proof is required. |
+| `requiresSegmentRef` | boolean | yes | Whether segment reference is required. |
+| `fulfillmentMethod` | enum | yes | Fulfillment method. |
+| `status` | enum | yes | `PUBLISHED`. |
+| `publishedAt` | RFC3339 UTC | yes | Publish timestamp. |
+| `aggregateVersion` | integer | yes | Aggregate version after publish. |
+
+### AncillaryCatalogItemSuspended
+
+| Field | Description |
+|---|---|
+| **Producer** | ancillary-service |
+| **Consumers** | deferred: offer-management, notification, reporting |
+| **Trigger** | `SuspendCatalogItem` command pauses sale of a published or suspended item. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `catalogItemId` | string | yes | Catalog item ID. |
+| `version` | integer | yes | Catalog version. |
+| `serviceType` | enum | yes | Ancillary service type. |
+| `reasonCode` | string | yes | Stable suspension reason. |
+| `previousStatus` | enum | yes | Previous catalog status. |
+| `status` | enum | yes | `SUSPENDED`. |
+| `suspendedAt` | RFC3339 UTC | yes | Suspension timestamp. |
+| `aggregateVersion` | integer | yes | Aggregate version after suspension. |
+
+### AncillaryCatalogItemSuperseded
+
+| Field | Description |
+|---|---|
+| **Producer** | ancillary-service |
+| **Consumers** | deferred: offer-management, notification, reporting |
+| **Trigger** | `SupersedeCatalogItem` command replaces a catalog version. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `catalogItemId` | string | yes | Superseded catalog item ID. |
+| `version` | integer | yes | Superseded version. |
+| `replacementCatalogItemId` | string | yes | Replacement catalog item ID. |
+| `serviceType` | enum | yes | Ancillary service type. |
+| `reasonCode` | string | yes | Stable supersession reason. |
+| `previousStatus` | enum | yes | Previous catalog status. |
+| `status` | enum | yes | `SUPERSEDED`. |
+| `supersededAt` | RFC3339 UTC | yes | Supersession timestamp. |
+| `aggregateVersion` | integer | yes | Aggregate version after supersession. |
+
+### AncillaryOfferQuoted
+
+| Field | Description |
+|---|---|
+| **Producer** | ancillary-service |
+| **Consumers** | deferred: offer-management, journey-order, notification, reporting |
+| **Trigger** | `QuoteAncillaryOffer` command succeeds after minimum eligibility and static catalog pricing. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ancillaryOfferId` | string | yes | Offer ID (`aof-<uuid>`). |
+| `offerVersion` | integer | yes | Offer version. |
+| `journeyOrderId` | string | no | Journey order association for post-ticket add-ons, if known. |
+| `offerRef` | string | no | Optional Offer Management reference. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | no | Segment reference for segment-bound services. |
+| `entitlementRef` | string | no | Entitlement proof or lookup reference. |
+| `catalogSnapshot` | object | yes | Catalog snapshot used for the quote. |
+| `quantity` | integer | yes | Positive quantity. |
+| `unitPrice` | Money | yes | Static catalog unit price. |
+| `totalPrice` | Money | yes | Quoted total. |
+| `eligibility` | object | yes | Minimum eligibility result. |
+| `validFrom` | RFC3339 UTC | yes | Quote validity start. |
+| `expiresAt` | RFC3339 UTC | yes | Quote expiry. |
+| `status` | enum | yes | `QUOTED`. |
+| `quotedAt` | RFC3339 UTC | yes | Quote timestamp. |
+| `aggregateVersion` | integer | yes | Aggregate version after quote. |
+
+### AncillaryOfferExpired
+
+| Field | Description |
+|---|---|
+| **Producer** | ancillary-service |
+| **Consumers** | deferred: offer-management, journey-order, notification, reporting |
+| **Trigger** | Quote validity window elapsed or explicit scheduler/domain expiry. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ancillaryOfferId` | string | yes | Expired ancillary offer ID. |
+| `offerVersion` | integer | yes | Version at expiry. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `journeyOrderId` | string | no | Associated Journey Order, if any. |
+| `catalogItemId` | string | yes | Quoted catalog item. |
+| `previousStatus` | enum | yes | `QUOTED` or `SELECTED`. |
+| `reason` | enum | yes | `VALIDITY_WINDOW_ELAPSED` or `EXPLICIT_EXPIRE_COMMAND`. |
+| `expiredAt` | RFC3339 UTC | yes | Expiry timestamp. |
+| `status` | enum | yes | `EXPIRED`. |
+| `aggregateVersion` | integer | yes | Aggregate version after expiry. |
+
+### AncillaryOrderItemSelected
+
+| Field | Description |
+|---|---|
+| **Producer** | ancillary-service |
+| **Consumers** | deferred: journey-order, notification, reporting |
+| **Trigger** | `SelectAncillaryOffer` creates an ancillary order item from a valid quote. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ancillaryOrderItemId` | string | yes | Order item ID (`aoi-<uuid>`). |
+| `journeyOrderId` | string | yes | Referenced Journey Order. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | no | Segment binding if applicable. |
+| `entitlementRef` | string | no | Entitlement proof if supplied. |
+| `ancillaryOfferId` | string | yes | Source offer. |
+| `offerVersion` | integer | yes | Source offer version. |
+| `catalogSnapshot` | object | yes | Catalog snapshot copied from the offer. |
+| `quantity` | integer | yes | Positive quantity. |
+| `payableAmount` | Money | yes | Informational amount payable outside this domain. |
+| `refundableAmount` | Money | yes | Initial refundable amount, normally zero or the payable amount by policy. |
+| `status` | enum | yes | `SELECTED`. |
+| `selectedAt` | RFC3339 UTC | yes | Selection timestamp. |
+| `aggregateVersion` | integer | yes | Aggregate version after selection. |
+
+### AncillaryOrderItemPendingConfirmation
+
+| Field | Description |
+|---|---|
+| **Producer** | ancillary-service |
+| **Consumers** | deferred: journey-order, notification, reporting |
+| **Trigger** | `ConfirmAncillaryItem` begins supplier/voucher/entitlement confirmation but is not final. |
+
+**Payload fields:** same identity, reference, `payableAmount`, and
+`refundableAmount` fields as `AncillaryOrderItemSelected`, plus `confirmationRef`
+(optional string), `reasonCode` (optional string), `previousStatus`, `status` =
+`PENDING_CONFIRMATION`, `transitionedAt`, and `aggregateVersion`.
+
+### AncillaryOrderItemConfirmed
+
+| Field | Description |
+|---|---|
+| **Producer** | ancillary-service |
+| **Consumers** | deferred: journey-order, notification, reporting |
+| **Trigger** | `ConfirmAncillaryItem` confirms the service after required prerequisites. |
+
+**Payload fields:** same identity, reference, `payableAmount`, and
+`refundableAmount` fields as `AncillaryOrderItemSelected`, plus optional
+`confirmationRef`, optional `entitlementRef`, `previousStatus`, `status` =
+`CONFIRMED`, `confirmedAt`, and `aggregateVersion`.
+
+### AncillaryOrderItemFulfillmentReady
+
+| Field | Description |
+|---|---|
+| **Producer** | ancillary-service |
+| **Consumers** | deferred: fulfillment, journey-order, notification, reporting |
+| **Trigger** | `MarkFulfillmentReady` records voucher, seat, consign, or service-window readiness. |
+
+**Payload fields:** same identity/reference fields as
+`AncillaryOrderItemSelected`, plus optional `providerRef`, optional
+`entitlementRef`, `previousStatus`, `status` = `FULFILLMENT_READY`, `readyAt`, and
+`aggregateVersion`.
+
+### AncillaryOrderItemFulfilled
+
+| Field | Description |
+|---|---|
+| **Producer** | ancillary-service |
+| **Consumers** | deferred: journey-order, finance-settlement, notification, post-sales, reporting |
+| **Trigger** | A fulfillment fact completes the service, such as meal issued, lounge redeemed, fast track used, pickup completed, baggage/consign completed, or insurance activated. |
+
+**Payload fields:** same identity/reference fields as
+`AncillaryOrderItemSelected`, plus `fulfillmentFact` (object), `previousStatus`,
+`status` = `FULFILLED`, `fulfilledAt`, and `aggregateVersion`.
+
+### AncillaryOrderItemFailed
+
+| Field | Description |
+|---|---|
+| **Producer** | ancillary-service |
+| **Consumers** | deferred: journey-order, notification, post-sales, reporting |
+| **Trigger** | Confirmation or fulfillment fails, including provider fulfillment failure facts. |
+
+**Payload fields:** same identity/reference fields as
+`AncillaryOrderItemSelected`, plus `failureCode` (string), optional
+`fulfillmentFact`, `compensable` (boolean), `previousStatus`, `status` =
+`FAILED`, `failedAt`, and `aggregateVersion`.
+
+### AncillaryOrderItemCancelled
+
+| Field | Description |
+|---|---|
+| **Producer** | ancillary-service |
+| **Consumers** | deferred: journey-order, finance-settlement, notification, post-sales, reporting |
+| **Trigger** | Explicit cancel command or `JourneyOrderCancelled` consumed from Journey Order. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ancillaryOrderItemId` | string | yes | Order item ID. |
+| `journeyOrderId` | string | yes | Referenced Journey Order. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | no | Segment binding if applicable. |
+| `catalogItemId` | string | yes | Catalog item. |
+| `serviceType` | enum | yes | Ancillary service type. |
+| `payableAmount` | Money | yes | Informational payable amount. |
+| `refundableAmount` | Money | yes | Current refundable suggestion. |
+| `reasonCode` | string | yes | Stable cancellation reason. |
+| `source` | enum | yes | `USER`, `OPS`, `SYSTEM`, `SUPPLIER`, or `JOURNEY_ORDER_CANCELLED`. |
+| `sourceEventId` | string | no | Consumed event ID when cancellation follows `JourneyOrderCancelled`. |
+| `previousStatus` | enum | yes | Previous order-item status. |
+| `status` | enum | yes | `CANCELLED`. |
+| `cancelledAt` | RFC3339 UTC | yes | Cancellation timestamp. |
+| `aggregateVersion` | integer | yes | Aggregate version after cancellation. |
+
+### AncillaryOrderItemRefundPending
+
+| Field | Description |
+|---|---|
+| **Producer** | ancillary-service |
+| **Consumers** | deferred: payment, finance-settlement, notification, post-sales, reporting |
+| **Trigger** | `SuggestAncillaryRefund` determines a refund is due; Payment execution is deferred. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ancillaryOrderItemId` | string | yes | Order item ID. |
+| `journeyOrderId` | string | yes | Referenced Journey Order. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `catalogItemId` | string | yes | Catalog item. |
+| `serviceType` | enum | yes | Ancillary service type. |
+| `payableAmount` | Money | yes | Original informational payable amount. |
+| `refundableAmount` | Money | yes | Suggested refundable amount. |
+| `recommendation` | enum | yes | `FULL_REFUND`, `PARTIAL_REFUND`, `NO_REFUND`, or `MANUAL_REVIEW`. |
+| `reasonCode` | string | yes | Refund suggestion reason. |
+| `postSalesCaseId` | string | no | Post Sales case reference when supplied. |
+| `previousStatus` | enum | yes | Previous order-item status. |
+| `status` | enum | yes | `REFUND_PENDING` when a refund is due; otherwise the item remains in its previous status and no event is emitted. |
+| `requestedAt` | RFC3339 UTC | yes | Refund suggestion timestamp. |
+| `aggregateVersion` | integer | yes | Aggregate version after transition. |
+
+### AncillaryOrderItemRefunded
+
+| Field | Description |
+|---|---|
+| **Producer** | ancillary-service |
+| **Consumers** | deferred: journey-order, finance-settlement, notification, post-sales, reporting |
+| **Trigger** | `RecordAncillaryRefunded` records external Payment or operations refund completion. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ancillaryOrderItemId` | string | yes | Order item ID. |
+| `journeyOrderId` | string | yes | Referenced Journey Order. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `catalogItemId` | string | yes | Catalog item. |
+| `serviceType` | enum | yes | Ancillary service type. |
+| `refundRef` | string | yes | External refund reference. |
+| `refundedAmount` | Money | yes | Amount recorded as refunded. |
+| `previousStatus` | enum | yes | Previous order-item status. |
+| `status` | enum | yes | `REFUNDED`. |
+| `refundedAt` | RFC3339 UTC | yes | Refund completion timestamp. |
+| `aggregateVersion` | integer | yes | Aggregate version after refund record. |
+
+### AncillaryFulfillmentFactRecorded
+
+| Field | Description |
+|---|---|
+| **Producer** | ancillary-service |
+| **Consumers** | deferred: fulfillment, finance-settlement, notification, post-sales, reporting |
+| **Trigger** | `RecordFulfillmentFact` appends an idempotent fulfillment fact to an order item. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ancillaryOrderItemId` | string | yes | Order item ID. |
+| `journeyOrderId` | string | yes | Referenced Journey Order. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | no | Segment binding if applicable. |
+| `catalogItemId` | string | yes | Catalog item. |
+| `serviceType` | enum | yes | Ancillary service type. |
+| `fulfillmentFact` | object | yes | Embedded fulfillment fact. |
+| `previousStatus` | enum | yes | Status before applying the fact. |
+| `status` | enum | yes | Current order-item status after applying the fact. |
+| `aggregateVersion` | integer | yes | Aggregate version after recording the fact. |
+
+## Accepted Commands
+
+| Command | Sender / Trigger | Produced event |
+|---|---|---|
+| `CreateCatalogItem` | API gateway / operations via `POST /api/v1/ancillary-catalog-items` | no integration event in this wave |
+| `DeleteDraftCatalogItem` | API gateway / operations via `DELETE /api/v1/ancillary-catalog-items/{catalogItemId}` for draft-only cleanup | no integration event in this wave |
+| `PublishCatalogItem` | API gateway / operations via `/publish` | `AncillaryCatalogItemPublished` |
+| `SuspendCatalogItem` | API gateway / operations via `/suspend` | `AncillaryCatalogItemSuspended` |
+| `SupersedeCatalogItem` | API gateway / operations via `/supersede` | `AncillaryCatalogItemSuperseded` |
+| `QuoteAncillaryOffer` | API gateway/UI via `/quote` after draft collection | `AncillaryOfferQuoted` |
+| `ExpireAncillaryOffer` | Scheduler/domain policy | `AncillaryOfferExpired` |
+| `SelectAncillaryOffer` | API gateway/UI via `/select` | `AncillaryOrderItemSelected` |
+| `ConfirmAncillaryItem` | API gateway/ops/orchestration via `/confirm` | `AncillaryOrderItemPendingConfirmation` or `AncillaryOrderItemConfirmed` |
+| `MarkFulfillmentReady` | API gateway/ops/provider ACL via `/fulfillment-ready` | `AncillaryOrderItemFulfillmentReady` |
+| `RecordFulfillmentFact` | API gateway/ops/provider ACL via `/fulfillment-facts` | `AncillaryFulfillmentFactRecorded` plus optional lifecycle event |
+| `CancelAncillaryItem` | API gateway/ops or `JourneyOrderCancelled` consumer | `AncillaryOrderItemCancelled` |
+| `SuggestAncillaryRefund` | API gateway/post-sales workflow via `/refund-suggestions` | `AncillaryOrderItemRefundPending` when refund is due |
+| `RecordAncillaryRefunded` | API gateway/ops/payment-result recorder via `/refunded` | `AncillaryOrderItemRefunded` |
+
+## Consumed upstream events
+
+### JourneyOrderCancelled
+
+| Field | Description |
+|---|---|
+| **Source stream** | `events:journey-order` |
+| **Consumer group** | `ancillary-service` |
+| **Purpose** | Automatically cancel non-terminal `AncillaryOrderItem` records associated with the cancelled Journey Order. |
+
+Required consumed payload fields from the Journey Order event are `journeyOrderId`
+and the envelope `eventId`/`occurredAt`. Ancillary Service MUST process this event
+through its inbox/consumed-event log. For each associated order item not already
+terminal (`FULFILLED`, `REFUNDED`, or terminal `CANCELLED`), it emits
+`AncillaryOrderItemCancelled` with:
+
+- `source = JOURNEY_ORDER_CANCELLED`
+- `sourceEventId = <consumed envelope eventId>`
+- `reasonCode = JOURNEY_ORDER_CANCELLED`
+
+No Journey Order contract shape is changed by this subscription.
+
+## Deferred downstream touchpoints
+
+| Downstream context | Deferred events | Purpose when activated |
+|---|---|---|
+| Finance Settlement | `AncillaryOrderItemFulfilled`, `AncillaryOrderItemCancelled`, `AncillaryOrderItemRefundPending`, `AncillaryOrderItemRefunded`, `AncillaryFulfillmentFactRecorded` | Revenue recognition, refund/retention facts, supplier-cost read models. |
+| Notification | quoted/expired, order-item lifecycle, refund, and fulfillment-fact events | User-facing ancillary confirmations, failures, voucher/redeem, and refund progress. |
+| Post Sales | order-item cancellation, failure, fulfillment, refund-pending/refunded, fulfillment facts | Main-ticket after-sales impact evaluation and future compensation workflows. |
+| Journey Order | order-item selected/confirmed/ready/fulfilled/cancelled/refunded lifecycle | Future order-detail projection only; this wave does not modify Journey Order contracts. |
+| Fulfillment | `AncillaryOrderItemFulfillmentReady`, `AncillaryFulfillmentFactRecorded`, selected completion lifecycle facts | Future service voucher and evidence handoff. |
+| Reporting | all Ancillary Service events | Attach rate, refund rate, fulfillment failure, and supplier-performance read models. |

--- a/docs/08-contracts/events/ancillary-service.md
+++ b/docs/08-contracts/events/ancillary-service.md
@@ -465,8 +465,9 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | **Consumer group** | `ancillary-service` |
 | **Purpose** | Automatically cancel non-terminal `AncillaryOrderItem` records associated with the cancelled Journey Order. |
 
-Required consumed payload fields from the Journey Order event are `journeyOrderId`
-and the envelope `eventId`/`occurredAt`. Ancillary Service MUST process this event
+Required consumed payload fields from the Journey Order event are `orderId`
+(the producer-contract field name in events/journey-order.md, mapped internally
+to this domain's `journeyOrderId`) and the envelope `eventId`/`occurredAt`. Ancillary Service MUST process this event
 through its inbox/consumed-event log. For each associated order item not already
 terminal (`FULFILLED`, `REFUNDED`, or terminal `CANCELLED`), it emits
 `AncillaryOrderItemCancelled` with:

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -74,6 +74,7 @@ context.
 | 24 | `dispatch` | `events:dispatch` | DispatchRequested, DriverAssigned, DriverEtaUpdated, DriverArrived, RideStarted, RideEnded, DriverCancelled, DispatchUserCancelled, DispatchNoShowRecorded, DispatchFailed |
 | 25 | `wallet-promotion` | `events:wallet-promotion` | BenefitIssued, BenefitReserved, BenefitRedeemed, BenefitReservationReleased, BenefitExpired, BenefitRevoked, BenefitRedemptionReversed |
 | 26 | `disruption-recovery` | `events:disruption-recovery` | DisruptionReported, IncidentOpened, RecoveryCaseOpened, RecoveryOptionsGenerated, RecoveryOptionSelected, RecoveryExecutionStarted, RecoveryCompleted, RecoveryFailed, RecoveryCaseClosed, ServiceAlertPublished |
+| 27 | `ancillary-service` | `events:ancillary-service` | AncillaryCatalogItemPublished, AncillaryCatalogItemSuspended, AncillaryCatalogItemSuperseded, AncillaryOfferQuoted, AncillaryOfferExpired, AncillaryOrderItemSelected, AncillaryOrderItemPendingConfirmation, AncillaryOrderItemConfirmed, AncillaryOrderItemFulfillmentReady, AncillaryOrderItemFulfilled, AncillaryOrderItemFailed, AncillaryOrderItemCancelled, AncillaryOrderItemRefundPending, AncillaryOrderItemRefunded, AncillaryFulfillmentFactRecorded |
 
 ### Dead-Letter Streams
 
@@ -281,6 +282,7 @@ plus notification/finance/reporting fan-in.
 | 54 | `events:wallet-promotion` | `notification` | Benefit arrival, expiry, redemption, revocation, and reversal user touchpoints; concrete consumption deferred to a later wave |
 | 55 | `events:wallet-promotion` | `reporting` | Wallet / Promotion lifecycle metrics and read models |
 | 56 | `events:post-sales` | `disruption-recovery` | PostSalesApplied converges REFUND recovery execution |
+| 57 | `events:journey-order` | `ancillary-service` | RULING (2026-07-09): JourneyOrderCancelled is the only upstream event consumed by Ancillary Service in this activation wave; it automatically cancels associated non-terminal AncillaryOrderItem records. |
 
 ### Cross-Cutting Consumers
 
@@ -303,6 +305,15 @@ wave. Disruption Recovery has one active inbound subscription: it consumes
 recovery options after the downstream Post Sales case reaches `APPLIED`.
 Service Plan, Provider Integration, Fulfillment, and Transfer Management signal
 sources are deferred; Transfer Management belongs to wave 18.
+### Deferred Ancillary Service Subscriptions
+
+`events:ancillary-service` is registered as a produced stream in this contract.
+Ancillary Service actively consumes only `JourneyOrderCancelled` from
+`events:journey-order` in this activation wave. Finance Settlement, Notification,
+and Post Sales are documented downstream touchpoints for ancillary order-item,
+refund, and fulfillment-fact events, but their concrete consumer implementations
+are deferred. Journey Order contract shapes are not changed by this activation;
+any order-detail projection of ancillary items is future work.
 
 ### Deferred Dispatch Subscriptions
 


### PR DESCRIPTION
## Summary
- Add Ancillary Service HTTP API contract for catalog, offer, order-item, refund suggestion, and fulfillment fact endpoints
- Add Ancillary Service events/commands contract with lifecycle, fulfillment fact, and JourneyOrderCancelled consumption details
- Register events:ancillary-service and active journey-order subscription in messaging.md

## Validation
- make check
- make contract-lint