### PR TITLE
fix(rust-kit): handler.as_ref() in subscribe reconnect loop

### DIFF
--- a/platform/rust-kit/src/messaging.rs
+++ b/platform/rust-kit/src/messaging.rs
@@ -1122,7 +1122,7 @@ pub mod redis_runtime {
                         streams.clone(),
                         group.clone(),
                         consumer_name.clone(),
-                        handler,
+                        handler.as_ref(),
                         false,
                     )
                     .await


### PR DESCRIPTION
Follow-up to #254/#255 — the reconnect loop passed Box handler directly instead of as_ref(). Broke all Rust service builds.