### PR TITLE
REQ-123 activate wallet consumers

### DIFF
--- a/deploy/e2e/15-wallet.sh
+++ b/deploy/e2e/15-wallet.sh
@@ -16,6 +16,36 @@ benefit_body() { local acct=$1 amount=$2 until=$3 reason=${4:-GOODWILL_COMP}; ca
 {"accountId":"$acct","benefitType":"BALANCE","balanceType":"PROMOTION_CREDIT","amount":{"currency":"CNY","minorUnits":$amount},"issuanceSource":"MANUAL_OPS","applicableScope":{"scopeType":"ANY_TRIP","currency":"CNY"},"redemptionRule":{"singleUse":false,"requiresReservation":false},"revocationRule":{},"validFrom":"$(past_time 60)","validUntil":"$until","businessReason":{"reasonType":"MANUAL_OPS","reasonCode":"$reason","referenceType":"MANUAL_ACTION","referenceId":"act-$(uuid7)"}}
 JSON
 }
+
+stream_notification_template_for_recipient() { # TEMPLATE RECIPIENT_REF -> yes/empty
+  k exec "$(redis_pod)" -- redis-cli XREVRANGE events:notification + - COUNT 300 > /tmp/wallet-notification-stream.txt 2>/dev/null
+  TEMPLATE="$1" RECIPIENT="$2" python3 - << 'PYEX'
+import re, os, json
+raw = open("/tmp/wallet-notification-stream.txt").read()
+template = os.environ["TEMPLATE"]
+recipient = os.environ["RECIPIENT"]
+for m in re.finditer(r'\{.*\}', raw):
+    try:
+        e = json.loads(m.group(0).encode().decode('unicode_escape'))
+    except Exception:
+        continue
+    payload = e.get("payload", {})
+    if e.get("eventType") == "NotificationScheduled" and payload.get("templateCode") == template and payload.get("recipientRef") == recipient:
+        print("yes")
+        break
+PYEX
+}
+benefit_cost_seen() { # ACCOUNT BENEFIT EVENT_TYPE -> yes/empty
+  req GET finance-settlement "/api/v1/benefit-costs?accountId=$1&limit=50&offset=0"
+  BENEFIT="$2" EVENT_TYPE="$3" BODY="$RESP" python3 - << 'PYEX'
+import json, os
+data = json.loads(os.environ.get("BODY", "{}"))
+for item in data.get("items", []):
+    if item.get("benefitId") == os.environ["BENEFIT"] and item.get("eventType") == os.environ["EVENT_TYPE"]:
+        print("yes")
+        break
+PYEX
+}
 wallet_amounts() {
   local acct=$1
   req GET wallet-promotion "/api/v1/wallet-accounts/$acct"
@@ -27,6 +57,15 @@ ACCT="acc-$(uuid7)"; BODY=$(benefit_body "$ACCT" 1000 "$(future_time 3600)")
 req POST wallet-promotion /api/v1/benefits "$BODY"; check_code 201 "issue benefit"; BEN=$(jget "['benefitId']")
 req GET wallet-promotion "/api/v1/benefits/$BEN"; check_code 200 "get issued benefit"; [ "$(jget "['status']")" = ISSUED ] && ok "issued status observable" || bad "issued status mismatch"
 read A R D < <(wallet_amounts "$ACCT"); [ "$A $R $D" = "1000 0 0" ] && ok "wallet credited" || bad "wallet after issue $A/$R/$D"
+FIN_COST=""; NOTIFY_ISSUED=""
+for attempt in 1 2 3 4 5; do
+  FIN_COST=$(benefit_cost_seen "$ACCT" "$BEN" BenefitIssued)
+  NOTIFY_ISSUED=$(stream_notification_template_for_recipient wallet_benefit_issued "$ACCT")
+  [ "$FIN_COST" = yes ] && [ "$NOTIFY_ISSUED" = yes ] && break
+  sleep 3
+done
+[ "$FIN_COST" = yes ] && ok "finance benefit-costs contains issued $BEN" || bad "finance benefit-costs missing issued $BEN"
+[ "$NOTIFY_ISSUED" = yes ] && ok "notification scheduled wallet_benefit_issued for $ACCT" || bad "notification missing wallet_benefit_issued for $ACCT"
 RESREF="ord-$(uuid7)"; req POST wallet-promotion "/api/v1/benefits/$BEN/reserve" "{\"amount\":{\"currency\":\"CNY\",\"minorUnits\":400},\"reservationRef\":\"$RESREF\",\"reservationExpiresAt\":\"$(future_time 600)\",\"businessReason\":{\"reasonType\":\"ORDER_PURCHASE\",\"reasonCode\":\"ORDER_BENEFIT_RESERVE\",\"referenceType\":\"ORDER\",\"referenceId\":\"$RESREF\"}}"; check_code 200 "reserve benefit"
 read A R D < <(wallet_amounts "$ACCT"); [ "$A $R $D" = "600 400 0" ] && ok "wallet frozen" || bad "wallet after reserve $A/$R/$D"
 req POST wallet-promotion "/api/v1/benefits/$BEN/redeem" "{\"amount\":{\"currency\":\"CNY\",\"minorUnits\":400},\"redemptionRef\":\"$RESREF\",\"reservationRef\":\"$RESREF\",\"businessReason\":{\"reasonType\":\"ORDER_PURCHASE\",\"reasonCode\":\"ORDER_BENEFIT_USE\",\"referenceType\":\"ORDER\",\"referenceId\":\"$RESREF\"}}"; check_code 200 "redeem reserved benefit"; RED=$(jget "['redemption']['redemptionId']")
@@ -39,6 +78,13 @@ echo "== wallet-promotion expiry and revoke"
 ACCT_E="acc-$(uuid7)"; req POST wallet-promotion /api/v1/benefits "$(benefit_body "$ACCT_E" 250 "$(future_time 2)" SHORT_VALIDITY)"; check_code 201 "issue short benefit"; BEN_E=$(jget "['benefitId']"); sleep 8
 req GET wallet-promotion "/api/v1/benefits/$BEN_E"; [ "$(jget "['status']")" = EXPIRED ] && ok "expired benefit rests observable" || bad "expired status $(jget "['status']")"
 read A R D < <(wallet_amounts "$ACCT_E"); [ "$A $R" = "0 0" ] && ok "expiry removes exposure" || bad "wallet after expiry $A/$R/$D"
+FIN_EXPIRED=""
+for attempt in 1 2 3 4 5; do
+  FIN_EXPIRED=$(benefit_cost_seen "$ACCT_E" "$BEN_E" BenefitExpired)
+  [ "$FIN_EXPIRED" = yes ] && break
+  sleep 3
+done
+[ "$FIN_EXPIRED" = yes ] && ok "finance benefit-costs contains expired $BEN_E" || bad "finance benefit-costs missing expired $BEN_E"
 ACCT_R="acc-$(uuid7)"; req POST wallet-promotion /api/v1/benefits "$(benefit_body "$ACCT_R" 300 "$(future_time 3600)" REVOKE_TEST)"; check_code 201 "issue revocable benefit"; BEN_R=$(jget "['benefitId']")
 req POST wallet-promotion "/api/v1/benefits/$BEN_R/revoke" "{\"businessReason\":{\"reasonType\":\"CUSTOMER_SERVICE_ADJUSTMENT\",\"reasonCode\":\"ADMIN_REVOKE\",\"referenceType\":\"MANUAL_ACTION\",\"referenceId\":\"act-$(uuid7)\"}}"; check_code 200 "revoke benefit"
 req GET wallet-promotion "/api/v1/benefits/$BEN_R"; [ "$(jget "['status']")" = REVOKED ] && ok "revoked benefit rests observable" || bad "revoked status mismatch"

--- a/docs/08-contracts/api/finance-settlement.md
+++ b/docs/08-contracts/api/finance-settlement.md
@@ -78,6 +78,31 @@ return the original response; reusing a key with a different body returns
 
 **Response (200):** Paginated response.
 
+
+### List Benefit Costs
+
+**GET** `/api/v1/benefit-costs?accountId={accountId}&limit=20&offset=0`
+
+Internal operations read endpoint for SYSTEM/OPS benefit cost attribution from
+Wallet / Promotion events. `accountId` is optional; when omitted the endpoint
+returns all cost entries in reverse occurrence order.
+
+**Response (200):** Paginated response with `items`, `total`, `limit`, and `offset`.
+
+Item fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `benefitId` | string | Wallet benefit ID. |
+| `accountId` | string | Benefit owner / cost attribution account. |
+| `issuanceSource` | enum | `MANUAL_OPS`, `POST_SALES_COMP`, `DISRUPTION_COMP`, or `UNKNOWN` when no prior issuance attribution is available for a lifecycle fact. |
+| `caseId` | string | Optional post-sales/disruption case reference; lifecycle events inherit the latest known benefit attribution when the event payload does not carry it. |
+| `amount` | Money | Signed cost delta in Money minorUnits. Issuance/redemption are positive; reversal/revocation/expiry are negative reductions. |
+| `eventType` | enum | `BenefitIssued`, `BenefitRedeemed`, `BenefitReversed`, `BenefitRevoked`, or `BenefitExpired`. |
+| `occurredAt` | RFC3339 UTC | Event payload timestamp parsed from wallet RFC3339 fields. |
+
+**Error codes:** `VALIDATION_FAILED`
+
 ### Get Invoice
 
 **GET** `/api/v1/invoices/{invoiceId}`

--- a/docs/08-contracts/events/wallet-promotion.md
+++ b/docs/08-contracts/events/wallet-promotion.md
@@ -22,9 +22,10 @@ Activation-wave rulings:
   `DISRUPTION_COMP`.
 - Payment contracts are unchanged. Combination payment is not part of this wave;
   future note: a later wave will define the "cash remaining payable" interface.
-- Finance Settlement and Notification are event consumers at the contract
-  surface, but their concrete consumer implementations are deferred to a later
-  wave. Reporting may consume all events for read models and metrics.
+- Finance Settlement and Notification are active event consumers in wave 19.
+  Finance records benefit cost attribution; Notification sends issued/expired/
+  revoked touchpoints and intentionally ack-skips redemption noise. Reporting may
+  consume all events for read models and metrics.
 - Every event payload carries the `businessReason` that caused the state or
   balance change. Producers MUST NOT include unmasked documents or other
   sensitive personal data in reason descriptions.
@@ -90,7 +91,7 @@ Event payloads use the same seven-state enum as the HTTP API: `ISSUED`,
 | Field | Description |
 |---|---|
 | **Producer** | wallet-promotion |
-| **Consumers** | finance-settlement (deferred), notification (deferred), reporting |
+| **Consumers** | finance-settlement, notification, reporting |
 | **Trigger** | `IssueBenefit` command accepted from manual operations or post-sales compensation issuance request. |
 
 **Payload:**
@@ -123,7 +124,7 @@ Event payloads use the same seven-state enum as the HTTP API: `ISSUED`,
 | Field | Description |
 |---|---|
 | **Producer** | wallet-promotion |
-| **Consumers** | finance-settlement (deferred), notification (deferred), reporting |
+| **Consumers** | reporting; finance-settlement and notification ack-skip. |
 | **Trigger** | `ReserveBenefit` command freezes available benefit value for an order, post-sales workflow, or other business reference. |
 
 **Payload:**
@@ -151,7 +152,7 @@ Event payloads use the same seven-state enum as the HTTP API: `ISSUED`,
 | Field | Description |
 |---|---|
 | **Producer** | wallet-promotion |
-| **Consumers** | finance-settlement (deferred), notification (deferred), reporting |
+| **Consumers** | finance-settlement, reporting; notification intentionally ack-skips (redemption notifications are noisy). |
 | **Trigger** | `RedeemBenefit` command consumes benefit value and creates an idempotent `BenefitRedemption` record. |
 
 **Payload:**
@@ -181,7 +182,7 @@ Event payloads use the same seven-state enum as the HTTP API: `ISSUED`,
 | Field | Description |
 |---|---|
 | **Producer** | wallet-promotion |
-| **Consumers** | finance-settlement (deferred), notification (deferred), reporting |
+| **Consumers** | reporting; finance-settlement and notification ack-skip. |
 | **Trigger** | `ReleaseReservedBenefit` command releases a prior reservation because the business use ended or timed out. |
 
 **Payload:**
@@ -208,7 +209,7 @@ Event payloads use the same seven-state enum as the HTTP API: `ISSUED`,
 | Field | Description |
 |---|---|
 | **Producer** | wallet-promotion |
-| **Consumers** | finance-settlement (deferred), notification (deferred), reporting |
+| **Consumers** | finance-settlement, notification, reporting |
 | **Trigger** | `ExpireBenefit` scheduler/domain policy runs when `validUntil` has elapsed before the benefit reaches a terminal state. |
 
 **Payload:**
@@ -235,7 +236,7 @@ Event payloads use the same seven-state enum as the HTTP API: `ISSUED`,
 | Field | Description |
 |---|---|
 | **Producer** | wallet-promotion |
-| **Consumers** | finance-settlement (deferred), notification (deferred), reporting |
+| **Consumers** | finance-settlement, notification, reporting |
 | **Trigger** | `RevokeBenefit` command revokes an issued or released benefit according to its revocation rule. |
 
 **Payload:**
@@ -261,7 +262,7 @@ Event payloads use the same seven-state enum as the HTTP API: `ISSUED`,
 | Field | Description |
 |---|---|
 | **Producer** | wallet-promotion |
-| **Consumers** | finance-settlement (deferred), notification (deferred), reporting |
+| **Consumers** | finance-settlement, reporting; notification intentionally ack-skips (redemption reversal notifications are noisy). |
 | **Trigger** | `ReverseRedemption` command compensates a prior `BenefitRedeemed` fact. |
 
 **Payload:**

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -279,8 +279,8 @@ plus notification/finance/reporting fan-in.
 | 50 | `events:journey-order` | `waitlist` | JourneyOrderConfirmed/JourneyOrderCancelled advance a matching request to FULFILLED or return it to QUEUED |
 | 51 | `events:waitlist` | `notification` | Waitlist success, failure/requeue, expiry, and cancellation user touchpoints |
 | 52 | `events:waitlist` | `reporting` | Waitlist lifecycle metrics and read models |
-| 53 | `events:wallet-promotion` | `finance-settlement` | Benefit issuance, reservation, redemption, release, expiry, revocation, and reversal facts for future cost attribution and settlement read models; concrete consumption deferred to a later wave |
-| 54 | `events:wallet-promotion` | `notification` | Benefit arrival, expiry, redemption, revocation, and reversal user touchpoints; concrete consumption deferred to a later wave |
+| 53 | `events:wallet-promotion` | `finance-settlement` | Benefit issuance, redemption, expiry, revocation, and reversal facts for active benefit cost attribution read models |
+| 54 | `events:wallet-promotion` | `notification` | Active benefit arrival, expiry, and revocation user touchpoints; BenefitRedeemed and reversal facts are ack-skipped to avoid noisy notifications |
 | 55 | `events:wallet-promotion` | `reporting` | Wallet / Promotion lifecycle metrics and read models |
 | 56 | `events:post-sales` | `disruption-recovery` | PostSalesApplied converges REFUND recovery execution |
 | 57 | `events:journey-order` | `ancillary-service` | RULING (2026-07-09): JourneyOrderCancelled is the only upstream event consumed by Ancillary Service in this activation wave; it automatically cancels associated non-terminal AncillaryOrderItem records. |
@@ -293,9 +293,9 @@ analytics, and cross-cutting concerns:
 
 | Consumer Group (Context) | Subscribed Streams | Purpose |
 |---|---|---|
-| `reporting` | All active `events:*` streams except `events:dispatch`, `events:wallet-promotion`, `events:disruption-recovery`, and `events:transfer-management` until their deferred-consumer activation waves | Business metrics, funnel analysis, operational dashboards |
-| `finance-settlement` | `events:payment`, `events:provider-integration`, `events:booking-orchestration`, `events:post-sales` | Revenue recognition, reconciliation, invoice generation. Wallet / Promotion benefit-cost events are a documented deferred consumer (events/wallet-promotion.md). |
-| `notification` | `events:journey-order`, `events:booking-orchestration`, `events:payment`, `events:entitlement-ticketing`, `events:post-sales`, `events:waitlist` | User-facing notification triggers. Wallet / Promotion benefit touchpoints are a documented deferred consumer. |
+| `reporting` | All active `events:*` streams except `events:dispatch`, `events:disruption-recovery`, and `events:transfer-management` until their deferred-consumer activation waves | Business metrics, funnel analysis, operational dashboards |
+| `finance-settlement` | `events:payment`, `events:provider-integration`, `events:booking-orchestration`, `events:post-sales`, `events:wallet-promotion` | Revenue recognition, reconciliation, invoice generation, and Wallet / Promotion benefit-cost attribution. |
+| `notification` | `events:journey-order`, `events:booking-orchestration`, `events:payment`, `events:entitlement-ticketing`, `events:post-sales`, `events:wallet-promotion` | User-facing notification triggers including Wallet / Promotion issued, expired, and revoked benefit touchpoints. |
 
 ### Disruption Recovery subscriptions
 

--- a/services/finance-settlement/migrations/002_benefit_cost_entries.sql
+++ b/services/finance-settlement/migrations/002_benefit_cost_entries.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS benefit_cost_entries (
+  event_id        text PRIMARY KEY,
+  benefit_id      text NOT NULL,
+  account_id      text NOT NULL,
+  issuance_source text NOT NULL,
+  case_id         text,
+  currency        text NOT NULL,
+  amount          numeric(19, 4) NOT NULL,
+  event_type      text NOT NULL,
+  occurred_at     timestamptz NOT NULL,
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_benefit_cost_entries_account_occurred
+  ON benefit_cost_entries (account_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_benefit_cost_entries_benefit_occurred
+  ON benefit_cost_entries (benefit_id, occurred_at DESC);

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/adapters/http/FinanceSettlementController.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/adapters/http/FinanceSettlementController.java
@@ -1,5 +1,6 @@
 package com.trainticket.financesettlement.adapters.http;
 
+import com.trainticket.financesettlement.application.BenefitCostEntry;
 import com.trainticket.financesettlement.application.DomainEventEnvelopeMapper;
 import com.trainticket.financesettlement.application.FinanceSettlementApplicationService;
 import com.trainticket.financesettlement.application.FinanceSettlementApplicationService.Page;
@@ -46,6 +47,16 @@ public class FinanceSettlementController {
     @ResponseStatus(HttpStatus.CREATED)
     public InvoiceResponse generateInvoice(@RequestBody GenerateInvoiceRequest request, HttpServletRequest httpRequest) {
         return InvoiceResponse.from(service.generateInvoice(request.orderId(), (String) httpRequest.getAttribute("X-Correlation-Id")));
+    }
+
+    @GetMapping("/api/v1/benefit-costs")
+    public PagedResponse<BenefitCostResponse> listBenefitCosts(
+        @RequestParam(required = false) String accountId,
+        @RequestParam(defaultValue = "20") int limit,
+        @RequestParam(defaultValue = "0") int offset
+    ) {
+        Page<BenefitCostEntry> page = service.listBenefitCosts(accountId, limit, offset);
+        return new PagedResponse<>(page.items().stream().map(BenefitCostResponse::from).toList(), page.total(), page.limit(), page.offset());
     }
 
     @GetMapping("/api/v1/reconciliation-cases")
@@ -106,6 +117,28 @@ public class FinanceSettlementController {
                 reconciliationCase.status().name(),
                 reconciliationCase.resolution(),
                 reconciliationCase.resolutionNote()
+            );
+        }
+    }
+
+    public record BenefitCostResponse(
+        String benefitId,
+        String accountId,
+        String issuanceSource,
+        String caseId,
+        Map<String, Object> amount,
+        String eventType,
+        Instant occurredAt
+    ) {
+        static BenefitCostResponse from(BenefitCostEntry entry) {
+            return new BenefitCostResponse(
+                entry.benefitId(),
+                entry.accountId(),
+                entry.issuanceSource(),
+                entry.caseId(),
+                DomainEventEnvelopeMapper.moneyPayload(entry.amount()),
+                entry.eventType(),
+                entry.occurredAt()
             );
         }
     }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/adapters/messaging/RedisMessagingProperties.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/adapters/messaging/RedisMessagingProperties.java
@@ -11,7 +11,8 @@ public class RedisMessagingProperties {
         "events:payment",
         "events:provider-integration",
         "events:booking-orchestration",
-        "events:post-sales"
+        "events:post-sales",
+        "events:wallet-promotion"
     );
 
     private final String url;

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/ApplicationConfiguration.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/ApplicationConfiguration.java
@@ -29,11 +29,12 @@ public class ApplicationConfiguration {
         RevenueRecognitionRepository revenueRecognitions,
         ReconciliationCaseRepository reconciliationCases,
         InvoiceRepository invoices,
+        FinanceSettlementProjectionRepository projections,
         EventPublisher eventPublisher,
         DomainEventEnvelopeMapper envelopeMapper,
         Clock clock
     ) {
-        return new FinanceSettlementApplicationService(revenueRecognitions, reconciliationCases, invoices, eventPublisher, envelopeMapper, clock);
+        return new FinanceSettlementApplicationService(revenueRecognitions, reconciliationCases, invoices, projections, eventPublisher, envelopeMapper, clock);
     }
 
     @Bean

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/BenefitCostEntry.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/BenefitCostEntry.java
@@ -1,0 +1,34 @@
+package com.trainticket.financesettlement.application;
+
+import com.trainticket.financesettlement.domain.Money;
+import java.time.Instant;
+import java.util.Objects;
+
+public record BenefitCostEntry(
+    String eventId,
+    String benefitId,
+    String accountId,
+    String issuanceSource,
+    String caseId,
+    Money amount,
+    String eventType,
+    Instant occurredAt
+) {
+    public BenefitCostEntry {
+        eventId = requireText(eventId, "eventId");
+        benefitId = requireText(benefitId, "benefitId");
+        accountId = requireText(accountId, "accountId");
+        issuanceSource = requireText(issuanceSource, "issuanceSource");
+        eventType = requireText(eventType, "eventType");
+        Objects.requireNonNull(amount, "amount is required");
+        Objects.requireNonNull(occurredAt, "occurredAt is required");
+        caseId = caseId == null || caseId.isBlank() ? null : caseId;
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+        return value;
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementApplicationService.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementApplicationService.java
@@ -18,6 +18,7 @@ public class FinanceSettlementApplicationService {
     private final RevenueRecognitionRepository revenueRecognitions;
     private final ReconciliationCaseRepository reconciliationCases;
     private final InvoiceRepository invoices;
+    private final FinanceSettlementProjectionRepository projections;
     private final EventPublisher eventPublisher;
     private final DomainEventEnvelopeMapper envelopeMapper;
     private final Clock clock;
@@ -28,7 +29,7 @@ public class FinanceSettlementApplicationService {
         EventPublisher eventPublisher,
         DomainEventEnvelopeMapper envelopeMapper
     ) {
-        this(revenueRecognitions, reconciliationCases, new InMemoryInvoiceRepository(), eventPublisher, envelopeMapper, Clock.systemUTC());
+        this(revenueRecognitions, reconciliationCases, new InMemoryInvoiceRepository(), new InMemoryFinanceSettlementProjectionRepository(), eventPublisher, envelopeMapper, Clock.systemUTC());
     }
 
     public FinanceSettlementApplicationService(
@@ -39,9 +40,22 @@ public class FinanceSettlementApplicationService {
         DomainEventEnvelopeMapper envelopeMapper,
         Clock clock
     ) {
+        this(revenueRecognitions, reconciliationCases, invoices, new InMemoryFinanceSettlementProjectionRepository(), eventPublisher, envelopeMapper, clock);
+    }
+
+    public FinanceSettlementApplicationService(
+        RevenueRecognitionRepository revenueRecognitions,
+        ReconciliationCaseRepository reconciliationCases,
+        InvoiceRepository invoices,
+        FinanceSettlementProjectionRepository projections,
+        EventPublisher eventPublisher,
+        DomainEventEnvelopeMapper envelopeMapper,
+        Clock clock
+    ) {
         this.revenueRecognitions = revenueRecognitions;
         this.reconciliationCases = reconciliationCases;
         this.invoices = invoices;
+        this.projections = projections;
         this.eventPublisher = eventPublisher;
         this.envelopeMapper = envelopeMapper;
         this.clock = clock;
@@ -75,6 +89,17 @@ public class FinanceSettlementApplicationService {
         }
         List<ReconciliationCase> items = reconciliationCases.find(orderId, limit, offset);
         return new Page<>(items, reconciliationCases.count(orderId), limit, offset);
+    }
+
+    public Page<BenefitCostEntry> listBenefitCosts(String accountId, int limit, int offset) {
+        if (limit < 1 || limit > 100) {
+            throw new ValidationException("limit must be between 1 and 100");
+        }
+        if (offset < 0) {
+            throw new ValidationException("offset must not be negative");
+        }
+        List<BenefitCostEntry> items = projections.findBenefitCostEntries(accountId, limit, offset);
+        return new Page<>(items, projections.countBenefitCostEntries(accountId), limit, offset);
     }
 
     public Invoice generateInvoice(String orderId, String correlationId) {

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
@@ -8,8 +8,10 @@ import com.trainticket.financesettlement.domain.Money;
 import com.trainticket.financesettlement.domain.ReconciliationCase;
 import com.trainticket.financesettlement.domain.RevenueRecognition;
 import com.trainticket.platformkit.messaging.EventEnvelope;
+import com.trainticket.platformkit.messaging.PrefixedIds;
 import java.math.BigDecimal;
 import java.time.Clock;
+import java.time.Instant;
 import java.util.Currency;
 import java.util.List;
 import java.util.Map;
@@ -92,6 +94,7 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
     @Override
     @Transactional
     public HandlerResult handle(EventEnvelope envelope) {
+        validateEnvelopeIds(envelope);
         ConsumedEventLog log = ConsumedEventLog.record(envelope.eventId(), envelope.producer(), envelope.eventType(), clock.instant());
         boolean preRecorded = consumedEvents.guardsTransactionally();
         if (preRecorded && !consumedEvents.recordIfNew(log)) {
@@ -116,6 +119,14 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
                 envelope.eventId(), envelope.eventType(), ex.getClass().getName(), ex.getMessage(), ex);
             rollbackCurrentTransactionIfActive();
             return HandlerResult.FATAL_FAILURE;
+        }
+    }
+
+    private static void validateEnvelopeIds(EventEnvelope envelope) {
+        PrefixedIds.requireEventId(envelope.eventId());
+        PrefixedIds.requireCorrelationId(envelope.correlationId());
+        if (envelope.causationId() != null) {
+            PrefixedIds.requireCausationId(envelope.causationId());
         }
     }
 
@@ -146,10 +157,59 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
             case "PostSalesApplied" -> {
                 if (service != null) applyPostSales(envelope, payload);
             }
+            case "BenefitIssued", "BenefitRedeemed", "BenefitRedemptionReversed", "BenefitRevoked", "BenefitExpired" -> recordBenefitCostEntry(envelope, payload);
             default -> {
                 // Streams contain event types that do not affect finance settlement.
             }
         }
+    }
+
+    private void recordBenefitCostEntry(EventEnvelope envelope, Map<String, Object> payload) {
+        String benefitId = text(payload, "benefitId");
+        BenefitCostEntry previousEntry = projections.findLatestBenefitCostEntryForBenefit(benefitId).orElse(null);
+        projections.saveBenefitCostEntry(new BenefitCostEntry(
+            envelope.eventId(),
+            benefitId,
+            text(payload, "accountId"),
+            optionalText(payload, "issuanceSource").orElse(previousEntry == null ? "UNKNOWN" : previousEntry.issuanceSource()),
+            optionalText(payload, "caseId").orElse(previousEntry == null ? null : previousEntry.caseId()),
+            benefitCostAmount(envelope.eventType(), payload),
+            normalizedBenefitCostEventType(envelope.eventType()),
+            benefitOccurredAt(envelope, payload)
+        ));
+    }
+
+    private static Money benefitCostAmount(String eventType, Map<String, Object> payload) {
+        return switch (eventType) {
+            case "BenefitIssued" -> money(payload.get("issuedAmount"), "issuedAmount");
+            case "BenefitRedeemed" -> money(payload.get("redeemedAmount"), "redeemedAmount");
+            case "BenefitRedemptionReversed" -> money(payload.get("reversedAmount"), "reversedAmount").negate();
+            case "BenefitRevoked" -> money(payload.get("revokedAmount"), "revokedAmount").negate();
+            case "BenefitExpired" -> money(payload.get("expiredAmount"), "expiredAmount").negate();
+            default -> throw new IllegalArgumentException("unsupported benefit cost event type " + eventType);
+        };
+    }
+
+    private static String normalizedBenefitCostEventType(String eventType) {
+        return switch (eventType) {
+            case "BenefitRedemptionReversed" -> "BenefitReversed";
+            default -> eventType;
+        };
+    }
+
+    private static Instant benefitOccurredAt(EventEnvelope envelope, Map<String, Object> payload) {
+        String timestampField = switch (envelope.eventType()) {
+            case "BenefitIssued" -> "issuedAt";
+            case "BenefitRedeemed" -> "redeemedAt";
+            case "BenefitRedemptionReversed" -> "reversedAt";
+            case "BenefitRevoked" -> "revokedAt";
+            case "BenefitExpired" -> "expiredAt";
+            default -> null;
+        };
+        if (timestampField == null) {
+            return envelope.occurredAt();
+        }
+        return optionalText(payload, timestampField).map(Instant::parse).orElse(envelope.occurredAt());
     }
 
     private void rememberPaymentIntentOrderReference(Map<String, Object> payload) {

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementProjectionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementProjectionRepository.java
@@ -1,6 +1,7 @@
 package com.trainticket.financesettlement.application;
 
 import com.trainticket.financesettlement.domain.Money;
+import java.util.List;
 import java.util.Optional;
 
 public interface FinanceSettlementProjectionRepository {
@@ -11,4 +12,12 @@ public interface FinanceSettlementProjectionRepository {
     Optional<Money> findApprovedRefund(String caseId);
 
     void saveApprovedRefund(String caseId, Money amount);
+
+    void saveBenefitCostEntry(BenefitCostEntry entry);
+
+    Optional<BenefitCostEntry> findLatestBenefitCostEntryForBenefit(String benefitId);
+
+    List<BenefitCostEntry> findBenefitCostEntries(String accountId, int limit, int offset);
+
+    long countBenefitCostEntries(String accountId);
 }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryFinanceSettlementProjectionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryFinanceSettlementProjectionRepository.java
@@ -1,6 +1,8 @@
 package com.trainticket.financesettlement.application;
 
 import com.trainticket.financesettlement.domain.Money;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -10,6 +12,7 @@ import org.springframework.stereotype.Repository;
 public class InMemoryFinanceSettlementProjectionRepository implements FinanceSettlementProjectionRepository {
     private final ConcurrentMap<String, FinanceSettlementEventHandler.PaymentCaptureFact> capturesByOrderId = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Money> approvedRefundsByCaseId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, BenefitCostEntry> benefitCostEntriesByEventId = new ConcurrentHashMap<>();
 
     @Override
     public Optional<FinanceSettlementEventHandler.PaymentCaptureFact> findCapture(String orderId) {
@@ -29,5 +32,34 @@ public class InMemoryFinanceSettlementProjectionRepository implements FinanceSet
     @Override
     public void saveApprovedRefund(String caseId, Money amount) {
         approvedRefundsByCaseId.put(caseId, amount);
+    }
+
+    @Override
+    public void saveBenefitCostEntry(BenefitCostEntry entry) {
+        benefitCostEntriesByEventId.put(entry.eventId(), entry);
+    }
+
+    @Override
+    public Optional<BenefitCostEntry> findLatestBenefitCostEntryForBenefit(String benefitId) {
+        return benefitCostEntriesByEventId.values().stream()
+            .filter(entry -> benefitId.equals(entry.benefitId()))
+            .max(Comparator.comparing(BenefitCostEntry::occurredAt).thenComparing(BenefitCostEntry::eventId));
+    }
+
+    @Override
+    public List<BenefitCostEntry> findBenefitCostEntries(String accountId, int limit, int offset) {
+        return benefitCostEntriesByEventId.values().stream()
+            .filter(entry -> accountId == null || accountId.isBlank() || accountId.equals(entry.accountId()))
+            .sorted(Comparator.comparing(BenefitCostEntry::occurredAt).reversed().thenComparing(BenefitCostEntry::eventId))
+            .skip(offset)
+            .limit(limit)
+            .toList();
+    }
+
+    @Override
+    public long countBenefitCostEntries(String accountId) {
+        return benefitCostEntriesByEventId.values().stream()
+            .filter(entry -> accountId == null || accountId.isBlank() || accountId.equals(entry.accountId()))
+            .count();
     }
 }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/PostgresFinanceSettlementProjectionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/PostgresFinanceSettlementProjectionRepository.java
@@ -1,11 +1,14 @@
 package com.trainticket.financesettlement.infrastructure.persistence;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import com.trainticket.financesettlement.application.BenefitCostEntry;
 import com.trainticket.financesettlement.application.FinanceSettlementEventHandler;
 import com.trainticket.financesettlement.application.FinanceSettlementProjectionRepository;
 import com.trainticket.financesettlement.domain.Money;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.Currency;
+import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -87,6 +90,114 @@ public class PostgresFinanceSettlementProjectionRepository implements FinanceSet
             amount.currency().getCurrencyCode(),
             amount.amount()
         );
+    }
+
+    @Override
+    public void saveBenefitCostEntry(BenefitCostEntry entry) {
+        jdbc.update(
+            """
+                INSERT INTO benefit_cost_entries(event_id, benefit_id, account_id, issuance_source, case_id, currency, amount, event_type, occurred_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (event_id) DO UPDATE SET
+                  benefit_id = EXCLUDED.benefit_id,
+                  account_id = EXCLUDED.account_id,
+                  issuance_source = EXCLUDED.issuance_source,
+                  case_id = EXCLUDED.case_id,
+                  currency = EXCLUDED.currency,
+                  amount = EXCLUDED.amount,
+                  event_type = EXCLUDED.event_type,
+                  occurred_at = EXCLUDED.occurred_at
+                """,
+            entry.eventId(),
+            entry.benefitId(),
+            entry.accountId(),
+            entry.issuanceSource(),
+            entry.caseId(),
+            entry.amount().currency().getCurrencyCode(),
+            entry.amount().amount(),
+            entry.eventType(),
+            Timestamp.from(entry.occurredAt())
+        );
+    }
+
+    @Override
+    public Optional<BenefitCostEntry> findLatestBenefitCostEntryForBenefit(String benefitId) {
+        return jdbc.query(
+            """
+                SELECT event_id, benefit_id, account_id, issuance_source, case_id, currency, amount, event_type, occurred_at
+                FROM benefit_cost_entries
+                WHERE benefit_id = ?
+                ORDER BY occurred_at DESC, event_id ASC
+                LIMIT 1
+                """,
+            rs -> rs.next() ? Optional.of(new BenefitCostEntry(
+                rs.getString("event_id"),
+                rs.getString("benefit_id"),
+                rs.getString("account_id"),
+                rs.getString("issuance_source"),
+                rs.getString("case_id"),
+                money(rs.getString("currency"), rs.getString("amount")),
+                rs.getString("event_type"),
+                rs.getTimestamp("occurred_at").toInstant()
+            )) : Optional.empty(),
+            benefitId
+        );
+    }
+
+    @Override
+    public List<BenefitCostEntry> findBenefitCostEntries(String accountId, int limit, int offset) {
+        if (accountId == null || accountId.isBlank()) {
+            return jdbc.query(
+                """
+                    SELECT event_id, benefit_id, account_id, issuance_source, case_id, currency, amount, event_type, occurred_at
+                    FROM benefit_cost_entries
+                    ORDER BY occurred_at DESC, event_id ASC
+                    LIMIT ? OFFSET ?
+                    """,
+                (rs, rowNum) -> new BenefitCostEntry(
+                    rs.getString("event_id"),
+                    rs.getString("benefit_id"),
+                    rs.getString("account_id"),
+                    rs.getString("issuance_source"),
+                    rs.getString("case_id"),
+                    money(rs.getString("currency"), rs.getString("amount")),
+                    rs.getString("event_type"),
+                    rs.getTimestamp("occurred_at").toInstant()
+                ),
+                limit,
+                offset
+            );
+        }
+        return jdbc.query(
+            """
+                SELECT event_id, benefit_id, account_id, issuance_source, case_id, currency, amount, event_type, occurred_at
+                FROM benefit_cost_entries
+                WHERE account_id = ?
+                ORDER BY occurred_at DESC, event_id ASC
+                LIMIT ? OFFSET ?
+                """,
+            (rs, rowNum) -> new BenefitCostEntry(
+                rs.getString("event_id"),
+                rs.getString("benefit_id"),
+                rs.getString("account_id"),
+                rs.getString("issuance_source"),
+                rs.getString("case_id"),
+                money(rs.getString("currency"), rs.getString("amount")),
+                rs.getString("event_type"),
+                rs.getTimestamp("occurred_at").toInstant()
+            ),
+            accountId,
+            limit,
+            offset
+        );
+    }
+
+    @Override
+    public long countBenefitCostEntries(String accountId) {
+        Long count = accountId == null || accountId.isBlank()
+            ? jdbc.queryForObject("SELECT count(*) FROM benefit_cost_entries", Long.class)
+            : jdbc.queryForObject("SELECT count(*) FROM benefit_cost_entries WHERE account_id = ?", Long.class, accountId);
+        return count == null ? 0L : count;
     }
 
     private static Money money(String currency, String amount) {

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/adapters/http/FinanceSettlementControllerTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/adapters/http/FinanceSettlementControllerTest.java
@@ -7,7 +7,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.trainticket.financesettlement.application.BenefitCostEntry;
 import com.trainticket.financesettlement.application.FinanceSettlementApplicationService;
+import com.trainticket.financesettlement.application.FinanceSettlementProjectionRepository;
 import com.trainticket.financesettlement.domain.Money;
 import com.trainticket.financesettlement.domain.ReconciliationCase;
 import com.trainticket.financesettlement.domain.RevenueRecognition;
@@ -29,6 +31,9 @@ class FinanceSettlementControllerTest {
 
     @Autowired
     FinanceSettlementApplicationService service;
+
+    @Autowired
+    FinanceSettlementProjectionRepository projections;
 
     private RevenueRecognition recognition;
     private ReconciliationCase reconciliationCase;
@@ -80,6 +85,32 @@ class FinanceSettlementControllerTest {
             .andExpect(jsonPath("$.total").value(1))
             .andExpect(jsonPath("$.limit").value(20))
             .andExpect(jsonPath("$.offset").value(0));
+    }
+
+
+    @Test
+    void listsBenefitCostsForOperations() throws Exception {
+        projections.saveBenefitCostEntry(new BenefitCostEntry(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0f101",
+            "ben-test-001",
+            "acc-test-001",
+            "MANUAL_OPS",
+            null,
+            Money.of("CNY", "10.00"),
+            "BenefitIssued",
+            Instant.parse("2026-07-05T10:02:00Z")
+        ));
+
+        mockMvc.perform(get("/api/v1/benefit-costs").param("accountId", "acc-test-001").param("limit", "20").param("offset", "0"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items", hasSize(1)))
+            .andExpect(jsonPath("$.items[0].benefitId").value("ben-test-001"))
+            .andExpect(jsonPath("$.items[0].accountId").value("acc-test-001"))
+            .andExpect(jsonPath("$.items[0].issuanceSource").value("MANUAL_OPS"))
+            .andExpect(jsonPath("$.items[0].amount.currency").value("CNY"))
+            .andExpect(jsonPath("$.items[0].amount.minorUnits").value(1000))
+            .andExpect(jsonPath("$.items[0].eventType").value("BenefitIssued"))
+            .andExpect(jsonPath("$.items[0].occurredAt").value("2026-07-05T10:02:00Z"));
     }
 
     @Test

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
@@ -390,6 +390,107 @@ class MessagingTest {
         assertFalse(((String) ((Map<?, ?>) opened.payload()).get("description")).contains("order-unknown-for-"));
     }
 
+    @Test
+    void walletBenefitEventsCreateCostEntriesAndDeduplicateReplay() {
+        InMemoryConsumedEventLogRepository consumedEvents = new InMemoryConsumedEventLogRepository();
+        InMemoryFinanceSettlementProjectionRepository projections = new InMemoryFinanceSettlementProjectionRepository();
+        FinanceSettlementEventHandler handler = new FinanceSettlementEventHandler(
+            consumedEvents,
+            new InMemoryPaymentIntentOrderReferenceRepository(),
+            new InMemorySegmentBookingOrderReferenceRepository(),
+            projections,
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC),
+            null
+        );
+        EventEnvelope issued = new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e301", "BenefitIssued", Instant.parse("2026-07-05T09:59:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e301", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0e301", "wallet-promotion", 1, Map.of(
+                "benefitId", "ben-1",
+                "accountId", "acc-1",
+                "issuanceSource", "POST_SALES_COMP",
+                "caseId", "psc-1",
+                "issuedAmount", Map.of("currency", "CNY", "minorUnits", 1200),
+                "issuedAt", "2026-07-05T09:58:59Z"
+            ));
+
+        assertEquals(HandlerResult.SUCCESS, handler.handle(issued));
+        assertEquals(HandlerResult.SUCCESS, handler.handle(issued));
+
+        List<BenefitCostEntry> entries = projections.findBenefitCostEntries("acc-1", 20, 0);
+        assertEquals(1, entries.size());
+        BenefitCostEntry entry = entries.getFirst();
+        assertEquals("ben-1", entry.benefitId());
+        assertEquals("POST_SALES_COMP", entry.issuanceSource());
+        assertEquals("psc-1", entry.caseId());
+        assertEquals("BenefitIssued", entry.eventType());
+        assertEquals(Money.of("CNY", "12.00"), entry.amount());
+        assertEquals(Instant.parse("2026-07-05T09:58:59Z"), entry.occurredAt());
+    }
+
+    @Test
+    void walletTerminalEventsUseRfc3339PayloadTimestampsAndSignedAmounts() {
+        InMemoryConsumedEventLogRepository consumedEvents = new InMemoryConsumedEventLogRepository();
+        InMemoryFinanceSettlementProjectionRepository projections = new InMemoryFinanceSettlementProjectionRepository();
+        FinanceSettlementEventHandler handler = new FinanceSettlementEventHandler(
+            consumedEvents,
+            new InMemoryPaymentIntentOrderReferenceRepository(),
+            new InMemorySegmentBookingOrderReferenceRepository(),
+            projections,
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC),
+            null
+        );
+
+        assertEquals(HandlerResult.SUCCESS, handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e302", "BenefitExpired", Instant.parse("2026-07-05T10:01:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e302", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0e302", "wallet-promotion", 1, Map.of(
+                "benefitId", "ben-2",
+                "accountId", "acc-2",
+                "expiredAmount", Map.of("currency", "CNY", "minorUnits", 250),
+                "expiredAt", "2026-07-05T10:00:30Z"
+            ))));
+        assertEquals(HandlerResult.SUCCESS, handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e303", "BenefitRedemptionReversed", Instant.parse("2026-07-05T10:02:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e302", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0e302", "wallet-promotion", 1, Map.of(
+                "benefitId", "ben-2",
+                "accountId", "acc-2",
+                "reversedAmount", Map.of("currency", "CNY", "minorUnits", 125),
+                "reversedAt", "2026-07-05T10:01:30Z"
+            ))));
+
+        List<BenefitCostEntry> entries = projections.findBenefitCostEntries("acc-2", 20, 0);
+        assertEquals(2, entries.size());
+        assertTrue(entries.stream().anyMatch(entry -> entry.eventType().equals("BenefitExpired")
+            && entry.amount().equals(Money.of("CNY", "-2.50"))
+            && entry.occurredAt().equals(Instant.parse("2026-07-05T10:00:30Z"))));
+        assertTrue(entries.stream().anyMatch(entry -> entry.eventType().equals("BenefitReversed")
+            && entry.amount().equals(Money.of("CNY", "-1.25"))));
+    }
+
+    @Test
+    void unknownWalletEventTypeAckSkipsWithoutCostEntry() {
+        InMemoryConsumedEventLogRepository consumedEvents = new InMemoryConsumedEventLogRepository();
+        InMemoryFinanceSettlementProjectionRepository projections = new InMemoryFinanceSettlementProjectionRepository();
+        FinanceSettlementEventHandler handler = new FinanceSettlementEventHandler(
+            consumedEvents,
+            new InMemoryPaymentIntentOrderReferenceRepository(),
+            new InMemorySegmentBookingOrderReferenceRepository(),
+            projections,
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC),
+            null
+        );
+
+        HandlerResult result = handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e304", "BenefitReserved", Instant.parse("2026-07-05T10:01:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e302", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0e302", "wallet-promotion", 1, Map.of(
+                "benefitId", "ben-2",
+                "accountId", "acc-2"
+            )));
+
+        assertEquals(HandlerResult.SUCCESS, result);
+        assertEquals(0, projections.countBenefitCostEntries("acc-2"));
+        assertEquals(1, consumedEvents.saveCount);
+    }
+
     private static final class RecordingPublisher implements EventPublisher {
         private final List<EventEnvelope> published = new ArrayList<>();
 

--- a/services/notification/src/adapters/messaging/stream-config.ts
+++ b/services/notification/src/adapters/messaging/stream-config.ts
@@ -8,6 +8,7 @@ export const NOTIFICATION_SUBSCRIBED_STREAMS = Object.freeze([
   "events:payment",
   "events:entitlement-ticketing",
   "events:post-sales",
+  "events:wallet-promotion",
 ]);
 
 export function notificationConsumerName(instanceId = process.env.HOSTNAME ?? process.pid.toString()): string {

--- a/services/notification/src/adapters/storage/runtime.ts
+++ b/services/notification/src/adapters/storage/runtime.ts
@@ -170,6 +170,12 @@ function templateCodeFor(eventType: string): string | undefined {
       return "post_sales_failed";
     case "ChangeApplied":
       return "change_applied";
+    case "BenefitIssued":
+      return "wallet_benefit_issued";
+    case "BenefitExpired":
+      return "wallet_benefit_expired";
+    case "BenefitRevoked":
+      return "wallet_benefit_revoked";
     default:
       return undefined;
   }
@@ -205,6 +211,7 @@ function triggerBusinessRefFor(envelope: EventEnvelope): string | undefined {
     ?? stringValue(payload.paymentIntentId)
     ?? stringValue(payload.refundId)
     ?? stringValue(payload.entitlementId)
+    ?? stringValue(payload.benefitId)
     ?? stringValue(payload.segmentBookingId)
     ?? stringValue(payload.caseId)
     ?? stringValue(payload.postSalesCaseId)

--- a/services/notification/src/application/notification-service.ts
+++ b/services/notification/src/application/notification-service.ts
@@ -185,6 +185,7 @@ function triggerBusinessRef(envelope: EventEnvelope): string | undefined {
     ?? stringValue(payload.paymentIntentId)
     ?? stringValue(payload.refundId)
     ?? stringValue(payload.entitlementId)
+    ?? stringValue(payload.benefitId)
     ?? stringValue(payload.segmentBookingId)
     ?? stringValue(payload.caseId)
     ?? stringValue(payload.postSalesCaseId)
@@ -315,6 +316,25 @@ const CONTRACT_FIELDS_BY_EVENT: Readonly<Record<string, readonly RequiredField[]
     { name: "newEntitlementRef", type: "string" },
     { name: "changeOfferRef", type: "string" },
   ],
+  BenefitIssued: [
+    { name: "benefitId", type: "string" },
+    { name: "accountId", type: "string" },
+    { name: "issuedAmount", type: "money" },
+    { name: "issuanceSource", type: "string" },
+    { name: "issuedAt", type: "string" },
+  ],
+  BenefitExpired: [
+    { name: "benefitId", type: "string" },
+    { name: "accountId", type: "string" },
+    { name: "expiredAmount", type: "money" },
+    { name: "expiredAt", type: "string" },
+  ],
+  BenefitRevoked: [
+    { name: "benefitId", type: "string" },
+    { name: "accountId", type: "string" },
+    { name: "revokedAmount", type: "money" },
+    { name: "revokedAt", type: "string" },
+  ],
 });
 
 function validateTriggerContract(envelope: EventEnvelope): void {
@@ -340,10 +360,27 @@ function envelopeContractViolations(envelope: EventEnvelope): string[] {
       violations.push(`${field} must be a non-empty string`);
     }
   }
+  if (!hasPrefix(envelope.eventId, "evt-")) {
+    violations.push("eventId must use evt- prefix");
+  }
+  if (!hasPrefix(envelope.correlationId, "corr-")) {
+    violations.push("correlationId must use corr- prefix");
+  }
+  if (envelope.causationId !== undefined && !hasAnyPrefix(envelope.causationId, ["cmd-", "evt-"])) {
+    violations.push("causationId must use cmd- or evt- prefix");
+  }
   if (typeof envelope.schemaVersion !== "number" || !Number.isInteger(envelope.schemaVersion) || envelope.schemaVersion < 1) {
     violations.push("schemaVersion must be a positive integer");
   }
   return violations;
+}
+
+function hasPrefix(value: unknown, prefix: string): boolean {
+  return typeof value === "string" && value.startsWith(prefix) && value.length > prefix.length;
+}
+
+function hasAnyPrefix(value: unknown, prefixes: readonly string[]): boolean {
+  return prefixes.some((prefix) => hasPrefix(value, prefix));
 }
 
 function fieldViolation(payload: Record<string, unknown>, field: RequiredField): string[] {
@@ -412,6 +449,12 @@ function mappingFor(eventType: string): TriggerMapping | undefined {
       return postSalesMapping("post_sales_failed", "POST_SALES_FAILED");
     case "ChangeApplied":
       return postSalesMapping("change_applied", "CHANGE_APPLIED");
+    case "BenefitIssued":
+      return walletBenefitMapping("wallet_benefit_issued", "WALLET_BENEFIT_ISSUED");
+    case "BenefitExpired":
+      return walletBenefitMapping("wallet_benefit_expired", "WALLET_BENEFIT_EXPIRED");
+    case "BenefitRevoked":
+      return walletBenefitMapping("wallet_benefit_revoked", "WALLET_BENEFIT_REVOKED");
     default:
       return undefined;
   }
@@ -456,6 +499,16 @@ function ticketIssuedMapping(): TriggerMapping {
     channel: "EMAIL",
     recipient: (payload) => recipientFromDirectFields(payload) ?? stringValue(payload.travelerRef),
     variables: (payload) => pickStringVariables(payload, ["entitlementId", "journeyOrderId", "orderId", "orderItemId", "segmentBookingId", "segmentRef", "credentialNo", "credentialType"]),
+  };
+}
+
+function walletBenefitMapping(templateCode: string, intent: string): TriggerMapping {
+  return {
+    templateCode,
+    intent,
+    channel: "IN_APP",
+    recipient: (payload) => stringValue(payload.accountId),
+    variables: (payload) => pickStringVariables(payload, ["benefitId", "accountId", "issuanceSource", "caseId", "status"]),
   };
 }
 

--- a/services/notification/src/messaging.test.ts
+++ b/services/notification/src/messaging.test.ts
@@ -278,4 +278,67 @@ describe("notification messaging integration surface", () => {
     assert.equal(await service.handleExternalTrigger(upstream), "ignored");
     assert.equal(publisher.envelopes.length, 0);
   });
+
+  it("notifies account recipients when wallet benefits are issued", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const service = new NotificationApplicationService(publisher);
+    const upstream: EventEnvelope = {
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c226",
+      eventType: "BenefitIssued",
+      schemaVersion: 1,
+      producer: "wallet-promotion",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      occurredAt: "2026-07-05T10:00:00.000Z",
+      payload: {
+        benefitId: "ben-test-001",
+        accountId: "acc-test-001",
+        issuedAmount: { currency: "CNY", minorUnits: 1000 },
+        issuanceSource: "MANUAL_OPS",
+        issuedAt: "2026-07-05T10:00:00.000Z",
+      },
+    };
+
+    assert.equal(await service.handleExternalTrigger(upstream), "delivered");
+    assert.equal(publisher.envelopes[0].eventType, "NotificationScheduled");
+    assert.equal(publisher.envelopes[0].payload.recipientRef, "acc-test-001");
+    assert.equal(publisher.envelopes[0].payload.templateCode, "wallet_benefit_issued");
+  });
+
+  it("does not notify noisy wallet benefit redemptions", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const service = new NotificationApplicationService(publisher);
+    const upstream: EventEnvelope = {
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c227",
+      eventType: "BenefitRedeemed",
+      schemaVersion: 1,
+      producer: "wallet-promotion",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      occurredAt: "2026-07-05T10:00:00.000Z",
+      payload: { benefitId: "ben-test-001", accountId: "acc-test-001" },
+    };
+
+    assert.equal(await service.handleExternalTrigger(upstream), "ignored");
+    assert.equal(publisher.envelopes.length, 0);
+  });
+
+  it("ack-skips unknown wallet event types", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const service = new NotificationApplicationService(publisher);
+    const upstream: EventEnvelope = {
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c228",
+      eventType: "BenefitReserved",
+      schemaVersion: 1,
+      producer: "wallet-promotion",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      occurredAt: "2026-07-05T10:00:00.000Z",
+      payload: { benefitId: "ben-test-001", accountId: "acc-test-001" },
+    };
+
+    assert.equal(await service.handleExternalTrigger(upstream), "ignored");
+    assert.equal(publisher.envelopes.length, 0);
+  });
+
 });


### PR DESCRIPTION
## Summary\n- Activate finance-settlement wallet-promotion consumption with benefit cost entries, persistence, and ops read API.\n- Activate notification wallet benefit issued/expired/revoked triggers and ack-skip redemption noise.\n- Update wallet messaging contracts and e2e wallet assertions.\n\n## Validation\n- services/finance-settlement: mvn test -DskipITs\n- services/notification: npm test\n- make check