### PR TITLE
fix(rust-kit): Redis subscriber reconnects on connection loss

### DIFF
--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
@@ -20,7 +20,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class RedisEventSubscriber implements EventSubscriber {
     public static final int MAX_DELIVERY_ATTEMPTS = 5;
     private static final Logger LOGGER = LoggerFactory.getLogger(RedisEventSubscriber.class);
-    private static final long POLL_FAILURE_BACKOFF_MILLIS = 1_000;
+    private static final long INITIAL_BACKOFF_SECONDS = 1;
+    private static final long MAX_BACKOFF_SECONDS = 30;
     private static final int LAST_FAILURE_CACHE_SIZE = 1_024;
 
     private final RedisStreamOperations streams;
@@ -83,6 +84,7 @@ public class RedisEventSubscriber implements EventSubscriber {
     }
 
     private void poll(List<String> streamNames, String group, String consumerName, EventHandler handler) {
+        long backoffSeconds = INITIAL_BACKOFF_SECONDS;
         while (running.get()) {
             for (String stream : streamNames) {
                 try {
@@ -91,12 +93,14 @@ public class RedisEventSubscriber implements EventSubscriber {
                     for (RedisStreamOperations.StreamEntry message : streams.readGroup(stream, group, consumerName)) {
                         handle(stream, group, consumerName, message, handler, streams.deliveryCount(stream, group, message.id()));
                     }
+                    backoffSeconds = INITIAL_BACKOFF_SECONDS;
                 } catch (RuntimeException exception) {
-                    // Keep the subscriber alive; messages read but not acked remain in the Redis PEL for recovery/DLQ policy.
-                    // Consumer-group creation and polling both happen in this background loop so Redis outages
-                    // never abort service startup. Failures back off and retry on the next loop.
-                    LOGGER.warn("service={} stream={} poll iteration failed; backing off", group, stream, exception);
-                    sleepQuietly(POLL_FAILURE_BACKOFF_MILLIS);
+                    if (Thread.currentThread().isInterrupted()) {
+                        return;
+                    }
+                    LOGGER.warn("service={} stream={} poll iteration failed; reconnecting in {}s", group, stream, backoffSeconds, exception);
+                    sleepQuietly(backoffSeconds * 1_000L);
+                    backoffSeconds = Math.min(backoffSeconds * 2, MAX_BACKOFF_SECONDS);
                 }
             }
         }

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
@@ -86,6 +86,42 @@ class RedisEventSubscriberTest {
 
 
     @Test
+    void pollBacksOffExponentiallyOnConsecutiveFailuresAndResetsOnSuccess() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        EventEnvelope event = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of("id", "1"));
+        String eventJson = objectMapper.writeValueAsString(event);
+        FailThenSucceedStreams streams = new FailThenSucceedStreams(
+            3,
+            List.of(new RedisStreamOperations.StreamEntry("1-0", eventJson))
+        );
+
+        RedisEventSubscriber subscriber = new RedisEventSubscriber(streams, objectMapper, null);
+        Logger logger = (Logger) LoggerFactory.getLogger(RedisEventSubscriber.class);
+        ListAppender<ILoggingEvent> logs = new ListAppender<>();
+        logs.start();
+        logger.addAppender(logs);
+        CountDownLatch handled = new CountDownLatch(1);
+        try {
+            subscriber.subscribe(List.of("events:payment"), "journey-order", "consumer-1", envelope -> {
+                handled.countDown();
+                return HandlerResult.SUCCESS;
+            });
+            assertThat(handled.await(15, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            subscriber.close();
+            logger.detachAppender(logs);
+        }
+        List<String> reconnectLogs = logs.list.stream()
+            .filter(e -> e.getFormattedMessage().contains("reconnecting in"))
+            .map(ILoggingEvent::getFormattedMessage)
+            .toList();
+        assertThat(reconnectLogs).hasSize(3);
+        assertThat(reconnectLogs.get(0)).contains("reconnecting in 1s");
+        assertThat(reconnectLogs.get(1)).contains("reconnecting in 2s");
+        assertThat(reconnectLogs.get(2)).contains("reconnecting in 4s");
+    }
+
+    @Test
     void maxDeliveryAttemptsUsesLastRuntimeExceptionAsFailureReasonWithoutRedispatching() throws Exception {
         ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
         EventEnvelope event = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of("id", "1"));
@@ -107,6 +143,38 @@ class RedisEventSubscriberTest {
         assertThat(streams.dlqMetadata.get().failureReason()).isEqualTo("IllegalStateException: payment parse failed");
         assertThat(streams.dlqMetadata.get().attempts()).isEqualTo(RedisEventSubscriber.MAX_DELIVERY_ATTEMPTS);
         assertThat(streams.acked).contains("1-0");
+    }
+
+    private static final class FailThenSucceedStreams implements RedisStreamOperations {
+        private final int failCount;
+        private final List<StreamEntry> successBatch;
+        private final List<String> acked = new ArrayList<>();
+        private int readGroupCalls;
+        private boolean delivered;
+
+        private FailThenSucceedStreams(int failCount, List<StreamEntry> successBatch) {
+            this.failCount = failCount;
+            this.successBatch = successBatch;
+        }
+
+        @Override public void createGroup(String stream, String group) {}
+        @Override public String publish(String stream, String envelopeJson) { return "1-0"; }
+
+        @Override
+        public synchronized List<StreamEntry> readGroup(String stream, String group, String consumerName) {
+            readGroupCalls++;
+            if (readGroupCalls <= failCount) {
+                throw new RuntimeException("Connection refused (os error 111)");
+            }
+            if (delivered) return List.of();
+            delivered = true;
+            return successBatch;
+        }
+
+        @Override public List<StreamEntry> autoClaim(String stream, String group, String consumerName) { return List.of(); }
+        @Override public int deliveryCount(String stream, String group, String messageId) { return 1; }
+        @Override public void ack(String stream, String group, String messageId) { acked.add(messageId); }
+        @Override public void moveToDlq(String stream, String envelopeJson, DlqMetadata metadata) {}
     }
 
     private static final class FakeRedisStreams implements RedisStreamOperations {

--- a/platform/rust-kit/src/messaging.rs
+++ b/platform/rust-kit/src/messaging.rs
@@ -1043,7 +1043,7 @@ pub mod redis_runtime {
             streams: Vec<String>,
             group: String,
             consumer_name: String,
-            handler: Box<dyn Fn(EventEnvelope) -> HandlerFuture + Send + Sync>,
+            handler: &(dyn Fn(EventEnvelope) -> HandlerFuture + Send + Sync),
             run_once: bool,
         ) -> Result<(), SubscribeFailed> {
             Self::create_groups_with_ops(ops, &streams, &group).await?;
@@ -1057,7 +1057,7 @@ pub mod redis_runtime {
                         &streams,
                         &group,
                         &consumer_name,
-                        handler.as_ref(),
+                        handler,
                     )
                     .await
                 {
@@ -1078,7 +1078,7 @@ pub mod redis_runtime {
                     }
                 };
                 for message in messages {
-                    self.process_message(ops, &group, &consumer_name, message, handler.as_ref())
+                    self.process_message(ops, &group, &consumer_name, message, handler)
                         .await?;
                 }
                 if run_once {
@@ -1096,14 +1096,50 @@ pub mod redis_runtime {
             consumer_name: String,
             handler: Box<dyn Fn(EventEnvelope) -> HandlerFuture + Send + Sync>,
         ) -> Result<(), SubscribeFailed> {
-            let connection = self
-                .client
-                .get_multiplexed_async_connection()
-                .await
-                .map_err(|error| SubscribeFailed(error.to_string()))?;
-            let mut ops = RedisStreamOps { connection };
-            self.subscribe_with_ops(&mut ops, streams, group, consumer_name, handler, false)
-                .await
+            let mut delay = 1u64;
+            loop {
+                if self.stop.load(std::sync::atomic::Ordering::SeqCst) {
+                    return Ok(());
+                }
+                let connection = match self.client.get_multiplexed_async_connection().await {
+                    Ok(c) => {
+                        delay = 1;
+                        c
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            "Redis subscriber connection failed: {error}, reconnecting in {delay}s"
+                        );
+                        sleep(Duration::from_secs(delay)).await;
+                        delay = (delay * 2).min(30);
+                        continue;
+                    }
+                };
+                let mut ops = RedisStreamOps { connection };
+                match self
+                    .subscribe_with_ops(
+                        &mut ops,
+                        streams.clone(),
+                        group.clone(),
+                        consumer_name.clone(),
+                        handler,
+                        false,
+                    )
+                    .await
+                {
+                    Ok(()) => return Ok(()),
+                    Err(error) => {
+                        if self.stop.load(std::sync::atomic::Ordering::SeqCst) {
+                            return Ok(());
+                        }
+                        tracing::warn!(
+                            "Redis subscriber disconnected: {error}, reconnecting in {delay}s"
+                        );
+                        sleep(Duration::from_secs(delay)).await;
+                        delay = (delay * 2).min(30);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Wraps `RedisEventSubscriber.subscribe()` in a retry loop with exponential backoff (1s → 30s cap)
- Previously, initial connection failure or mid-stream `process_message` errors caused the subscriber thread to exit permanently
- Root cause: entitlement-ticketing subscriber died after Redis restart during 12-restart e2e test with `SubscribeFailed("Connection refused (os error 111)")`
- Changes `subscribe_with_ops` handler parameter from `Box<dyn Fn>` to `&dyn Fn` for reuse across reconnect iterations

## Test plan
- [x] `cargo test` — 14 pass, 0 fail
- [x] `cargo check` — clean
- [ ] 12-restart e2e test: all Rust services should maintain subscriber after Redis restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)