### PR TITLE
REQ-119 transfer management contracts

### DIFF
--- a/docs/08-contracts/api/disruption-recovery.md
+++ b/docs/08-contracts/api/disruption-recovery.md
@@ -12,15 +12,15 @@ contract is scoped to the ADR-0002 third activation wave and is bounded by
 
 Activation-wave rulings:
 
-- The only disruption signal source in this wave is **operations reporting** via
-  `POST /api/v1/disruptions`. The request represents the Customer
-  Service/Admin manual rows from the upstream table and MUST carry
+- The disruption signal source in this wave is **operations/system reporting** via
+  `POST /api/v1/disruptions`. The request represents Customer Service/Admin
+  manual rows or Transfer Management system reports and MUST carry
   `disruptionType`, `scheduledServiceRef` and/or `segmentRef`, `serviceDate`,
   `evidence`, and explicit `affectedOrderIds`. Automatic `segmentRef` to order
   fan-out is deferred because Journey Order has no by-segment query contract.
-- Service Plan, Provider Integration, Fulfillment, and Transfer Management event
-  sources are deferred. Most of those events are not in production today;
-  Transfer Management is wave 18.
+- Service Plan, Provider Integration, and Fulfillment event sources remain
+  deferred. Transfer Management wave 18 opens protected missed-connection
+  recovery through outbound HTTP to this API, not through a new input event.
 - An `Incident` is opened or merged by the same report. This wave merges by
   `(scheduledServiceRef, serviceDate)` when `scheduledServiceRef` is present;
   otherwise the report opens a distinct incident for its supplied scope.
@@ -48,7 +48,7 @@ camelCase and enum values are SCREAMING_SNAKE_CASE.
 
 | Enum | Values |
 |---|---|
-| `disruptionType` | `SERVICE_DELAY`, `SERVICE_CANCELLED`, `SERVICE_SUSPENDED`, `SAILING_SUSPENDED`, `ROAD_CLOSED`, `WEATHER`, `OPERATION_RESTRICTION`, `SUPPLIER_FAILURE`, `DRIVER_CANCELLED`, `DISPATCH_FAILED`, `STOP_CHANGED`, `PORT_CALL_CHANGED`, `BATCH_SYSTEM_EVENT`, `CONNECTION_MISSED` |
+| `disruptionType` | `SERVICE_DELAY`, `SERVICE_CANCELLED`, `SERVICE_SUSPENDED`, `SAILING_SUSPENDED`, `ROAD_CLOSED`, `WEATHER`, `OPERATION_RESTRICTION`, `SUPPLIER_FAILURE`, `DRIVER_CANCELLED`, `DISPATCH_FAILED`, `STOP_CHANGED`, `PORT_CALL_CHANGED`, `BATCH_SYSTEM_EVENT`, `CONNECTION_MISSED`, `MISSED_CONNECTION` |
 | `incidentStatus` | `DETECTED`, `CONFIRMED`, `BATCH_PROCESSING`, `MONITORING`, `RESOLVED`, `CLOSED` |
 | `recoveryCaseStatus` | `OPENED`, `ASSESSING_IMPACT`, `OPTIONS_GENERATED`, `AWAITING_USER_CHOICE`, `EXECUTING_RECOVERY`, `MANUAL_REVIEW`, `RECOVERED`, `DECLINED`, `FAILED`, `CLOSED` |
 | `recoveryOptionType` | `WAIT`, `REFUND`, `COMPENSATION`, `MANUAL` |
@@ -56,7 +56,7 @@ camelCase and enum values are SCREAMING_SNAKE_CASE.
 | `executionTarget` | `NONE`, `POST_SALES`, `WALLET_PROMOTION`, `MANUAL_QUEUE` |
 
 `REACCOMMODATION` is intentionally absent from the active option-type enum in
-this wave. It remains a domain capability but is deferred until wave 18.
+this wave. It remains a domain capability but is deferred until a later wave.
 
 ## RecoveryCase state machine
 
@@ -112,7 +112,7 @@ option set:
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `evidenceRef` | string | yes | Reference to the admin/customer-service evidence record or uploaded artifact. |
-| `sourceSystem` | enum | yes | `CUSTOMER_SERVICE` or `ADMIN`. Other upstream source systems are deferred. |
+| `sourceSystem` | enum | yes | `CUSTOMER_SERVICE`, `ADMIN`, or `TRANSFER_MANAGEMENT`. Other upstream source systems are deferred. |
 | `sourceRecordId` | string | yes | Upstream manual-row identifier. |
 | `summary` | string | yes | Operational summary; MUST NOT include unmasked documents or other sensitive personal data. |
 | `occurredAt` | RFC3339 UTC | no | When the disruption was observed, if known. |
@@ -251,9 +251,9 @@ return the original response. Reusing the same key with a different body returns
 | `scheduledServiceRef` | string | no | Scheduled service reference. Required when `segmentRef` is absent. |
 | `segmentRef` | string | no | Segment reference. Required when `scheduledServiceRef` is absent. |
 | `serviceDate` | string | yes | ISO `YYYY-MM-DD` operating date; used with `scheduledServiceRef` for incident merge. |
-| `evidence` | object | yes | Evidence object with `sourceSystem` of `CUSTOMER_SERVICE` or `ADMIN`. |
+| `evidence` | object | yes | Evidence object with `sourceSystem` of `CUSTOMER_SERVICE`, `ADMIN`, or `TRANSFER_MANAGEMENT`. |
 | `affectedOrderIds` | array[string] | yes | Explicit affected `ord-<uuid>` IDs. Must be non-empty. |
-| `reportedBy` | object | yes | Reporting actor; normally `CUSTOMER_SERVICE` or `OPERATIONS`. |
+| `reportedBy` | object | yes | Reporting actor; normally `CUSTOMER_SERVICE`, `OPERATIONS`, or `SYSTEM` for Transfer Management missed-connection reports. |
 
 **Response (202):**
 
@@ -268,7 +268,10 @@ incident is opened, `RecoveryCaseOpened` for each affected order, optionally
 `RecoveryOptionsGenerated`, and `ServiceAlertPublished` for the incident alert
 fact. A repeated report for an already known `(scheduledServiceRef, serviceDate)`
 merges into the existing incident and does not duplicate active cases for the
-same `(incidentId, journeyOrderId)`.
+same `(incidentId, journeyOrderId)`. Wave-18 implementation MUST update the
+Disruption Recovery code enum/validation allowlists for
+`reportedBy.actorType=SYSTEM`, `disruptionType=MISSED_CONNECTION`, and
+`evidence.sourceSystem=TRANSFER_MANAGEMENT`; this is not a docs-only increment.
 
 **Error codes:** `VALIDATION_FAILED`, `CONFLICT`, `DOMAIN_RULE_VIOLATION`,
 `IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
@@ -389,5 +392,6 @@ wave:
   the ServiceAlert read model is deferred.
 
 Deferred signal sources remain out of this wave: Service Plan, Provider
-Integration, Fulfillment, and Transfer Management events do not open incidents
-or cases until their activation waves.
+Integration, and Fulfillment events do not open incidents or cases until their
+activation waves. Transfer Management opens protected missed-connection recovery
+through this HTTP endpoint, not by publishing a Disruption Recovery input event.

--- a/docs/08-contracts/api/transfer-management.md
+++ b/docs/08-contracts/api/transfer-management.md
@@ -120,11 +120,16 @@ key.
 
 | Command | Material folded into UUID-v7 idempotency key |
 |---|---|
-| Create/evaluate transfer plan | `itineraryRef`, `planningSnapshotVersion`, `requestId` |
+| Create/evaluate transfer plan | `itineraryRef`, `planningSnapshotVersion`, `trigger` (`API`/`REFRESH`) |
 | Register connection | `journeyOrderId`, `previousSegmentRef`, `nextSegmentRef`, `travelerSetHash` |
 | Segment status report | `sourceSystem`, `sourceRecordId`, `segmentRef`, `reportType`, `observedAt` |
 | Publish MCT rule | `mctRuleId`, `version` |
 | Open Disruption Recovery report | `connectionId`, `missedAt`, `connectionVersion`, `journeyOrderId` |
+
+API-triggered commands use the client-supplied `Idempotency-Key` header
+directly as the command key; the fold materials above apply to commands the
+service originates internally (scheduled refreshes, event-driven
+re-evaluations, outbound reports).
 
 Outbound HTTP idempotency keys used for Disruption Recovery MUST be persisted
 before the call is attempted and reused on retry. Correlation and causation IDs

--- a/docs/08-contracts/api/transfer-management.md
+++ b/docs/08-contracts/api/transfer-management.md
@@ -1,0 +1,649 @@
+# Transfer Management — HTTP API
+
+Last updated: 2026-07-09
+
+## Overview
+
+Transfer Management owns transfer feasibility, connection runtime state,
+connection responsibility contracts, and published minimum connection time (MCT)
+rules. This contract activates the bounded context from
+`docs/02-domains/transfer-management.md` with ADR-0002 wave-18 scope cuts.
+
+Activation-wave rulings:
+
+- Active aggregates are `TransferPlan`, `Connection`, and `ConnectionContract`.
+  `MinimumConnectionTimeRule` is active as operations CRUD plus publish/retire;
+  a `PUBLISHED` version is immutable. `TransferRiskPolicy` CRUD is deferred:
+  all evaluations use built-in fixed policy version `builtin-v1`, and every risk
+  result MUST carry that value.
+- `Connection` uses the nine-state runtime machine below. RULING: once a
+  connection reaches `MISSED`, it MUST NOT transition back to `FEASIBLE`; it may
+  only converge to `RECOVERED`, `SELF_HANDLED`, or a terminal state.
+- Fulfillment does not currently publish segment-level delay/arrival/cancelled
+  facts. Runtime inputs are accepted through the system/ops endpoint
+  `POST /api/v1/segment-status-reports`. Future Fulfillment events may replace
+  this adapter without changing aggregate invariants.
+- Evaluation reads the itinerary snapshot from Trip Planning by `itineraryRef`,
+  uses this domain's published MCT rules, and derives schedule windows from the
+  itinerary snapshot plus accepted segment-status reports. Place Network
+  topology/path integration is deferred; this wave records node refs, node types,
+  and transfer category but does not call Place Network.
+- Closed loop with Disruption Recovery is HTTP-first. When a protected connection
+  (`PROTECTED` or `SUPPLIER_PROTECTED`) becomes `MISSED`, Transfer Management
+  calls Disruption Recovery `POST /api/v1/disruptions` as a `SYSTEM` report with
+  `disruptionType=MISSED_CONNECTION` and
+  `evidence.sourceSystem=TRANSFER_MANAGEMENT`. It persists the outbound UUID-v7
+  idempotency key and the `recoveryCases[].caseId` values from the response.
+  `SELF_TRANSFER` missed connections publish facts only and do not open recovery
+  cases. `REACCOMMODATION` remains deferred to a later wave; Disruption Recovery
+  still offers `WAIT`, `REFUND`, `COMPENSATION`, and `MANUAL` only.
+
+Field shapes reference `docs/08-contracts/shared-primitives.md` for IDs,
+timestamps, event envelope fields, pagination conventions, and Money
+(`{currency, minorUnits}` when used by future extensions). All timestamps are
+RFC3339 UTC. JSON fields are camelCase and enum values are SCREAMING_SNAKE_CASE.
+Error codes follow `docs/08-contracts/api/README.md` / REQ-079.
+
+## Common enums
+
+| Enum | Values |
+|---|---|
+| `transferPlanStatus` | `DRAFT`, `EVALUATING`, `EVALUATED`, `UNSERVICEABLE`, `PUBLISHED`, `REFRESHING`, `EXPIRED` |
+| `connectionStatus` | `PLANNED`, `FEASIBLE`, `TIGHT`, `AT_RISK`, `MISSED`, `RECOVERED`, `SELF_HANDLED`, `COMPLETED`, `INVALIDATED` |
+| `connectionContractType` | `PROTECTED`, `SUPPLIER_PROTECTED`, `PLATFORM_ASSISTED`, `SELF_TRANSFER` |
+| `connectionContractStatus` | `PROPOSED`, `ELIGIBLE`, `REJECTED`, `CONFIRMED`, `ACTIVE`, `TRIGGERED`, `SETTLED`, `VOIDED` |
+| `riskLevel` | `FEASIBLE`, `TIGHT`, `AT_RISK`, `MISSED`, `RECOVERED` |
+| `transferCategory` | `SAME_STATION`, `CROSS_STATION`, `IN_STATION`, `TERMINAL_CHANGE`, `AIRPORT`, `PORT`, `BUS_TERMINAL`, `RIDESHARE_CONNECTOR`, `OTHER` |
+| `nodeType` | `STATION`, `AIRPORT_TERMINAL`, `PORT_TERMINAL`, `BUS_STOP`, `RIDESHARE_PICKUP`, `WALKING_NODE`, `OTHER` |
+| `segmentReportType` | `DELAY`, `ARRIVAL`, `CANCELLED` |
+| `mctRuleStatus` | `DRAFT`, `VALIDATED`, `PUBLISHED`, `RETIRED` |
+| `recoveryTriggerStatus` | `NOT_REQUIRED`, `PENDING`, `OPENED`, `FAILED` |
+
+`riskLevel` is an evaluation output and is intentionally separate from
+`connectionStatus`, which is the aggregate state machine.
+
+## State machines
+
+### TransferPlan
+
+| Status | Meaning | Allowed next statuses |
+|---|---|---|
+| `DRAFT` | Plan shell was created from an itinerary reference. | `EVALUATING`, `EXPIRED` |
+| `EVALUATING` | Connections are being assessed against itinerary, schedule window, and MCT rules. | `EVALUATED`, `UNSERVICEABLE` |
+| `EVALUATED` | All active connections have an assessment result. | `PUBLISHED`, `REFRESHING`, `EXPIRED` |
+| `UNSERVICEABLE` | Required data is missing or at least one transfer is impossible for this wave. | `REFRESHING`, `EXPIRED` |
+| `PUBLISHED` | Plan is visible to Trip Planning, Offer Management, or Journey Order. | `REFRESHING`, `EXPIRED` |
+| `REFRESHING` | Upstream schedule/status data changed and the plan is being re-evaluated. | `EVALUATED`, `UNSERVICEABLE`, `EXPIRED` |
+| `EXPIRED` | Planning/offer window ended. | Terminal |
+
+### Connection
+
+| Status | Meaning | Allowed next statuses |
+|---|---|---|
+| `PLANNED` | Connection was registered from planned itinerary/schedule data. | `FEASIBLE`, `TIGHT`, `INVALIDATED` |
+| `FEASIBLE` | Available window exceeds MCT and buffer threshold. | `TIGHT`, `AT_RISK`, `COMPLETED`, `INVALIDATED` |
+| `TIGHT` | Still reachable but with insufficient buffer. | `FEASIBLE`, `AT_RISK`, `MISSED`, `COMPLETED` |
+| `AT_RISK` | Delay, cancellation, baggage/security, or schedule report creates high risk. | `TIGHT`, `MISSED`, `RECOVERED` |
+| `MISSED` | Next-segment cutoff cannot be met or the next segment is closed/cancelled. | `RECOVERED`, `SELF_HANDLED` |
+| `RECOVERED` | Disruption Recovery completed an acceptable recovery path or the connection was otherwise restored. | `COMPLETED` |
+| `SELF_HANDLED` | Self-transfer traveler handles or abandons the missed connection without protected recovery. | `COMPLETED` |
+| `COMPLETED` | Next segment boarded/started or the risk window ended. | Terminal |
+| `INVALIDATED` | Order cancellation, itinerary replacement, or contract withdrawal invalidated the connection. | Terminal |
+
+RULING: `MISSED` cannot transition to `FEASIBLE` even if a later status report
+arrives; later facts are recorded as timeline evidence and may produce
+`RECOVERED` only through explicit recovery convergence.
+
+### ConnectionContract
+
+| Status | Meaning | Allowed next statuses |
+|---|---|---|
+| `PROPOSED` | Contract option was generated for a connection. | `ELIGIBLE`, `REJECTED`, `VOIDED` |
+| `ELIGIBLE` | Validation passed and the contract may be accepted. | `CONFIRMED`, `VOIDED` |
+| `REJECTED` | The connection is not eligible for this contract option. | Terminal |
+| `CONFIRMED` | Offer/order accepted the contract snapshot. | `ACTIVE`, `VOIDED` |
+| `ACTIVE` | Journey has started and runtime monitoring may trigger responsibility. | `TRIGGERED`, `VOIDED` |
+| `TRIGGERED` | At-risk/missed state activated responsibility handling. | `SETTLED`, `VOIDED` |
+| `SETTLED` | Responsibility was handed off to recovery, assistance, or self-transfer facts. | Terminal |
+| `VOIDED` | Order/itinerary change removed this contract. | Terminal |
+
+## Identity and idempotency
+
+HTTP commands that mutate state require an `Idempotency-Key` header. The header
+value MUST be UUID-v7-shaped. A replay with the same body returns the original
+response; reuse with a different body returns `IDEMPOTENCY_KEY_REUSED`.
+
+Domain idempotency material from the domain document is not placed directly on
+the wire. The application folds stable material with SHA-256, stamps UUID version
+7 and RFC-4122 variant bits, and persists the resulting UUID-v7-shaped command
+key.
+
+| Command | Material folded into UUID-v7 idempotency key |
+|---|---|
+| Create/evaluate transfer plan | `itineraryRef`, `planningSnapshotVersion`, `requestId` |
+| Register connection | `journeyOrderId`, `previousSegmentRef`, `nextSegmentRef`, `travelerSetHash` |
+| Segment status report | `sourceSystem`, `sourceRecordId`, `segmentRef`, `reportType`, `observedAt` |
+| Publish MCT rule | `mctRuleId`, `version` |
+| Open Disruption Recovery report | `connectionId`, `missedAt`, `connectionVersion`, `journeyOrderId` |
+
+Outbound HTTP idempotency keys used for Disruption Recovery MUST be persisted
+before the call is attempted and reused on retry. Correlation and causation IDs
+on outbound events/commands use `corr-<uuid-v7>` and `cmd-<uuid-v7>` prefixes.
+
+## Resource representations
+
+### TransferPlan
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `transferPlanId` | string | yes | Canonical transfer plan ID (`tpl-<uuid>`). |
+| `itineraryRef` | string | yes | Trip Planning itinerary reference; the itinerary snapshot self-authenticates this reference. |
+| `planningSnapshotVersion` | integer | yes | Version/hash of the itinerary snapshot used for evaluation. |
+| `journeyOrderId` | string | no | Order ID when evaluating a purchased itinerary. |
+| `status` | enum | yes | Transfer plan status. |
+| `connections` | array[ConnectionSummary] | yes | Connections produced from adjacent itinerary legs. |
+| `evaluationVersion` | integer | yes | Monotonic plan evaluation version. |
+| `riskPolicyVersion` | string | yes | Always `builtin-v1` in this wave. |
+| `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
+| `updatedAt` | RFC3339 UTC | yes | Last mutation timestamp. |
+| `expiresAt` | RFC3339 UTC | no | Planning/offer expiry. |
+
+### ConnectionSummary
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `connectionId` | string | yes | Connection ID (`con-<uuid>`). |
+| `previousSegmentRef` | string | yes | Previous itinerary/order segment reference. |
+| `nextSegmentRef` | string | yes | Next itinerary/order segment reference. |
+| `transferCategory` | enum | yes | Transfer category used for MCT lookup. |
+| `status` | enum | yes | Connection runtime status. |
+| `riskLevel` | enum | yes | Latest evaluation risk level. |
+
+### Connection
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `connectionId` | string | yes | Connection ID (`con-<uuid>`). |
+| `transferPlanId` | string | yes | Owning transfer plan. |
+| `journeyOrderId` | string | no | Purchased order when known. Required before protected recovery is opened. |
+| `itineraryRef` | string | yes | Source Trip Planning itinerary reference. |
+| `previousSegmentRef` | string | yes | Previous segment reference. |
+| `nextSegmentRef` | string | yes | Next segment reference. |
+| `travelerRefs` | array[string] | yes | Traveler references affected by this connection. |
+| `fromNodeRef` | string | yes | Arrival node/place reference from itinerary snapshot. |
+| `toNodeRef` | string | yes | Departure node/place reference from itinerary snapshot. |
+| `fromNodeType` | enum | yes | Node type used for MCT lookup. |
+| `toNodeType` | enum | yes | Node type used for MCT lookup. |
+| `transferCategory` | enum | yes | Transfer category used for MCT lookup. |
+| `contractId` | string | yes | Confirmed or proposed connection contract ID. |
+| `contractType` | enum | yes | Contract type snapshot. |
+| `status` | enum | yes | Connection runtime status. |
+| `latestEvaluation` | RiskEvaluation | yes | Latest risk evaluation. |
+| `window` | ConnectionWindow | yes | Planned/actual transfer window. |
+| `recovery` | RecoveryCaseMapping | no | Present after protected missed-connection report opens recovery cases. |
+| `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
+| `updatedAt` | RFC3339 UTC | yes | Last mutation timestamp. |
+
+### ConnectionWindow
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `plannedArrivalAt` | RFC3339 UTC | yes | Previous segment planned arrival. |
+| `actualArrivalAt` | RFC3339 UTC | no | Reported actual arrival when known. |
+| `nextDepartureAt` | RFC3339 UTC | yes | Next segment planned departure. |
+| `nextCutoffAt` | RFC3339 UTC | yes | Boarding/check-in/driver-wait cutoff used for missed detection. |
+| `availableMinutes` | integer | yes | Minutes currently available for the connection; may be negative after cutoff. |
+| `mctMinutes` | integer | yes | Required minimum connection time from a published MCT rule. |
+| `bufferMinutes` | integer | yes | `availableMinutes - mctMinutes`. |
+
+### RiskEvaluation
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `riskEvaluationId` | string | yes | Evaluation ID (`tre-<uuid>`). |
+| `riskLevel` | enum | yes | Risk output, not aggregate state. |
+| `riskPolicyVersion` | string | yes | Always `builtin-v1`; TransferRiskPolicy management is deferred. |
+| `mctRuleId` | string | yes | Published MCT rule used. |
+| `mctRuleVersion` | integer | yes | Published MCT rule version. |
+| `availableMinutes` | integer | yes | Available transfer minutes used in the calculation. |
+| `requiredMinutes` | integer | yes | MCT minutes required. |
+| `reasons` | array[string] | yes | Explainable reason codes such as `INSUFFICIENT_BUFFER`, `PREVIOUS_SEGMENT_DELAYED`, or `NEXT_SEGMENT_CANCELLED`. |
+| `evaluatedAt` | RFC3339 UTC | yes | Evaluation timestamp. |
+
+### ConnectionContract
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `connectionContractId` | string | yes | Contract ID (`cct-<uuid>`). |
+| `connectionId` | string | yes | Connection this contract describes. |
+| `contractType` | enum | yes | Contract type. |
+| `status` | enum | yes | Contract status. |
+| `responsibleParty` | enum | yes | `PLATFORM`, `SUPPLIER`, `PLATFORM_ASSISTANCE`, or `TRAVELER`. |
+| `coverageSummary` | string | yes | User/customer-service safe summary; no unmasked PII. |
+| `disclosureVersion` | string | yes | Disclosure copy/version accepted by offer/order. |
+| `termsSnapshotRef` | string | no | Immutable supplier/platform terms snapshot. |
+| `confirmedAt` | RFC3339 UTC | no | Confirmation timestamp. |
+| `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
+| `updatedAt` | RFC3339 UTC | yes | Last mutation timestamp. |
+
+### MinimumConnectionTimeRule
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `mctRuleId` | string | yes | MCT rule ID (`mct-<uuid>`). |
+| `version` | integer | yes | Monotonic rule version; `PUBLISHED` versions are immutable. |
+| `status` | enum | yes | MCT rule status. |
+| `fromNodeType` | enum | yes | Arrival node type matched by the rule. |
+| `toNodeType` | enum | yes | Departure node type matched by the rule. |
+| `transferCategory` | enum | yes | Transfer category matched by the rule. |
+| `minimumMinutes` | integer | yes | Required minutes; must be positive. |
+| `conditions` | object | yes | Structured non-PII conditions such as baggage/security/accessibility flags. |
+| `validFrom` | RFC3339 UTC | yes | Rule effective start. |
+| `validUntil` | RFC3339 UTC | no | Rule effective end. |
+| `publishedAt` | RFC3339 UTC | no | Publish timestamp. |
+| `retiredAt` | RFC3339 UTC | no | Retire timestamp. |
+
+### SegmentStatusReport
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `segmentStatusReportId` | string | yes | Report ID (`tsr-<uuid>`). |
+| `segmentRef` | string | yes | Segment reported by system/ops. |
+| `reportType` | enum | yes | `DELAY`, `ARRIVAL`, or `CANCELLED`. |
+| `reportedBy` | object | yes | ActorRef; `actorType` is normally `SYSTEM` or `OPERATIONS`. |
+| `sourceSystem` | enum | yes | `OPERATIONS`, `ADMIN`, or future `FULFILLMENT`; current production uses ops/system reporting. |
+| `sourceRecordId` | string | yes | Source report row/event identifier for idempotency material. |
+| `observedAt` | RFC3339 UTC | yes | When the operational fact was observed. |
+| `estimatedArrivalAt` | RFC3339 UTC | for `DELAY` | Updated ETA for delayed previous segment. |
+| `actualArrivalAt` | RFC3339 UTC | for `ARRIVAL` | Actual arrival time. |
+| `cancelledAt` | RFC3339 UTC | for `CANCELLED` | Cancellation time. |
+| `reason` | string | no | Non-PII reason summary. |
+
+### ActorRef
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `actorType` | enum | yes | `SYSTEM`, `OPERATIONS`, `CUSTOMER_SERVICE`, or `USER` depending on command. |
+| `actorId` | string | yes | Service actor, operator, customer-service, or user reference. |
+
+### RecoveryCaseMapping
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `recoveryTriggerStatus` | enum | yes | `PENDING`, `OPENED`, or `FAILED` after a protected miss; `NOT_REQUIRED` is omitted from the object. |
+| `disruptionId` | string | no | Disruption Recovery report ID (`drp-<uuid>`) from the response. |
+| `incidentId` | string | no | Incident ID from the response. |
+| `caseIds` | array[string] | yes | Recovery case IDs returned by Disruption Recovery. |
+| `outboundIdempotencyKey` | string | yes | Persisted UUID-v7 key used for `POST /api/v1/disruptions`. |
+| `openedAt` | RFC3339 UTC | no | Time the response was accepted. |
+| `failureReason` | string | no | Sanitized failure reason if the outbound call failed. |
+
+## Endpoints
+
+### Create Transfer Plan
+
+**POST** `/api/v1/transfer-plans`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` UUID-v7-shaped header).
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `itineraryRef` | string | yes | Trip Planning itinerary reference. |
+| `planningSnapshotVersion` | integer | yes | Version/hash of the itinerary snapshot being evaluated. |
+| `journeyOrderId` | string | no | Order ID when evaluating a purchased itinerary. |
+| `travelerRefs` | array[string] | yes | Traveler references. |
+| `connectionIntents` | array[object] | no | Optional caller-supplied transfer hints; ignored fields are not persisted. |
+| `expiresAt` | RFC3339 UTC | no | Planning/offer expiry. |
+
+**Response (201):** `TransferPlan` resource.
+
+**Domain effects:** emits `TransferPlanCreated`; the service may synchronously
+enter `EVALUATING` and emit `TransferPlanEvaluated` when itinerary and MCT data
+are available.
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Evaluate Transfer Plan
+
+**POST** `/api/v1/transfer-plans/{transferPlanId}/evaluate`
+
+**Idempotency:** REQUIRED.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `planningSnapshotVersion` | integer | yes | Itinerary snapshot version to evaluate. |
+| `asOf` | RFC3339 UTC | no | Evaluation time; defaults to server time. |
+| `reason` | string | no | Non-PII reason for manual/ops re-evaluation. |
+
+**Response (200):** `TransferPlan` resource after evaluation.
+
+**Domain effects:** emits `TransferPlanEvaluated` and one
+`TransferRiskEvaluated` per registered connection whose risk changed.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Get Transfer Plan
+
+**GET** `/api/v1/transfer-plans/{transferPlanId}`
+
+**Response (200):** `TransferPlan` resource.
+
+**Error codes:** `NOT_FOUND`
+
+### Register Connection
+
+**POST** `/api/v1/connections`
+
+**Idempotency:** REQUIRED.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `transferPlanId` | string | yes | Owning transfer plan. |
+| `itineraryRef` | string | yes | Source Trip Planning itinerary reference. |
+| `journeyOrderId` | string | no | Purchased order when known. |
+| `previousSegmentRef` | string | yes | Previous segment reference. |
+| `nextSegmentRef` | string | yes | Next segment reference. |
+| `travelerRefs` | array[string] | yes | Affected travelers. |
+| `fromNodeRef` | string | yes | Arrival node/place reference. |
+| `toNodeRef` | string | yes | Departure node/place reference. |
+| `fromNodeType` | enum | yes | Arrival node type. |
+| `toNodeType` | enum | yes | Departure node type. |
+| `transferCategory` | enum | yes | Transfer category. |
+| `contractId` | string | yes | Associated connection contract. |
+| `window` | ConnectionWindow | yes | Planned transfer window. |
+
+**Response (201):** `Connection` resource.
+
+**Domain effects:** emits `ConnectionRegistered` and initial
+`TransferRiskEvaluated`.
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `CONFLICT`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Get Connection
+
+**GET** `/api/v1/connections/{connectionId}`
+
+**Response (200):** `Connection` resource.
+
+**Error codes:** `NOT_FOUND`
+
+### Report Segment Status
+
+**POST** `/api/v1/segment-status-reports`
+
+**Idempotency:** REQUIRED.
+
+This endpoint is the activation-wave runtime input channel for delay, arrival,
+and cancellation facts. It is intentionally compatible with future Fulfillment
+segment events: the report body is the material that will later be mapped from
+those events.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `segmentRef` | string | yes | Segment being reported. |
+| `reportType` | enum | yes | `DELAY`, `ARRIVAL`, or `CANCELLED`. |
+| `reportedBy` | object | yes | ActorRef; `SYSTEM` and `OPERATIONS` are accepted. |
+| `sourceSystem` | enum | yes | `OPERATIONS` or `ADMIN` in this wave; future `FULFILLMENT` may replace this path. |
+| `sourceRecordId` | string | yes | Source record ID for replay detection. |
+| `observedAt` | RFC3339 UTC | yes | Observation time. |
+| `estimatedArrivalAt` | RFC3339 UTC | for `DELAY` | Updated ETA. |
+| `actualArrivalAt` | RFC3339 UTC | for `ARRIVAL` | Actual arrival. |
+| `cancelledAt` | RFC3339 UTC | for `CANCELLED` | Cancellation time. |
+| `reason` | string | no | Non-PII reason. |
+
+**Response (202):**
+
+| Field | Type | Description |
+|---|---|---|
+| `report` | SegmentStatusReport | Accepted report. |
+| `updatedConnections` | array[Connection] | Connections whose runtime state/risk changed. |
+
+**Domain effects:** evaluates impacted connections. It may emit
+`TransferRiskEvaluated`, `TransferAtRisk`, `ConnectionMissed`,
+`ConnectionRecovered`, or `ConnectionRecoveryFailed`. For protected misses it may
+also call Disruption Recovery as described in [Outbound Disruption Recovery
+command](#outbound-disruption-recovery-command).
+
+**Error codes:** `VALIDATION_FAILED`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
+
+### Propose Connection Contract
+
+**POST** `/api/v1/connection-contracts`
+
+**Idempotency:** REQUIRED.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `connectionId` | string | yes | Connection receiving this contract option. |
+| `contractType` | enum | yes | Contract type. |
+| `responsibleParty` | enum | yes | `PLATFORM`, `SUPPLIER`, `PLATFORM_ASSISTANCE`, or `TRAVELER`. |
+| `coverageSummary` | string | yes | Safe display summary. |
+| `disclosureVersion` | string | yes | User-visible disclosure copy version. |
+| `termsSnapshotRef` | string | no | Immutable terms snapshot. |
+
+**Response (201):** `ConnectionContract` resource.
+
+**Domain effects:** emits `ConnectionContractProposed`.
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `CONFLICT`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`
+
+### Confirm Connection Contract
+
+**POST** `/api/v1/connection-contracts/{connectionContractId}/confirm`
+
+**Idempotency:** REQUIRED.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `acceptedByRef` | string | yes | Offer/order/user/system actor that accepted the contract. |
+| `acceptedVersion` | string | yes | Disclosure/terms version accepted. |
+| `confirmedAt` | RFC3339 UTC | no | Acceptance time; defaults to server time. |
+
+**Response (200):** `ConnectionContract` resource in `CONFIRMED` status.
+
+**Domain effects:** emits `ConnectionContractConfirmed`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`
+
+### Withdraw Connection Contract
+
+**POST** `/api/v1/connection-contracts/{connectionContractId}/withdraw`
+
+**Idempotency:** REQUIRED.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `withdrawnBy` | object | yes | ActorRef for the operation. |
+| `reason` | string | yes | Non-PII withdrawal reason. |
+
+**Response (200):** `ConnectionContract` resource in `VOIDED` or `REJECTED`
+status depending on previous state.
+
+**Domain effects:** emits `ConnectionContractWithdrawn`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`
+
+### Create MCT Rule
+
+**POST** `/api/v1/mct-rules`
+
+**Idempotency:** REQUIRED.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fromNodeType` | enum | yes | Arrival node type. |
+| `toNodeType` | enum | yes | Departure node type. |
+| `transferCategory` | enum | yes | Transfer category. |
+| `minimumMinutes` | integer | yes | Positive required minutes. |
+| `conditions` | object | yes | Structured condition flags; no PII. |
+| `validFrom` | RFC3339 UTC | yes | Effective start. |
+| `validUntil` | RFC3339 UTC | no | Effective end. |
+
+**Response (201):** `MinimumConnectionTimeRule` resource in `DRAFT` status.
+
+**Domain effects:** emits `MctRuleCreated`.
+
+**Error codes:** `VALIDATION_FAILED`, `CONFLICT`, `DOMAIN_RULE_VIOLATION`,
+`IDEMPOTENCY_KEY_REUSED`
+
+### Update MCT Rule Draft
+
+**PATCH** `/api/v1/mct-rules/{mctRuleId}`
+
+**Idempotency:** REQUIRED.
+
+Only `DRAFT` or `VALIDATED` rules may be updated. Published versions are
+immutable; changing a published rule requires creating a new version.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `minimumMinutes` | integer | no | Replacement positive minutes. |
+| `conditions` | object | no | Replacement non-PII conditions. |
+| `validFrom` | RFC3339 UTC | no | Replacement effective start. |
+| `validUntil` | RFC3339 UTC | no | Replacement effective end. |
+
+**Response (200):** Updated `MinimumConnectionTimeRule`.
+
+**Domain effects:** no bus event is required until publish/retire in this wave.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`
+
+### Publish MCT Rule
+
+**POST** `/api/v1/mct-rules/{mctRuleId}/publish`
+
+**Idempotency:** REQUIRED.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `publishedBy` | object | yes | ActorRef for the operation. |
+| `publishReason` | string | yes | Non-PII reason. |
+
+**Response (200):** `MinimumConnectionTimeRule` in `PUBLISHED` status.
+
+**Domain effects:** emits `MctRulePublished`. The published rule version is
+immutable.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`
+
+### Retire MCT Rule
+
+**POST** `/api/v1/mct-rules/{mctRuleId}/retire`
+
+**Idempotency:** REQUIRED.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `retiredBy` | object | yes | ActorRef for the operation. |
+| `retireReason` | string | yes | Non-PII reason. |
+| `retiredAt` | RFC3339 UTC | no | Retire time; defaults to server time. |
+
+**Response (200):** `MinimumConnectionTimeRule` in `RETIRED` status.
+
+**Domain effects:** emits `MctRuleRetired`.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`,
+`DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`
+
+### List MCT Rules
+
+**GET** `/api/v1/mct-rules?fromNodeType=STATION&toNodeType=STATION&transferCategory=SAME_STATION&status=PUBLISHED&limit=20&offset=0`
+
+**Query parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `fromNodeType` | enum | no | Optional node-type filter. |
+| `toNodeType` | enum | no | Optional node-type filter. |
+| `transferCategory` | enum | no | Optional category filter. |
+| `status` | enum | no | Optional rule status filter. |
+| `limit` | integer | no | Pagination limit, default 20, max 100. |
+| `offset` | integer | no | Pagination offset, default 0. |
+
+**Response (200):** Paginated response with `items`, `total`, `limit`, and
+`offset`, where each item is a `MinimumConnectionTimeRule`.
+
+**Error codes:** `VALIDATION_FAILED`
+
+## Outbound Disruption Recovery command
+
+When a `Connection` transitions to `MISSED` and `contractType` is `PROTECTED` or
+`SUPPLIER_PROTECTED`, Transfer Management sends:
+
+**POST** `/api/v1/disruptions` on Disruption Recovery
+
+**Headers:**
+
+| Header | Required | Description |
+|---|---|---|
+| `Idempotency-Key` | yes | Persisted UUID-v7 key folded from `connectionId`, `missedAt`, connection version, and `journeyOrderId`. |
+| `X-Correlation-Id` | yes | Existing `corr-<uuid-v7>` from the segment report or a generated correlation ID. |
+
+**Request body mapping:**
+
+| Field | Value |
+|---|---|
+| `disruptionType` | `MISSED_CONNECTION` |
+| `scheduledServiceRef` | Omitted unless the next segment has a scheduled-service reference in the itinerary snapshot. |
+| `segmentRef` | `nextSegmentRef` |
+| `serviceDate` | Operating date of the next segment. |
+| `evidence.evidenceRef` | `connectionId` or timeline evidence reference. |
+| `evidence.sourceSystem` | `TRANSFER_MANAGEMENT` |
+| `evidence.sourceRecordId` | `ConnectionMissed` envelope `eventId` or deterministic missed-transition reference. |
+| `evidence.summary` | Sanitized missed-connection summary with no unmasked PII. |
+| `evidence.occurredAt` | `missedAt` |
+| `affectedOrderIds` | Array containing `journeyOrderId`. |
+| `reportedBy.actorType` | `SYSTEM` |
+| `reportedBy.actorId` | `transfer-management` |
+
+**Response handling:** Transfer Management persists `disruption.disruptionId`,
+`incident.incidentId`, and each `recoveryCases[].caseId` in `RecoveryCaseMapping`.
+Subsequent `RecoveryCompleted` or `RecoveryFailed` events from
+`events:disruption-recovery` are matched by `caseId`.
+
+**Failure handling:** downstream unavailability records
+`recoveryTriggerStatus=FAILED` and a sanitized `failureReason`; retries reuse the
+same outbound idempotency key.
+
+## Deferred behavior
+
+- `TransferRiskPolicy` CRUD/simulation is deferred; the built-in fixed policy
+  version is always `builtin-v1`.
+- Place Network topology/path and external map-time integration are deferred.
+- Fulfillment segment events are deferred and may replace `segment-status-reports`
+  later.
+- Notification, Reporting, Customer Service, Offer Management, and Journey Order
+  consumption of Transfer Management events is documented as intended but not
+  registered as active downstream consumption in this wave.
+- `REACCOMMODATION` recovery option generation remains deferred to a later wave.

--- a/docs/08-contracts/events/disruption-recovery.md
+++ b/docs/08-contracts/events/disruption-recovery.md
@@ -10,14 +10,16 @@ by the activation rulings in `docs/08-contracts/api/disruption-recovery.md`.
 
 Activation-wave rulings:
 
-- The only signal source is the operations HTTP command
+- The active signal source is the operations/system HTTP command
   `POST /api/v1/disruptions`. It represents Customer Service/Admin manual rows
-  and carries a normalized `disruptionType`, `scheduledServiceRef` and/or
-  `segmentRef`, `evidence`, and explicit `affectedOrderIds`.
+  or Transfer Management system reports and carries a normalized
+  `disruptionType`, `scheduledServiceRef` and/or `segmentRef`, `evidence`, and
+  explicit `affectedOrderIds`.
 - Automatic `segmentRef` to orders fan-out is deferred because Journey Order has
-  no by-segment query contract. Service Plan, Provider Integration,
-  Fulfillment, and Transfer Management signal events are also deferred; Transfer
-  belongs to wave 18.
+  no by-segment query contract. Service Plan, Provider Integration, and
+  Fulfillment signal events remain deferred. Transfer Management wave 18 opens
+  protected missed-connection recovery through HTTP
+  `POST /api/v1/disruptions`, not by a new inbound event.
 - The report opens or merges an `Incident`; merge key is
   `(scheduledServiceRef, serviceDate)` when `scheduledServiceRef` is present.
   `ServiceAlert` is event-only in this wave: `ServiceAlertPublished` is
@@ -27,7 +29,7 @@ Activation-wave rulings:
   `OPTIONS_GENERATED`, `AWAITING_USER_CHOICE`, `EXECUTING_RECOVERY`,
   `MANUAL_REVIEW`, `RECOVERED`, `DECLINED`, `FAILED`, `CLOSED`.
 - `RecoveryOptionSet` supports `WAIT`, `REFUND`, `COMPENSATION`, and `MANUAL`.
-  `REACCOMMODATION` is deferred until wave 18 after Transfer Management.
+  `REACCOMMODATION` remains deferred until a later wave after Transfer Management.
 - Automatic rules may select only `WAIT`. `WAIT` completes as `RECOVERED` with
   no downstream command. `REFUND` calls the existing Post Sales HTTP contract
   using a deterministic idempotency key and converges on `PostSalesApplied`.
@@ -72,7 +74,7 @@ Downstream HTTP commands use deterministic idempotency keys:
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `evidenceRef` | string | yes | Reference to the customer-service/admin evidence record. |
-| `sourceSystem` | enum | yes | `CUSTOMER_SERVICE` or `ADMIN`; all other sources are deferred. |
+| `sourceSystem` | enum | yes | `CUSTOMER_SERVICE`, `ADMIN`, or `TRANSFER_MANAGEMENT`; all other sources are deferred. |
 | `sourceRecordId` | string | yes | Upstream manual-row identifier. |
 | `summary` | string | yes | Operational summary; must not include unmasked documents or sensitive personal data. |
 | `occurredAt` | RFC3339 UTC | no | Observation time if known. |
@@ -249,7 +251,7 @@ Downstream HTTP commands use deterministic idempotency keys:
 | Field | Description |
 |---|---|
 | **Producer** | disruption-recovery |
-| **Consumers** | deferred: notification, reporting |
+| **Consumers** | transfer-management; deferred: notification, reporting |
 | **Trigger** | `WAIT` completes locally, Wallet / Promotion benefit issuance succeeds, or consumed `PostSalesApplied` converges a REFUND execution. |
 
 **Payload:**
@@ -271,7 +273,7 @@ Downstream HTTP commands use deterministic idempotency keys:
 | Field | Description |
 |---|---|
 | **Producer** | disruption-recovery |
-| **Consumers** | deferred: notification, reporting |
+| **Consumers** | transfer-management; deferred: notification, reporting |
 | **Trigger** | A selected option fails and cannot automatically converge. |
 
 **Payload:**
@@ -352,8 +354,11 @@ Downstream HTTP commands use deterministic idempotency keys:
 | `events:post-sales` | `PostSalesApplied` | Converge a selected `REFUND` option when the downstream Post Sales case reaches `APPLIED`. |
 
 No other upstream event subscription is active in this wave. Service Plan,
-Provider Integration, Fulfillment, and Transfer Management disruption sources
-are deferred.
+Provider Integration, and Fulfillment disruption sources are deferred. Transfer
+Management protected missed-connection reports arrive over HTTP with
+`disruptionType=MISSED_CONNECTION`, `reportedBy.actorType=SYSTEM`, and
+`evidence.sourceSystem=TRANSFER_MANAGEMENT`; the same wave implementation MUST
+update Disruption Recovery code enum/validation allowlists for those values.
 
 ## Deferred downstream touchpoints
 

--- a/docs/08-contracts/events/transfer-management.md
+++ b/docs/08-contracts/events/transfer-management.md
@@ -1,0 +1,478 @@
+# Transfer Management — Events & Commands
+
+Last updated: 2026-07-09
+
+## Scope and activation-wave rulings
+
+This contract lists the Transfer Management events active in ADR-0002 wave 18.
+It is bounded by `docs/02-domains/transfer-management.md` and the HTTP contract
+in `docs/08-contracts/api/transfer-management.md`.
+
+Activation-wave rulings:
+
+- Active aggregate events are for `TransferPlan`, `Connection`,
+  `ConnectionContract`, and `MinimumConnectionTimeRule`. `TransferRiskPolicy`
+  CRUD events are deferred; every risk evaluation carries
+  `riskPolicyVersion="builtin-v1"`.
+- Fulfillment segment delay/arrival/cancelled events are not active today.
+  Runtime facts enter through `POST /api/v1/segment-status-reports`; future
+  Fulfillment events may be mapped to the same command material.
+- Place Network topology/path integration is deferred. Event payloads carry the
+  itinerary/node refs and transfer category used by this wave's MCT lookup.
+- Protected missed connections use outbound HTTP to Disruption Recovery. Transfer
+  Management stores returned `caseId` mappings and consumes
+  `RecoveryCompleted`/`RecoveryFailed` by `caseId` to converge the `Connection`.
+  `SELF_TRANSFER` misses publish facts only.
+- Downstream Notification, Reporting, Offer Management, Journey Order, and
+  Customer Service consumers are deferred in this wave. The events below are
+  published to the registered stream, but no new downstream consumer is activated
+  except Transfer Management's inbound subscription to Disruption Recovery.
+
+All payload fields are camelCase, all enum values are SCREAMING_SNAKE_CASE, and
+all timestamps are RFC3339 UTC. Envelope fields, including optional trace context
+propagation, follow `docs/08-contracts/messaging.md` and
+`docs/08-contracts/shared-primitives.md`. Monetary values, if added in later
+extensions, use Money as `{currency, minorUnits}`.
+
+## Event identity and idempotency
+
+Transfer Management producers MUST assign deterministic event IDs per aggregate
+transition. The event ID is UUID-v7-shaped with version/variant bits stamped
+after folding the seed with SHA-256:
+
+```
+transfer-management:<eventType>:<aggregateId>:<aggregateVersion>
+```
+
+`aggregateId` is `transferPlanId`, `connectionId`, `connectionContractId`, or
+`mctRuleId` depending on the event. If a replayed command causes no new
+transition, no new event is emitted. Consumers still deduplicate by envelope
+`eventId`.
+
+Wire correlation and causation IDs MUST use `corr-<uuid-v7>` and
+`cmd-<uuid-v7>`/`evt-<uuid-v7>` prefixes. HTTP idempotency keys are UUID-v7
+shaped. Domain material such as `connectionId:missedAt:journeyOrderId` is folded
+into those UUID-v7 command keys; the material string itself is not used as a wire
+key. Outbound Disruption Recovery idempotency keys are persisted and reused.
+
+## Common payload objects
+
+### ConnectionWindow
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `plannedArrivalAt` | RFC3339 UTC | yes | Previous segment planned arrival. |
+| `actualArrivalAt` | RFC3339 UTC | no | Reported actual arrival when known. |
+| `nextDepartureAt` | RFC3339 UTC | yes | Next segment planned departure. |
+| `nextCutoffAt` | RFC3339 UTC | yes | Boarding/check-in/driver-wait cutoff used for missed detection. |
+| `availableMinutes` | integer | yes | Minutes currently available for transfer. |
+| `mctMinutes` | integer | yes | Published MCT requirement. |
+| `bufferMinutes` | integer | yes | `availableMinutes - mctMinutes`. |
+
+### RiskEvaluation
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `riskEvaluationId` | string | yes | Evaluation ID (`tre-<uuid>`). |
+| `riskLevel` | enum | yes | `FEASIBLE`, `TIGHT`, `AT_RISK`, `MISSED`, or `RECOVERED`. |
+| `riskPolicyVersion` | string | yes | Always `builtin-v1` in this wave. |
+| `mctRuleId` | string | yes | Published MCT rule used. |
+| `mctRuleVersion` | integer | yes | MCT rule version used. |
+| `availableMinutes` | integer | yes | Available transfer minutes. |
+| `requiredMinutes` | integer | yes | Required MCT minutes. |
+| `reasons` | array[string] | yes | Explainable reason codes; no PII. |
+| `evaluatedAt` | RFC3339 UTC | yes | Evaluation timestamp. |
+
+### ConnectionRef
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `connectionId` | string | yes | Connection ID (`con-<uuid>`). |
+| `transferPlanId` | string | yes | Owning transfer plan. |
+| `itineraryRef` | string | yes | Trip Planning itinerary reference. |
+| `journeyOrderId` | string | no | Purchased order when known. |
+| `previousSegmentRef` | string | yes | Previous segment. |
+| `nextSegmentRef` | string | yes | Next segment. |
+| `travelerRefs` | array[string] | yes | Affected travelers. |
+
+### RecoveryCaseMapping
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `disruptionId` | string | no | Disruption Recovery report ID. |
+| `incidentId` | string | no | Disruption Recovery incident ID. |
+| `caseIds` | array[string] | yes | Recovery case IDs returned by the response. |
+| `outboundIdempotencyKey` | string | yes | Persisted UUID-v7 idempotency key used for the HTTP command. |
+| `recoveryTriggerStatus` | enum | yes | `PENDING`, `OPENED`, or `FAILED`. |
+| `failureReason` | string | no | Sanitized failure reason. |
+
+## Published Events
+
+### TransferPlanCreated
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: offer-management, journey-order, reporting |
+| **Trigger** | `CreateTransferPlan` accepted from `POST /api/v1/transfer-plans`. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `transferPlanId` | string | yes | Transfer plan ID (`tpl-<uuid>`). |
+| `itineraryRef` | string | yes | Trip Planning itinerary reference. |
+| `planningSnapshotVersion` | integer | yes | Itinerary snapshot version/hash. |
+| `journeyOrderId` | string | no | Purchased order when known. |
+| `travelerRefs` | array[string] | yes | Traveler refs. |
+| `status` | enum | yes | `DRAFT` or `EVALUATING` if evaluation starts synchronously. |
+| `riskPolicyVersion` | string | yes | `builtin-v1`. |
+| `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
+| `expiresAt` | RFC3339 UTC | no | Planning/offer expiry. |
+
+### TransferPlanEvaluated
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: offer-management, journey-order, reporting |
+| **Trigger** | Plan evaluation completed or refreshed. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `transferPlanId` | string | yes | Transfer plan ID. |
+| `itineraryRef` | string | yes | Trip Planning itinerary reference. |
+| `planningSnapshotVersion` | integer | yes | Snapshot version evaluated. |
+| `journeyOrderId` | string | no | Purchased order when known. |
+| `status` | enum | yes | `EVALUATED` or `UNSERVICEABLE`. |
+| `evaluationVersion` | integer | yes | Monotonic evaluation version. |
+| `connectionIds` | array[string] | yes | Connections included in the plan. |
+| `riskPolicyVersion` | string | yes | `builtin-v1`. |
+| `evaluatedAt` | RFC3339 UTC | yes | Evaluation timestamp. |
+| `unserviceableReasons` | array[string] | no | Required when status is `UNSERVICEABLE`. |
+
+### TransferPlanExpired
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: offer-management, reporting |
+| **Trigger** | Planning/offer window expires. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `transferPlanId` | string | yes | Transfer plan ID. |
+| `itineraryRef` | string | yes | Trip Planning itinerary reference. |
+| `previousStatus` | enum | yes | Status before expiry. |
+| `status` | enum | yes | `EXPIRED`. |
+| `expiredAt` | RFC3339 UTC | yes | Expiry timestamp. |
+| `reason` | string | no | Non-PII expiry reason. |
+
+### ConnectionRegistered
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: journey-order, customer-service, reporting |
+| **Trigger** | `RegisterConnection` command creates a connection. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `connectionId` | string | yes | Connection ID. |
+| `transferPlanId` | string | yes | Owning plan. |
+| `itineraryRef` | string | yes | Source itinerary. |
+| `journeyOrderId` | string | no | Purchased order when known. |
+| `previousSegmentRef` | string | yes | Previous segment. |
+| `nextSegmentRef` | string | yes | Next segment. |
+| `travelerRefs` | array[string] | yes | Affected travelers. |
+| `fromNodeRef` | string | yes | Arrival node/place. |
+| `toNodeRef` | string | yes | Departure node/place. |
+| `fromNodeType` | enum | yes | Arrival node type. |
+| `toNodeType` | enum | yes | Departure node type. |
+| `transferCategory` | enum | yes | MCT transfer category. |
+| `contractId` | string | yes | Associated contract. |
+| `contractType` | enum | yes | Contract type snapshot. |
+| `status` | enum | yes | `PLANNED`, `FEASIBLE`, or `TIGHT` after initial evaluation. |
+| `window` | object | yes | ConnectionWindow. |
+| `registeredAt` | RFC3339 UTC | yes | Registration timestamp. |
+
+### TransferRiskEvaluated
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: offer-management, journey-order, customer-service, reporting |
+| **Trigger** | Initial, scheduled, or segment-report-driven risk evaluation completes. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `connection` | object | yes | ConnectionRef. |
+| `previousStatus` | enum | no | Prior connection status if it changed. |
+| `status` | enum | yes | Current connection status. |
+| `evaluation` | object | yes | RiskEvaluation. |
+| `window` | object | yes | ConnectionWindow used. |
+| `sourceReportId` | string | no | Segment status report ID that triggered evaluation. |
+
+### TransferAtRisk
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: notification, customer-service, reporting |
+| **Trigger** | A connection transitions to `AT_RISK`. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `connection` | object | yes | ConnectionRef. |
+| `previousStatus` | enum | yes | Prior status, normally `FEASIBLE` or `TIGHT`. |
+| `status` | enum | yes | `AT_RISK`. |
+| `riskLevel` | enum | yes | `AT_RISK`. |
+| `riskPolicyVersion` | string | yes | `builtin-v1`. |
+| `reasons` | array[string] | yes | Explainable risk reasons. |
+| `window` | object | yes | ConnectionWindow. |
+| `detectedAt` | RFC3339 UTC | yes | Detection timestamp. |
+
+### ConnectionMissed
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: notification, customer-service, reporting |
+| **Trigger** | A connection transitions to `MISSED`. Protected contracts also start the outbound Disruption Recovery HTTP command. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `connection` | object | yes | ConnectionRef. |
+| `previousStatus` | enum | yes | Prior status. |
+| `status` | enum | yes | `MISSED`. |
+| `riskLevel` | enum | yes | `MISSED`. |
+| `contractType` | enum | yes | Contract type snapshot. |
+| `missedAt` | RFC3339 UTC | yes | Missed decision timestamp. |
+| `missedCause` | enum | yes | `PREVIOUS_SEGMENT_DELAYED`, `PREVIOUS_SEGMENT_CANCELLED`, `NEXT_SEGMENT_CANCELLED`, `CUTOFF_EXPIRED`, or `OPS_DECLARED`. |
+| `window` | object | yes | ConnectionWindow. |
+| `recoveryRequired` | boolean | yes | `true` only for `PROTECTED` and `SUPPLIER_PROTECTED`. |
+| `recovery` | object | no | RecoveryCaseMapping when an outbound call has been attempted or opened. |
+
+### ConnectionRecovered
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: notification, customer-service, reporting |
+| **Trigger** | Consumed Disruption Recovery `RecoveryCompleted` matches a stored `caseId`, or an explicit controlled recovery command restores the connection. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `connection` | object | yes | ConnectionRef. |
+| `previousStatus` | enum | yes | `MISSED` or `AT_RISK`. |
+| `status` | enum | yes | `RECOVERED`. |
+| `riskLevel` | enum | yes | `RECOVERED`. |
+| `recoveryCaseId` | string | no | Matched Disruption Recovery case ID. |
+| `disruptionRecoveryEventId` | string | no | Consumed envelope event ID when event-driven. |
+| `recoveredAt` | RFC3339 UTC | yes | Recovery convergence timestamp. |
+| `recoverySummary` | string | no | Sanitized summary; no unmasked PII. |
+
+### ConnectionRecoveryFailed
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: customer-service, reporting |
+| **Trigger** | Consumed Disruption Recovery `RecoveryFailed` matches a stored `caseId`, or the outbound recovery report failed permanently. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `connection` | object | yes | ConnectionRef. |
+| `status` | enum | yes | Current status remains `MISSED`. |
+| `recoveryCaseId` | string | no | Matched recovery case ID. |
+| `disruptionRecoveryEventId` | string | no | Consumed envelope event ID when event-driven. |
+| `failedAt` | RFC3339 UTC | yes | Failure timestamp. |
+| `reason` | string | yes | Sanitized failure reason; no sensitive personal data. |
+
+### ConnectionContractProposed
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: offer-management, journey-order, reporting |
+| **Trigger** | Contract option proposed for a connection. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `connectionContractId` | string | yes | Contract ID (`cct-<uuid>`). |
+| `connectionId` | string | yes | Connection ID. |
+| `contractType` | enum | yes | Contract type. |
+| `status` | enum | yes | `PROPOSED`, `ELIGIBLE`, or `REJECTED`. |
+| `responsibleParty` | enum | yes | `PLATFORM`, `SUPPLIER`, `PLATFORM_ASSISTANCE`, or `TRAVELER`. |
+| `coverageSummary` | string | yes | Safe display summary. |
+| `disclosureVersion` | string | yes | Disclosure version. |
+| `termsSnapshotRef` | string | no | Immutable terms snapshot. |
+| `proposedAt` | RFC3339 UTC | yes | Proposal timestamp. |
+
+### ConnectionContractConfirmed
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: journey-order, customer-service, reporting |
+| **Trigger** | Offer/order accepts the contract snapshot. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `connectionContractId` | string | yes | Contract ID. |
+| `connectionId` | string | yes | Connection ID. |
+| `contractType` | enum | yes | Contract type. |
+| `previousStatus` | enum | yes | Previous contract status. |
+| `status` | enum | yes | `CONFIRMED`. |
+| `acceptedByRef` | string | yes | Offer/order/user/system acceptance reference. |
+| `acceptedVersion` | string | yes | Accepted disclosure/terms version. |
+| `confirmedAt` | RFC3339 UTC | yes | Confirmation timestamp. |
+
+### ConnectionContractWithdrawn
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: journey-order, customer-service, reporting |
+| **Trigger** | Contract is withdrawn, voided, or rejected by controlled command. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `connectionContractId` | string | yes | Contract ID. |
+| `connectionId` | string | yes | Connection ID. |
+| `contractType` | enum | yes | Contract type. |
+| `previousStatus` | enum | yes | Previous contract status. |
+| `status` | enum | yes | `VOIDED` or `REJECTED`. |
+| `withdrawnBy` | object | yes | ActorRef. |
+| `reason` | string | yes | Non-PII reason. |
+| `withdrawnAt` | RFC3339 UTC | yes | Withdrawal timestamp. |
+
+### MctRuleCreated
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: reporting |
+| **Trigger** | Operations creates a draft MCT rule. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `mctRuleId` | string | yes | MCT rule ID (`mct-<uuid>`). |
+| `version` | integer | yes | Rule version. |
+| `status` | enum | yes | `DRAFT`. |
+| `fromNodeType` | enum | yes | Arrival node type. |
+| `toNodeType` | enum | yes | Departure node type. |
+| `transferCategory` | enum | yes | Transfer category. |
+| `minimumMinutes` | integer | yes | Positive MCT minutes. |
+| `conditions` | object | yes | Non-PII condition flags. |
+| `validFrom` | RFC3339 UTC | yes | Effective start. |
+| `validUntil` | RFC3339 UTC | no | Effective end. |
+| `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
+
+### MctRulePublished
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: trip-planning, offer-management, reporting |
+| **Trigger** | Operations publishes a validated MCT rule version. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `mctRuleId` | string | yes | MCT rule ID. |
+| `version` | integer | yes | Published immutable version. |
+| `previousStatus` | enum | yes | Previous status. |
+| `status` | enum | yes | `PUBLISHED`. |
+| `fromNodeType` | enum | yes | Arrival node type. |
+| `toNodeType` | enum | yes | Departure node type. |
+| `transferCategory` | enum | yes | Transfer category. |
+| `minimumMinutes` | integer | yes | Positive MCT minutes. |
+| `conditions` | object | yes | Non-PII condition flags. |
+| `validFrom` | RFC3339 UTC | yes | Effective start. |
+| `validUntil` | RFC3339 UTC | no | Effective end. |
+| `publishedBy` | object | yes | ActorRef. |
+| `publishedAt` | RFC3339 UTC | yes | Publish timestamp. |
+
+### MctRuleRetired
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: trip-planning, offer-management, reporting |
+| **Trigger** | Operations retires a published MCT rule version. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `mctRuleId` | string | yes | MCT rule ID. |
+| `version` | integer | yes | Retired version. |
+| `previousStatus` | enum | yes | Previous status, normally `PUBLISHED`. |
+| `status` | enum | yes | `RETIRED`. |
+| `retiredBy` | object | yes | ActorRef. |
+| `retireReason` | string | yes | Non-PII reason. |
+| `retiredAt` | RFC3339 UTC | yes | Retire timestamp. |
+
+## Accepted Commands
+
+| Command | Sender / Trigger | Produced event |
+|---|---|---|
+| `CreateTransferPlan` | HTTP `POST /api/v1/transfer-plans` | `TransferPlanCreated` |
+| `EvaluateTransferPlan` | HTTP `POST /api/v1/transfer-plans/{transferPlanId}/evaluate` | `TransferPlanEvaluated`, `TransferRiskEvaluated` |
+| `RegisterConnection` | HTTP `POST /api/v1/connections` or application flow after plan creation | `ConnectionRegistered`, `TransferRiskEvaluated` |
+| `ReportSegmentStatus` | HTTP `POST /api/v1/segment-status-reports` | `TransferRiskEvaluated`, `TransferAtRisk`, `ConnectionMissed`, `ConnectionRecovered`, `ConnectionRecoveryFailed` |
+| `ProposeConnectionContract` | HTTP `POST /api/v1/connection-contracts` | `ConnectionContractProposed` |
+| `ConfirmConnectionContract` | HTTP `POST /api/v1/connection-contracts/{connectionContractId}/confirm` | `ConnectionContractConfirmed` |
+| `WithdrawConnectionContract` | HTTP `POST /api/v1/connection-contracts/{connectionContractId}/withdraw` | `ConnectionContractWithdrawn` |
+| `CreateMctRule` | HTTP `POST /api/v1/mct-rules` | `MctRuleCreated` |
+| `PublishMctRule` | HTTP `POST /api/v1/mct-rules/{mctRuleId}/publish` | `MctRulePublished` |
+| `RetireMctRule` | HTTP `POST /api/v1/mct-rules/{mctRuleId}/retire` | `MctRuleRetired` |
+| `RecordRecoveryCompleted` | Consumed Disruption Recovery `RecoveryCompleted` by `caseId` | `ConnectionRecovered` |
+| `RecordRecoveryFailed` | Consumed Disruption Recovery `RecoveryFailed` by `caseId` | `ConnectionRecoveryFailed` |
+
+## Consumed upstream events
+
+| Upstream stream | Event type | Purpose |
+|---|---|---|
+| `events:disruption-recovery` | `RecoveryCompleted` | Match payload `caseId` to stored recovery-case mapping and transition the related connection to `RECOVERED`. |
+| `events:disruption-recovery` | `RecoveryFailed` | Match payload `caseId` to stored recovery-case mapping, keep the connection `MISSED`, and record sanitized failure evidence. |
+
+Fulfillment runtime facts are intentionally not consumed from the bus in this
+wave because segment-level delay/arrival/cancelled events are not produced today.
+The system/ops segment-status reporting endpoint is the active adapter.
+
+## Deferred downstream touchpoints
+
+| Downstream context | Deferred events | Purpose when activated |
+|---|---|---|
+| Notification | `TransferAtRisk`, `ConnectionMissed`, `ConnectionRecovered` | User-facing transfer risk and recovery notifications. |
+| Reporting | all Transfer Management events | Connection success rate, MCT quality, protected exposure, and supplier quality metrics. |
+| Journey Order | `ConnectionContractConfirmed`, `ConnectionMissed`, `ConnectionRecovered` | Order-detail responsibility and recovery display. |
+| Offer Management | `TransferPlanEvaluated`, `ConnectionContractProposed`, `MctRulePublished` | Quote-time feasibility and contract display. |
+| Customer Service | `TransferAtRisk`, `ConnectionMissed`, `ConnectionRecovered`, `ConnectionRecoveryFailed` | Support timeline and responsibility explanation. |

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -75,6 +75,7 @@ context.
 | 25 | `wallet-promotion` | `events:wallet-promotion` | BenefitIssued, BenefitReserved, BenefitRedeemed, BenefitReservationReleased, BenefitExpired, BenefitRevoked, BenefitRedemptionReversed |
 | 26 | `disruption-recovery` | `events:disruption-recovery` | DisruptionReported, IncidentOpened, RecoveryCaseOpened, RecoveryOptionsGenerated, RecoveryOptionSelected, RecoveryExecutionStarted, RecoveryCompleted, RecoveryFailed, RecoveryCaseClosed, ServiceAlertPublished |
 | 27 | `ancillary-service` | `events:ancillary-service` | AncillaryCatalogItemPublished, AncillaryCatalogItemSuspended, AncillaryCatalogItemSuperseded, AncillaryOfferQuoted, AncillaryOfferExpired, AncillaryOrderItemSelected, AncillaryOrderItemPendingConfirmation, AncillaryOrderItemConfirmed, AncillaryOrderItemFulfillmentReady, AncillaryOrderItemFulfilled, AncillaryOrderItemFailed, AncillaryOrderItemCancelled, AncillaryOrderItemRefundPending, AncillaryOrderItemRefunded, AncillaryFulfillmentFactRecorded |
+| 28 | `transfer-management` | `events:transfer-management` | TransferPlanCreated, TransferPlanEvaluated, TransferPlanExpired, ConnectionRegistered, TransferRiskEvaluated, TransferAtRisk, ConnectionMissed, ConnectionRecovered, ConnectionRecoveryFailed, ConnectionContractProposed, ConnectionContractConfirmed, ConnectionContractWithdrawn, MctRuleCreated, MctRulePublished, MctRuleRetired |
 
 ### Dead-Letter Streams
 
@@ -252,14 +253,14 @@ plus notification/finance/reporting fan-in.
 | 25 | `events:entitlement-ticketing` | `booking-orchestration` | EntitlementIssued to mark segment ticketed |
 | 26 | `events:entitlement-ticketing` | `notification` | Ticketing events for user notifications |
 | 26a | `events:entitlement-ticketing` | `capacity-availability` | RULING (2026-07-07): EntitlementVoided (payload `references.segmentBookingRef`) releases the matching hold promptly. Closes the refund-applied gap: post-sales flips APPLIED on `CapacityReleased`, which previously only arrived via booking-orchestration's lazy fallback (~90s). Row 30 (release on PostSalesApplied) stays as idempotent backstop. |
-| 27 | `events:fulfillment` | `transfer-management` | future-scope; arrival/delay facts are not part of the phase-1 contract |
+| 27 | `events:fulfillment` | `transfer-management` | deferred; wave-18 runtime input uses `POST /api/v1/segment-status-reports` until Fulfillment publishes segment-level delay/arrival/cancelled facts |
 | 28 | `events:fulfillment` | `entitlement-ticketing` | BoardingVerified for entitlement lifecycle |
 | 29 | `events:post-sales` | `payment` | PostSalesApproved to trigger refund |
 | 30 | `events:post-sales` | `capacity-availability` | PostSalesApplied to release capacity |
 | 31 | `events:post-sales` | `entitlement-ticketing` | PostSalesApproved to void entitlement |
 | 32 | `events:post-sales` | `journey-order` | PostSalesApplied to adjust order |
 | 33 | `events:post-sales` | `notification` | Post-sales events for user notifications |
-| 34 | `events:transfer-management` | *(none for disruption-recovery in this wave)* | Transfer risk/recovery signals are deferred to wave 18 |
+| 34 | `events:transfer-management` | *(none — downstream consumers deferred)* | Transfer risk, connection, contract, and MCT facts are produced in wave 18; Notification/Reporting/Journey Order/Customer Service consumption is deferred |
 | 35 | `events:disruption-recovery` | *(none — downstream consumers deferred)* | Disruption recovery notification/reporting/order touchpoints are documented in `events/disruption-recovery.md` but not active in this wave |
 | 36 | `events:notification` | *(none — notification owns its stream)* | Notification events are not consumed by other business contexts in phase 1 |
 | 37 | `events:traveler-profile` | `offer-management` | Profile changes for eligibility checks |
@@ -283,6 +284,7 @@ plus notification/finance/reporting fan-in.
 | 55 | `events:wallet-promotion` | `reporting` | Wallet / Promotion lifecycle metrics and read models |
 | 56 | `events:post-sales` | `disruption-recovery` | PostSalesApplied converges REFUND recovery execution |
 | 57 | `events:journey-order` | `ancillary-service` | RULING (2026-07-09): JourneyOrderCancelled is the only upstream event consumed by Ancillary Service in this activation wave; it automatically cancels associated non-terminal AncillaryOrderItem records. |
+| 58 | `events:disruption-recovery` | `transfer-management` | RecoveryCompleted/RecoveryFailed converge protected missed connections by stored `caseId` mapping. |
 
 ### Cross-Cutting Consumers
 
@@ -291,7 +293,7 @@ analytics, and cross-cutting concerns:
 
 | Consumer Group (Context) | Subscribed Streams | Purpose |
 |---|---|---|
-| `reporting` | All active `events:*` streams except `events:dispatch`, `events:wallet-promotion`, and `events:disruption-recovery` until their deferred-consumer activation waves | Business metrics, funnel analysis, operational dashboards |
+| `reporting` | All active `events:*` streams except `events:dispatch`, `events:wallet-promotion`, `events:disruption-recovery`, and `events:transfer-management` until their deferred-consumer activation waves | Business metrics, funnel analysis, operational dashboards |
 | `finance-settlement` | `events:payment`, `events:provider-integration`, `events:booking-orchestration`, `events:post-sales` | Revenue recognition, reconciliation, invoice generation. Wallet / Promotion benefit-cost events are a documented deferred consumer (events/wallet-promotion.md). |
 | `notification` | `events:journey-order`, `events:booking-orchestration`, `events:payment`, `events:entitlement-ticketing`, `events:post-sales`, `events:waitlist` | User-facing notification triggers. Wallet / Promotion benefit touchpoints are a documented deferred consumer. |
 
@@ -303,8 +305,11 @@ consumption of its lifecycle and alert facts is deferred in this activation
 wave. Disruption Recovery has one active inbound subscription: it consumes
 `PostSalesApplied` from `events:post-sales` to converge selected `REFUND`
 recovery options after the downstream Post Sales case reaches `APPLIED`.
-Service Plan, Provider Integration, Fulfillment, and Transfer Management signal
-sources are deferred; Transfer Management belongs to wave 18.
+Service Plan, Provider Integration, and Fulfillment signal sources remain
+deferred. Transfer Management opens protected missed-connection cases through
+Disruption Recovery HTTP and actively consumes `RecoveryCompleted` and
+`RecoveryFailed` from `events:disruption-recovery` by stored `caseId`.
+
 ### Deferred Ancillary Service Subscriptions
 
 `events:ancillary-service` is registered as a produced stream in this contract.

--- a/services/disruption-recovery/src/disruption_recovery/application/service.py
+++ b/services/disruption-recovery/src/disruption_recovery/application/service.py
@@ -12,6 +12,7 @@ from train_ticket_platform.events import EventEnvelope, rfc3339_utc
 from disruption_recovery.domain import (
     ActorRef,
     DomainError,
+    DISRUPTION_TYPES,
     PreconditionFailed,
     Evidence,
     ExecutionTarget,
@@ -199,6 +200,8 @@ class DisruptionRecoveryService:
         evidence = Evidence(**dict(data.get("evidence") or {}))
         reported_by = ActorRef(**dict(data.get("reportedBy") or {}))
         disruption_type = require_text(str(data.get("disruptionType") or ""), "disruptionType")
+        if disruption_type not in DISRUPTION_TYPES:
+            raise DomainError("disruptionType is invalid")
         service_date = require_text(str(data.get("serviceDate") or ""), "serviceDate")
         scheduled = str(data.get("scheduledServiceRef") or "").strip() or None
         segment = str(data.get("segmentRef") or "").strip() or None

--- a/services/disruption-recovery/src/disruption_recovery/domain.py
+++ b/services/disruption-recovery/src/disruption_recovery/domain.py
@@ -47,6 +47,25 @@ class ExecutionTarget(StrEnum):
     MANUAL_QUEUE = "MANUAL_QUEUE"
 
 
+DISRUPTION_TYPES = {
+    "SERVICE_DELAY",
+    "SERVICE_CANCELLED",
+    "SERVICE_SUSPENDED",
+    "SAILING_SUSPENDED",
+    "ROAD_CLOSED",
+    "WEATHER",
+    "OPERATION_RESTRICTION",
+    "SUPPLIER_FAILURE",
+    "DRIVER_CANCELLED",
+    "DISPATCH_FAILED",
+    "STOP_CHANGED",
+    "PORT_CALL_CHANGED",
+    "BATCH_SYSTEM_EVENT",
+    "CONNECTION_MISSED",
+    "MISSED_CONNECTION",
+}
+
+
 TERMINAL_BEFORE_CLOSE = {RecoveryCaseStatus.RECOVERED, RecoveryCaseStatus.DECLINED, RecoveryCaseStatus.FAILED}
 ALLOWED_TRANSITIONS: dict[RecoveryCaseStatus, set[RecoveryCaseStatus]] = {
     RecoveryCaseStatus.OPENED: {RecoveryCaseStatus.ASSESSING_IMPACT, RecoveryCaseStatus.MANUAL_REVIEW},
@@ -96,7 +115,7 @@ class Evidence:
 
     def __post_init__(self) -> None:
         require_text(self.evidenceRef, "evidenceRef")
-        if self.sourceSystem not in {"CUSTOMER_SERVICE", "ADMIN"}:
+        if self.sourceSystem not in {"CUSTOMER_SERVICE", "ADMIN", "TRANSFER_MANAGEMENT"}:
             raise DomainError("evidence.sourceSystem is invalid")
         require_text(self.sourceRecordId, "sourceRecordId")
         require_text(self.summary, "summary")

--- a/services/disruption-recovery/tests/test_api.py
+++ b/services/disruption-recovery/tests/test_api.py
@@ -120,3 +120,27 @@ def test_select_option_precondition_failure_maps_to_412() -> None:
     wait = case["optionSet"]["options"][0]
     response = client.post(f"/api/v1/recovery-cases/{case['caseId']}/select-option", json={"optionId": wait["optionId"], "selectedBy": {"actorType": "USER", "actorId": "acc-1"}}, headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8000-000000000113"})
     assert response.status_code == 412
+
+
+def test_transfer_management_missed_connection_report_values_are_accepted() -> None:
+    app = create_app(store=InMemoryStore())
+    client = TestClient(app)
+    body = {
+        "disruptionType": "MISSED_CONNECTION",
+        "segmentRef": "seg-0194f2e0-7b3e-7610-8000-000000000222",
+        "serviceDate": "2026-08-02",
+        "evidence": {
+            "evidenceRef": "con-0194f2e0-7b3e-7610-8000-000000000333",
+            "sourceSystem": "TRANSFER_MANAGEMENT",
+            "sourceRecordId": "evt-0194f2e0-7b3e-7610-8000-000000000444",
+            "summary": "Protected missed connection",
+        },
+        "affectedOrderIds": ["ord-0194f2e0-7b3e-7610-8000-000000000555"],
+        "reportedBy": {"actorType": "SYSTEM", "actorId": "transfer-management"},
+    }
+    response = client.post("/api/v1/disruptions", json=body, headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8000-000000000114"})
+    assert response.status_code == 202
+    data = response.json()
+    assert data["disruption"]["disruptionType"] == "MISSED_CONNECTION"
+    assert data["disruption"]["evidence"]["sourceSystem"] == "TRANSFER_MANAGEMENT"
+    assert data["disruption"]["reportedBy"]["actorType"] == "SYSTEM"


### PR DESCRIPTION
## Summary
- Add Transfer Management HTTP and event contracts for ADR-0002 wave 18
- Register transfer-management stream and Disruption Recovery subscription matrix changes
- Add Disruption Recovery missed-connection contract increment and implementation validation for Transfer Management reports

## Validation
- python3 scripts/contract_lint.py
- cd services/disruption-recovery && uv run python -m unittest discover -s tests
- make check (failed in existing ancillary-service npm ci lockfile mismatch: Missing @trainticket/ts-kit@0.1.0 from lock file)