### PR TITLE
docs: add seat assignment contracts

### DIFF
--- a/docs/08-contracts/README.md
+++ b/docs/08-contracts/README.md
@@ -37,6 +37,7 @@ docs/08-contracts/
     ├── waitlist.md
     ├── dispatch.md
     ├── wallet-promotion.md
+    ├── seat-assignment.md
     └── finance-settlement-events.md
 ```
 

--- a/docs/08-contracts/api/README.md
+++ b/docs/08-contracts/api/README.md
@@ -154,6 +154,7 @@ correlation IDs.
 | 25 | `wallet-promotion.md` | Wallet / Promotion | activation wave in progress |
 | 26 | `disruption-recovery.md` | Disruption Recovery | activation wave in progress |
 | 27 | `ancillary-service.md` | Ancillary Service | activation wave in progress |
+| 28 | `seat-assignment.md` | Seat Assignment | activation wave in progress (ADR-0003 wave A) |
 
 ## Open Issues
 

--- a/docs/08-contracts/api/entitlement-ticketing.md
+++ b/docs/08-contracts/api/entitlement-ticketing.md
@@ -1,6 +1,6 @@
 # Entitlement & Ticketing — HTTP API
 
-Last updated: 2026-07-05
+Last updated: 2026-07-09
 
 ## Overview
 
@@ -27,6 +27,7 @@ timestamps, and Money.
 | `travelerRef` | string | yes | Traveler reference (`tvl-<uuid>`). |
 | `segmentRef` | string | yes | Segment reference (`seg-<uuid>`). |
 | `issuePurpose` | string | yes | Purpose: `INITIAL`, `REPLACEMENT`, `MANUAL_RECOVERY`, `PROVIDER_REBUILD`, `DISRUPTION_REPLACEMENT` |
+| `seatPreferences` | object | no | Seat Assignment preferences. Needs same-wave implementation with `docs/08-contracts/api/seat-assignment.md` `SeatPreferences`; validate `acceptStanding`, `adjacencyPreference`, `preferredSeatPositions`, `preferredBerthPositions`, `sameCompartment`, `avoidSeatUnitRefs`, and `preferenceVersion`. |
 
 **Response (201):**
 
@@ -39,6 +40,7 @@ timestamps, and Money.
 | `credentialType` | string | Type: `E_TICKET`, `PAPER_TICKET`, `PICKUP_CODE`, `BOARDING_PASS`, `FERRY_TICKET`, `COACH_E_TICKET`, `RIDE_CODE` |
 | `status` | enum | `ISSUED`, `VOIDED`, `BOARDED`, `NO_SHOW`, `SUSPENDED`. RULING (2026-07-06): there is no `USED` status — `FulfillmentCompleted` leaves the ticket `BOARDED`; `BOARDED`, `NO_SHOW`, and `VOIDED` are terminal. |
 | `issuedAt` | timestamp | Issue timestamp. |
+| `seatRef` | object | no | Seat Assignment credential display fact. Needs same-wave implementation with `docs/08-contracts/api/seat-assignment.md` `SeatRef`; required for train/seat-assigned issuance paths, including `allocationType=STANDING` success. |
 
 **Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `PRECONDITION_FAILED`, `CONFLICT`, `DOMAIN_RULE_VIOLATION`
 
@@ -81,6 +83,22 @@ timestamps, and Money.
 **Query parameters:** `journeyOrderId` (required), `limit`, `offset`
 
 **Response (200):** Paginated response.
+
+
+### Seat Assignment increment — needs same-wave implementation
+
+ADR-0003 wave A adds Seat Assignment to the issuance path. This API contract
+increment is **not docs-only**: the Entitlement & Ticketing implementation must be
+updated in the same wave.
+
+| Touchpoint | Required implementation change |
+|---|---|
+| Issue request DTO / deserializer | Accept optional `seatPreferences` using the shape from `docs/08-contracts/api/seat-assignment.md`. |
+| Issue command validator | Validate `acceptStanding`, adjacency, seat position, berth position, and degradation enums as SCREAMING_SNAKE_CASE. |
+| Ticket issuance application service | Before committing a credential, call Seat Assignment `POST /api/v1/internal/seat-allocations` with a persisted UUID-v7 `Idempotency-Key` folded from `segmentBookingId`, `travelerRef`, `capacityHoldId`, normalized `seatPreferences`, and `issuePurpose`. |
+| Credential value object / persistence | Persist and expose `seatRef` exactly as Seat Assignment `SeatRef`; `STANDING` is a valid issued credential display fact. |
+| Event/outbox schema | Add `seatRef` and `seatAllocationId` to `EntitlementIssued` as documented in `docs/08-contracts/events/entitlement-ticketing.md`. |
+| Tests | Add enum/validation coverage for `allocationType`, `berthPosition`, `seatPosition`, `adjacencyPreference`, and `degradationReason`. |
 
 ## Bus-only commands
 

--- a/docs/08-contracts/api/seat-assignment.md
+++ b/docs/08-contracts/api/seat-assignment.md
@@ -1,0 +1,449 @@
+# Seat Assignment — HTTP API
+
+Last updated: 2026-07-09
+
+## Overview
+
+Seat Assignment owns versioned seat/berth maps and the concrete assignment of a
+traveler to a `SeatUnit` or to the successful `STANDING` no-seat semantic. It does
+not own Capacity & Availability counts, holds, payment, booking saga state, or
+Entitlement credential issuance.
+
+Activation-wave rulings:
+
+- **RULING (ADR-0003 wave A): SeatMap is operations CRUD.** Operators create and
+  maintain SeatMaps by submitting deterministic SIM composition seed data. Seat
+  Assignment does not consume a real railway seat-map network and does not infer
+  SeatMaps from legacy random seat assignment.
+- **RULING (ADR-0003 wave A): allocation is called from Entitlement & Ticketing.**
+  Entitlement & Ticketing performs an outbound internal HTTP call to Seat
+  Assignment in the ticket-issuance path before it commits the credential. The
+  same wave must implement the Entitlement contract additions documented in
+  `docs/08-contracts/api/entitlement-ticketing.md`: issue requests may carry
+  `seatPreferences`, and issued credentials carry `seatRef`.
+- `STANDING` is a successful allocation result. It never creates a virtual
+  `SeatUnit`, does not consume adjacency capacity, and must not be displayed as
+  "seat pending".
+- Adjacent seats/berths are best effort. Seat Assignment may downgrade adjacency
+  while still returning a successful allocation, but it must publish the downgrade
+  fact in `AdjacentAllocationSolved` / `AdjacencyDegradationAccepted`.
+- Capacity release remains owned by Capacity & Availability. Seat Assignment
+  consumes `CapacityReleased` and `CapacityHoldExpired` events to recover concrete
+  seat assignments for the matching `holdId`; it does not replace `ReleaseHold`.
+
+Field shapes reference `docs/08-contracts/shared-primitives.md` for IDs,
+timestamps, event envelope fields, and pagination conventions. All JSON fields are
+camelCase, enum values are SCREAMING_SNAKE_CASE, and timestamps are RFC3339 UTC.
+Money is not used in this contract.
+
+## Identity, idempotency, and tracing
+
+State-changing HTTP endpoints require an `Idempotency-Key` header whose value is a
+UUID-v7-shaped string. API-triggered commands use the header value directly as the
+command key and fold it into a command id `cmd-<uuid-v7>` for events and outbound
+trace wiring. `X-Correlation-Id`, when supplied, is folded/validated as
+`corr-<uuid-v7>`; otherwise Seat Assignment generates a new `corr-<uuid-v7>`.
+
+Internal event-driven and service-originated commands do not put domain material
+on the wire. The application canonicalizes the material listed below, hashes it
+with SHA-256, stamps UUID version 7 and RFC-4122 variant bits, persists the
+resulting UUID-v7-shaped key, and reuses it on retry.
+
+| Command source | Wire key behavior | Material folded when Seat Assignment originates or consumes internally |
+|---|---|---|
+| Operator `POST /api/v1/seat-maps` | Use `Idempotency-Key` header directly. | Not applicable. |
+| Operator publish/retire/seat-unit mutation | Use `Idempotency-Key` header directly. | Not applicable. |
+| Entitlement internal allocation call | Entitlement sends a persisted UUID-v7 `Idempotency-Key`; Seat Assignment uses it directly. | Entitlement must persist a key folded from `segmentBookingId`, `travelerRef`, `capacityHoldId`, normalized `seatPreferences`, and `issuePurpose`. |
+| Consumed `EntitlementIssued` confirmation | No HTTP key. | `seatAllocationId`, `entitlementId`, consumed envelope `eventId`. |
+| Consumed `EntitlementVoided` / `EntitlementIssueFailed` release | No HTTP key. | `seatAllocationId` or `segmentBookingId`, reason, consumed envelope `eventId`. |
+| Consumed `CapacityReleased` recovery | No HTTP key. | `holdId`, `capacityUnitRef`, normalized `interval`, consumed envelope `eventId`. |
+| Consumed `CapacityHoldExpired` recovery | No HTTP key. | `holdId`, `capacityUnitRef`, normalized `interval`, consumed envelope `eventId`. |
+
+Replays with the same key and same canonical body return the original response.
+Reusing the same key with different material returns `IDEMPOTENCY_KEY_REUSED`
+(422). Terminal allocations (`CONFIRMED`, `RELEASED`, `EXPIRED`, `FAILED`,
+`MISSED`) remain observable via GET; terminal GETs are restful and do not
+resurrect state.
+
+## Enums
+
+### SeatMap status
+
+| Status | Meaning | Terminal |
+|---|---|---|
+| `DRAFT` | SeatMap was built from SIM seed data and is not assignable. | no |
+| `VALIDATING` | SeatUnit, coach, class, and interval compatibility checks are running. | no |
+| `PUBLISHED` | This version is authoritative for new allocations. | no |
+| `SUPERSEDED` | A later version is authoritative; this version remains for historical interpretation. | no |
+| `RETIRED` | Service ended or map was withdrawn; query only. | yes |
+| `FAILED` | Build or validation failed; not assignable. | yes |
+
+### SeatAllocation status
+
+| Status | Meaning | Allowed next statuses |
+|---|---|---|
+| `REQUESTED` | Allocation command accepted and being evaluated. | `ALLOCATED`, `STANDING`, `FAILED`, `MISSED` |
+| `ALLOCATED` | A concrete SeatUnit/berth is temporarily assigned. | `CONFIRMED`, `RELEASED`, `EXPIRED`, `ALLOCATED`, `MISSED` |
+| `STANDING` | No concrete SeatUnit; successful no-seat allocation. | `CONFIRMED`, `RELEASED`, `EXPIRED`, `MISSED` |
+| `CONFIRMED` | Entitlement was issued and the credential displays this seat fact. | `RELEASED` |
+| `RELEASED` | Assignment was returned to the seat pool. | Terminal |
+| `EXPIRED` | Capacity hold expired before confirmation. | Terminal |
+| `FAILED` | Allocation failed and cannot be retried in-place. | Terminal |
+| `MISSED` | Late or saga-already-closed fact; cannot be retried in-place. | Terminal |
+
+### Allocation and preference enums
+
+| Enum | Values |
+|---|---|
+| `allocationType` | `SEAT`, `BERTH`, `STANDING` |
+| `berthPosition` | `UPPER`, `MIDDLE`, `LOWER`, `SIDE_UPPER`, `SIDE_LOWER` |
+| `seatPosition` | `WINDOW`, `AISLE`, `MIDDLE`, `LOWER_DECK`, `UPPER_DECK` |
+| `adjacencyPreference` | `NONE`, `SAME_COACH`, `SAME_ROW`, `ADJACENT`, `SAME_COMPARTMENT` |
+| `degradationReason` | `NONE`, `NO_ADJACENT_BLOCK`, `CLASS_MISMATCH`, `INTERVAL_CONFLICT`, `BERTH_PREFERENCE_UNAVAILABLE`, `STANDING_ASSIGNED`, `POLICY_LIMIT` |
+| `releaseReason` | `VOIDED`, `CHANGED`, `ISSUE_FAILED`, `CAPACITY_RELEASED`, `HOLD_EXPIRED`, `DISRUPTION`, `MANUAL_CORRECTION` |
+| `failureReason` | `NO_COMPATIBLE_SEAT`, `OVERLAPPING_ALLOCATION`, `CAPACITY_REFERENCE_MISSING`, `PREFERENCE_UNSATISFIABLE`, `SEAT_MAP_VERSION_STALE`, `IDEMPOTENCY_CONFLICT` |
+
+## Resource representations
+
+### SeatMap
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatMapId` | string | yes | Canonical SeatMap ID (`smap-<uuid>`). |
+| `scheduledServiceRef` | string | yes | Scheduled service reference (`ss-<uuid>`). |
+| `serviceDate` | string | yes | Operating date in `YYYY-MM-DD` local service calendar form. |
+| `compositionVersion` | string | yes | Operator/SIM composition version. Published versions are immutable. |
+| `seatMapVersion` | integer | yes | Monotonic version for this SeatMap. |
+| `source` | enum | yes | `SIM_SEED` in this wave. |
+| `compositionSeed` | string | yes | Deterministic seed used by the SIM gateway. Same seed + version + mapping version produces the same topology. |
+| `mappingVersion` | string | yes | SIM-to-core mapping version. |
+| `status` | enum | yes | SeatMap status. |
+| `coaches` | array[Coach] | yes | Coach topology. |
+| `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
+| `publishedAt` | RFC3339 UTC | no | Publish timestamp for assignable versions. |
+| `retiredAt` | RFC3339 UTC | no | Retirement timestamp for terminal maps. |
+
+### Coach
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `coachRef` | string | yes | Stable coach reference within the SeatMap (`coach-<uuid>` or deterministic SIM code mapped by ACL). |
+| `coachNo` | string | yes | Passenger-facing coach number. |
+| `classRef` | string | yes | Seat class/cabin reference that must match the capacity class. |
+| `coachType` | enum | yes | `SEAT`, `BERTH`, `MIXED`, `STANDING_ONLY`. |
+| `assignable` | boolean | yes | Whether this coach may receive new concrete allocations. |
+| `seatUnits` | array[SeatUnit] | yes | Concrete units. Empty for `STANDING_ONLY`. |
+
+### SeatUnit
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatUnitRef` | string | yes | Stable seat/berth reference (`su-<uuid>`). |
+| `coachRef` | string | yes | Parent coach reference. |
+| `coachNo` | string | yes | Passenger-facing coach number. |
+| `seatNo` | string | yes | Passenger-facing seat/berth number inside the coach. |
+| `allocationType` | enum | yes | `SEAT` or `BERTH`; never `STANDING`. |
+| `berthPosition` | enum | no | Required when `allocationType=BERTH`. |
+| `seatPosition` | enum | no | Seat position hint when known. |
+| `rowNo` | string | no | Row or compartment number for adjacency solving. |
+| `adjacencyGroupKey` | string | no | Deterministic key for seats/berths considered adjacent. |
+| `assignable` | boolean | yes | False when maintenance/reserved/fault marks block allocation. |
+| `unavailableReason` | string | no | Operator reason; do not include unmasked personal data. |
+
+### SeatPreferences
+
+`SeatPreferences` is shared with Entitlement & Ticketing issue requests in this
+wave. Entitlement must pass the same shape when calling Seat Assignment.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `acceptStanding` | boolean | yes | Whether a `STANDING` allocation is acceptable when no concrete compatible SeatUnit can be assigned. |
+| `adjacencyPreference` | enum | no | Desired grouping: `NONE`, `SAME_COACH`, `SAME_ROW`, `ADJACENT`, `SAME_COMPARTMENT`. Default `NONE`. |
+| `adjacencyGroupRef` | string | no | Client/order-level grouping reference for fellow travelers. |
+| `preferredSeatPositions` | array[enum] | no | Ordered seat preferences using `seatPosition` values. |
+| `preferredBerthPositions` | array[enum] | no | Ordered berth preferences using `berthPosition` values. |
+| `sameCompartment` | boolean | no | Stronger berth adjacency hint; best effort only. |
+| `avoidSeatUnitRefs` | array[string] | no | SeatUnits to avoid when known from prior failed attempts. |
+| `preferenceVersion` | string | yes | Stable version/hash of the preference snapshot used for idempotency folding. |
+
+### SeatRef
+
+`SeatRef` is the credential display shape returned to Entitlement & Ticketing and
+stored on issued credentials.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatAllocationId` | string | yes | Seat allocation ID (`salloc-<uuid>`). |
+| `allocationType` | enum | yes | `SEAT`, `BERTH`, or `STANDING`. |
+| `seatMapId` | string | no | SeatMap ID for concrete `SEAT`/`BERTH`; omitted for `STANDING`. |
+| `seatMapVersion` | integer | no | SeatMap version for concrete `SEAT`/`BERTH`; omitted for `STANDING`. |
+| `seatUnitRef` | string | no | Concrete SeatUnit for `SEAT`/`BERTH`; omitted for `STANDING`. |
+| `coachNo` | string | no | Passenger-facing coach number for concrete allocations. |
+| `seatNo` | string | no | Passenger-facing seat/berth number for concrete allocations. |
+| `berthPosition` | enum | no | Present for berth allocations when known. |
+| `displayLabel` | string | yes | Safe passenger-facing label, for example `05车 12A` or `STANDING`. |
+| `degraded` | boolean | yes | True when a requested adjacency/berth/position preference was downgraded. |
+| `degradationReason` | enum | no | Required when `degraded=true`. |
+
+### SeatAllocation
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatAllocationId` | string | yes | Allocation ID (`salloc-<uuid>`). |
+| `segmentBookingId` | string | yes | Segment booking ID (`sb-<uuid>`). |
+| `journeyOrderId` | string | yes | Parent order ID (`ord-<uuid>`). |
+| `travelerRef` | string | yes | Traveler reference (`tvl-<uuid>` or shared structured TravelerRef). |
+| `segmentRef` | string | yes | Service segment reference. |
+| `scheduledServiceRef` | string | yes | Scheduled service reference. |
+| `serviceDate` | string | yes | Operating date in `YYYY-MM-DD`. |
+| `capacityHoldId` | string | yes | Capacity hold ID (`hold-<uuid>`). |
+| `capacityUnitRef` | string | yes | Capacity unit reference from Capacity & Availability. |
+| `interval` | object | yes | `StationInterval` with `fromSeq` and `toSeq`; half-open `[from,to)`. |
+| `seatRef` | SeatRef | yes | Concrete or standing display fact. |
+| `status` | enum | yes | SeatAllocation status. |
+| `preferences` | SeatPreferences | no | Normalized preference snapshot used for solving. |
+| `createdAt` | RFC3339 UTC | yes | Allocation creation timestamp. |
+| `confirmedAt` | RFC3339 UTC | no | Entitlement confirmation timestamp. |
+| `releasedAt` | RFC3339 UTC | no | Release timestamp. |
+| `expiresAt` | RFC3339 UTC | no | Capacity hold expiry observed at allocation time. |
+
+## Endpoints
+
+### Create SeatMap from SIM seed
+
+**POST** `/api/v1/seat-maps`
+
+**Idempotency:** REQUIRED (`Idempotency-Key` UUID-v7-shaped header).
+
+Creates a draft SeatMap from deterministic SIM composition seed data. Same
+`scheduledServiceRef + serviceDate + compositionVersion + compositionSeed +
+mappingVersion` must produce the same coach/SeatUnit topology.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `scheduledServiceRef` | string | yes | Scheduled service reference (`ss-<uuid>`). |
+| `serviceDate` | string | yes | Operating date in `YYYY-MM-DD`. |
+| `compositionVersion` | string | yes | Operator/SIM composition version. |
+| `compositionSeed` | string | yes | Deterministic seed; no real provider credentials or network endpoints. |
+| `mappingVersion` | string | yes | Mapping version for SIM code to core SeatUnitRef. |
+| `changeScenario` | string | no | Deterministic SIM scenario such as `BASE`, `COACH_REPLACED`, `SEAT_DISABLED`. |
+| `operatorRef` | string | yes | Operator/admin actor reference; no personal documents. |
+
+**Response (201):** `SeatMap` resource with `status=DRAFT` or `FAILED`.
+
+**Error codes:** `VALIDATION_FAILED` (400), `CONFLICT` (409),
+`IDEMPOTENCY_KEY_REUSED` (422), `DOMAIN_RULE_VIOLATION` (422), `UNAVAILABLE`
+(503).
+
+### Publish SeatMap version
+
+**POST** `/api/v1/seat-maps/{seatMapId}/publish`
+
+**Idempotency:** REQUIRED.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `expectedSeatMapVersion` | integer | yes | Optimistic version expected by the operator. |
+| `publishReason` | string | yes | Operator reason; do not include sensitive personal data. |
+| `operatorRef` | string | yes | Operator/admin actor reference. |
+
+**Response (200):** `SeatMap` resource with `status=PUBLISHED`.
+
+**Error codes:** `NOT_FOUND` (404), `PRECONDITION_FAILED` (412), `CONFLICT`
+(409), `IDEMPOTENCY_KEY_REUSED` (422), `DOMAIN_RULE_VIOLATION` (422),
+`UNAVAILABLE` (503).
+
+### Retire SeatMap version
+
+**POST** `/api/v1/seat-maps/{seatMapId}/retire`
+
+**Idempotency:** REQUIRED.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `expectedSeatMapVersion` | integer | yes | Optimistic version expected by the operator. |
+| `retireReason` | enum | yes | `SERVICE_ENDED`, `SUPERSEDED`, `OPERATOR_WITHDRAWAL`, `MANUAL_CORRECTION`. |
+| `operatorRef` | string | yes | Operator/admin actor reference. |
+
+**Response (200):** `SeatMap` resource with `status=RETIRED` or `SUPERSEDED`.
+
+**Error codes:** `NOT_FOUND` (404), `PRECONDITION_FAILED` (412), `CONFLICT`
+(409), `IDEMPOTENCY_KEY_REUSED` (422), `DOMAIN_RULE_VIOLATION` (422),
+`UNAVAILABLE` (503).
+
+### Mark SeatUnit unavailable
+
+**POST** `/api/v1/seat-maps/{seatMapId}/seat-units/{seatUnitRef}/mark-unavailable`
+
+**Idempotency:** REQUIRED.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `expectedSeatMapVersion` | integer | yes | Optimistic version expected by the operator. |
+| `unavailableReason` | enum | yes | `MAINTENANCE`, `RESERVED`, `FAULT`, `OPERATOR_BLOCK`, `SIM_SCENARIO`. |
+| `operatorRef` | string | yes | Operator/admin actor reference. |
+
+**Response (200):** `SeatMap` resource after the SeatUnit is blocked.
+
+**Error codes:** `NOT_FOUND` (404), `PRECONDITION_FAILED` (412), `CONFLICT`
+(409), `IDEMPOTENCY_KEY_REUSED` (422), `DOMAIN_RULE_VIOLATION` (422),
+`UNAVAILABLE` (503).
+
+### Reopen SeatUnit
+
+**POST** `/api/v1/seat-maps/{seatMapId}/seat-units/{seatUnitRef}/reopen`
+
+**Idempotency:** REQUIRED.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `expectedSeatMapVersion` | integer | yes | Optimistic version expected by the operator. |
+| `reopenReason` | enum | yes | `MAINTENANCE_CLEARED`, `RESERVATION_CLEARED`, `FAULT_CLEARED`, `MANUAL_CORRECTION`. |
+| `operatorRef` | string | yes | Operator/admin actor reference. |
+
+**Response (200):** `SeatMap` resource after the SeatUnit is assignable again.
+
+**Error codes:** `NOT_FOUND` (404), `PRECONDITION_FAILED` (412), `CONFLICT`
+(409), `IDEMPOTENCY_KEY_REUSED` (422), `DOMAIN_RULE_VIOLATION` (422),
+`UNAVAILABLE` (503).
+
+### Get SeatMap
+
+**GET** `/api/v1/seat-maps/{seatMapId}`
+
+**Response (200):** `SeatMap` resource. `RETIRED`, `SUPERSEDED`, and `FAILED`
+SeatMaps remain queryable.
+
+**Error codes:** `NOT_FOUND` (404).
+
+### List SeatMaps
+
+**GET** `/api/v1/seat-maps?scheduledServiceRef={scheduledServiceRef}&serviceDate={serviceDate}&limit=20&offset=0`
+
+**Query parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `scheduledServiceRef` | string | yes | Scheduled service reference. |
+| `serviceDate` | string | yes | Operating date in `YYYY-MM-DD`. |
+| `status` | enum | no | Optional SeatMap status filter. |
+| `limit` | integer | no | Pagination limit, default 20, max 100. |
+| `offset` | integer | no | Pagination offset, default 0. |
+
+**Response (200):** Paginated response with `items`, `total`, `limit`, and
+`offset`, where each item is a `SeatMap` resource.
+
+**Error codes:** `VALIDATION_FAILED` (400).
+
+### Allocate seat for ticket issuance
+
+**POST** `/api/v1/internal/seat-allocations`
+
+**Idempotency:** REQUIRED. Caller is Entitlement & Ticketing in the issuance path.
+The caller must persist and reuse the UUID-v7 key across retries. This endpoint is
+internal to bounded-context integration and is not a customer seat-selection API.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `segmentBookingId` | string | yes | Segment booking ID (`sb-<uuid>`). |
+| `journeyOrderId` | string | yes | Parent order ID (`ord-<uuid>`). |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | yes | Service segment reference. |
+| `scheduledServiceRef` | string | yes | Scheduled service reference. |
+| `serviceDate` | string | yes | Operating date in `YYYY-MM-DD`. |
+| `capacityHoldId` | string | yes | Capacity hold ID that already exists in Capacity & Availability. |
+| `capacityUnitRef` | string | yes | Capacity unit reference from the hold/confirmation fact. |
+| `interval` | object | yes | `StationInterval` with `fromSeq` and `toSeq`; half-open `[from,to)`. |
+| `classRef` | string | yes | Required seat class/cabin; must match SeatMap/coach class. |
+| `issuePurpose` | enum | yes | Entitlement purpose: `INITIAL`, `REPLACEMENT`, `MANUAL_RECOVERY`, `PROVIDER_REBUILD`, `DISRUPTION_REPLACEMENT`. |
+| `seatPreferences` | SeatPreferences | no | Optional preferences; absence means no preference and `acceptStanding=false`. |
+| `expiresAt` | RFC3339 UTC | yes | Capacity hold expiry known to the caller. |
+
+**Response (201):**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatAllocationId` | string | yes | Allocation ID (`salloc-<uuid>`). |
+| `status` | enum | yes | `ALLOCATED` or `STANDING`. |
+| `seatRef` | SeatRef | yes | Display fact for Entitlement credential creation. |
+| `expiresAt` | RFC3339 UTC | yes | Hold expiry copied from the request. |
+
+**Error codes:** `VALIDATION_FAILED` (400), `NOT_FOUND` (404), `CONFLICT` (409),
+`PRECONDITION_FAILED` (412), `IDEMPOTENCY_KEY_REUSED` (422),
+`DOMAIN_RULE_VIOLATION` (422), `UNAVAILABLE` (503).
+
+- `CONFLICT` is returned for overlapping concrete SeatUnit allocation or same
+  idempotency key with an already committed but incompatible transition.
+- `PRECONDITION_FAILED` is returned when the SeatMap version is stale or no
+  published SeatMap matches the requested scheduled service/date/class.
+- `DOMAIN_RULE_VIOLATION` is returned when no compatible seat exists and
+  `seatPreferences.acceptStanding` is false.
+- If `acceptStanding=true`, lack of concrete SeatUnit is a successful `STANDING`
+  response, not an error.
+
+### Get SeatAllocation
+
+**GET** `/api/v1/seat-allocations/{seatAllocationId}`
+
+**Response (200):** `SeatAllocation` resource. Terminal statuses remain queryable.
+
+**Error codes:** `NOT_FOUND` (404).
+
+### List SeatAllocations by segment booking
+
+**GET** `/api/v1/seat-allocations?segmentBookingId={segmentBookingId}&limit=20&offset=0`
+
+**Query parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `segmentBookingId` | string | yes | Segment booking ID (`sb-<uuid>`). |
+| `status` | enum | no | Optional SeatAllocation status filter. |
+| `limit` | integer | no | Pagination limit, default 20, max 100. |
+| `offset` | integer | no | Pagination offset, default 0. |
+
+**Response (200):** Paginated response with `items`, `total`, `limit`, and
+`offset`, where each item is a `SeatAllocation` resource.
+
+**Error codes:** `VALIDATION_FAILED` (400).
+
+## Bus-only behavior
+
+The following lifecycle commands have no public HTTP endpoint in this activation
+wave:
+
+- `ConfirmSeatAllocation` — triggered by consuming `EntitlementIssued`.
+- `ReleaseSeatAllocation` — triggered by consuming `EntitlementVoided`,
+  `EntitlementIssueFailed`, `CapacityReleased`, or operator-approved correction.
+- `ExpireSeatAllocation` — triggered by consuming `CapacityHoldExpired`.
+- `AcceptAdjacencyDegradation` — internal solver/audit command when the policy
+  accepts a downgraded adjacency outcome.
+- `AppendSeatAllocationLedgerEvent` — internal immutable audit ledger append.
+
+## Entitlement & Ticketing contract increment — needs same-wave implementation
+
+The additions to `docs/08-contracts/api/entitlement-ticketing.md` and
+`docs/08-contracts/events/entitlement-ticketing.md` are part of this Seat
+Assignment activation and are **not docs-only**. They require same-wave code
+changes in Entitlement & Ticketing at these touchpoints:
+
+| Touchpoint | Required implementation change |
+|---|---|
+| Issue HTTP request DTO / deserializer | Accept optional `seatPreferences` using the field names and enums above. |
+| Issue command validator | Validate `acceptStanding`, adjacency, seat position, and berth position enums; reject non-SCREAMING_SNAKE values. |
+| Ticket issuance application service | Before committing the credential, call `POST /api/v1/internal/seat-allocations` with a persisted UUID-v7 idempotency key and propagate `corr-` / `cmd-` trace IDs. |
+| Credential value object / projection | Persist and expose `seatRef` exactly as the `SeatRef` shape above, including `STANDING`. |
+| Entitlement events outbox | Include `seatRef` and `seatAllocationId` on `EntitlementIssued`; include enough entitlement/segment reference for Seat Assignment to confirm or release. |
+| Enum/schema tests | Add validation coverage for `allocationType`, `berthPosition`, `seatPosition`, `adjacencyPreference`, and `degradationReason`. |

--- a/docs/08-contracts/events/capacity-availability.md
+++ b/docs/08-contracts/events/capacity-availability.md
@@ -1,6 +1,6 @@
 # Capacity & Availability — Events & Commands
 
-Last updated: 2026-07-04
+Last updated: 2026-07-09
 
 ## Published Events
 
@@ -93,7 +93,7 @@ Last updated: 2026-07-04
 | Field | Description |
 |---|---|
 | **Producer** | capacity-availability |
-| **Consumers** | booking-orchestration, waitlist |
+| **Consumers** | booking-orchestration, waitlist, seat-assignment |
 | **Trigger** | `ReleaseHold` command processed (cancellation, refund, or compensation). |
 
 **Payload:**
@@ -113,7 +113,7 @@ Last updated: 2026-07-04
 | Field | Description |
 |---|---|
 | **Producer** | capacity-availability |
-| **Consumers** | booking-orchestration |
+| **Consumers** | booking-orchestration, seat-assignment |
 | **Trigger** | Hold TTL elapsed without confirmation. |
 
 **Payload:**

--- a/docs/08-contracts/events/entitlement-ticketing.md
+++ b/docs/08-contracts/events/entitlement-ticketing.md
@@ -1,6 +1,6 @@
 # Entitlement & Ticketing — Events & Commands
 
-Last updated: 2026-07-04
+Last updated: 2026-07-09
 
 ## Published Events
 
@@ -9,7 +9,7 @@ Last updated: 2026-07-04
 | Field | Description |
 |---|---|
 | **Producer** | entitlement-ticketing |
-| **Consumers** | booking-orchestration, journey-order, notification, fulfillment |
+| **Consumers** | booking-orchestration, journey-order, notification, fulfillment, seat-assignment |
 | **Trigger** | `IssueEntitlement` command processed; ticket/credential generated. |
 
 **Payload:**
@@ -25,13 +25,15 @@ Last updated: 2026-07-04
 | `credentialNo` | string | yes | Unique credential/ticket number. |
 | `credentialType` | string | yes | Type of credential: `E_TICKET`, `PAPER_TICKET`, `PICKUP_CODE`, `BOARDING_PASS`, `FERRY_TICKET`, `COACH_E_TICKET`, `RIDE_CODE`. |
 | `issuedAt` | RFC3339 UTC | yes | Issue timestamp. |
+| `seatAllocationId` | string | no | Seat Assignment allocation ID (`salloc-<uuid>`). Needs same-wave implementation; required for train/seat-assigned issuance paths. |
+| `seatRef` | object | no | Seat Assignment `SeatRef` display fact. Needs same-wave implementation; required when `seatAllocationId` is present and may carry `allocationType=STANDING`. |
 
 ### EntitlementVoided
 
 | Field | Description |
 |---|---|
 | **Producer** | entitlement-ticketing |
-| **Consumers** | booking-orchestration, notification, post-sales, capacity-availability |
+| **Consumers** | booking-orchestration, notification, post-sales, capacity-availability, seat-assignment |
 | **Trigger** | `VoidEntitlement` command processed. |
 
 **Payload:**
@@ -44,6 +46,7 @@ Last updated: 2026-07-04
 | `reason` | string | yes | Void reason: `REFUND`, `CHANGE`, `DISRUPTION`, `RISK`, `MANUAL_CORRECTION`. |
 | `policy` | string | yes | Void policy: `NORMAL` or `EXCEPTIONAL_RULE`. |
 | `businessCaseRef` | string | no | Reference to the post-sales or recovery case that authorised the void. |
+| `seatAllocationId` | string | no | Seat Assignment allocation ID (`salloc-<uuid>`) when the entitlement carries one; needs same-wave implementation for prompt release. |
 
 ### EntitlementBoarded
 
@@ -115,7 +118,7 @@ Last updated: 2026-07-04
 | Field | Description |
 |---|---|
 | **Producer** | entitlement-ticketing |
-| **Consumers** | booking-orchestration |
+| **Consumers** | booking-orchestration, seat-assignment |
 | **Trigger** | Entitlement issuance failed. |
 
 **Payload:**
@@ -127,6 +130,18 @@ Last updated: 2026-07-04
 | `failureCode` | string | yes | Machine-readable failure code. |
 | `failureMessage` | string | no | Human-readable failure description. |
 | `failedAt` | RFC3339 UTC | yes | Failure timestamp. |
+| `segmentBookingId` | `SegmentBookingId` | no | Segment booking ID when available; needs same-wave implementation so Seat Assignment can release an unconfirmed allocation. |
+| `seatAllocationId` | string | no | Seat Assignment allocation ID (`salloc-<uuid>`) when allocation already happened; needs same-wave implementation. |
+
+
+## Seat Assignment increment — needs same-wave implementation
+
+ADR-0003 wave A requires Entitlement & Ticketing code changes in the same wave as
+this contract increment. The implementation must update the IssueEntitlement
+command schema, validators, issuance application service, Seat Assignment HTTP
+client adapter, credential persistence/projection, and outbox/event serializers.
+The relevant enum validation surface is `allocationType`, `berthPosition`,
+`seatPosition`, `adjacencyPreference`, and `degradationReason`.
 
 ## Accepted Commands
 
@@ -147,6 +162,9 @@ Last updated: 2026-07-04
 | `credentialType` | string | yes | Type of credential. |
 | `providerRef` | string | no | Provider reference if externally-issued credential. |
 | `providerConfirmationNo` | string | no | Provider confirmation number. |
+| `seatPreferences` | object | no | Seat Assignment `SeatPreferences` from issue request. Needs same-wave implementation and validation before Seat Assignment call. |
+| `seatAllocationId` | string | no | Seat Assignment allocation ID returned by the issuance-path call; required before committing a seat-assigned credential. |
+| `seatRef` | object | no | Seat Assignment `SeatRef` returned by the issuance-path call; persisted on the credential and emitted with `EntitlementIssued`. |
 
 ### VoidEntitlement
 

--- a/docs/08-contracts/events/seat-assignment.md
+++ b/docs/08-contracts/events/seat-assignment.md
@@ -1,0 +1,645 @@
+# Seat Assignment — Events & Commands
+
+Last updated: 2026-07-09
+
+## Scope and activation-wave rulings
+
+This contract promotes the Seat Assignment lifecycle from
+`docs/02-domains/seat-assignment.md` into cross-context wire contracts for
+ADR-0003 wave A.
+
+Activation-wave rulings:
+
+- **RULING: SeatMap is operations CRUD.** SeatMap facts are produced only from
+  operator/SIM seed commands in this wave. No real provider seat-map integration
+  is active.
+- **RULING: allocation happens in the Entitlement & Ticketing issuance path.**
+  Entitlement calls `POST /api/v1/internal/seat-allocations`; Seat Assignment
+  returns a `seatRef` for credential display. Entitlement contract increments are
+  marked "needs same-wave implementation" in its API/events files and in
+  `docs/08-contracts/api/seat-assignment.md`.
+- `StandingAssigned` is a success fact. It is not a failed allocation and does
+  not create a virtual SeatUnit.
+- Adjacent allocation is best effort. Downgrade must be explicit in
+  `AdjacentAllocationSolved` or `AdjacencyDegradationAccepted`.
+- Seat Assignment consumes existing Capacity & Availability event names and
+  fields: `CapacityReleased` (`holdId`, `inventoryPoolId`, `capacityUnitRef`,
+  `segmentRef`, `interval`, `releasedAt`, `releaseReason`) and
+  `CapacityHoldExpired` (`holdId`, `inventoryPoolId`, `capacityUnitRef`,
+  `interval`, `expiredAt`) to release/expire matching seat assignments.
+
+All payload fields are camelCase, enum values are SCREAMING_SNAKE_CASE, and all
+timestamps are RFC3339 UTC. Envelope fields and optional trace context follow
+`docs/08-contracts/messaging.md` and `docs/08-contracts/shared-primitives.md`.
+
+## Event identity and idempotency
+
+Seat Assignment producers MUST assign deterministic event IDs per aggregate
+transition so retries do not create duplicate facts. The event ID seed is:
+
+```
+seat-assignment:<eventType>:<aggregateId>:<aggregateVersion>
+```
+
+The seed is SHA-256 folded, stamped with UUID version 7 and RFC-4122 variant bits,
+and serialized with the `evt-<uuid-v7>` prefix in the envelope `eventId`. If a
+replayed command or consumed upstream event applies no new transition, no new
+event is emitted. Consumers still deduplicate by envelope `eventId`.
+
+Command ids use `cmd-<uuid-v7>` and correlations use `corr-<uuid-v7>`. HTTP API
+commands use the caller's UUID-v7 `Idempotency-Key` directly as the command key;
+internal commands fold canonical materials as listed in the API contract. Same
+key + same material replays the existing result. Same key + different material
+emits or returns an idempotency conflict (`IDEMPOTENCY_CONFLICT` /
+`IDEMPOTENCY_KEY_REUSED`) and must not mutate the previous allocation.
+
+## Shared payload objects
+
+### StationInterval
+
+Seat Assignment uses the same interval semantics as Capacity & Availability:
+half-open `[fromSeq,toSeq)`. Overlap exists when
+`existingFromSeq < requestToSeq && requestFromSeq < existingToSeq`.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fromSeq` | integer | yes | Inclusive origin stop sequence. |
+| `toSeq` | integer | yes | Exclusive destination stop sequence; must be greater than `fromSeq`. |
+
+### SeatPreferences
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `acceptStanding` | boolean | yes | Whether a `STANDING` allocation is acceptable. |
+| `adjacencyPreference` | enum | no | `NONE`, `SAME_COACH`, `SAME_ROW`, `ADJACENT`, `SAME_COMPARTMENT`. |
+| `adjacencyGroupRef` | string | no | Client/order-level grouping reference for fellow travelers. |
+| `preferredSeatPositions` | array[enum] | no | `WINDOW`, `AISLE`, `MIDDLE`, `LOWER_DECK`, `UPPER_DECK`. |
+| `preferredBerthPositions` | array[enum] | no | `UPPER`, `MIDDLE`, `LOWER`, `SIDE_UPPER`, `SIDE_LOWER`. |
+| `sameCompartment` | boolean | no | Best-effort berth grouping hint. |
+| `avoidSeatUnitRefs` | array[string] | no | SeatUnit refs to avoid. |
+| `preferenceVersion` | string | yes | Stable preference snapshot version used for idempotency folding. |
+
+### SeatRef
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatAllocationId` | string | yes | Allocation ID (`salloc-<uuid>`). |
+| `allocationType` | enum | yes | `SEAT`, `BERTH`, or `STANDING`. |
+| `seatMapId` | string | no | SeatMap ID for concrete allocations. |
+| `seatMapVersion` | integer | no | SeatMap version for concrete allocations. |
+| `seatUnitRef` | string | no | Concrete SeatUnit for `SEAT`/`BERTH`; omitted for `STANDING`. |
+| `coachNo` | string | no | Passenger-facing coach number. |
+| `seatNo` | string | no | Passenger-facing seat/berth number. |
+| `berthPosition` | enum | no | Present for berth allocations when known. |
+| `displayLabel` | string | yes | Passenger-facing label such as `05车 12A` or `STANDING`. |
+| `degraded` | boolean | yes | Whether preferences were downgraded. |
+| `degradationReason` | enum | no | Required when `degraded=true`: `NO_ADJACENT_BLOCK`, `CLASS_MISMATCH`, `INTERVAL_CONFLICT`, `BERTH_PREFERENCE_UNAVAILABLE`, `STANDING_ASSIGNED`, or `POLICY_LIMIT`. |
+
+## Published Events
+
+### SeatMapBuilt
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | reporting |
+| **Trigger** | `BuildSeatMap` command accepted from `POST /api/v1/seat-maps`. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatMapId` | string | yes | SeatMap ID (`smap-<uuid>`). |
+| `scheduledServiceRef` | string | yes | Scheduled service reference. |
+| `serviceDate` | string | yes | Operating date in `YYYY-MM-DD`. |
+| `compositionVersion` | string | yes | Operator/SIM composition version. |
+| `seatMapVersion` | integer | yes | SeatMap version after build. |
+| `compositionSeed` | string | yes | Deterministic SIM seed. |
+| `mappingVersion` | string | yes | SIM-to-core mapping version. |
+| `coachCount` | integer | yes | Number of coaches built. |
+| `seatUnitCount` | integer | yes | Number of concrete SeatUnits built. |
+| `status` | enum | yes | `DRAFT`. |
+| `builtAt` | RFC3339 UTC | yes | Build timestamp. |
+
+### SeatMapBuildFailed
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | reporting |
+| **Trigger** | SIM seed validation or topology build failed deterministically. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatMapId` | string | yes | SeatMap ID allocated for the failed attempt. |
+| `scheduledServiceRef` | string | yes | Scheduled service reference. |
+| `serviceDate` | string | yes | Operating date in `YYYY-MM-DD`. |
+| `compositionVersion` | string | yes | Operator/SIM composition version. |
+| `compositionSeed` | string | yes | Deterministic SIM seed. |
+| `mappingVersion` | string | yes | Mapping version. |
+| `failureReason` | enum | yes | `INVALID_SEED`, `DUPLICATE_SEAT_UNIT`, `CLASS_MAPPING_MISSING`, `STOP_SEQUENCE_MISMATCH`, `SIM_SCENARIO_UNSUPPORTED`. |
+| `failedAt` | RFC3339 UTC | yes | Failure timestamp. |
+| `status` | enum | yes | `FAILED`. |
+
+### SeatMapVersionPublished
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | reporting |
+| **Trigger** | Operator publishes a validated SeatMap version. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatMapId` | string | yes | SeatMap ID. |
+| `scheduledServiceRef` | string | yes | Scheduled service reference. |
+| `serviceDate` | string | yes | Operating date in `YYYY-MM-DD`. |
+| `compositionVersion` | string | yes | Composition version. |
+| `seatMapVersion` | integer | yes | Published version. |
+| `publishedAt` | RFC3339 UTC | yes | Publish timestamp. |
+| `operatorRef` | string | yes | Operator/admin actor reference. |
+| `status` | enum | yes | `PUBLISHED`. |
+
+### SeatMapVersionRetired
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | reporting |
+| **Trigger** | Operator retires or supersedes a SeatMap version. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatMapId` | string | yes | SeatMap ID. |
+| `scheduledServiceRef` | string | yes | Scheduled service reference. |
+| `serviceDate` | string | yes | Operating date in `YYYY-MM-DD`. |
+| `seatMapVersion` | integer | yes | Retired/superseded version. |
+| `retireReason` | enum | yes | `SERVICE_ENDED`, `SUPERSEDED`, `OPERATOR_WITHDRAWAL`, `MANUAL_CORRECTION`. |
+| `retiredAt` | RFC3339 UTC | yes | Retirement timestamp. |
+| `operatorRef` | string | yes | Operator/admin actor reference. |
+| `status` | enum | yes | `RETIRED` or `SUPERSEDED`. |
+
+### SeatUnitUnavailableMarked
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | reporting |
+| **Trigger** | Operator marks a SeatUnit unavailable. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatMapId` | string | yes | SeatMap ID. |
+| `seatMapVersion` | integer | yes | SeatMap version. |
+| `seatUnitRef` | string | yes | SeatUnit reference. |
+| `coachNo` | string | yes | Passenger-facing coach number. |
+| `seatNo` | string | yes | Passenger-facing seat/berth number. |
+| `unavailableReason` | enum | yes | `MAINTENANCE`, `RESERVED`, `FAULT`, `OPERATOR_BLOCK`, `SIM_SCENARIO`. |
+| `markedAt` | RFC3339 UTC | yes | Mark timestamp. |
+| `operatorRef` | string | yes | Operator/admin actor reference. |
+
+### SeatUnitReopened
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | reporting |
+| **Trigger** | Operator reopens a previously unavailable SeatUnit. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatMapId` | string | yes | SeatMap ID. |
+| `seatMapVersion` | integer | yes | SeatMap version. |
+| `seatUnitRef` | string | yes | SeatUnit reference. |
+| `coachNo` | string | yes | Passenger-facing coach number. |
+| `seatNo` | string | yes | Passenger-facing seat/berth number. |
+| `reopenReason` | enum | yes | `MAINTENANCE_CLEARED`, `RESERVATION_CLEARED`, `FAULT_CLEARED`, `MANUAL_CORRECTION`. |
+| `reopenedAt` | RFC3339 UTC | yes | Reopen timestamp. |
+| `operatorRef` | string | yes | Operator/admin actor reference. |
+
+### AdjacencyGroupCreated
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | reporting |
+| **Trigger** | Allocation request includes an adjacency group for fellow travelers. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `adjacencyGroupId` | string | yes | Adjacency group ID (`adj-<uuid>`). |
+| `journeyOrderId` | string | yes | Parent order ID. |
+| `segmentRef` | string | yes | Segment reference. |
+| `travelerRefs` | array[string] | yes | Sorted traveler references in the group. |
+| `preference` | enum | yes | Requested adjacency preference. |
+| `preferenceVersion` | string | yes | Preference snapshot version. |
+| `status` | enum | yes | `OPEN`. |
+| `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
+
+### AdjacentAllocationSolved
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | notification, reporting |
+| **Trigger** | Seat Assignment solves an adjacency group with full or partial satisfaction. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `adjacencyGroupId` | string | yes | Adjacency group ID. |
+| `journeyOrderId` | string | yes | Parent order ID. |
+| `segmentRef` | string | yes | Segment reference. |
+| `seatAllocationIds` | array[string] | yes | Allocation IDs included in the result. |
+| `result` | enum | yes | `SATISFIED`, `PARTIALLY_SATISFIED`, or `FAILED`. |
+| `degraded` | boolean | yes | True when the requested adjacency was downgraded. |
+| `degradationReason` | enum | no | Required when `degraded=true`. |
+| `solvedAt` | RFC3339 UTC | yes | Solve timestamp. |
+| `status` | enum | yes | `SATISFIED`, `PARTIALLY_SATISFIED`, or `FAILED`. |
+
+### AdjacencyDegradationAccepted
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | notification, reporting |
+| **Trigger** | Policy or caller accepts a best-effort adjacency downgrade. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `adjacencyGroupId` | string | yes | Adjacency group ID. |
+| `journeyOrderId` | string | yes | Parent order ID. |
+| `seatAllocationIds` | array[string] | yes | Allocations proceeding after downgrade. |
+| `acceptedByRef` | string | yes | `POLICY` or operator/caller reference. |
+| `degradationReason` | enum | yes | Downgrade reason. |
+| `acceptedAt` | RFC3339 UTC | yes | Acceptance timestamp. |
+
+### AdjacencyGroupCancelled
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | reporting |
+| **Trigger** | Upstream cancellation closes an open adjacency group. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `adjacencyGroupId` | string | yes | Adjacency group ID. |
+| `journeyOrderId` | string | yes | Parent order ID. |
+| `cancelReason` | enum | yes | `BOOKING_CANCELLED`, `ISSUE_FAILED`, `MANUAL_CORRECTION`. |
+| `cancelledAt` | RFC3339 UTC | yes | Cancellation timestamp. |
+| `status` | enum | yes | `CANCELLED`. |
+
+### BerthPreferenceRecorded
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | reporting |
+| **Trigger** | Allocation request records berth-specific preferences. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `berthPreferenceRequestId` | string | yes | Berth preference request ID (`bpr-<uuid>`). |
+| `segmentBookingId` | string | yes | Segment booking ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `preferredBerthPositions` | array[enum] | yes | Ordered berth preferences. |
+| `sameCompartment` | boolean | yes | Whether same-compartment solving was requested. |
+| `preferenceVersion` | string | yes | Preference snapshot version. |
+| `recordedAt` | RFC3339 UTC | yes | Record timestamp. |
+
+### BerthPreferenceApplied
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | reporting |
+| **Trigger** | Berth preference is applied or downgraded during allocation. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `berthPreferenceRequestId` | string | yes | Berth preference request ID. |
+| `seatAllocationId` | string | yes | Allocation ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `requestedPositions` | array[enum] | yes | Requested berth positions. |
+| `assignedPosition` | enum | no | Assigned berth position when concrete berth allocated. |
+| `degraded` | boolean | yes | True when requested berth preference was not met. |
+| `degradationReason` | enum | no | Required when degraded. |
+| `appliedAt` | RFC3339 UTC | yes | Apply timestamp. |
+
+### BerthPreferenceCancelled
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | reporting |
+| **Trigger** | Upstream cancellation or manual correction cancels a berth preference request. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `berthPreferenceRequestId` | string | yes | Berth preference request ID. |
+| `segmentBookingId` | string | yes | Segment booking ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `cancelReason` | enum | yes | `BOOKING_CANCELLED`, `ISSUE_FAILED`, `MANUAL_CORRECTION`. |
+| `cancelledAt` | RFC3339 UTC | yes | Cancellation timestamp. |
+
+### SeatAllocated
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | entitlement-ticketing, booking-orchestration, notification, reporting |
+| **Trigger** | `AllocateSeat` succeeds with a concrete SeatUnit/berth. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatAllocationId` | string | yes | Allocation ID (`salloc-<uuid>`). |
+| `segmentBookingId` | string | yes | Segment booking ID (`sb-<uuid>`). |
+| `journeyOrderId` | string | yes | Parent order ID (`ord-<uuid>`). |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | yes | Segment reference. |
+| `scheduledServiceRef` | string | yes | Scheduled service reference. |
+| `serviceDate` | string | yes | Operating date in `YYYY-MM-DD`. |
+| `capacityHoldId` | string | yes | Capacity hold ID. |
+| `capacityUnitRef` | string | yes | Capacity unit reference. |
+| `interval` | StationInterval | yes | Station interval. |
+| `seatRef` | SeatRef | yes | Concrete display fact; `allocationType` is `SEAT` or `BERTH`. |
+| `preferences` | SeatPreferences | no | Normalized preference snapshot. |
+| `allocatedAt` | RFC3339 UTC | yes | Allocation timestamp. |
+| `expiresAt` | RFC3339 UTC | yes | Hold expiry known at allocation time. |
+| `status` | enum | yes | `ALLOCATED`. |
+
+### StandingAssigned
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | entitlement-ticketing, booking-orchestration, notification, reporting |
+| **Trigger** | Allocation succeeds as no-seat standing because capacity exists and standing is accepted. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatAllocationId` | string | yes | Allocation ID. |
+| `segmentBookingId` | string | yes | Segment booking ID. |
+| `journeyOrderId` | string | yes | Parent order ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentRef` | string | yes | Segment reference. |
+| `scheduledServiceRef` | string | yes | Scheduled service reference. |
+| `serviceDate` | string | yes | Operating date in `YYYY-MM-DD`. |
+| `capacityHoldId` | string | yes | Capacity hold ID. |
+| `capacityUnitRef` | string | yes | Capacity unit reference. |
+| `interval` | StationInterval | yes | Station interval. |
+| `seatRef` | SeatRef | yes | `allocationType=STANDING`, `displayLabel=STANDING`, no `seatUnitRef`. |
+| `preferences` | SeatPreferences | no | Normalized preference snapshot. |
+| `assignedAt` | RFC3339 UTC | yes | Assignment timestamp. |
+| `expiresAt` | RFC3339 UTC | yes | Hold expiry known at assignment time. |
+| `status` | enum | yes | `STANDING`. |
+
+### SeatAllocationConfirmed
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | booking-orchestration, notification, reporting |
+| **Trigger** | Seat Assignment consumes `EntitlementIssued` for an active allocation. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatAllocationId` | string | yes | Allocation ID. |
+| `entitlementId` | string | yes | Issued entitlement ID. |
+| `segmentBookingId` | string | yes | Segment booking ID. |
+| `journeyOrderId` | string | yes | Parent order ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `seatRef` | SeatRef | yes | Credential display fact confirmed by Entitlement. |
+| `confirmedAt` | RFC3339 UTC | yes | Confirmation timestamp. |
+| `sourceEventId` | string | yes | Consumed `EntitlementIssued` envelope `eventId`. |
+| `status` | enum | yes | `CONFIRMED`. |
+
+### SeatAllocationReleased
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | booking-orchestration, notification, reporting |
+| **Trigger** | Seat Assignment releases an allocation after `EntitlementVoided`, `EntitlementIssueFailed`, `CapacityReleased`, or manual correction. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatAllocationId` | string | yes | Allocation ID. |
+| `segmentBookingId` | string | yes | Segment booking ID. |
+| `journeyOrderId` | string | yes | Parent order ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `capacityHoldId` | string | yes | Capacity hold ID. |
+| `seatRef` | SeatRef | yes | Seat/standing fact being released. |
+| `releaseReason` | enum | yes | `VOIDED`, `CHANGED`, `ISSUE_FAILED`, `CAPACITY_RELEASED`, `DISRUPTION`, or `MANUAL_CORRECTION`. |
+| `releasedAt` | RFC3339 UTC | yes | Release timestamp. |
+| `sourceEventId` | string | no | Consumed upstream envelope `eventId`, required for event-driven releases. |
+| `status` | enum | yes | `RELEASED`. |
+
+### SeatAllocationExpired
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | booking-orchestration, notification, reporting |
+| **Trigger** | Seat Assignment consumes `CapacityHoldExpired` for an active unconfirmed allocation. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatAllocationId` | string | yes | Allocation ID. |
+| `segmentBookingId` | string | yes | Segment booking ID. |
+| `journeyOrderId` | string | yes | Parent order ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `capacityHoldId` | string | yes | Expired hold ID. |
+| `capacityUnitRef` | string | yes | Capacity unit reference from the consumed event. |
+| `interval` | StationInterval | yes | Expired interval from Capacity. |
+| `seatRef` | SeatRef | yes | Seat/standing fact being expired. |
+| `expiredAt` | RFC3339 UTC | yes | Expiry timestamp from Capacity. |
+| `sourceEventId` | string | yes | Consumed `CapacityHoldExpired` envelope `eventId`. |
+| `status` | enum | yes | `EXPIRED`. |
+
+### SeatAllocationFailed
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | entitlement-ticketing, booking-orchestration, reporting |
+| **Trigger** | Allocation cannot be completed and standing is not an accepted success path. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatAllocationId` | string | yes | Allocation ID or requested allocation ID for the failed attempt. |
+| `segmentBookingId` | string | yes | Segment booking ID. |
+| `journeyOrderId` | string | yes | Parent order ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `capacityHoldId` | string | no | Capacity hold ID when known. |
+| `failureReason` | enum | yes | `NO_COMPATIBLE_SEAT`, `OVERLAPPING_ALLOCATION`, `CAPACITY_REFERENCE_MISSING`, `PREFERENCE_UNSATISFIABLE`, `SEAT_MAP_VERSION_STALE`, or `IDEMPOTENCY_CONFLICT`. |
+| `retryable` | boolean | yes | Whether the caller may retry with a new command/key. |
+| `failedAt` | RFC3339 UTC | yes | Failure timestamp. |
+| `status` | enum | yes | `FAILED`. |
+
+### SeatAllocationMissed
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | booking-orchestration, reporting |
+| **Trigger** | Allocation window or upstream saga already closed before Seat Assignment could act. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatAllocationId` | string | yes | Allocation ID. |
+| `segmentBookingId` | string | yes | Segment booking ID. |
+| `journeyOrderId` | string | yes | Parent order ID. |
+| `missedReason` | enum | yes | `LATE_EVENT`, `SAGA_TERMINATED`, `SERVICE_DEPARTED`, `MANUAL_CUTOFF`. |
+| `missedAt` | RFC3339 UTC | yes | Miss timestamp. |
+| `sourceEventId` | string | no | Upstream event that caused the missed transition, if any. |
+| `status` | enum | yes | `MISSED`. |
+
+### SeatReassigned
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | entitlement-ticketing, booking-orchestration, notification, reporting |
+| **Trigger** | Operator-approved or disruption-driven reassignment changes a concrete SeatUnit. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `seatAllocationId` | string | yes | Allocation ID. |
+| `segmentBookingId` | string | yes | Segment booking ID. |
+| `journeyOrderId` | string | yes | Parent order ID. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `oldSeatRef` | SeatRef | yes | Previous seat display fact. |
+| `newSeatRef` | SeatRef | yes | Replacement seat display fact. |
+| `reassignReason` | enum | yes | `DISRUPTION`, `SEAT_UNAVAILABLE`, `MANUAL_CORRECTION`. |
+| `reassignedAt` | RFC3339 UTC | yes | Reassignment timestamp. |
+| `operatorRef` | string | no | Operator/admin actor reference for manual changes. |
+| `status` | enum | yes | `ALLOCATED` or `CONFIRMED` depending on the previous lifecycle state. |
+
+### SeatAllocationLedgerAppended
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | reporting |
+| **Trigger** | Immutable allocation ledger records a lifecycle fact. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ledgerEventId` | string | yes | Ledger entry ID (`sled-<uuid>`). |
+| `seatAllocationId` | string | yes | Allocation ID. |
+| `ledgerEventType` | enum | yes | `ALLOCATED`, `STANDING_ASSIGNED`, `CONFIRMED`, `RELEASED`, `EXPIRED`, `FAILED`, `MISSED`, `REASSIGNED`. |
+| `sourceEventId` | string | yes | Source envelope event ID or self event ID for the lifecycle fact. |
+| `appendedAt` | RFC3339 UTC | yes | Append timestamp. |
+
+### SeatAllocationCorrectionAppended
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | reporting |
+| **Trigger** | Operator-approved manual correction is appended without rewriting history. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ledgerEventId` | string | yes | Ledger entry ID. |
+| `seatAllocationId` | string | yes | Allocation ID. |
+| `correctionCaseId` | string | yes | Manual correction/audit case reference. |
+| `correctionVersion` | integer | yes | Monotonic correction version for this allocation. |
+| `correctionReason` | enum | yes | `DISPLAY_FIX`, `MANUAL_RELEASE`, `MANUAL_REASSIGN`, `AUDIT_REPAIR`. |
+| `operatorRef` | string | yes | Operator/admin actor reference. |
+| `appendedAt` | RFC3339 UTC | yes | Append timestamp. |
+
+### SeatAllocationDiscrepancyDetected
+
+| Field | Description |
+|---|---|
+| **Producer** | seat-assignment |
+| **Consumers** | reporting |
+| **Trigger** | Reconciliation detects mismatch between SeatMap occupancy, ledger, and upstream facts. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `discrepancyId` | string | yes | Discrepancy ID (`sdisc-<uuid>`). |
+| `seatMapId` | string | yes | SeatMap ID. |
+| `seatMapVersion` | integer | yes | SeatMap version checked. |
+| `detectionRunId` | string | yes | Reconciliation run reference. |
+| `discrepancyType` | enum | yes | `OVERLAP`, `MISSING_RELEASE`, `UNKNOWN_CAPACITY_HOLD`, `LEDGER_GAP`. |
+| `seatAllocationIds` | array[string] | yes | Related allocation IDs; empty when none can be identified. |
+| `detectedAt` | RFC3339 UTC | yes | Detection timestamp. |
+
+## Accepted Commands
+
+### AllocateSeat / AssignStanding
+
+| Field | Description |
+|---|---|
+| **Sender** | entitlement-ticketing |
+| **Transport** | Internal HTTP `POST /api/v1/internal/seat-allocations`; no event-bus command in this wave. |
+| **Payload** | See `docs/08-contracts/api/seat-assignment.md` request table. |
+
+### ConfirmSeatAllocation
+
+| Field | Description |
+|---|---|
+| **Sender** | entitlement-ticketing via consumed `EntitlementIssued` event |
+| **Trigger** | Entitlement credential committed with `seatRef`. |
+
+**Payload material folded internally:** `seatAllocationId`, `entitlementId`, and
+consumed envelope `eventId`.
+
+### ReleaseSeatAllocation / ExpireSeatAllocation
+
+| Field | Description |
+|---|---|
+| **Sender** | entitlement-ticketing or capacity-availability via consumed events |
+| **Trigger** | `EntitlementVoided`, `EntitlementIssueFailed`, `CapacityReleased`, or `CapacityHoldExpired`. |
+
+**Payload material folded internally:** `seatAllocationId` or `holdId`, release or
+expiry reason, and consumed envelope `eventId`.

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -1,6 +1,6 @@
 # Messaging Contract — Redis Streams Event Bus
 
-**Last updated:** 2026-07-03  
+**Last updated:** 2026-07-09
 **Spec version:** 1.0.0  
 **ADR:** [0001-event-bus-redis-streams.md](../adr/0001-event-bus-redis-streams.md)
 
@@ -57,7 +57,7 @@ context.
 | 8 | `booking-orchestration` | `events:booking-orchestration` | BookingSagaStarted, SegmentReservationRequested, SegmentReservationConfirmed, SegmentReservationFailed, SegmentTicketed, SegmentBookingCancelled |
 | 9 | `payment` | `events:payment` | PaymentIntentCreated, PaymentCaptured, PaymentIntentFailed, PaymentExpired, RefundRequested, RefundSettled, RefundFailed |
 | 10 | `provider-integration` | `events:provider-integration` | ProviderReservationConfirmed, ProviderReservationFailed, ProviderReservationCancelled, ProviderBoardingAccepted |
-| 11 | `entitlement-ticketing` | `events:entitlement-ticketing` | EntitlementIssued, EntitlementVoided, EntitlementSuspended, EntitlementReinstated |
+| 11 | `entitlement-ticketing` | `events:entitlement-ticketing` | EntitlementIssued, EntitlementVoided, EntitlementBoarded, EntitlementSuspended, EntitlementResumed, EntitlementUsed, EntitlementIssueFailed |
 | 12 | `fulfillment` | `events:fulfillment` | BoardingVerified, NoShowRecorded, FulfillmentCompleted, EvidenceDisputeOpened, EvidenceDisputeResolved, SegmentArrived, SegmentDelayed, SegmentCancelled |
 | 13 | `post-sales` | `events:post-sales` | PostSalesCaseOpened, PostSalesRequested, PostSalesEligibilityEvaluated, PostSalesDecisionQuoted, PostSalesApproved, PostSalesRejected, PostSalesApplied |
 | 14 | `notification` | `events:notification` | NotificationScheduled, NotificationDispatched, NotificationDelivered, NotificationFailed, NotificationCancelled |
@@ -76,6 +76,7 @@ context.
 | 26 | `disruption-recovery` | `events:disruption-recovery` | DisruptionReported, IncidentOpened, RecoveryCaseOpened, RecoveryOptionsGenerated, RecoveryOptionSelected, RecoveryExecutionStarted, RecoveryCompleted, RecoveryFailed, RecoveryCaseClosed, ServiceAlertPublished |
 | 27 | `ancillary-service` | `events:ancillary-service` | AncillaryCatalogItemPublished, AncillaryCatalogItemSuspended, AncillaryCatalogItemSuperseded, AncillaryOfferQuoted, AncillaryOfferExpired, AncillaryOrderItemSelected, AncillaryOrderItemPendingConfirmation, AncillaryOrderItemConfirmed, AncillaryOrderItemFulfillmentReady, AncillaryOrderItemFulfilled, AncillaryOrderItemFailed, AncillaryOrderItemCancelled, AncillaryOrderItemRefundPending, AncillaryOrderItemRefunded, AncillaryFulfillmentFactRecorded |
 | 28 | `transfer-management` | `events:transfer-management` | TransferPlanCreated, TransferPlanEvaluated, TransferPlanExpired, ConnectionRegistered, TransferRiskEvaluated, TransferAtRisk, ConnectionMissed, ConnectionRecovered, ConnectionRecoveryFailed, ConnectionContractProposed, ConnectionContractConfirmed, ConnectionContractWithdrawn, MctRuleCreated, MctRulePublished, MctRuleRetired |
+| 29 | `seat-assignment` | `events:seat-assignment` | SeatMapBuilt, SeatMapBuildFailed, SeatMapVersionPublished, SeatMapVersionRetired, SeatUnitUnavailableMarked, SeatUnitReopened, AdjacencyGroupCreated, AdjacentAllocationSolved, AdjacencyDegradationAccepted, AdjacencyGroupCancelled, BerthPreferenceRecorded, BerthPreferenceApplied, BerthPreferenceCancelled, SeatAllocated, StandingAssigned, SeatAllocationConfirmed, SeatAllocationReleased, SeatAllocationExpired, SeatAllocationFailed, SeatAllocationMissed, SeatReassigned, SeatAllocationLedgerAppended, SeatAllocationCorrectionAppended, SeatAllocationDiscrepancyDetected |
 
 ### Dead-Letter Streams
 
@@ -285,6 +286,12 @@ plus notification/finance/reporting fan-in.
 | 56 | `events:post-sales` | `disruption-recovery` | PostSalesApplied converges REFUND recovery execution |
 | 57 | `events:journey-order` | `ancillary-service` | RULING (2026-07-09): JourneyOrderCancelled is the only upstream event consumed by Ancillary Service in this activation wave; it automatically cancels associated non-terminal AncillaryOrderItem records. |
 | 58 | `events:disruption-recovery` | `transfer-management` | RecoveryCompleted/RecoveryFailed converge protected missed connections by stored `caseId` mapping. RULING (2026-07-09): for self-executed `REACCOMMODATION`, `RecoveryCompleted` for an already `RECOVERED` connection and matching `caseId` is acknowledged as an idempotent no-op. |
+| 59 | `events:capacity-availability` | `seat-assignment` | CapacityReleased and CapacityHoldExpired release or expire matching active seat allocations by `holdId`; Seat Assignment explicitly ignores AvailabilitySnapshot/CapacityHeld/CapacityHoldConfirmed for lifecycle mutation in this wave. |
+| 60 | `events:entitlement-ticketing` | `seat-assignment` | EntitlementIssued confirms an active seat allocation; EntitlementVoided and EntitlementIssueFailed release active allocations. EntitlementBoarded/Suspended/Resumed/Used are explicitly ignored by Seat Assignment. |
+| 61 | `events:seat-assignment` | `entitlement-ticketing` | SeatAllocated/StandingAssigned/SeatAllocationFailed support issuance-path reconciliation and idempotent retry handling; Entitlement does not consume SeatMap CRUD or ledger/discrepancy events. |
+| 62 | `events:seat-assignment` | `booking-orchestration` | Seat allocation lifecycle facts inform saga observability/compensation; Booking Orchestration does not use them to replace Capacity hold/confirm/release commands. |
+| 63 | `events:seat-assignment` | `notification` | Seat assignment, standing, reassignment, release, and adjacency degradation user touchpoints; SeatMap CRUD, ledger, and discrepancy events are explicitly ignored. |
+| 64 | `events:seat-assignment` | `reporting` | SeatMap, allocation, standing, degradation, release, expiry, ledger, and discrepancy metrics/read models. |
 
 ### Cross-Cutting Consumers
 
@@ -293,9 +300,28 @@ analytics, and cross-cutting concerns:
 
 | Consumer Group (Context) | Subscribed Streams | Purpose |
 |---|---|---|
-| `reporting` | All active `events:*` streams except `events:dispatch`, `events:disruption-recovery`, and `events:transfer-management` until their deferred-consumer activation waves | Business metrics, funnel analysis, operational dashboards |
+| `reporting` | All active `events:*` streams except `events:dispatch`, `events:disruption-recovery`, and `events:transfer-management` until their deferred-consumer activation waves; includes `events:seat-assignment` in ADR-0003 wave A | Business metrics, funnel analysis, operational dashboards |
 | `finance-settlement` | `events:payment`, `events:provider-integration`, `events:booking-orchestration`, `events:post-sales`, `events:wallet-promotion` | Revenue recognition, reconciliation, invoice generation, and Wallet / Promotion benefit-cost attribution. |
-| `notification` | `events:journey-order`, `events:booking-orchestration`, `events:payment`, `events:entitlement-ticketing`, `events:post-sales`, `events:wallet-promotion` | User-facing notification triggers including Wallet / Promotion issued, expired, and revoked benefit touchpoints. |
+| `notification` | `events:journey-order`, `events:booking-orchestration`, `events:payment`, `events:entitlement-ticketing`, `events:post-sales`, `events:wallet-promotion`, `events:seat-assignment` | User-facing notification triggers including Wallet / Promotion issued, expired, revoked benefit touchpoints, and seat/standing/degradation changes. |
+
+
+### Seat Assignment subscriptions
+
+`events:seat-assignment` is registered in ADR-0003 wave A. Active consumers are
+Entitlement & Ticketing, Booking Orchestration, Notification, and Reporting as
+listed in rows 61-64. Entitlement consumes only allocation/standing/failure facts
+needed for issuance-path reconciliation; it explicitly excludes SeatMap CRUD,
+ledger, and discrepancy facts. Notification consumes user-visible assignment,
+standing, reassignment, release, expiry, and adjacency degradation touchpoints; it
+explicitly excludes SeatMap CRUD and ledger/discrepancy facts.
+
+Seat Assignment has two active inbound subscriptions in this wave: Capacity &
+Availability `CapacityReleased` / `CapacityHoldExpired`, and Entitlement &
+Ticketing `EntitlementIssued` / `EntitlementVoided` / `EntitlementIssueFailed`.
+It explicitly does not consume Waitlist, Dispatch, Wallet / Promotion, Disruption
+Recovery, Transfer Management, or Provider Integration streams in this wave. SIM
+composition behavior is deterministic and seed-driven through operations HTTP, not
+through a provider stream.
 
 ### Disruption Recovery subscriptions
 


### PR DESCRIPTION
## Summary
- Add Seat Assignment API and event contracts for ADR-0003 wave A
- Register seat-assignment streams/subscriptions and Capacity/Entitlement consumers
- Document same-wave Entitlement & Ticketing contract/code touchpoints for seatPreferences and seatRef

## Validation
- make contract-lint