### PR TITLE
REQ-126 transfer topology and risk policy

### DIFF
--- a/deploy/e2e/19-transfer.sh
+++ b/deploy/e2e/19-transfer.sh
@@ -12,6 +12,15 @@ PY
 
 json_get() { python3 -c "import sys,json; d=json.load(sys.stdin); print($1)"; }
 
+RUN=$(uuid7 | tail -c 13)
+
+req POST place-network /api/v1/places "{\"placeType\":\"STATION\",\"canonicalName\":\"Transfer E2E $RUN station\",\"code\":\"TM$RUN\",\"timezone\":\"UTC\"}"
+check_code 201 "create place-network place"
+PLACE=$(jget "['placeId']")
+req POST place-network /api/v1/transport-nodes "{\"placeId\":\"$PLACE\",\"displayName\":\"Transfer E2E node\",\"servingModes\":[\"RAIL\"]}"
+check_code 201 "create place-network node"
+NODE=$(jget "['nodeId']")
+
 req POST transfer-management /api/v1/mct-rules "{\"fromNodeType\":\"STATION\",\"toNodeType\":\"STATION\",\"transferCategory\":\"SAME_STATION\",\"minimumMinutes\":20,\"conditions\":{},\"validFrom\":\"2025-01-01T00:00:00Z\"}"
 check_code 201 "create mct rule"
 MCT=$(jget "['mctRuleId']")
@@ -20,15 +29,15 @@ check_code 200 "publish mct rule"
 req PATCH transfer-management "/api/v1/mct-rules/$MCT" "{\"minimumMinutes\":25}"
 check_code 412 "published mct immutable"
 
-RUN=$(uuid7 | tail -c 13)
-
 create_connection() {
   local typ=$1 suffix=$2
   req POST transfer-management /api/v1/transfer-plans "{\"itineraryRef\":\"iti-tm-$suffix\",\"planningSnapshotVersion\":1,\"journeyOrderId\":\"jo-tm-$suffix\",\"travelerRefs\":[\"trav-$suffix\"]}"
   check_code 201 "create transfer plan $typ"
   local plan; plan=$(jget "['transferPlanId']")
-  req POST transfer-management /api/v1/connections "{\"transferPlanId\":\"$plan\",\"itineraryRef\":\"iti-tm-$suffix\",\"journeyOrderId\":\"jo-tm-$suffix\",\"previousSegmentRef\":\"seg-prev-$suffix\",\"nextSegmentRef\":\"seg-next-$suffix\",\"travelerRefs\":[\"trav-$suffix\"],\"fromNodeRef\":\"sta-a\",\"toNodeRef\":\"sta-a\",\"fromNodeType\":\"STATION\",\"toNodeType\":\"STATION\",\"transferCategory\":\"SAME_STATION\",\"contractId\":\"cct-$suffix\",\"contractType\":\"$typ\",\"window\":{\"plannedArrivalAt\":\"$(iso 0)\",\"nextDepartureAt\":\"$(iso 60)\",\"nextCutoffAt\":\"$(iso 50)\"}}"
+  req POST transfer-management /api/v1/connections "{\"transferPlanId\":\"$plan\",\"itineraryRef\":\"iti-tm-$suffix\",\"journeyOrderId\":\"jo-tm-$suffix\",\"previousSegmentRef\":\"seg-prev-$suffix\",\"nextSegmentRef\":\"seg-next-$suffix\",\"travelerRefs\":[\"trav-$suffix\"],\"fromNodeRef\":\"$NODE\",\"toNodeRef\":\"$NODE\",\"fromNodeType\":\"STATION\",\"toNodeType\":\"STATION\",\"transferCategory\":\"SAME_STATION\",\"contractId\":\"cct-$suffix\",\"contractType\":\"$typ\",\"window\":{\"plannedArrivalAt\":\"$(iso 0)\",\"nextDepartureAt\":\"$(iso 60)\",\"nextCutoffAt\":\"$(iso 50)\"}}"
   check_code 201 "register connection $typ"
+  PGV=$(echo "$RESP" | json_get 'd["latestEvaluation"].get("placeGraphVersion", "")')
+  [ -n "$PGV" ] && ok "connection evaluation has placeGraphVersion" || bad "missing placeGraphVersion"
   jget "['connectionId']"
 }
 
@@ -43,6 +52,41 @@ miss_connection() {
   CASE=$(echo "$RESP" | json_get '((d["updatedConnections"][0].get("recovery") or {}).get("caseIds",[""])[0])')
   [ -n "$CASE" ] && ok "disruption recovery case opened $CASE" || bad "missing recovery case $suffix"
 }
+
+
+req POST transfer-management /api/v1/transfer-plans "{\"itineraryRef\":\"iti-tm-bad-$RUN\",\"planningSnapshotVersion\":1,\"journeyOrderId\":\"jo-tm-bad-$RUN\",\"travelerRefs\":[\"trav-bad-$RUN\"]}"
+check_code 201 "create bad-node transfer plan"
+BAD_PLAN=$(jget "['transferPlanId']")
+req POST transfer-management /api/v1/connections "{\"transferPlanId\":\"$BAD_PLAN\",\"itineraryRef\":\"iti-tm-bad-$RUN\",\"journeyOrderId\":\"jo-tm-bad-$RUN\",\"previousSegmentRef\":\"seg-prev-bad-$RUN\",\"nextSegmentRef\":\"seg-next-bad-$RUN\",\"travelerRefs\":[\"trav-bad-$RUN\"],\"fromNodeRef\":\"tnd-missing-$RUN\",\"toNodeRef\":\"$NODE\",\"fromNodeType\":\"STATION\",\"toNodeType\":\"STATION\",\"transferCategory\":\"SAME_STATION\",\"contractId\":\"cct-bad-$RUN\",\"contractType\":\"SELF_TRANSFER\",\"window\":{\"plannedArrivalAt\":\"$(iso 0)\",\"nextDepartureAt\":\"$(iso 60)\",\"nextCutoffAt\":\"$(iso 50)\"}}"
+check_code 422 "missing place-network node rejected"
+
+req POST transfer-management /api/v1/risk-policies "{\"version\":\"e2e-aggressive-$RUN\",\"thresholds\":{\"tightMinutes\":999,\"atRiskMinutes\":120},\"createdBy\":{\"actorType\":\"OPERATIONS\",\"actorId\":\"ops-e2e\"}}"
+check_code 201 "create aggressive risk policy"
+RISK_POLICY=$(jget "['riskPolicyId']")
+RISK_VERSION=$(jget "['version']")
+req POST transfer-management "/api/v1/risk-policies/$RISK_POLICY/activate" "{\"activatedBy\":{\"actorType\":\"OPERATIONS\",\"actorId\":\"ops-e2e\"},\"activateReason\":\"e2e\"}"
+check_code 200 "activate aggressive risk policy"
+AGG=$(create_connection SELF_TRANSFER "aggr-$RUN" | tail -1)
+req GET transfer-management "/api/v1/connections/$AGG"
+check_code 200 "get aggressive-policy connection"
+STATUS=$(jget "['status']")
+RPV=$(jget "['latestEvaluation']['riskPolicyVersion']")
+[ "$STATUS" = "AT_RISK" ] && ok "aggressive policy makes connection at-risk" || bad "aggressive status $STATUS"
+[ "$RPV" = "$RISK_VERSION" ] && ok "riskPolicyVersion uses active policy" || bad "riskPolicyVersion $RPV"
+req GET transfer-management /api/v1/risk-policies/active
+check_code 200 "get active risk policy"
+req POST transfer-management /api/v1/risk-policies "{\"version\":\"builtin-v1\",\"thresholds\":{\"tightMinutes\":10,\"atRiskMinutes\":0},\"createdBy\":{\"actorType\":\"OPERATIONS\",\"actorId\":\"ops-e2e\"}}"
+check_code 201 "create default risk policy"
+DEFAULT_POLICY=$(jget "['riskPolicyId']")
+req POST transfer-management "/api/v1/risk-policies/$DEFAULT_POLICY/activate" "{\"activatedBy\":{\"actorType\":\"OPERATIONS\",\"actorId\":\"ops-e2e\"},\"activateReason\":\"e2e default\"}"
+check_code 200 "activate default risk policy"
+DEF=$(create_connection SELF_TRANSFER "default-$RUN" | tail -1)
+req GET transfer-management "/api/v1/connections/$DEF"
+check_code 200 "get default-policy connection"
+STATUS=$(jget "['status']")
+RPV=$(jget "['latestEvaluation']['riskPolicyVersion']")
+[ "$STATUS" = "FEASIBLE" ] && ok "default policy restores feasible baseline" || bad "default status $STATUS"
+[ "$RPV" = "builtin-v1" ] && ok "default riskPolicyVersion builtin-v1" || bad "default riskPolicyVersion $RPV"
 
 CON=$(create_connection PROTECTED "prot-$RUN" | tail -1)
 miss_connection "prot-$RUN"

--- a/deploy/k8s/services.yaml
+++ b/deploy/k8s/services.yaml
@@ -2539,6 +2539,8 @@ spec:
               value: postgresql://trainticket:trainticket-dev@postgres:5432/transfer_management
             - name: DISRUPTION_RECOVERY_URL
               value: http://disruption-recovery:8080
+            - name: PLACE_NETWORK_URL
+              value: http://place-network:8080
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME

--- a/docs/08-contracts/api/transfer-management.md
+++ b/docs/08-contracts/api/transfer-management.md
@@ -11,11 +11,11 @@ rules. This contract activates the bounded context from
 
 Activation-wave rulings:
 
-- Active aggregates are `TransferPlan`, `Connection`, and `ConnectionContract`.
-  `MinimumConnectionTimeRule` is active as operations CRUD plus publish/retire;
-  a `PUBLISHED` version is immutable. `TransferRiskPolicy` CRUD is deferred:
-  all evaluations use built-in fixed policy version `builtin-v1`, and every risk
-  result MUST carry that value.
+- Active aggregates are `TransferPlan`, `Connection`, `ConnectionContract`, and
+  `TransferRiskPolicy`. `MinimumConnectionTimeRule` is active as operations CRUD
+  plus publish/retire; a `PUBLISHED` version is immutable. Risk evaluations use
+  the currently active risk policy version. If no active policy exists, the
+  backwards-compatible built-in policy `builtin-v1` is used and recorded.
 - `Connection` uses the nine-state runtime machine below. RULING: once a
   connection reaches `MISSED`, it MUST NOT transition back to `FEASIBLE`; it may
   only converge to `RECOVERED`, `SELF_HANDLED`, or a terminal state.
@@ -24,10 +24,16 @@ Activation-wave rulings:
   through the system/ops fallback endpoint `POST /api/v1/segment-status-reports`;
   both paths share aggregate invariants.
 - Evaluation reads the itinerary snapshot from Trip Planning by `itineraryRef`,
-  uses this domain's published MCT rules, and derives schedule windows from the
-  itinerary snapshot plus accepted segment-status reports. Place Network
-  topology/path integration is deferred; this wave records node refs, node types,
-  and transfer category but does not call Place Network.
+  reads Place Network transport nodes by `fromNodeRef`/`toNodeRef` with
+  `GET /api/v1/transport-nodes/{nodeId}` and parent place type via
+  `GET /api/v1/places/{placeId}`, uses this domain's published MCT rules, and
+  derives schedule windows from the itinerary snapshot plus accepted
+  segment-status reports. The current Place Network contract exposes node
+  identity, place ID, serving modes, and created timestamp only; it does not
+  expose walking/access-time weights, so MCT minutes remain sourced from
+  published Transfer Management MCT rules. Read failures during evaluation are
+  non-blocking and produce `degraded=true` with `degradedReasons`. Missing nodes
+  during registration are rejected with validation failure.
 - Closed loop with Disruption Recovery is HTTP-first. When a protected connection
   (`PROTECTED` or `SUPPLIER_PROTECTED`) becomes `MISSED`, Transfer Management
   calls Disruption Recovery `POST /api/v1/disruptions` as a `SYSTEM` report with
@@ -83,7 +89,7 @@ Error codes follow `docs/08-contracts/api/README.md` / REQ-079.
 
 | Status | Meaning | Allowed next statuses |
 |---|---|---|
-| `PLANNED` | Connection was registered from planned itinerary/schedule data. | `FEASIBLE`, `TIGHT`, `INVALIDATED` |
+| `PLANNED` | Connection was registered from planned itinerary/schedule data. | `FEASIBLE`, `TIGHT`, `AT_RISK`, `INVALIDATED` |
 | `FEASIBLE` | Available window exceeds MCT and buffer threshold. | `TIGHT`, `AT_RISK`, `COMPLETED`, `INVALIDATED` |
 | `TIGHT` | Still reachable but with insufficient buffer. | `FEASIBLE`, `AT_RISK`, `MISSED`, `COMPLETED` |
 | `AT_RISK` | Delay, cancellation, baggage/security, or schedule report creates high risk. | `TIGHT`, `MISSED`, `RECOVERED` |
@@ -152,7 +158,7 @@ on outbound events/commands use `corr-<uuid-v7>` and `cmd-<uuid-v7>` prefixes.
 | `status` | enum | yes | Transfer plan status. |
 | `connections` | array[ConnectionSummary] | yes | Connections produced from adjacent itinerary legs. |
 | `evaluationVersion` | integer | yes | Monotonic plan evaluation version. |
-| `riskPolicyVersion` | string | yes | Always `builtin-v1` in this wave. |
+| `riskPolicyVersion` | string | yes | Active TransferRiskPolicy version used by latest plan evaluation, or `builtin-v1` fallback. |
 | `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
 | `updatedAt` | RFC3339 UTC | yes | Last mutation timestamp. |
 | `expiresAt` | RFC3339 UTC | no | Planning/offer expiry. |
@@ -213,12 +219,15 @@ on outbound events/commands use `corr-<uuid-v7>` and `cmd-<uuid-v7>` prefixes.
 |---|---|---|---|
 | `riskEvaluationId` | string | yes | Evaluation ID (`tre-<uuid>`). |
 | `riskLevel` | enum | yes | Risk output, not aggregate state. |
-| `riskPolicyVersion` | string | yes | Always `builtin-v1`; TransferRiskPolicy management is deferred. |
+| `riskPolicyVersion` | string | yes | Active TransferRiskPolicy version used, or `builtin-v1` fallback when no active policy exists. |
 | `mctRuleId` | string | yes | Published MCT rule used. |
 | `mctRuleVersion` | integer | yes | Published MCT rule version. |
 | `availableMinutes` | integer | yes | Available transfer minutes used in the calculation. |
 | `requiredMinutes` | integer | yes | MCT minutes required. |
-| `reasons` | array[string] | yes | Explainable reason codes such as `INSUFFICIENT_BUFFER`, `PREVIOUS_SEGMENT_DELAYED`, or `NEXT_SEGMENT_CANCELLED`. |
+| `reasons` | array[string] | yes | Explainable reason codes such as `THRESHOLD_TIGHT_BUFFER_LT_10_MIN`, `PREVIOUS_SEGMENT_DELAYED`, or `NEXT_SEGMENT_CANCELLED`. |
+| `placeGraphVersion` | string | no | Snapshot identifier derived from Place Network node IDs and node `createdAt` timestamps when topology read succeeds. |
+| `degraded` | boolean | no | `true` when optional Place Network read enhancement failed but evaluation completed. |
+| `degradedReasons` | array[string] | no | Non-PII degradation codes, e.g. `PLACE_NETWORK_UNAVAILABLE`. Required when `degraded=true`. |
 | `evaluatedAt` | RFC3339 UTC | yes | Evaluation timestamp. |
 
 ### ConnectionContract
@@ -254,6 +263,24 @@ on outbound events/commands use `corr-<uuid-v7>` and `cmd-<uuid-v7>` prefixes.
 | `publishedAt` | RFC3339 UTC | no | Publish timestamp. |
 | `retiredAt` | RFC3339 UTC | no | Retire timestamp. |
 
+
+### TransferRiskPolicy
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `riskPolicyId` | string | yes | Risk policy ID (`trp-<uuid>`). |
+| `version` | string | yes | Operator supplied immutable version label written into evaluations. |
+| `status` | enum | yes | `DRAFT`, `ACTIVE`, or `RETIRED`. |
+| `thresholds.tightMinutes` | integer | yes | Buffer below this minute boundary is `TIGHT` unless the at-risk boundary is hit. |
+| `thresholds.atRiskMinutes` | integer | yes | Buffer below this minute boundary is `AT_RISK`; at-risk applies when buffer is below this boundary; setting a wide value makes at-risk more aggressive. |
+| `createdBy` | ActorRef | yes | Operations actor creating the policy. |
+| `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
+| `activatedAt` | RFC3339 UTC | no | Activation timestamp. |
+| `retiredAt` | RFC3339 UTC | no | Automatic retirement timestamp after another policy is activated. |
+
+Active policies are immutable through the public API. Activating a new policy
+automatically retires the previously active policy. Retired policies cannot be
+reactivated.
 
 ### ReaccommodateConnectionRequest
 
@@ -653,6 +680,43 @@ immutable.
 **Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`,
 `DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`
 
+
+### Create Transfer Risk Policy
+
+**POST** `/api/v1/risk-policies`
+
+**Idempotency:** REQUIRED.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `version` | string | yes | Immutable operator version label. |
+| `thresholds.tightMinutes` | integer | yes | Tight buffer minute boundary. |
+| `thresholds.atRiskMinutes` | integer | yes | At-risk buffer minute boundary. |
+| `createdBy` | ActorRef | yes | Operations actor. |
+
+**Response (201):** `TransferRiskPolicy` in `DRAFT` status.
+
+### Activate Transfer Risk Policy
+
+**POST** `/api/v1/risk-policies/{riskPolicyId}/activate`
+
+**Idempotency:** REQUIRED. Activates the policy, retires any previously active
+policy, and emits `RiskPolicyActivated`. Active versions are not mutable; create
+and activate a new policy for changes. Retired policies cannot be reactivated.
+
+**Request:** `activatedBy` ActorRef and optional `activateReason`.
+
+**Response (200):** Active `TransferRiskPolicy`.
+
+### Get Active Transfer Risk Policy
+
+**GET** `/api/v1/risk-policies/active`
+
+**Response (200):** Active `TransferRiskPolicy`, or the built-in fallback shape
+with `version=builtin-v1` and `builtin=true` when no active policy exists.
+
 ### List MCT Rules
 
 **GET** `/api/v1/mct-rules?fromNodeType=STATION&toNodeType=STATION&transferCategory=SAME_STATION&status=PUBLISHED&limit=20&offset=0`
@@ -715,9 +779,11 @@ same outbound idempotency key.
 
 ## Deferred behavior
 
-- `TransferRiskPolicy` CRUD/simulation is deferred; the built-in fixed policy
-  version is always `builtin-v1`.
-- Place Network topology/path and external map-time integration are deferred.
+- TransferRiskPolicy simulation and future richer policy dimensions are deferred;
+  this wave activates create/activate/current for runtime evaluation.
+- Place Network walking/access-time weights remain deferred because the current
+  Place Network contract exposes no such fields; Transfer Management only reads
+  current node/place identity and node created timestamp for `placeGraphVersion`.
 - Notification, Reporting, Customer Service, Offer Management, and Journey Order
   consumption of Transfer Management events is documented as intended but not
   registered as active downstream consumption in this wave.

--- a/docs/08-contracts/events/transfer-management.md
+++ b/docs/08-contracts/events/transfer-management.md
@@ -11,14 +11,17 @@ in `docs/08-contracts/api/transfer-management.md`.
 Activation-wave rulings:
 
 - Active aggregate events are for `TransferPlan`, `Connection`,
-  `ConnectionContract`, and `MinimumConnectionTimeRule`. `TransferRiskPolicy`
-  CRUD events are deferred; every risk evaluation carries
-  `riskPolicyVersion="builtin-v1"`.
+  `ConnectionContract`, `MinimumConnectionTimeRule`, and `TransferRiskPolicy`.
+  Every risk evaluation carries the active policy version, or `builtin-v1` when
+  no active policy exists.
 - Fulfillment segment delay/arrival/cancelled events are not active today.
   Runtime facts enter through `POST /api/v1/segment-status-reports`; future
   Fulfillment events may be mapped to the same command material.
-- Place Network topology/path integration is deferred. Event payloads carry the
-  itinerary/node refs and transfer category used by this wave's MCT lookup.
+- Place Network node/place read integration is active for evaluation metadata.
+  Event payloads carry itinerary/node refs, transfer category, and risk
+  evaluations may include `placeGraphVersion` or degradation fields. Place
+  Network walking/access-time weights remain deferred because that contract has no
+  such fields.
 - Protected missed connections use outbound HTTP to Disruption Recovery. Transfer
   Management stores returned `caseId` mappings and consumes
   `RecoveryCompleted`/`RecoveryFailed` by `caseId` to converge the `Connection`.
@@ -80,12 +83,15 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 |---|---|---|---|
 | `riskEvaluationId` | string | yes | Evaluation ID (`tre-<uuid>`). |
 | `riskLevel` | enum | yes | `FEASIBLE`, `TIGHT`, `AT_RISK`, `MISSED`, or `RECOVERED`. |
-| `riskPolicyVersion` | string | yes | Always `builtin-v1` in this wave. |
+| `riskPolicyVersion` | string | yes | Active TransferRiskPolicy version, or `builtin-v1` fallback. |
 | `mctRuleId` | string | yes | Published MCT rule used. |
 | `mctRuleVersion` | integer | yes | MCT rule version used. |
 | `availableMinutes` | integer | yes | Available transfer minutes. |
 | `requiredMinutes` | integer | yes | Required MCT minutes. |
-| `reasons` | array[string] | yes | Explainable reason codes; no PII. |
+| `reasons` | array[string] | yes | Explainable reason codes and threshold hits; no PII. |
+| `placeGraphVersion` | string | no | Derived from Place Network node IDs and created timestamps when available. |
+| `degraded` | boolean | no | `true` when optional Place Network read enhancement failed but evaluation completed. |
+| `degradedReasons` | array[string] | no | Degradation codes such as `PLACE_NETWORK_UNAVAILABLE`; required when degraded. |
 | `evaluatedAt` | RFC3339 UTC | yes | Evaluation timestamp. |
 
 ### ConnectionRef
@@ -132,7 +138,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | `journeyOrderId` | string | no | Purchased order when known. |
 | `travelerRefs` | array[string] | yes | Traveler refs. |
 | `status` | enum | yes | `DRAFT` or `EVALUATING` if evaluation starts synchronously. |
-| `riskPolicyVersion` | string | yes | `builtin-v1`. |
+| `riskPolicyVersion` | string | yes | Active TransferRiskPolicy version or `builtin-v1`. |
 | `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
 | `expiresAt` | RFC3339 UTC | no | Planning/offer expiry. |
 
@@ -155,7 +161,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | `status` | enum | yes | `EVALUATED` or `UNSERVICEABLE`. |
 | `evaluationVersion` | integer | yes | Monotonic evaluation version. |
 | `connectionIds` | array[string] | yes | Connections included in the plan. |
-| `riskPolicyVersion` | string | yes | `builtin-v1`. |
+| `riskPolicyVersion` | string | yes | Active TransferRiskPolicy version or `builtin-v1`. |
 | `evaluatedAt` | RFC3339 UTC | yes | Evaluation timestamp. |
 | `unserviceableReasons` | array[string] | no | Required when status is `UNSERVICEABLE`. |
 
@@ -205,7 +211,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | `transferCategory` | enum | yes | MCT transfer category. |
 | `contractId` | string | yes | Associated contract. |
 | `contractType` | enum | yes | Contract type snapshot. |
-| `status` | enum | yes | `PLANNED`, `FEASIBLE`, or `TIGHT` after initial evaluation. |
+| `status` | enum | yes | `PLANNED`, `FEASIBLE`, `TIGHT`, or `AT_RISK` after initial evaluation. |
 | `window` | object | yes | ConnectionWindow. |
 | `registeredAt` | RFC3339 UTC | yes | Registration timestamp. |
 
@@ -244,7 +250,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | `previousStatus` | enum | yes | Prior status, normally `FEASIBLE` or `TIGHT`. |
 | `status` | enum | yes | `AT_RISK`. |
 | `riskLevel` | enum | yes | `AT_RISK`. |
-| `riskPolicyVersion` | string | yes | `builtin-v1`. |
+| `riskPolicyVersion` | string | yes | Active TransferRiskPolicy version or `builtin-v1`. |
 | `reasons` | array[string] | yes | Explainable risk reasons. |
 | `window` | object | yes | ConnectionWindow. |
 | `detectedAt` | RFC3339 UTC | yes | Detection timestamp. |
@@ -386,6 +392,28 @@ a normal transition to `RECOVERED`.
 | `reason` | string | yes | Non-PII reason. |
 | `withdrawnAt` | RFC3339 UTC | yes | Withdrawal timestamp. |
 
+
+### RiskPolicyActivated
+
+| Field | Description |
+|---|---|
+| **Producer** | transfer-management |
+| **Consumers** | deferred: reporting, operations audit |
+| **Trigger** | Operations activates a `TransferRiskPolicy`; any previous active policy is retired. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `riskPolicyId` | string | yes | Policy ID (`trp-<uuid>`). |
+| `version` | string | yes | Version label that evaluations write to `riskPolicyVersion`. |
+| `status` | enum | yes | `ACTIVE`. |
+| `thresholds` | object | yes | `{tightMinutes, atRiskMinutes}` integer minute boundaries. |
+| `createdBy` | object | yes | ActorRef from creation. |
+| `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
+| `activatedBy` | object | yes | ActorRef that activated the policy. |
+| `activatedAt` | RFC3339 UTC | yes | Activation timestamp. |
+
 ### MctRuleCreated
 
 | Field | Description |
@@ -471,6 +499,8 @@ a normal transition to `RECOVERED`.
 | `CreateMctRule` | HTTP `POST /api/v1/mct-rules` | `MctRuleCreated` |
 | `PublishMctRule` | HTTP `POST /api/v1/mct-rules/{mctRuleId}/publish` | `MctRulePublished` |
 | `RetireMctRule` | HTTP `POST /api/v1/mct-rules/{mctRuleId}/retire` | `MctRuleRetired` |
+| `CreateRiskPolicy` | HTTP `POST /api/v1/risk-policies` | none until activation |
+| `ActivateRiskPolicy` | HTTP `POST /api/v1/risk-policies/{riskPolicyId}/activate` | `RiskPolicyActivated` |
 | `RecordRecoveryCompleted` | Consumed Disruption Recovery `RecoveryCompleted` by `caseId`; if the matching connection is already `RECOVERED` by `ReaccommodateConnection`, idempotently skip with no event | `ConnectionRecovered` or no-op |
 | `RecordRecoveryFailed` | Consumed Disruption Recovery `RecoveryFailed` by `caseId` | `ConnectionRecoveryFailed` |
 
@@ -481,9 +511,9 @@ a normal transition to `RECOVERED`.
 | `events:disruption-recovery` | `RecoveryCompleted` | Match payload `caseId` to stored recovery-case mapping and transition the related connection to `RECOVERED`; for self-executed `REACCOMMODATION`, an already `RECOVERED` connection with the same `caseId` is an idempotent no-op. |
 | `events:disruption-recovery` | `RecoveryFailed` | Match payload `caseId` to stored recovery-case mapping, keep the connection `MISSED`, and record sanitized failure evidence. |
 
-Fulfillment runtime facts are intentionally not consumed from the bus in this
-wave because segment-level delay/arrival/cancelled events are not produced today.
-The system/ops segment-status reporting endpoint is the active adapter.
+Fulfillment runtime facts are consumed when produced and mapped to the same
+segment-status command material; the system/ops segment-status reporting endpoint
+remains the active fallback adapter.
 
 ## Deferred downstream touchpoints
 

--- a/services/transfer-management/migrations/002_risk_policy_snapshots.sql
+++ b/services/transfer-management/migrations/002_risk_policy_snapshots.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS risk_policy_snapshots (
+  id text PRIMARY KEY,
+  version bigint NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_risk_policy_status ON risk_policy_snapshots ((data->>'status'));

--- a/services/transfer-management/src/transfer_management/adapters/storage/postgres.py
+++ b/services/transfer-management/src/transfer_management/adapters/storage/postgres.py
@@ -27,9 +27,12 @@ from transfer_management.domain import (
     ReportType,
     RiskEvaluation,
     RiskLevel,
+    RiskPolicyStatus,
+    RiskThresholds,
     SegmentStatusReport,
     TransferCategory,
     TransferPlan,
+    TransferRiskPolicy,
     TransferPlanStatus,
     parse_dt,
 )
@@ -50,12 +53,12 @@ def _json_obj(data: Mapping[str, Any] | str) -> Mapping[str, Any]:
 
 
 def plan_to_json(plan: TransferPlan) -> dict[str, Any]:
-    return {"transferPlanId": plan.transferPlanId, "itineraryRef": plan.itineraryRef, "planningSnapshotVersion": plan.planningSnapshotVersion, "journeyOrderId": plan.journeyOrderId, "travelerRefs": list(plan.travelerRefs), "status": plan.status.value, "connections": list(plan.connections), "evaluationVersion": plan.evaluationVersion, "createdAt": _dt(plan.createdAt), "updatedAt": _dt(plan.updatedAt), "expiresAt": _dt(plan.expiresAt) if plan.expiresAt else None}
+    return {"transferPlanId": plan.transferPlanId, "itineraryRef": plan.itineraryRef, "planningSnapshotVersion": plan.planningSnapshotVersion, "journeyOrderId": plan.journeyOrderId, "travelerRefs": list(plan.travelerRefs), "status": plan.status.value, "connections": list(plan.connections), "evaluationVersion": plan.evaluationVersion, "riskPolicyVersion": plan.riskPolicyVersion, "createdAt": _dt(plan.createdAt), "updatedAt": _dt(plan.updatedAt), "expiresAt": _dt(plan.expiresAt) if plan.expiresAt else None}
 
 
 def plan_from_json(data: Mapping[str, Any] | str, version: int = 0) -> TransferPlan:
     data = _json_obj(data)
-    return TransferPlan(str(data["transferPlanId"]), str(data["itineraryRef"]), int(data["planningSnapshotVersion"]), data.get("journeyOrderId"), tuple(data.get("travelerRefs") or ()), TransferPlanStatus(str(data["status"])), tuple(data.get("connections") or ()), int(data["evaluationVersion"]), _parse(data.get("createdAt")) or datetime.now(UTC), _parse(data.get("updatedAt")) or datetime.now(UTC), _parse(data.get("expiresAt")), version=version)
+    return TransferPlan(str(data["transferPlanId"]), str(data["itineraryRef"]), int(data["planningSnapshotVersion"]), data.get("journeyOrderId"), tuple(data.get("travelerRefs") or ()), TransferPlanStatus(str(data["status"])), tuple(data.get("connections") or ()), int(data["evaluationVersion"]), _parse(data.get("createdAt")) or datetime.now(UTC), _parse(data.get("updatedAt")) or datetime.now(UTC), _parse(data.get("expiresAt")), str(data.get("riskPolicyVersion") or "builtin-v1"), version)
 
 
 def evaluation_to_json(e: RiskEvaluation) -> dict[str, Any]:
@@ -63,7 +66,7 @@ def evaluation_to_json(e: RiskEvaluation) -> dict[str, Any]:
 
 
 def evaluation_from_json(data: Mapping[str, Any]) -> RiskEvaluation:
-    return RiskEvaluation(str(data["riskEvaluationId"]), RiskLevel(str(data["riskLevel"])), str(data["mctRuleId"]), int(data["mctRuleVersion"]), int(data["availableMinutes"]), int(data["requiredMinutes"]), tuple(data.get("reasons") or ()), _parse(data.get("evaluatedAt")) or datetime.now(UTC), str(data.get("riskPolicyVersion") or "builtin-v1"))
+    return RiskEvaluation(str(data["riskEvaluationId"]), RiskLevel(str(data["riskLevel"])), str(data["mctRuleId"]), int(data["mctRuleVersion"]), int(data["availableMinutes"]), int(data["requiredMinutes"]), tuple(data.get("reasons") or ()), _parse(data.get("evaluatedAt")) or datetime.now(UTC), str(data.get("riskPolicyVersion") or "builtin-v1"), data.get("placeGraphVersion"), bool(data.get("degraded") or False), tuple(data.get("degradedReasons") or ()))
 
 
 def window_from_json(data: Mapping[str, Any]) -> ConnectionWindow:
@@ -103,6 +106,12 @@ def report_to_json(r: SegmentStatusReport) -> dict[str, Any]:
     return r.to_json()
 
 
+def risk_policy_from_json(data: Mapping[str, Any] | str) -> TransferRiskPolicy:
+    data = _json_obj(data)
+    thresholds = dict(data.get("thresholds") or {})
+    return TransferRiskPolicy(str(data["riskPolicyId"]), str(data["version"]), RiskPolicyStatus(str(data["status"])), RiskThresholds(int(thresholds.get("tightMinutes") or 0), int(thresholds.get("atRiskMinutes") or 0)), ActorRef(**dict(data.get("createdBy") or {"actorType": "SYSTEM", "actorId": "unknown"})), _parse(data.get("createdAt")) or datetime.now(UTC), _parse(data.get("activatedAt")), _parse(data.get("retiredAt")))
+
+
 @dataclass
 class _UnitOfWorkState:
     connection: Any | None = None
@@ -123,6 +132,7 @@ class PostgresTransferManagementStore(InMemoryStore):
         self._plans = SnapshotRepository("transfer_plan_snapshots")
         self._connections = SnapshotRepository("connection_snapshots")
         self._contracts = SnapshotRepository("connection_contract_snapshots")
+        self._risk_policies = SnapshotRepository("risk_policy_snapshots")
         self._processed = ProcessedEventsGuard()
 
     @contextmanager
@@ -239,6 +249,31 @@ class PostgresTransferManagementStore(InMemoryStore):
             rows = conn.execute("SELECT data FROM mct_rule_snapshots ORDER BY data->>'mctRuleId'").fetchall()
             return tuple(rule_from_json(row[0]) for row in rows)
         return self._with_conn(read)
+
+    def save_risk_policy(self, policy: TransferRiskPolicy) -> None:
+        def write(conn: Any) -> None:
+            self._risk_policies.save(conn, policy.riskPolicyId, policy.to_json(), self._take("risk_policy", policy.riskPolicyId))
+        self._with_conn(write)
+
+    def get_risk_policy(self, policy_id: str) -> TransferRiskPolicy:
+        def read(conn: Any) -> TransferRiskPolicy:
+            snap = self._risk_policies.get(conn, policy_id)
+            if snap is None: raise NotFoundError(f"risk policy not found: {policy_id}")
+            version, data = snap; self._remember("risk_policy", policy_id, version); return risk_policy_from_json(data)
+        return self._with_conn(read)
+
+    def list_risk_policies(self) -> tuple[TransferRiskPolicy, ...]:
+        def read(conn: Any) -> tuple[TransferRiskPolicy, ...]:
+            rows = conn.execute("SELECT id, version, data FROM risk_policy_snapshots ORDER BY data->>'createdAt', id").fetchall()
+            items = []
+            for aggregate_id, version, data in rows:
+                self._remember("risk_policy", str(aggregate_id), int(version)); items.append(risk_policy_from_json(data))
+            return tuple(items)
+        return self._with_conn(read)
+
+    def get_active_risk_policy(self) -> TransferRiskPolicy | None:
+        policies = [p for p in self.list_risk_policies() if p.status is RiskPolicyStatus.ACTIVE]
+        return max(policies, key=lambda p: (p.activatedAt or p.createdAt, p.riskPolicyId)) if policies else None
 
     def find_report_by_source_key(self, source_key: str) -> SegmentStatusReport | None:
         def read(conn: Any) -> SegmentStatusReport | None:

--- a/services/transfer-management/src/transfer_management/api.py
+++ b/services/transfer-management/src/transfer_management/api.py
@@ -18,6 +18,7 @@ from .adapters.messaging import DISRUPTION_RECOVERY_STREAM, FULFILLMENT_STREAM
 from .adapters.storage.postgres import PostgresTransferManagementStore
 from .application.service import InMemoryStore, TransferManagementService
 from .downstream import DisruptionRecoveryClient, DownstreamError
+from .topology import PlaceNetworkClient
 from .runtime import health, profile
 from .web.errors import register_exception_handlers
 from .web.handlers import router as transfer_router
@@ -124,9 +125,11 @@ def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, o
         return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
 
 
-def configure_transfer_routes(app: FastAPI, store: Any | None = None, idempotency_store: IdempotencyStore | None = None, downstream: Any | None = None) -> None:
+def configure_transfer_routes(app: FastAPI, store: Any | None = None, idempotency_store: IdempotencyStore | None = None, downstream: Any | None = None, topology: Any | None = None) -> None:
     store = store or InMemoryStore()
-    service = TransferManagementService(store, downstream or DisruptionRecoveryClient())
+    if topology is None:
+        topology = PlaceNetworkClient("") if type(store) is InMemoryStore else PlaceNetworkClient()
+    service = TransferManagementService(store, downstream or DisruptionRecoveryClient(), topology)
     unit_of_work = getattr(store, "unit_of_work", None)
     if callable(unit_of_work):
         @app.middleware("http")
@@ -135,7 +138,7 @@ def configure_transfer_routes(app: FastAPI, store: Any | None = None, idempotenc
                 return await call_next(request)
     app.state.transfer_management_service = service
     app.state.transfer_management_store = store
-    configure_idempotency_middleware(app, idempotency_store or BoundedInMemoryIdempotencyStore(), require_key=True, include_path_prefixes=("/api/v1/transfer-plans", "/api/v1/connections", "/api/v1/segment-status-reports", "/api/v1/connection-contracts", "/api/v1/mct-rules"))
+    configure_idempotency_middleware(app, idempotency_store or BoundedInMemoryIdempotencyStore(), require_key=True, include_path_prefixes=("/api/v1/transfer-plans", "/api/v1/connections", "/api/v1/segment-status-reports", "/api/v1/connection-contracts", "/api/v1/mct-rules", "/api/v1/risk-policies"))
     for route in transfer_router.routes:
         app.router.routes.append(route)
 
@@ -170,7 +173,7 @@ def _postgres_store_from_env(app: FastAPI) -> tuple[Any, IdempotencyStore | None
     return store, PostgresIdempotencyStore(pool)
 
 
-def create_app(tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None, store: Any | None = None, idempotency_store: IdempotencyStore | None = None, downstream: Any | None = None) -> FastAPI:
+def create_app(tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None, store: Any | None = None, idempotency_store: IdempotencyStore | None = None, downstream: Any | None = None, topology: Any | None = None) -> FastAPI:
     app = FastAPI(title="Transfer Management", version="0.1.0")
     init_opentelemetry(profile()["service_id"], app=app)
     if store is None:
@@ -178,7 +181,7 @@ def create_app(tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | Non
         idempotency_store = idempotency_store or default_idempotency_store
     register_exception_handlers(app)
     configure_runtime_endpoints(app, tracer, otel_tracer or opentelemetry_tracer_from_env(profile()["service_id"]))
-    configure_transfer_routes(app, store, idempotency_store, downstream)
+    configure_transfer_routes(app, store, idempotency_store, downstream, topology)
     holder = getattr(app.state, "_tm_service_holder", None)
     if isinstance(holder, dict):
         holder["service"] = app.state.transfer_management_service

--- a/services/transfer-management/src/transfer_management/application/service.py
+++ b/services/transfer-management/src/transfer_management/application/service.py
@@ -503,10 +503,12 @@ class TransferManagementService:
         policy = self.store.get_risk_policy(policy_id)
         active = self._active_risk_policy()
         events: list[EventEnvelope] = []
+        # Validate the target BEFORE touching the currently active policy:
+        # a failed activation must not leave the system policy-less.
+        activated = policy.activate(at)
         if active and active.riskPolicyId != policy.riskPolicyId:
             retired = active.retire(at)
             self.store.save_risk_policy(retired)
-        activated = policy.activate(at)
         self.store.save_risk_policy(activated)
         if policy.status is not RiskPolicyStatus.ACTIVE:
             payload = activated.to_json() | {"activatedBy": actor.to_json(), "activatedAt": rfc3339_utc(at)}

--- a/services/transfer-management/src/transfer_management/application/service.py
+++ b/services/transfer-management/src/transfer_management/application/service.py
@@ -30,9 +30,12 @@ from transfer_management.domain import (
     ReportType,
     RiskEvaluation,
     RiskLevel,
+    RiskPolicyStatus,
+    RiskThresholds,
     SegmentStatusReport,
     TransferCategory,
     TransferPlan,
+    TransferRiskPolicy,
     TransferPlanStatus,
     now_utc,
     optional_dt,
@@ -40,6 +43,7 @@ from transfer_management.domain import (
     require_text,
 )
 from transfer_management.downstream import DisruptionRecoveryClient, DownstreamError
+from transfer_management.topology import PlaceNetworkClient, PlaceNetworkUnavailable, PlaceNetworkValidationError
 
 PRODUCER = "transfer-management"
 PROTECTED_TYPES = {ContractType.PROTECTED, ContractType.SUPPLIER_PROTECTED}
@@ -52,6 +56,10 @@ class NotFoundError(KeyError):
 
 
 PreconditionFailedError = PreconditionFailed
+
+
+class ValidationFailedError(ValueError):
+    pass
 
 
 def folded_uuid7(material: str) -> str:
@@ -78,6 +86,7 @@ class InMemoryStore:
         self.connections: dict[str, Connection] = {}
         self.contracts: dict[str, ConnectionContract] = {}
         self.mct_rules: dict[str, MctRule] = {}
+        self.risk_policies: dict[str, TransferRiskPolicy] = {}
         self.reports: dict[str, SegmentStatusReport] = {}
         self.processed_events: set[str] = set()
         self._outbox: list[EventEnvelope] = []
@@ -166,6 +175,24 @@ class InMemoryStore:
             items = filtered
         return tuple(sorted(items, key=lambda r: (r.mctRuleId, r.version)))
 
+    def save_risk_policy(self, policy: TransferRiskPolicy) -> None:
+        self.risk_policies[policy.riskPolicyId] = policy
+
+    def get_risk_policy(self, policy_id: str) -> TransferRiskPolicy:
+        try:
+            return self.risk_policies[policy_id]
+        except KeyError as exc:
+            raise NotFoundError(f"risk policy not found: {policy_id}") from exc
+
+    def list_risk_policies(self) -> tuple[TransferRiskPolicy, ...]:
+        return tuple(sorted(self.risk_policies.values(), key=lambda p: (p.createdAt, p.riskPolicyId)))
+
+    def get_active_risk_policy(self) -> TransferRiskPolicy | None:
+        active = [p for p in self.risk_policies.values() if p.status is RiskPolicyStatus.ACTIVE]
+        if not active:
+            return None
+        return max(active, key=lambda p: (p.activatedAt or p.createdAt, p.riskPolicyId))
+
     def find_report_by_source_key(self, source_key: str) -> SegmentStatusReport | None:
         return self.reports.get(source_key)
 
@@ -219,9 +246,10 @@ def segment_status_report_from_fulfillment_event(envelope: EventEnvelope) -> dic
     return data
 
 class TransferManagementService:
-    def __init__(self, store: Any, downstream: DisruptionRecoveryClient | None = None) -> None:
+    def __init__(self, store: Any, downstream: DisruptionRecoveryClient | None = None, topology: PlaceNetworkClient | None = None) -> None:
         self.store = store
         self.downstream = downstream or DisruptionRecoveryClient()
+        self.topology = topology or PlaceNetworkClient("")
 
     def transaction(self) -> Any:
         transaction = getattr(self.store, "transaction", None)
@@ -255,6 +283,8 @@ class TransferManagementService:
                 reasons.append("NO_PUBLISHED_MCT_RULE")
                 break
         plan = plan.evaluated(int(data.get("planningSnapshotVersion") or plan.planningSnapshotVersion), tuple(c.connectionId for c in connections), at, unserviceable)
+        active_policy = self._active_risk_policy()
+        plan = replace(plan, riskPolicyVersion=active_policy.version if active_policy else "builtin-v1")
         self.store.save_plan(plan)
         payload = {"transferPlanId": plan.transferPlanId, "itineraryRef": plan.itineraryRef, "planningSnapshotVersion": plan.planningSnapshotVersion, "status": plan.status.value, "evaluationVersion": plan.evaluationVersion, "connectionIds": list(plan.connections), "riskPolicyVersion": plan.riskPolicyVersion, "evaluatedAt": rfc3339_utc(at)} | ({"journeyOrderId": plan.journeyOrderId} if plan.journeyOrderId else {})
         if reasons:
@@ -285,17 +315,29 @@ class TransferManagementService:
     def register_connection(self, data: Mapping[str, Any], correlation_id: str, causation_id: str) -> dict[str, Any]:
         at = now_utc()
         plan = self.store.get_plan(require_text(data.get("transferPlanId"), "transferPlanId"))
-        rule = self._require_published_rule(NodeType(str(data.get("fromNodeType"))), NodeType(str(data.get("toNodeType"))), TransferCategory(str(data.get("transferCategory"))), at)
+        from_node_type = NodeType(str(data.get("fromNodeType")))
+        to_node_type = NodeType(str(data.get("toNodeType")))
+        from_node_ref = require_text(data.get("fromNodeRef"), "fromNodeRef")
+        to_node_ref = require_text(data.get("toNodeRef"), "toNodeRef")
+        degraded_reasons: tuple[str, ...] = ()
+        try:
+            topology = self.topology.validate_connection_nodes(from_node_ref, to_node_ref, from_node_type, to_node_type)
+        except PlaceNetworkValidationError as exc:
+            raise ValidationFailedError(str(exc)) from exc
+        except PlaceNetworkUnavailable:
+            topology = None
+            degraded_reasons = ("PLACE_NETWORK_UNAVAILABLE",)
+        rule = self._require_published_rule(from_node_type, to_node_type, TransferCategory(str(data.get("transferCategory"))), at)
         window_data = dict(data.get("window") or {})
         planned = parse_dt(window_data.get("plannedArrivalAt"), "window.plannedArrivalAt")
         departure = parse_dt(window_data.get("nextDepartureAt"), "window.nextDepartureAt")
         cutoff = parse_dt(window_data.get("nextCutoffAt") or window_data.get("nextDepartureAt"), "window.nextCutoffAt")
         window = ConnectionWindow.build(planned, departure, cutoff, int(window_data.get("mctMinutes") or rule.minimumMinutes), optional_dt(window_data.get("actualArrivalAt")))
-        evaluation = self._evaluate_window(window, rule, at, new_prefixed_uuid7("tre"), ())
+        evaluation = self._evaluate_window(window, rule, at, new_prefixed_uuid7("tre"), (), topology.placeGraphVersion if topology else None, degraded_reasons)
         contract_id = require_text(data.get("contractId"), "contractId")
         contract_type = ContractType(str(data.get("contractType")))
         status = ConnectionStatus.FEASIBLE if evaluation.riskLevel is RiskLevel.FEASIBLE else ConnectionStatus.TIGHT if evaluation.riskLevel is RiskLevel.TIGHT else ConnectionStatus.AT_RISK
-        connection = Connection(new_prefixed_uuid7("con"), plan.transferPlanId, require_text(data.get("itineraryRef"), "itineraryRef"), require_text(data.get("previousSegmentRef"), "previousSegmentRef"), require_text(data.get("nextSegmentRef"), "nextSegmentRef"), tuple(str(x) for x in data.get("travelerRefs") or []), require_text(data.get("fromNodeRef"), "fromNodeRef"), require_text(data.get("toNodeRef"), "toNodeRef"), NodeType(str(data.get("fromNodeType"))), NodeType(str(data.get("toNodeType"))), TransferCategory(str(data.get("transferCategory"))), contract_id, contract_type, ConnectionStatus.PLANNED, evaluation, window, at, at, str(data.get("journeyOrderId") or plan.journeyOrderId or "").strip() or None, serviceDate=str(data.get("serviceDate") or cutoff.date().isoformat()), scheduledServiceRef=str(data.get("scheduledServiceRef") or "").strip() or None)
+        connection = Connection(new_prefixed_uuid7("con"), plan.transferPlanId, require_text(data.get("itineraryRef"), "itineraryRef"), require_text(data.get("previousSegmentRef"), "previousSegmentRef"), require_text(data.get("nextSegmentRef"), "nextSegmentRef"), tuple(str(x) for x in data.get("travelerRefs") or []), from_node_ref, to_node_ref, from_node_type, to_node_type, TransferCategory(str(data.get("transferCategory"))), contract_id, contract_type, ConnectionStatus.PLANNED, evaluation, window, at, at, str(data.get("journeyOrderId") or plan.journeyOrderId or "").strip() or None, serviceDate=str(data.get("serviceDate") or cutoff.date().isoformat()), scheduledServiceRef=str(data.get("scheduledServiceRef") or "").strip() or None)
         connection = connection.transition(status, at)
         plan = plan.add_connection(connection.connectionId, at)
         self.store.save_plan(plan)
@@ -448,6 +490,35 @@ class TransferManagementService:
         offset = max(0, int(filters.get("offset") or 0))
         return {"items": [r.to_json() for r in items[offset:offset + limit]], "total": total, "limit": limit, "offset": offset}
 
+    def create_risk_policy(self, data: Mapping[str, Any], correlation_id: str, causation_id: str) -> dict[str, Any]:
+        at = now_utc()
+        thresholds = dict(data.get("thresholds") or {})
+        policy = TransferRiskPolicy(new_prefixed_uuid7("trp"), require_text(data.get("version"), "version"), RiskPolicyStatus.DRAFT, RiskThresholds(int(thresholds.get("tightMinutes") if thresholds.get("tightMinutes") is not None else 10), int(thresholds.get("atRiskMinutes") if thresholds.get("atRiskMinutes") is not None else 0)), ActorRef(**dict(data.get("createdBy") or {})), at)
+        self.store.save_risk_policy(policy)
+        return policy.to_json()
+
+    def activate_risk_policy(self, policy_id: str, data: Mapping[str, Any], correlation_id: str, causation_id: str) -> dict[str, Any]:
+        at = now_utc()
+        actor = ActorRef(**dict(data.get("activatedBy") or {}))
+        policy = self.store.get_risk_policy(policy_id)
+        active = self._active_risk_policy()
+        events: list[EventEnvelope] = []
+        if active and active.riskPolicyId != policy.riskPolicyId:
+            retired = active.retire(at)
+            self.store.save_risk_policy(retired)
+        activated = policy.activate(at)
+        self.store.save_risk_policy(activated)
+        if policy.status is not RiskPolicyStatus.ACTIVE:
+            payload = activated.to_json() | {"activatedBy": actor.to_json(), "activatedAt": rfc3339_utc(at)}
+            events.append(_envelope("RiskPolicyActivated", activated.riskPolicyId, 1, payload, correlation_id, causation_id, at))
+            self._append(events)
+        return activated.to_json()
+
+    def get_active_risk_policy(self) -> dict[str, Any]:
+        policy = self._active_risk_policy()
+        if policy is None:
+            return {"riskPolicyId": "builtin", "version": "builtin-v1", "status": "ACTIVE", "thresholds": {"tightMinutes": 10, "atRiskMinutes": 0}, "builtin": True}
+        return policy.to_json()
 
     def handle_fulfillment_event(self, envelope: EventEnvelope, stream: str | None = None) -> bool:
         if envelope.eventType not in FULFILLMENT_SEGMENT_EVENT_TYPES:
@@ -510,21 +581,21 @@ class TransferManagementService:
             raise DomainError("NO_PUBLISHED_MCT_RULE")
         return rule
 
-    def _evaluate_window(self, window: ConnectionWindow, rule: MctRule, at: datetime, evaluation_id: str, extra_reasons: Iterable[str]) -> RiskEvaluation:
-        reasons = list(extra_reasons)
-        if window.availableMinutes < 0 or "NEXT_SEGMENT_CANCELLED" in reasons or "PREVIOUS_SEGMENT_CANCELLED" in reasons:
-            level = RiskLevel.MISSED
-            if window.availableMinutes < 0:
-                reasons.append("CUTOFF_EXPIRED")
-        elif window.bufferMinutes < 0:
-            level = RiskLevel.AT_RISK
-            reasons.append("INSUFFICIENT_BUFFER")
-        elif window.bufferMinutes < 10:
-            level = RiskLevel.TIGHT
-            reasons.append("LOW_BUFFER")
-        else:
-            level = RiskLevel.FEASIBLE
-        return RiskEvaluation(evaluation_id, level, rule.mctRuleId, rule.version, window.availableMinutes, rule.minimumMinutes, tuple(dict.fromkeys(reasons)), at)
+    def _active_risk_policy(self) -> TransferRiskPolicy | None:
+        getter = getattr(self.store, "get_active_risk_policy", None)
+        if callable(getter):
+            return getter()
+        policies = list(getattr(self.store, "risk_policies", {}).values())
+        active = [policy for policy in policies if policy.status is RiskPolicyStatus.ACTIVE]
+        return max(active, key=lambda p: (p.activatedAt or p.createdAt, p.riskPolicyId)) if active else None
+
+    def _evaluate_window(self, window: ConnectionWindow, rule: MctRule, at: datetime, evaluation_id: str, extra_reasons: Iterable[str], place_graph_version: str | None = None, degraded_reasons: Iterable[str] = ()) -> RiskEvaluation:
+        policy = self._active_risk_policy()
+        if policy is None:
+            policy = TransferRiskPolicy("builtin", "builtin-v1", RiskPolicyStatus.ACTIVE, RiskThresholds(10, 0), ActorRef("SYSTEM", "transfer-management"), at, at)
+        level, reasons = policy.classify(window.availableMinutes, window.bufferMinutes, tuple(extra_reasons))
+        degraded = tuple(dict.fromkeys(degraded_reasons))
+        return RiskEvaluation(evaluation_id, level, rule.mctRuleId, rule.version, window.availableMinutes, rule.minimumMinutes, reasons, at, policy.version, place_graph_version, bool(degraded), degraded)
 
     def _refresh_connection(self, connection: Connection, at: datetime, correlation_id: str, causation_id: str, report: SegmentStatusReport | None) -> tuple[Connection, list[EventEnvelope]]:
         previous_status = connection.status
@@ -542,11 +613,19 @@ class TransferManagementService:
             elif report.segmentRef == connection.nextSegmentRef and report.reportType is ReportType.CANCELLED:
                 reasons.append("NEXT_SEGMENT_CANCELLED")
         rule = self._require_published_rule(connection.fromNodeType, connection.toNodeType, connection.transferCategory, at)
-        evaluation = self._evaluate_window(window, rule, at, new_prefixed_uuid7("tre"), reasons)
+        place_graph_version = connection.latestEvaluation.placeGraphVersion
+        degraded_reasons: tuple[str, ...] = ()
+        try:
+            topology = self.topology.fetch_snapshot(connection.fromNodeRef, connection.toNodeRef)
+            if topology is not None:
+                place_graph_version = topology.placeGraphVersion
+        except (PlaceNetworkUnavailable, PlaceNetworkValidationError):
+            degraded_reasons = ("PLACE_NETWORK_UNAVAILABLE",)
+        evaluation = self._evaluate_window(window, rule, at, new_prefixed_uuid7("tre"), reasons, place_graph_version, degraded_reasons)
         updated = connection.apply_evaluation(evaluation, window, at)
         events = [self._risk_event(updated, previous_status if previous_status != updated.status else None, correlation_id, causation_id, at, report.segmentStatusReportId if report else None)]
         if updated.status is ConnectionStatus.AT_RISK and previous_status != ConnectionStatus.AT_RISK:
-            events.append(_envelope("TransferAtRisk", updated.connectionId, updated.version + 2, {"connection": updated.ref_json(), "previousStatus": previous_status.value, "status": "AT_RISK", "riskLevel": "AT_RISK", "riskPolicyVersion": "builtin-v1", "reasons": list(evaluation.reasons), "window": updated.window.to_json(), "detectedAt": rfc3339_utc(at)}, correlation_id, causation_id, at))
+            events.append(_envelope("TransferAtRisk", updated.connectionId, updated.version + 2, {"connection": updated.ref_json(), "previousStatus": previous_status.value, "status": "AT_RISK", "riskLevel": "AT_RISK", "riskPolicyVersion": evaluation.riskPolicyVersion, "reasons": list(evaluation.reasons), "window": updated.window.to_json(), "detectedAt": rfc3339_utc(at)}, correlation_id, causation_id, at))
         if updated.status is ConnectionStatus.MISSED and previous_status != ConnectionStatus.MISSED:
             cause = "OPS_DECLARED"
             if "PREVIOUS_SEGMENT_CANCELLED" in evaluation.reasons:

--- a/services/transfer-management/src/transfer_management/domain.py
+++ b/services/transfer-management/src/transfer_management/domain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 
 from train_ticket_platform.events import rfc3339_utc
 
@@ -100,6 +100,11 @@ class MctRuleStatus(StrEnum):
     PUBLISHED = "PUBLISHED"
     RETIRED = "RETIRED"
 
+class RiskPolicyStatus(StrEnum):
+    DRAFT = "DRAFT"
+    ACTIVE = "ACTIVE"
+    RETIRED = "RETIRED"
+
 
 class RecoveryTriggerStatus(StrEnum):
     NOT_REQUIRED = "NOT_REQUIRED"
@@ -118,7 +123,7 @@ TRANSFER_PLAN_TRANSITIONS = {
     TransferPlanStatus.EXPIRED: set(),
 }
 CONNECTION_TRANSITIONS = {
-    ConnectionStatus.PLANNED: {ConnectionStatus.FEASIBLE, ConnectionStatus.TIGHT, ConnectionStatus.INVALIDATED},
+    ConnectionStatus.PLANNED: {ConnectionStatus.FEASIBLE, ConnectionStatus.TIGHT, ConnectionStatus.AT_RISK, ConnectionStatus.INVALIDATED},
     ConnectionStatus.FEASIBLE: {ConnectionStatus.TIGHT, ConnectionStatus.AT_RISK, ConnectionStatus.COMPLETED, ConnectionStatus.INVALIDATED},
     ConnectionStatus.TIGHT: {ConnectionStatus.FEASIBLE, ConnectionStatus.AT_RISK, ConnectionStatus.MISSED, ConnectionStatus.COMPLETED},
     ConnectionStatus.AT_RISK: {ConnectionStatus.TIGHT, ConnectionStatus.MISSED, ConnectionStatus.RECOVERED},
@@ -224,9 +229,12 @@ class RiskEvaluation:
     reasons: tuple[str, ...]
     evaluatedAt: datetime
     riskPolicyVersion: str = RISK_POLICY_VERSION
+    placeGraphVersion: str | None = None
+    degraded: bool = False
+    degradedReasons: tuple[str, ...] = ()
 
     def to_json(self) -> dict[str, Any]:
-        return {
+        data = {
             "riskEvaluationId": self.riskEvaluationId,
             "riskLevel": self.riskLevel.value,
             "riskPolicyVersion": self.riskPolicyVersion,
@@ -237,6 +245,12 @@ class RiskEvaluation:
             "reasons": list(self.reasons),
             "evaluatedAt": rfc3339_utc(self.evaluatedAt),
         }
+        if self.placeGraphVersion:
+            data["placeGraphVersion"] = self.placeGraphVersion
+        if self.degraded:
+            data["degraded"] = True
+            data["degradedReasons"] = list(self.degradedReasons)
+        return data
 
 
 @dataclass(frozen=True, slots=True)
@@ -535,4 +549,64 @@ class SegmentStatusReport:
             data["cancelledAt"] = rfc3339_utc(self.cancelledAt)
         if self.reason:
             data["reason"] = self.reason
+        return data
+
+
+@dataclass(frozen=True, slots=True)
+class RiskThresholds:
+    tightMinutes: int
+    atRiskMinutes: int
+
+    def __post_init__(self) -> None:
+        if self.tightMinutes < 0 or self.atRiskMinutes < 0:
+            raise DomainError("risk policy thresholds must be non-negative")
+
+    def to_json(self) -> dict[str, int]:
+        return {"tightMinutes": self.tightMinutes, "atRiskMinutes": self.atRiskMinutes}
+
+
+@dataclass(frozen=True, slots=True)
+class TransferRiskPolicy:
+    riskPolicyId: str
+    version: str
+    status: RiskPolicyStatus
+    thresholds: RiskThresholds
+    createdBy: ActorRef
+    createdAt: datetime
+    activatedAt: datetime | None = None
+    retiredAt: datetime | None = None
+
+    def activate(self, at: datetime) -> "TransferRiskPolicy":
+        if self.status is RiskPolicyStatus.RETIRED:
+            raise PreconditionFailed("retired risk policy cannot be activated")
+        if self.status is RiskPolicyStatus.ACTIVE:
+            return self
+        return replace(self, status=RiskPolicyStatus.ACTIVE, activatedAt=at)
+
+    def retire(self, at: datetime) -> "TransferRiskPolicy":
+        if self.status is RiskPolicyStatus.RETIRED:
+            return self
+        return replace(self, status=RiskPolicyStatus.RETIRED, retiredAt=at)
+
+    def classify(self, available_minutes: int, buffer_minutes: int, reasons: Iterable[str]) -> tuple[RiskLevel, tuple[str, ...]]:
+        explanation = list(reasons)
+        if "NEXT_SEGMENT_CANCELLED" in explanation or "PREVIOUS_SEGMENT_CANCELLED" in explanation:
+            return RiskLevel.MISSED, tuple(dict.fromkeys(explanation))
+        if available_minutes < 0:
+            explanation.append("CUTOFF_EXPIRED")
+            return RiskLevel.MISSED, tuple(dict.fromkeys(explanation))
+        if buffer_minutes < self.thresholds.atRiskMinutes:
+            explanation.append(f"THRESHOLD_AT_RISK_BUFFER_LT_{self.thresholds.atRiskMinutes}_MIN")
+            return RiskLevel.AT_RISK, tuple(dict.fromkeys(explanation))
+        if buffer_minutes < self.thresholds.tightMinutes:
+            explanation.append(f"THRESHOLD_TIGHT_BUFFER_LT_{self.thresholds.tightMinutes}_MIN")
+            return RiskLevel.TIGHT, tuple(dict.fromkeys(explanation))
+        return RiskLevel.FEASIBLE, tuple(dict.fromkeys(explanation))
+
+    def to_json(self) -> dict[str, Any]:
+        data = {"riskPolicyId": self.riskPolicyId, "version": self.version, "status": self.status.value, "thresholds": self.thresholds.to_json(), "createdBy": self.createdBy.to_json(), "createdAt": rfc3339_utc(self.createdAt)}
+        if self.activatedAt:
+            data["activatedAt"] = rfc3339_utc(self.activatedAt)
+        if self.retiredAt:
+            data["retiredAt"] = rfc3339_utc(self.retiredAt)
         return data

--- a/services/transfer-management/src/transfer_management/topology.py
+++ b/services/transfer-management/src/transfer_management/topology.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Any, Mapping
+
+import httpx
+
+from transfer_management.domain import NodeType
+
+
+class PlaceNetworkUnavailable(RuntimeError):
+    pass
+
+
+class PlaceNetworkValidationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class TopologyNode:
+    nodeId: str
+    placeId: str
+    placeType: str | None
+    createdAt: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class TopologySnapshot:
+    fromNode: TopologyNode
+    toNode: TopologyNode
+
+    @property
+    def placeGraphVersion(self) -> str:
+        from_version = self.fromNode.createdAt or "unversioned"
+        to_version = self.toNode.createdAt or "unversioned"
+        return f"place-network:{self.fromNode.nodeId}@{from_version}:{self.toNode.nodeId}@{to_version}"
+
+
+class PlaceNetworkClient:
+    def __init__(self, base_url: str | None = None, timeout: float = 2.0, retries: int = 1) -> None:
+        if base_url is None:
+            base_url = os.getenv("PLACE_NETWORK_URL")
+        self.base_url = ("http://place-network:8080" if base_url is None else base_url).rstrip("/")
+        self.timeout = timeout
+        self.retries = max(0, retries)
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.base_url)
+
+    def fetch_snapshot(self, from_node_ref: str, to_node_ref: str) -> TopologySnapshot | None:
+        if not self.enabled:
+            return None
+        return TopologySnapshot(self._get_node(from_node_ref), self._get_node(to_node_ref))
+
+    def validate_connection_nodes(self, from_node_ref: str, to_node_ref: str, from_node_type: NodeType, to_node_type: NodeType) -> TopologySnapshot | None:
+        snapshot = self.fetch_snapshot(from_node_ref, to_node_ref)
+        if snapshot is None:
+            return None
+        self._validate_node_type(snapshot.fromNode, from_node_type, "fromNodeType")
+        self._validate_node_type(snapshot.toNode, to_node_type, "toNodeType")
+        return snapshot
+
+    def _get_json(self, path: str) -> Mapping[str, Any]:
+        last_error: Exception | None = None
+        for _ in range(self.retries + 1):
+            try:
+                with httpx.Client(timeout=self.timeout) as client:
+                    response = client.get(f"{self.base_url}{path}", headers={"Accept": "application/json"})
+                if response.status_code == 404:
+                    raise PlaceNetworkValidationError(f"place-network resource not found: {path}")
+                if response.status_code >= 500:
+                    raise PlaceNetworkUnavailable(f"place-network returned {response.status_code}")
+                if response.status_code >= 400:
+                    raise PlaceNetworkValidationError(f"place-network rejected lookup {response.status_code}")
+                payload = response.json()
+                if not isinstance(payload, Mapping):
+                    raise PlaceNetworkUnavailable("place-network returned invalid body")
+                return payload
+            except PlaceNetworkValidationError:
+                raise
+            except (httpx.HTTPError, ValueError) as exc:
+                last_error = exc
+        raise PlaceNetworkUnavailable(str(last_error) if last_error else "place-network unavailable")
+
+    def _get_node(self, node_ref: str) -> TopologyNode:
+        node = self._get_json(f"/api/v1/transport-nodes/{node_ref}")
+        node_id = str(node.get("nodeId") or "")
+        place_id = str(node.get("placeId") or "")
+        if not node_id or not place_id:
+            raise PlaceNetworkUnavailable("place-network node response missing nodeId or placeId")
+        place = self._get_json(f"/api/v1/places/{place_id}")
+        place_type = str(place.get("placeType") or "") or None
+        return TopologyNode(node_id, place_id, place_type, str(node.get("createdAt") or "") or None)
+
+    def _validate_node_type(self, node: TopologyNode, expected: NodeType, field_name: str) -> None:
+        if node.placeType is None:
+            return
+        allowed = {
+            NodeType.STATION: {"STATION"},
+            NodeType.AIRPORT_TERMINAL: {"AIRPORT"},
+            NodeType.PORT_TERMINAL: {"PORT"},
+        }.get(expected)
+        if allowed is not None and node.placeType not in allowed:
+            raise PlaceNetworkValidationError(f"{field_name} does not match place-network placeType {node.placeType}")

--- a/services/transfer-management/src/transfer_management/web/errors.py
+++ b/services/transfer-management/src/transfer_management/web/errors.py
@@ -7,7 +7,7 @@ from fastapi.responses import JSONResponse
 
 from train_ticket_platform.http import error_response, register_exception_handlers as register_base
 
-from transfer_management.application.service import NotFoundError, PreconditionFailedError
+from transfer_management.application.service import NotFoundError, PreconditionFailedError, ValidationFailedError
 from transfer_management.domain import DomainError, PreconditionFailed
 from transfer_management.downstream import DownstreamError
 
@@ -18,6 +18,10 @@ def register_exception_handlers(app: FastAPI) -> None:
     @app.exception_handler(NotFoundError)
     async def not_found(request: Request, exc: NotFoundError) -> JSONResponse:
         return error_response(request, "NOT_FOUND", str(exc), 404)
+
+    @app.exception_handler(ValidationFailedError)
+    async def validation_failed(request: Request, exc: ValidationFailedError) -> JSONResponse:
+        return error_response(request, "VALIDATION_FAILED", str(exc), 422)
 
     @app.exception_handler(PreconditionFailed)
     @app.exception_handler(PreconditionFailedError)

--- a/services/transfer-management/src/transfer_management/web/handlers.py
+++ b/services/transfer-management/src/transfer_management/web/handlers.py
@@ -107,6 +107,17 @@ class RetireRuleRequest(LooseModel):
     retiredAt: str | None = None
 
 
+class RiskPolicyRequest(LooseModel):
+    version: str
+    thresholds: dict[str, Any]
+    createdBy: dict[str, Any]
+
+
+class ActivateRiskPolicyRequest(LooseModel):
+    activatedBy: dict[str, Any]
+    activateReason: str | None = None
+
+
 def _service(request: Request) -> TransferManagementService:
     return request.app.state.transfer_management_service
 
@@ -208,3 +219,18 @@ def retire_mct_rule(rule_id: str, body: RetireRuleRequest, request: Request) -> 
 @router.get("/mct-rules")
 def list_mct_rules(request: Request, fromNodeType: str | None = None, toNodeType: str | None = None, transferCategory: str | None = None, status: str | None = None, limit: int = 20, offset: int = 0) -> dict[str, Any]:
     return _service(request).list_mct_rules({"fromNodeType": fromNodeType, "toNodeType": toNodeType, "transferCategory": transferCategory, "status": status, "limit": limit, "offset": offset})
+
+
+@router.post("/risk-policies", status_code=201)
+def create_risk_policy(body: RiskPolicyRequest, request: Request) -> dict[str, Any]:
+    return _service(request).create_risk_policy(body.model_dump(exclude_none=True), _corr(request), _cause(request))
+
+
+@router.post("/risk-policies/{policy_id}/activate")
+def activate_risk_policy(policy_id: str, body: ActivateRiskPolicyRequest, request: Request) -> dict[str, Any]:
+    return _service(request).activate_risk_policy(policy_id, body.model_dump(exclude_none=True), _corr(request), _cause(request))
+
+
+@router.get("/risk-policies/active")
+def get_active_risk_policy(request: Request) -> dict[str, Any]:
+    return _service(request).get_active_risk_policy()

--- a/services/transfer-management/tests/test_api.py
+++ b/services/transfer-management/tests/test_api.py
@@ -297,3 +297,19 @@ def test_missing_place_network_node_registration_returns_validation_failed() -> 
     res = client.post("/api/v1/connections", headers={"Idempotency-Key": idem()}, json={"transferPlanId": plan.json()["transferPlanId"], "itineraryRef": "iti-missing-node", "journeyOrderId": "jo-missing-node", "previousSegmentRef": "seg-a", "nextSegmentRef": "seg-b", "travelerRefs": ["trav-1"], "fromNodeRef": "missing", "toNodeRef": "sta", "fromNodeType": "STATION", "toNodeType": "STATION", "transferCategory": "SAME_STATION", "contractId": "cct-missing", "contractType": "SELF_TRANSFER", "window": {"plannedArrivalAt": rfc3339_utc(now), "nextDepartureAt": rfc3339_utc(now + timedelta(minutes=60)), "nextCutoffAt": rfc3339_utc(now + timedelta(minutes=50))}})
     assert res.status_code == 422, res.text
     assert res.json()["code"] == "VALIDATION_FAILED"
+
+
+def test_failed_activation_does_not_retire_the_active_policy() -> None:
+    client, store, _ = setup_client()
+    def make(version):
+        res = client.post("/api/v1/risk-policies", headers={"Idempotency-Key": idem()}, json={"version": version, "thresholds": {"tightMinutes": 15, "atRiskMinutes": 5}, "createdBy": {"actorType": "OPERATIONS", "actorId": "ops"}})
+        assert res.status_code == 201, res.text
+        return res.json()["riskPolicyId"]
+    p1, p2 = make("v1"), make("v2")
+    for pid in (p1, p2):
+        res = client.post(f"/api/v1/risk-policies/{pid}/activate", headers={"Idempotency-Key": idem()}, json={"activatedBy": {"actorType": "OPERATIONS", "actorId": "ops"}})
+        assert res.status_code == 200, res.text
+    res = client.post(f"/api/v1/risk-policies/{p1}/activate", headers={"Idempotency-Key": idem()}, json={"activatedBy": {"actorType": "OPERATIONS", "actorId": "ops"}})
+    assert res.status_code == 412, res.text
+    res = client.get("/api/v1/risk-policies/active")
+    assert res.json()["riskPolicyId"] == p2, res.text

--- a/services/transfer-management/tests/test_api.py
+++ b/services/transfer-management/tests/test_api.py
@@ -17,6 +17,32 @@ def idem() -> str:
     return new_uuid7()
 
 
+class FakeTopology:
+    def __init__(self, place_graph_version: str = "place-network:test-v1", fail: bool = False, missing: bool = False) -> None:
+        self.place_graph_version = place_graph_version
+        self.fail = fail
+        self.missing = missing
+
+    @property
+    def enabled(self):
+        return True
+
+    def validate_connection_nodes(self, from_node_ref, to_node_ref, from_node_type, to_node_type):
+        if self.missing:
+            from transfer_management.topology import PlaceNetworkValidationError
+            raise PlaceNetworkValidationError("place-network resource not found: /api/v1/transport-nodes/missing")
+        if self.fail:
+            from transfer_management.topology import PlaceNetworkUnavailable
+            raise PlaceNetworkUnavailable("boom")
+        return type("Snapshot", (), {"placeGraphVersion": self.place_graph_version})()
+
+    def fetch_snapshot(self, from_node_ref, to_node_ref):
+        if self.fail:
+            from transfer_management.topology import PlaceNetworkUnavailable
+            raise PlaceNetworkUnavailable("boom")
+        return type("Snapshot", (), {"placeGraphVersion": self.place_graph_version})()
+
+
 class FakeDownstream:
     def __init__(self, failures: int = 0) -> None:
         self.calls = []
@@ -35,10 +61,10 @@ class FakeDownstream:
         return {"disruption": {"disruptionId": "drp-1"}, "incident": {"incidentId": "inc-1"}, "recoveryCases": [{"caseId": "rcv-1"}]}
 
 
-def setup_client(downstream: FakeDownstream | None = None) -> tuple[TestClient, InMemoryStore, FakeDownstream]:
+def setup_client(downstream: FakeDownstream | None = None, topology=None) -> tuple[TestClient, InMemoryStore, FakeDownstream]:
     store = InMemoryStore()
     downstream = downstream or FakeDownstream()
-    return TestClient(create_app(store=store, downstream=downstream), raise_server_exceptions=False), store, downstream
+    return TestClient(create_app(store=store, downstream=downstream, topology=topology), raise_server_exceptions=False), store, downstream
 
 
 def create_rule(client: TestClient) -> str:
@@ -218,3 +244,56 @@ def test_fulfillment_segment_delayed_event_marks_connection_at_risk() -> None:
     updated = service.get_connection(connection["connectionId"])
     assert updated["status"] == "AT_RISK"
     assert store.mark_processed(envelope.eventId, "events:fulfillment") is False
+
+
+def test_topology_degradation_path_marks_evaluation_degraded() -> None:
+    client, _, _ = setup_client(topology=FakeTopology(fail=True))
+    con = create_plan_and_connection(client, "SELF_TRANSFER")
+    now = datetime.now(UTC).replace(microsecond=0)
+    res = client.post("/api/v1/segment-status-reports", headers={"Idempotency-Key": idem()}, json={"segmentRef": "seg-a", "reportType": "DELAY", "reportedBy": {"actorType": "SYSTEM", "actorId": "sys"}, "sourceSystem": "OPERATIONS", "sourceRecordId": "r-topo", "observedAt": rfc3339_utc(now), "estimatedArrivalAt": rfc3339_utc(now + timedelta(minutes=35))})
+    assert res.status_code == 202, res.text
+    evaluation = res.json()["updatedConnections"][0]["latestEvaluation"]
+    assert evaluation["degraded"] is True
+    assert evaluation["degradedReasons"] == ["PLACE_NETWORK_UNAVAILABLE"]
+
+
+def test_topology_place_graph_version_is_recorded() -> None:
+    client, _, _ = setup_client(topology=FakeTopology("place-network:test-v2"))
+    con = create_plan_and_connection(client, "SELF_TRANSFER")
+    evaluation = con["latestEvaluation"]
+    assert evaluation["placeGraphVersion"] == "place-network:test-v2"
+
+
+def test_active_risk_policy_version_drives_evaluation() -> None:
+    client, _, _ = setup_client()
+    res = client.post("/api/v1/risk-policies", headers={"Idempotency-Key": idem()}, json={"version": "ops-aggressive-v1", "thresholds": {"tightMinutes": 999, "atRiskMinutes": 120}, "createdBy": {"actorType": "OPERATIONS", "actorId": "ops"}})
+    assert res.status_code == 201, res.text
+    policy_id = res.json()["riskPolicyId"]
+    res = client.post(f"/api/v1/risk-policies/{policy_id}/activate", headers={"Idempotency-Key": idem()}, json={"activatedBy": {"actorType": "OPERATIONS", "actorId": "ops"}})
+    assert res.status_code == 200, res.text
+    con = create_plan_and_connection(client, "SELF_TRANSFER")
+    assert con["status"] == "AT_RISK"
+    assert con["latestEvaluation"]["riskPolicyVersion"] == "ops-aggressive-v1"
+    assert any(reason == "THRESHOLD_AT_RISK_BUFFER_LT_120_MIN" for reason in con["latestEvaluation"]["reasons"])
+
+
+def test_risk_policy_activation_retires_previous_active_and_active_is_immutable() -> None:
+    client, store, _ = setup_client()
+    first = client.post("/api/v1/risk-policies", headers={"Idempotency-Key": idem()}, json={"version": "ops-v1", "thresholds": {"tightMinutes": 10, "atRiskMinutes": 0}, "createdBy": {"actorType": "OPERATIONS", "actorId": "ops"}}).json()
+    second = client.post("/api/v1/risk-policies", headers={"Idempotency-Key": idem()}, json={"version": "ops-v2", "thresholds": {"tightMinutes": 15, "atRiskMinutes": 5}, "createdBy": {"actorType": "OPERATIONS", "actorId": "ops"}}).json()
+    assert client.post(f"/api/v1/risk-policies/{first['riskPolicyId']}/activate", headers={"Idempotency-Key": idem()}, json={"activatedBy": {"actorType": "OPERATIONS", "actorId": "ops"}}).status_code == 200
+    assert client.post(f"/api/v1/risk-policies/{second['riskPolicyId']}/activate", headers={"Idempotency-Key": idem()}, json={"activatedBy": {"actorType": "OPERATIONS", "actorId": "ops"}}).status_code == 200
+    assert store.get_risk_policy(first["riskPolicyId"]).status.value == "RETIRED"
+    assert client.get("/api/v1/risk-policies/active").json()["version"] == "ops-v2"
+    assert client.post(f"/api/v1/risk-policies/{first['riskPolicyId']}/activate", headers={"Idempotency-Key": idem()}, json={"activatedBy": {"actorType": "OPERATIONS", "actorId": "ops"}}).status_code == 412
+
+
+def test_missing_place_network_node_registration_returns_validation_failed() -> None:
+    client, _, _ = setup_client(topology=FakeTopology(missing=True))
+    create_rule(client)
+    plan = client.post("/api/v1/transfer-plans", headers={"Idempotency-Key": idem()}, json={"itineraryRef": "iti-missing-node", "planningSnapshotVersion": 1, "travelerRefs": ["trav-1"], "journeyOrderId": "jo-missing-node"})
+    assert plan.status_code == 201, plan.text
+    now = datetime.now(UTC).replace(microsecond=0)
+    res = client.post("/api/v1/connections", headers={"Idempotency-Key": idem()}, json={"transferPlanId": plan.json()["transferPlanId"], "itineraryRef": "iti-missing-node", "journeyOrderId": "jo-missing-node", "previousSegmentRef": "seg-a", "nextSegmentRef": "seg-b", "travelerRefs": ["trav-1"], "fromNodeRef": "missing", "toNodeRef": "sta", "fromNodeType": "STATION", "toNodeType": "STATION", "transferCategory": "SAME_STATION", "contractId": "cct-missing", "contractType": "SELF_TRANSFER", "window": {"plannedArrivalAt": rfc3339_utc(now), "nextDepartureAt": rfc3339_utc(now + timedelta(minutes=60)), "nextCutoffAt": rfc3339_utc(now + timedelta(minutes=50))}})
+    assert res.status_code == 422, res.text
+    assert res.json()["code"] == "VALIDATION_FAILED"


### PR DESCRIPTION
## Summary
- add Place Network topology read adapter for transfer evaluations with placeGraphVersion/degraded metadata
- activate TransferRiskPolicy create/activate/current endpoints and wire active policy versions into risk evaluation
- update transfer-management contracts, storage migration, k8s env, and e2e transfer flow

## Validation
- services/transfer-management: uv run pytest -q tests
- make check