### PR TITLE
feat(stress): open-loop stress driver + correctness auditor + S1/S2 scenarios

### DIFF
--- a/deploy/stress/README.md
+++ b/deploy/stress/README.md
@@ -1,0 +1,111 @@
+# Stress Test Infrastructure
+
+Open-loop stress driver and post-run correctness auditor for the train-ticket
+microservice system running on `kind-arl-test`.
+
+## Prerequisites
+
+```bash
+pip install aiohttp pyyaml
+```
+
+The auditor also requires `kubectl` configured with context `kind-arl-test`
+and access to the `train-ticket` namespace.
+
+## Quick start
+
+### 1. Run a stress scenario
+
+From the e2e-curl pod (in-cluster) or from the host with port-forward:
+
+```bash
+# Rush scenario: 200 workers competing for 50 seats, closed-loop
+python3 driver.py --scenario scenarios/s1-rush.yaml --report /tmp/s1-report.json
+
+# Staircase scenario: open-loop with stepped RPS from 10 to 150
+python3 driver.py --scenario scenarios/s2-staircase.yaml --report /tmp/s2-report.json
+```
+
+CLI overrides:
+
+```bash
+# Override RPS, duration, and worker count
+python3 driver.py --scenario scenarios/s2-staircase.yaml \
+    --rps 50 --duration 120 --workers 100 \
+    --report /tmp/custom-report.json
+```
+
+### 2. Audit the results
+
+After the driver finishes, run the auditor to check six correctness invariants:
+
+```bash
+python3 auditor.py \
+    --scenario scenarios/s1-rush.yaml \
+    --report /tmp/s1-report.json \
+    --output /tmp/s1-audit.json
+```
+
+The auditor queries PostgreSQL and Redis directly via `kubectl exec` and
+verifies:
+
+1. **Inventory conservation** -- confirmed orders <= segment capacity
+2. **Seat uniqueness** -- no duplicate seat assignments per segment
+3. **Fund conservation** -- captures match order totals; refunds <= captures
+4. **No stuck orders** -- all sagas terminal, outbox drained, DLQ empty
+5. **Idempotent single-effect** -- each idempotency key produces exactly one effect
+6. **Clean losers** -- rush failures are contractual, not 500s
+
+Exit code 0 = all assertions passed; exit code 1 = at least one failed.
+
+### 3. Running from the e2e-curl pod
+
+```bash
+kubectl --context kind-arl-test exec -it deploy/e2e-curl -n train-ticket -- bash
+cd /stress
+python3 driver.py --scenario scenarios/s1-rush.yaml
+```
+
+## Scenario format
+
+See `scenarios/s1-rush.yaml` and `scenarios/s2-staircase.yaml` for annotated
+examples. Key fields:
+
+| Field | Description |
+|-------|-------------|
+| `load.model` | `open` (token bucket) or `closed` (fixed workers) |
+| `load.rps` | Target requests/second (open-loop only) |
+| `load.workers` | Concurrent coroutines |
+| `load.staircase` | List of `{rps, hold_seconds}` steps |
+| `mix.purchase` | Weight for purchase chains |
+| `mix.refund` | Weight for refund chains |
+| `mix.browse` | Weight for browse chains |
+| `constraints.target_capacity` | Expected seat count (for auditor assertions) |
+
+## Architecture
+
+```
+driver.py
+  TokenBucket       -- open-loop arrival control
+  LatencyTracker    -- per-endpoint p50/p95/p99/max
+  StressDriver      -- reads scenario, spawns workers
+  purchase_chain()  -- search -> quote -> offer -> order -> reserve -> pay -> ticket
+  refund_chain()    -- post-sales case -> evaluate -> approve
+  browse_chain()    -- search + quote, no purchase
+  StaffSim          -- drives reservation + ticketing queues
+
+auditor.py
+  query_db()        -- kubectl exec psql
+  query_redis()     -- kubectl exec redis-cli
+  6 assertion fns   -- each returns AssertionResult
+```
+
+## Output
+
+The driver writes a JSON report with:
+- Per-chain latency histograms
+- Per-endpoint latency histograms
+- HTTP status code counts
+- Outcome tallies (purchased, refunded, failed, etc.)
+
+The auditor writes a JSON audit report with pass/fail for each assertion.

--- a/deploy/stress/auditor.py
+++ b/deploy/stress/auditor.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python3
+"""Post-run correctness checker for stress test results.
+
+Queries PostgreSQL (via kubectl exec) and Redis to verify six hard invariants
+that must hold regardless of load level:
+
+  1. Inventory conservation — confirmed orders <= capacity
+  2. Seat uniqueness       — no duplicate seatRef per segment+date
+  3. Fund conservation     — captures = order amounts; refunds <= captures
+  4. No stuck orders       — all sagas terminal; outbox drained; DLQ = 0
+  5. Idempotent single-effect — each idempotency key -> exactly 1 effect
+  6. Clean losers          — in rush scenarios, all failures are contractual
+
+Usage:
+  python3 auditor.py --scenario scenarios/s1-rush.yaml --report /tmp/s1-report.json
+  python3 auditor.py --scenario scenarios/s1-rush.yaml  # no report, DB-only checks
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+KUBE_CONTEXT = "kind-arl-test"
+KUBE_NAMESPACE = "train-ticket"
+POSTGRES_POD = "postgres-0"
+POSTGRES_USER = "trainticket"
+REDIS_POD = "redis-0"
+
+# Contractual error codes that are acceptable "clean" failures in rush
+# scenarios.  Any 4xx error code with one of these bodies is not a bug.
+CLEAN_FAILURE_CODES = frozenset({
+    "CAPACITY_EXHAUSTED",
+    "SEGMENT_FULL",
+    "INVENTORY_UNAVAILABLE",
+    "OFFER_EXPIRED",
+    "SEAT_UNAVAILABLE",
+    "CONFLICT",
+    "SAGA_COMPENSATION",
+    "ORDER_REJECTED",
+    "RESERVATION_DENIED",
+})
+
+
+# ---------------------------------------------------------------------------
+# kubectl helpers
+# ---------------------------------------------------------------------------
+
+
+def _kubectl_exec(pod: str, command: list[str], namespace: str = KUBE_NAMESPACE) -> str:
+    """Run a command inside a pod via kubectl exec and return stdout."""
+    cmd = [
+        "kubectl", "--context", KUBE_CONTEXT,
+        "exec", "-n", namespace, pod, "--",
+    ] + command
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            if stderr:
+                print(f"[kubectl] stderr: {stderr}", file=sys.stderr)
+        return result.stdout.strip()
+    except subprocess.TimeoutExpired:
+        print(f"[kubectl] timeout: {' '.join(cmd)}", file=sys.stderr)
+        return ""
+    except FileNotFoundError:
+        print("[kubectl] kubectl not found; returning empty result", file=sys.stderr)
+        return ""
+
+
+def query_db(database: str, sql: str) -> str:
+    """Execute a SQL query against a PostgreSQL database via kubectl exec."""
+    return _kubectl_exec(
+        POSTGRES_POD,
+        ["psql", "-U", POSTGRES_USER, "-d", database, "-t", "-A", "-c", sql],
+    )
+
+
+def query_redis(cmd: str) -> str:
+    """Execute a Redis command via kubectl exec."""
+    parts = cmd.split()
+    return _kubectl_exec(REDIS_POD, ["redis-cli"] + parts)
+
+
+# ---------------------------------------------------------------------------
+# Assertion result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AssertionResult:
+    name: str
+    passed: bool
+    details: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Assertion implementations
+# ---------------------------------------------------------------------------
+
+
+def assert_inventory_conservation(cfg: dict, report: dict | None) -> AssertionResult:
+    """Confirmed orders must not exceed capacity for any segment+date."""
+    name = "inventory_conservation"
+    constraints = cfg.get("constraints", {})
+    target_capacity = constraints.get("target_capacity")
+
+    # Query the seat-assignment or booking database for confirmed bookings
+    # grouped by segment.
+    sql = """
+        SELECT segment_ref, COUNT(*) as confirmed
+        FROM segment_bookings
+        WHERE status IN ('CONFIRMED', 'ACTIVE', 'TICKETED')
+        GROUP BY segment_ref
+        ORDER BY confirmed DESC
+        LIMIT 20;
+    """
+    raw = query_db("booking_orchestration", sql)
+    if not raw:
+        # Try alternative table name
+        sql_alt = """
+            SELECT segment_ref, COUNT(*) as confirmed
+            FROM booking_saga
+            WHERE status IN ('COMPLETED', 'CONFIRMED')
+            GROUP BY segment_ref
+            ORDER BY confirmed DESC
+            LIMIT 20;
+        """
+        raw = query_db("booking_orchestration", sql_alt)
+
+    segments: dict[str, int] = {}
+    violations: list[str] = []
+    for line in raw.splitlines():
+        parts = line.split("|")
+        if len(parts) >= 2:
+            seg = parts[0].strip()
+            count = int(parts[1].strip())
+            segments[seg] = count
+            if target_capacity is not None and count > int(target_capacity):
+                violations.append(f"{seg}: {count} > {target_capacity}")
+
+    # Also check via the driver report if available
+    report_purchased = 0
+    if report:
+        results = report.get("results", {})
+        report_purchased = results.get("purchased", 0)
+        if target_capacity is not None and report_purchased > int(target_capacity):
+            violations.append(
+                f"report.purchased={report_purchased} > capacity={target_capacity}"
+            )
+
+    passed = len(violations) == 0
+    return AssertionResult(
+        name=name,
+        passed=passed,
+        details={
+            "segments": segments,
+            "target_capacity": target_capacity,
+            "report_purchased": report_purchased,
+            "violations": violations,
+        },
+    )
+
+
+def assert_seat_uniqueness(cfg: dict, report: dict | None) -> AssertionResult:
+    """No duplicate seatRef per segment+date."""
+    name = "seat_uniqueness"
+    sql = """
+        SELECT segment_ref, seat_ref, COUNT(*) as cnt
+        FROM seat_assignments
+        WHERE seat_ref IS NOT NULL
+        GROUP BY segment_ref, seat_ref
+        HAVING COUNT(*) > 1
+        LIMIT 20;
+    """
+    raw = query_db("seat_assignment", sql)
+    if not raw:
+        # Try alternative database / table
+        sql_alt = """
+            SELECT segment_ref, seat_ref, COUNT(*) as cnt
+            FROM segment_bookings
+            WHERE seat_ref IS NOT NULL
+            GROUP BY segment_ref, seat_ref
+            HAVING COUNT(*) > 1
+            LIMIT 20;
+        """
+        raw = query_db("booking_orchestration", sql_alt)
+
+    duplicates: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        parts = line.split("|")
+        if len(parts) >= 3:
+            duplicates.append({
+                "segment_ref": parts[0].strip(),
+                "seat_ref": parts[1].strip(),
+                "count": int(parts[2].strip()),
+            })
+
+    passed = len(duplicates) == 0
+    return AssertionResult(
+        name=name,
+        passed=passed,
+        details={"duplicates": duplicates},
+    )
+
+
+def assert_fund_conservation(cfg: dict, report: dict | None) -> AssertionResult:
+    """sum(captures) = sum(order amounts); sum(refunds) <= sum(captures)."""
+    name = "fund_conservation"
+
+    # Total captures
+    sql_captures = """
+        SELECT COALESCE(SUM(amount_minor), 0) FROM payment_intents
+        WHERE status = 'CAPTURED';
+    """
+    raw_captures = query_db("payment", sql_captures)
+    total_captures = int(raw_captures.strip()) if raw_captures.strip().isdigit() else 0
+
+    # Total order amounts
+    sql_orders = """
+        SELECT COALESCE(SUM(total_minor), 0) FROM journey_orders
+        WHERE status IN ('CONFIRMED', 'COMPLETED');
+    """
+    raw_orders = query_db("journey_order", sql_orders)
+    total_orders = int(raw_orders.strip()) if raw_orders.strip().isdigit() else 0
+
+    # Total refunds
+    sql_refunds = """
+        SELECT COALESCE(SUM(amount_minor), 0) FROM payment_intents
+        WHERE status = 'REFUNDED' OR purpose = 'refund';
+    """
+    raw_refunds = query_db("payment", sql_refunds)
+    if not raw_refunds.strip().lstrip("-").isdigit():
+        # Try alternative
+        sql_refunds_alt = """
+            SELECT COALESCE(SUM(refund_amount_minor), 0) FROM refunds;
+        """
+        raw_refunds = query_db("payment", sql_refunds_alt)
+    total_refunds = int(raw_refunds.strip()) if raw_refunds.strip().lstrip("-").isdigit() else 0
+
+    violations: list[str] = []
+    # Allow a small tolerance for timing (in-flight captures not yet settled)
+    if total_captures > 0 and total_orders > 0:
+        diff = abs(total_captures - total_orders)
+        # More than 5% divergence is a problem
+        if diff > max(total_captures, total_orders) * 0.05:
+            violations.append(
+                f"captures ({total_captures}) != orders ({total_orders}), diff={diff}"
+            )
+
+    if total_refunds > total_captures:
+        violations.append(
+            f"refunds ({total_refunds}) > captures ({total_captures})"
+        )
+
+    passed = len(violations) == 0
+    return AssertionResult(
+        name=name,
+        passed=passed,
+        details={
+            "total_captures": total_captures,
+            "total_orders": total_orders,
+            "total_refunds": total_refunds,
+            "violations": violations,
+        },
+    )
+
+
+def assert_no_stuck_orders(cfg: dict, report: dict | None) -> AssertionResult:
+    """All sagas should be terminal; outbox drained; DLQ empty."""
+    name = "no_stuck_orders"
+    details: dict[str, Any] = {}
+    violations: list[str] = []
+
+    # Non-terminal sagas
+    sql_sagas = """
+        SELECT status, COUNT(*) FROM booking_saga
+        WHERE status NOT IN ('COMPLETED', 'COMPENSATED', 'FAILED', 'CANCELLED')
+        GROUP BY status;
+    """
+    raw_sagas = query_db("booking_orchestration", sql_sagas)
+    stuck_sagas: dict[str, int] = {}
+    for line in raw_sagas.splitlines():
+        parts = line.split("|")
+        if len(parts) >= 2:
+            status = parts[0].strip()
+            count = int(parts[1].strip())
+            stuck_sagas[status] = count
+    details["stuck_sagas"] = stuck_sagas
+    if stuck_sagas:
+        total_stuck = sum(stuck_sagas.values())
+        violations.append(f"{total_stuck} non-terminal saga(s): {stuck_sagas}")
+
+    # Outbox drain check
+    for db_name in ("booking_orchestration", "journey_order", "payment"):
+        sql_outbox = """
+            SELECT COUNT(*) FROM outbox_events
+            WHERE published = false OR published IS NULL;
+        """
+        raw = query_db(db_name, sql_outbox)
+        count = int(raw.strip()) if raw.strip().isdigit() else 0
+        details[f"outbox_pending_{db_name}"] = count
+        if count > 0:
+            violations.append(f"{db_name}: {count} unpublished outbox event(s)")
+
+    # DLQ check (via Redis)
+    dlq_len = query_redis("LLEN dlq:events")
+    dlq_count = int(dlq_len) if dlq_len.strip().isdigit() else 0
+    details["dlq_count"] = dlq_count
+    if dlq_count > 0:
+        violations.append(f"DLQ has {dlq_count} message(s)")
+
+    passed = len(violations) == 0
+    return AssertionResult(
+        name=name,
+        passed=passed,
+        details=details,
+        error="; ".join(violations) if violations else None,
+    )
+
+
+def assert_idempotent_single_effect(cfg: dict, report: dict | None) -> AssertionResult:
+    """Each idempotency key must map to exactly one effect row."""
+    name = "idempotent_single_effect"
+
+    # Check payment intents for duplicate idempotency keys
+    sql = """
+        SELECT idempotency_key, COUNT(*) as cnt
+        FROM payment_intents
+        WHERE idempotency_key IS NOT NULL
+        GROUP BY idempotency_key
+        HAVING COUNT(*) > 1
+        LIMIT 20;
+    """
+    raw = query_db("payment", sql)
+    duplicates: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        parts = line.split("|")
+        if len(parts) >= 2:
+            duplicates.append({
+                "idempotency_key": parts[0].strip(),
+                "count": int(parts[1].strip()),
+            })
+
+    # Also check journey orders
+    sql_orders = """
+        SELECT idempotency_key, COUNT(*) as cnt
+        FROM journey_orders
+        WHERE idempotency_key IS NOT NULL
+        GROUP BY idempotency_key
+        HAVING COUNT(*) > 1
+        LIMIT 20;
+    """
+    raw_orders = query_db("journey_order", sql_orders)
+    for line in raw_orders.splitlines():
+        parts = line.split("|")
+        if len(parts) >= 2:
+            duplicates.append({
+                "idempotency_key": parts[0].strip(),
+                "count": int(parts[1].strip()),
+                "table": "journey_orders",
+            })
+
+    passed = len(duplicates) == 0
+    return AssertionResult(
+        name=name,
+        passed=passed,
+        details={"duplicates": duplicates},
+    )
+
+
+def assert_clean_losers(cfg: dict, report: dict | None) -> AssertionResult:
+    """In rush scenarios, all failures must be contractual error codes."""
+    name = "clean_losers"
+
+    if not report:
+        return AssertionResult(
+            name=name,
+            passed=True,
+            details={"skipped": "no report provided"},
+        )
+
+    results = report.get("results", {})
+    error_counts = report.get("error_counts", {})
+
+    # Collect all failure entries from the results
+    failures: dict[str, int] = {}
+    dirty_failures: dict[str, int] = {}
+
+    for key, count in results.items():
+        if not key.startswith("failed:") and not key.startswith("crashed:"):
+            continue
+        failures[key] = count
+
+        # Check if the failure reason matches a clean code
+        parts = key.split(":")
+        step = parts[-1] if len(parts) > 1 else key
+        is_clean = any(code.lower() in step.lower() for code in CLEAN_FAILURE_CODES)
+
+        if not is_clean:
+            # Check if it is a known transport/timeout — those are infra, not bugs
+            if "transport" in step.lower() or "timeout" in step.lower():
+                continue
+            dirty_failures[key] = count
+
+    # For rush scenarios (mix.purchase == 1.0), we are strict about dirty failures
+    is_rush = float(cfg.get("mix", {}).get("purchase", 0)) == 1.0
+    constraints = cfg.get("constraints", {})
+    has_capacity = constraints.get("target_capacity") is not None
+
+    if is_rush and has_capacity:
+        passed = len(dirty_failures) == 0
+    else:
+        # For non-rush scenarios, just report; do not fail
+        passed = True
+
+    return AssertionResult(
+        name=name,
+        passed=passed,
+        details={
+            "is_rush_scenario": is_rush and has_capacity,
+            "total_failures": sum(failures.values()),
+            "failures": failures,
+            "dirty_failures": dirty_failures,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+ALL_ASSERTIONS = [
+    ("inventory_conservation", assert_inventory_conservation),
+    ("seat_uniqueness", assert_seat_uniqueness),
+    ("fund_conservation", assert_fund_conservation),
+    ("no_stuck_orders", assert_no_stuck_orders),
+    ("idempotent_single_effect", assert_idempotent_single_effect),
+    ("clean_losers", assert_clean_losers),
+]
+
+
+def run_all_assertions(
+    cfg: dict, report: dict | None
+) -> list[AssertionResult]:
+    results: list[AssertionResult] = []
+    for name, fn in ALL_ASSERTIONS:
+        print(f"[audit] checking {name} ...", end=" ", flush=True)
+        try:
+            result = fn(cfg, report)
+        except Exception as exc:
+            result = AssertionResult(
+                name=name, passed=False,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+        status = "PASS" if result.passed else "FAIL"
+        print(status, flush=True)
+        results.append(result)
+    return results
+
+
+def build_output(
+    scenario_name: str, results: list[AssertionResult]
+) -> dict[str, Any]:
+    total = len(results)
+    passed = sum(1 for r in results if r.passed)
+    failed = total - passed
+    return {
+        "scenario": scenario_name,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "assertions": [
+            {
+                "name": r.name,
+                "passed": r.passed,
+                "details": r.details,
+                **({"error": r.error} if r.error else {}),
+            }
+            for r in results
+        ],
+        "summary": {"total": total, "passed": passed, "failed": failed},
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Post-run correctness auditor for stress tests"
+    )
+    parser.add_argument(
+        "--scenario", required=True, help="Path to scenario YAML"
+    )
+    parser.add_argument(
+        "--report", default=None, help="Path to driver JSON report"
+    )
+    parser.add_argument(
+        "--output", default=None, help="Path to write audit JSON output"
+    )
+    parser.add_argument(
+        "--context", default=KUBE_CONTEXT, help="kubectl context"
+    )
+    parser.add_argument(
+        "--namespace", default=KUBE_NAMESPACE, help="Kubernetes namespace"
+    )
+    parser.add_argument(
+        "--postgres-pod", default=POSTGRES_POD, help="PostgreSQL pod name"
+    )
+    parser.add_argument(
+        "--redis-pod", default=REDIS_POD, help="Redis pod name"
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    # Apply CLI overrides to module-level config
+    global KUBE_CONTEXT, KUBE_NAMESPACE, POSTGRES_POD, REDIS_POD
+    KUBE_CONTEXT = args.context
+    KUBE_NAMESPACE = args.namespace
+    POSTGRES_POD = args.postgres_pod
+    REDIS_POD = args.redis_pod
+
+    with open(args.scenario) as f:
+        cfg = yaml.safe_load(f)
+
+    report: dict | None = None
+    if args.report:
+        with open(args.report) as f:
+            report = json.load(f)
+
+    scenario_name = cfg.get("name", "unknown")
+    print(f"\n{'=' * 60}", flush=True)
+    print(f"Auditing scenario: {scenario_name}", flush=True)
+    print(f"{'=' * 60}\n", flush=True)
+
+    results = run_all_assertions(cfg, report)
+    output = build_output(scenario_name, results)
+
+    # Write output
+    output_path = args.output
+    if output_path is None:
+        output_path = f"/tmp/{scenario_name}-audit.json"
+    with open(output_path, "w") as f:
+        json.dump(output, f, indent=2)
+    print(f"\n[audit] results written to {output_path}", flush=True)
+
+    # Summary
+    summary = output["summary"]
+    print(f"\n{'=' * 60}", flush=True)
+    print(
+        f"RESULT: {summary['passed']}/{summary['total']} passed, "
+        f"{summary['failed']} failed",
+        flush=True,
+    )
+    print(f"{'=' * 60}\n", flush=True)
+
+    if summary["failed"] > 0:
+        print("Failed assertions:", flush=True)
+        for r in results:
+            if not r.passed:
+                print(f"  - {r.name}: {r.error or r.details}", flush=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/stress/driver.py
+++ b/deploy/stress/driver.py
@@ -1,0 +1,1096 @@
+#!/usr/bin/env python3
+"""Open-loop stress test driver for the train-ticket microservice system.
+
+Usage:
+  python3 driver.py --scenario scenarios/s1-rush.yaml --report /tmp/s1-report.json
+  python3 driver.py --scenario scenarios/s2-staircase.yaml --rps 50 --duration 120
+
+Key differences from the loadgen:
+  - Open-loop: a token bucket controls the arrival rate independently of
+    how fast (or slow) the system responds.
+  - Per-endpoint latency histograms with p50/p95/p99/max.
+  - Scenario YAML drives the load profile (rush, staircase, etc.).
+  - Machine-readable JSON report output for the auditor.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import math
+import os
+import random
+import signal
+import string
+import sys
+import time
+import uuid
+from collections import Counter, defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Any
+
+import aiohttp
+import yaml
+
+# ---------------------------------------------------------------------------
+# Utilities (compatible with loadgen conventions)
+# ---------------------------------------------------------------------------
+
+
+def uuid7() -> str:
+    """Generate a UUID v7 (time-ordered) as used by the greenfield services."""
+    ts = int(time.time() * 1000)
+    rand_a = random.getrandbits(12)
+    rand_b = random.getrandbits(62)
+    value = (ts << 80) | (0x7 << 76) | (rand_a << 64) | (0b10 << 62) | rand_b
+    return str(uuid.UUID(int=value))
+
+
+def now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def rand_name(rng: random.Random) -> tuple[str, str]:
+    given = rng.choice(
+        ["Wei", "Fang", "Min", "Jing", "Lei", "Yan", "Hao", "Xin", "Tao", "Mei"]
+    )
+    family = rng.choice(
+        ["Zhang", "Wang", "Li", "Zhao", "Chen", "Liu", "Yang", "Huang", "Zhou", "Wu"]
+    )
+    suffix = "".join(rng.choices(string.ascii_lowercase, k=4))
+    return given, f"{family}-{suffix}"
+
+
+def _bookable(itin: dict) -> bool:
+    """Real plan segments are seg-<uuid>; synthetic refs are rejected downstream."""
+    legs = itin.get("legs") or []
+    if not legs:
+        return False
+    ref = str(legs[0].get("serviceSegmentRef", ""))
+    return ref.startswith("seg-") and len(ref) == 40 and ref.count("-") == 5
+
+
+# ---------------------------------------------------------------------------
+# Token bucket — open-loop arrival control
+# ---------------------------------------------------------------------------
+
+
+class TokenBucket:
+    """Precise rate limiter: acquire() suspends until a token is available."""
+
+    def __init__(self, rate: float, burst: int = 1):
+        self._rate = max(rate, 0.001)
+        self._burst = max(burst, 1)
+        self._tokens = float(burst)
+        self._last = time.monotonic()
+        self._lock = asyncio.Lock()
+
+    @property
+    def rate(self) -> float:
+        return self._rate
+
+    def set_rate(self, rate: float) -> None:
+        self._rate = max(rate, 0.001)
+
+    async def acquire(self) -> None:
+        async with self._lock:
+            now = time.monotonic()
+            elapsed = now - self._last
+            self._tokens = min(self._tokens + elapsed * self._rate, float(self._burst))
+            self._last = now
+            if self._tokens >= 1.0:
+                self._tokens -= 1.0
+                return
+            wait = (1.0 - self._tokens) / self._rate
+            self._tokens = 0.0
+        await asyncio.sleep(wait)
+
+
+# ---------------------------------------------------------------------------
+# Per-endpoint latency tracking
+# ---------------------------------------------------------------------------
+
+
+class LatencyTracker:
+    """Accumulates per-endpoint latency samples and computes percentiles."""
+
+    def __init__(self, cap: int = 50_000):
+        self._data: dict[str, list[float]] = defaultdict(list)
+        self._cap = cap
+
+    def record(self, endpoint: str, ms: float) -> None:
+        buf = self._data[endpoint]
+        buf.append(ms)
+        if len(buf) > self._cap:
+            del buf[: len(buf) - self._cap]
+
+    def _pct(self, sorted_vals: list[float], p: float) -> float:
+        idx = max(0, int(math.ceil(len(sorted_vals) * p)) - 1)
+        return round(sorted_vals[idx], 2)
+
+    def summary(self) -> dict[str, dict[str, Any]]:
+        out: dict[str, dict[str, Any]] = {}
+        for ep, vals in self._data.items():
+            if not vals:
+                continue
+            s = sorted(vals)
+            out[ep] = {
+                "count": len(s),
+                "p50": self._pct(s, 0.50),
+                "p95": self._pct(s, 0.95),
+                "p99": self._pct(s, 0.99),
+                "max": round(s[-1], 2),
+            }
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class StepFailed(Exception):
+    def __init__(self, step: str, detail: str):
+        super().__init__(f"{step}: {detail}")
+        self.step = step
+
+
+# ---------------------------------------------------------------------------
+# HTTP client wrapper
+# ---------------------------------------------------------------------------
+
+
+class ApiClient:
+    def __init__(self, cfg: dict, latency: LatencyTracker):
+        self.template: str = cfg["target"]["base_url_template"]
+        self.timeout = aiohttp.ClientTimeout(
+            total=float(cfg["target"].get("request_timeout_seconds", 15))
+        )
+        self.latency = latency
+        self.status_counts: Counter = Counter()
+        self.error_counts: Counter = Counter()
+        self._session: aiohttp.ClientSession | None = None
+
+    async def session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(timeout=self.timeout)
+        return self._session
+
+    async def request(
+        self,
+        method: str,
+        service: str,
+        path: str,
+        body: dict | None = None,
+        headers: dict | None = None,
+        ok: tuple[int, ...] = (200, 201),
+        step: str = "",
+    ) -> tuple[int, Any]:
+        url = self.template.format(service=service) + path
+        hdrs = dict(headers or {})
+        if method in ("POST", "PUT", "PATCH") and "Idempotency-Key" not in hdrs:
+            hdrs["Idempotency-Key"] = uuid7()
+        endpoint_key = f"{service}:{method}:{path.split('?')[0]}"
+
+        t0 = time.monotonic()
+        try:
+            sess = await self.session()
+            resp = await sess.request(method, url, json=body, headers=hdrs)
+            status = resp.status
+            try:
+                data = await resp.json() if resp.content_length != 0 else {}
+            except Exception:
+                data = {}
+        except Exception as exc:
+            self.error_counts[f"{service}:transport"] += 1
+            raise StepFailed(step or path, f"transport: {exc}") from exc
+        finally:
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            self.latency.record(endpoint_key, elapsed_ms)
+
+        self.status_counts[f"{service}:{status}"] += 1
+        if ok and status not in ok:
+            self.error_counts[f"{service}:{status}"] += 1
+            raise StepFailed(
+                step or path, f"{method} {service}{path} -> {status} {str(data)[:200]}"
+            )
+        return status, data
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+
+# ---------------------------------------------------------------------------
+# Shared state for purchase references (needed by refund chain)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PurchaseRef:
+    order_id: str
+    saga_id: str
+    sb_id: str
+    segment_ref: str
+    traveler_ref: str
+    account_id: str
+    entitlement_id: str
+    total_minor: int
+
+
+class SharedState:
+    def __init__(self) -> None:
+        self.purchases: deque[PurchaseRef] = deque(maxlen=2000)
+        self.lock = asyncio.Lock()
+        # Staff work queues
+        self.q_reservation: deque = deque()
+        self.q_ticketing: deque = deque()
+
+    async def add_purchase(self, p: PurchaseRef) -> None:
+        async with self.lock:
+            self.purchases.append(p)
+
+    async def take_purchase(self, rng: random.Random) -> PurchaseRef | None:
+        async with self.lock:
+            if not self.purchases:
+                return None
+            idx = rng.randrange(len(self.purchases))
+            p = self.purchases[idx]
+            del self.purchases[idx]
+            return p
+
+
+# ---------------------------------------------------------------------------
+# Staff simulator (minimal — drives reservation + ticketing queues)
+# ---------------------------------------------------------------------------
+
+
+class StaffSim:
+    """Processes staff work queues: reservation driving and ticket issuing."""
+
+    def __init__(
+        self, cfg: dict, api: ApiClient, state: SharedState, rng: random.Random
+    ):
+        staff_cfg = cfg.get("staff", {})
+        self.api = api
+        self.state = state
+        self.rng = rng
+        self.think_min = float(staff_cfg.get("think_time_seconds", {}).get("min", 0.2))
+        self.think_max = float(staff_cfg.get("think_time_seconds", {}).get("max", 1.0))
+        self.queue_poll = float(staff_cfg.get("queue_poll_seconds", 0.3))
+        self.poll_attempts = int(cfg.get("polling", {}).get("attempts", 10))
+        self.poll_interval = float(cfg.get("polling", {}).get("interval_seconds", 3))
+        self.redis_url = cfg["target"].get("redis_url", "redis://redis:6379")
+
+    async def think(self) -> None:
+        await asyncio.sleep(self.rng.uniform(self.think_min, self.think_max))
+
+    async def worker(self, stop: asyncio.Event) -> None:
+        while not stop.is_set():
+            item = None
+            for q in (self.state.q_reservation, self.state.q_ticketing):
+                try:
+                    item = q.popleft()
+                    break
+                except IndexError:
+                    continue
+            if item is None:
+                await asyncio.sleep(self.queue_poll)
+                continue
+            try:
+                await self.think()
+                handler = getattr(self, f"do_{item['kind']}", None)
+                if handler:
+                    await handler(item)
+            except Exception as exc:
+                item["failed"] = True
+                item["error"] = f"{type(exc).__name__}: {exc}"
+
+    async def do_reservation(self, item: dict) -> None:
+        """Find the booking saga for an order and drive the reservation step."""
+        # Poll the journey-order for a saga reference instead of Redis,
+        # which is simpler for the stress driver context.
+        saga = None
+        for _ in range(self.poll_attempts):
+            try:
+                _, data = await self.api.request(
+                    "GET",
+                    "journey-order",
+                    f"/api/v1/journey-orders/{item['order']}",
+                    ok=(),
+                    step="staff-poll-order",
+                )
+                saga = (data or {}).get("sagaId")
+                if saga:
+                    break
+            except StepFailed:
+                pass
+            await asyncio.sleep(self.poll_interval)
+
+        if not saga:
+            # Fall back: try booking-orchestration list endpoint
+            try:
+                _, data = await self.api.request(
+                    "GET",
+                    "booking-orchestration",
+                    f"/api/v1/internal/booking-sagas?journeyOrderId={item['order']}",
+                    ok=(200,),
+                    step="staff-find-saga",
+                )
+                sagas = data if isinstance(data, list) else data.get("items", [])
+                if sagas:
+                    saga = sagas[0].get("sagaId")
+            except StepFailed:
+                pass
+
+        if not saga:
+            raise StepFailed("reservation", f"no saga found for order {item['order']}")
+
+        sb = f"sb-{uuid7()}"
+        await self.api.request(
+            "POST",
+            "booking-orchestration",
+            f"/api/v1/internal/booking-sagas/{saga}/request-reservation",
+            {
+                "segmentRef": item["seg"],
+                "travelerRef": item["traveler"],
+                "segmentBookingId": sb,
+            },
+            ok=(200,),
+            step="staff-reservation",
+        )
+        item["saga"] = saga
+        item["sb"] = sb
+
+    async def do_ticketing(self, item: dict) -> None:
+        _, data = await self.api.request(
+            "POST",
+            "entitlement-ticketing",
+            "/api/v1/entitlements",
+            {
+                "segmentBookingId": item["sb"],
+                "journeyOrderId": item["order"],
+                "travelerRef": item["traveler"],
+                "segmentRef": item["seg"],
+                "issuePurpose": "INITIAL",
+            },
+            step="staff-ticketing",
+        )
+        item["entitlement"] = data.get("entitlementId", "")
+
+
+# ---------------------------------------------------------------------------
+# Chain executors
+# ---------------------------------------------------------------------------
+
+
+async def _wait_for(item: dict, key: str, timeout: float) -> Any:
+    """Poll a staff work item until the expected key is filled."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if item.get("failed"):
+            raise StepFailed(
+                item.get("kind", "staff"), str(item.get("error", ""))[:200]
+            )
+        if item.get(key) is not None:
+            return item[key]
+        await asyncio.sleep(0.5)
+    raise StepFailed(item.get("kind", "staff"), f"timed out waiting for {key}")
+
+
+async def _poll_order(
+    api: ApiClient,
+    order_id: str,
+    want: set[str],
+    attempts: int,
+    interval: float,
+) -> str | None:
+    status = None
+    for _ in range(attempts):
+        try:
+            code, data = await api.request(
+                "GET",
+                "journey-order",
+                f"/api/v1/journey-orders/{order_id}",
+                ok=(),
+                step="poll-order",
+            )
+            if code == 200:
+                status = (data or {}).get("status")
+                if status in want:
+                    return status
+        except StepFailed:
+            pass
+        await asyncio.sleep(interval)
+    return status
+
+
+async def purchase_chain(
+    api: ApiClient,
+    cfg: dict,
+    state: SharedState,
+    rng: random.Random,
+    route: dict,
+    results: dict,
+) -> str:
+    """Single purchase chain: search -> quote -> offer -> order -> reserve -> pay -> ticket."""
+    poll_attempts = int(cfg.get("polling", {}).get("attempts", 10))
+    poll_interval = float(cfg.get("polling", {}).get("interval_seconds", 3))
+    staff_wait = 90.0
+
+    # 1. Identity
+    account_id = f"acc-{uuid7()}"
+    await api.request(
+        "POST",
+        "account",
+        "/api/v1/accounts",
+        {"accountId": account_id},
+        ok=(200, 201),
+        step="register-account",
+    )
+
+    given, family = rand_name(rng)
+    _, tvl_data = await api.request(
+        "POST",
+        "traveler-profile",
+        "/api/v1/travelers",
+        {
+            "accountId": account_id,
+            "travelerType": "ADULT",
+            "givenName": given,
+            "familyName": family,
+        },
+        step="create-traveler",
+    )
+    traveler = tvl_data["travelerId"]
+
+    # 2. Search
+    _, search_data = await api.request(
+        "POST",
+        "trip-planning",
+        "/api/v1/itineraries/search",
+        {
+            "originRef": route["origin"],
+            "destinationRef": route["destination"],
+            "departureDate": route["date"],
+            "travelerRefs": [traveler],
+            "channel": "WEB",
+        },
+        ok=(200,),
+        step="search",
+    )
+    itins = [i for i in (search_data.get("itineraries") or []) if _bookable(i)]
+    if not itins:
+        results["no_inventory"] += 1
+        return "no_inventory"
+    itin = rng.choice(itins) if len(itins) > 1 else itins[0]
+    itin_ref = itin["itineraryRef"]
+    seg_ref = itin["legs"][0]["serviceSegmentRef"]
+
+    # 3. Quote
+    await api.request(
+        "POST",
+        "fare-pricing",
+        "/api/v1/fare-quotes",
+        {
+            "travelerRefs": [traveler],
+            "channel": "WEB",
+            "segmentRefs": [seg_ref],
+        },
+        step="quote",
+    )
+
+    # 4. Offer
+    _, offer = await api.request(
+        "POST",
+        "offer-management",
+        "/api/v1/offers",
+        {
+            "accountId": account_id,
+            "channelId": "WEB",
+            "itineraryRef": itin_ref,
+            "travelerRefs": [traveler],
+        },
+        step="offer",
+    )
+
+    # 5. Order
+    _, order = await api.request(
+        "POST",
+        "journey-order",
+        "/api/v1/journey-orders",
+        {
+            "accountId": account_id,
+            "offerId": offer["offerId"],
+            "offerVersion": offer.get("offerVersion", 1),
+            "travelerRefs": [traveler],
+            "segmentRefs": [seg_ref],
+        },
+        step="order",
+    )
+    order_id = order["orderId"]
+
+    # 6. Reservation (staff-driven)
+    resv = {"kind": "reservation", "order": order_id, "seg": seg_ref, "traveler": traveler}
+    state.q_reservation.append(resv)
+    sb = await _wait_for(resv, "sb", staff_wait)
+
+    # 7. Payment
+    total_minor = int(offer.get("total", {}).get("minorUnits", 10750))
+    _, intent = await api.request(
+        "POST",
+        "payment",
+        "/api/v1/payment-intents",
+        {
+            "businessRef": order_id,
+            "purpose": "purchase",
+            "amount": {"currency": "CNY", "minorUnits": total_minor},
+            "payerRef": account_id,
+        },
+        step="payment-intent",
+    )
+    await api.request(
+        "POST",
+        "payment",
+        f"/api/v1/payment-intents/{intent['paymentIntentId']}/capture",
+        {},
+        ok=(200, 201),
+        step="payment-capture",
+    )
+
+    # 8. Ticketing (staff-driven)
+    tick = {
+        "kind": "ticketing",
+        "order": order_id,
+        "sb": sb,
+        "traveler": traveler,
+        "seg": seg_ref,
+    }
+    state.q_ticketing.append(tick)
+    ent = await _wait_for(tick, "entitlement", staff_wait)
+
+    # 9. Confirm
+    final = await _poll_order(api, order_id, {"CONFIRMED"}, poll_attempts, poll_interval)
+    if final != "CONFIRMED":
+        results["unconfirmed"] += 1
+        return "unconfirmed"
+
+    await state.add_purchase(
+        PurchaseRef(
+            order_id=order_id,
+            saga_id=resv.get("saga", ""),
+            sb_id=sb,
+            segment_ref=seg_ref,
+            traveler_ref=traveler,
+            account_id=account_id,
+            entitlement_id=ent,
+            total_minor=total_minor,
+        )
+    )
+    results["purchased"] += 1
+    return "purchased"
+
+
+async def refund_chain(
+    api: ApiClient,
+    state: SharedState,
+    rng: random.Random,
+    results: dict,
+) -> str:
+    """Single refund chain: post-sales case -> evaluate -> approve."""
+    p = await state.take_purchase(rng)
+    if p is None:
+        results["no_purchase_to_refund"] += 1
+        return "no_purchase_to_refund"
+
+    _, case = await api.request(
+        "POST",
+        "post-sales",
+        "/api/v1/post-sales-cases",
+        {
+            "journeyOrderId": p.order_id,
+            "caseType": "REFUND",
+            "scope": {
+                "orderItemRefs": [p.sb_id],
+                "segmentRefs": [p.segment_ref],
+                "travelerRefs": [p.traveler_ref],
+                "entitlementRefs": [p.entitlement_id],
+            },
+            "reasonCode": "CUSTOMER_REQUEST",
+            "actorRef": p.account_id,
+        },
+        step="refund-case",
+    )
+    case_id = case.get("caseId") or case.get("postSalesCaseId")
+    if not case_id:
+        raise StepFailed("refund-case", f"no case id: {str(case)[:150]}")
+
+    await api.request(
+        "POST",
+        "post-sales",
+        f"/api/v1/post-sales-cases/{case_id}/evaluate",
+        {},
+        ok=(200, 201),
+        step="refund-evaluate",
+    )
+    await api.request(
+        "POST",
+        "post-sales",
+        f"/api/v1/post-sales-cases/{case_id}/approve",
+        {},
+        ok=(200, 201),
+        step="refund-approve",
+    )
+
+    results["refunded"] += 1
+    return "refunded"
+
+
+async def browse_chain(
+    api: ApiClient,
+    rng: random.Random,
+    route: dict,
+    results: dict,
+) -> str:
+    """Search + quote, no purchase."""
+    account_id = f"acc-{uuid7()}"
+    await api.request(
+        "POST", "account", "/api/v1/accounts",
+        {"accountId": account_id}, ok=(200, 201), step="register-account",
+    )
+    given, family = rand_name(rng)
+    _, tvl_data = await api.request(
+        "POST", "traveler-profile", "/api/v1/travelers",
+        {"accountId": account_id, "travelerType": "ADULT",
+         "givenName": given, "familyName": family}, step="create-traveler",
+    )
+    traveler = tvl_data["travelerId"]
+
+    _, search_data = await api.request(
+        "POST", "trip-planning", "/api/v1/itineraries/search",
+        {"originRef": route["origin"], "destinationRef": route["destination"],
+         "departureDate": route["date"], "travelerRefs": [traveler], "channel": "WEB"},
+        ok=(200,), step="search",
+    )
+    itins = [i for i in (search_data.get("itineraries") or []) if _bookable(i)]
+    if itins:
+        seg_ref = itins[0]["legs"][0]["serviceSegmentRef"]
+        await api.request(
+            "POST", "fare-pricing", "/api/v1/fare-quotes",
+            {"travelerRefs": [traveler], "channel": "WEB",
+             "segmentRefs": [seg_ref]}, step="quote",
+        )
+
+    results["browsed"] += 1
+    return "browsed"
+
+
+# ---------------------------------------------------------------------------
+# Staircase controller
+# ---------------------------------------------------------------------------
+
+
+async def staircase_controller(
+    cfg: dict, bucket: TokenBucket, stop: asyncio.Event
+) -> None:
+    """Adjust the token bucket rate according to the staircase profile."""
+    steps = cfg.get("load", {}).get("staircase")
+    if not steps:
+        return
+    for step in steps:
+        if stop.is_set():
+            return
+        rps = float(step["rps"])
+        hold = float(step["hold_seconds"])
+        bucket.set_rate(rps)
+        print(f"[staircase] RPS -> {rps}, holding {hold}s", flush=True)
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=hold)
+            return
+        except asyncio.TimeoutError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Route resolution from seed config
+# ---------------------------------------------------------------------------
+
+
+async def resolve_routes(
+    api: ApiClient, cfg: dict, rng: random.Random
+) -> list[dict]:
+    """Discover bookable routes from the seed config via the place/search APIs."""
+    seed = cfg.get("seed", {})
+    cities = seed.get("cities", ["Beijing", "Shanghai"])
+    date = seed.get("departure_date", "2026-09-01")
+    constraints = cfg.get("constraints", {})
+    target_segments = constraints.get("target_segments")
+
+    # Discover place IDs
+    _, listing = await api.request(
+        "GET", "place-network", "/api/v1/places?limit=100&offset=0&status=ACTIVE",
+        ok=(200,), step="list-places",
+    )
+    by_name: dict[str, str] = {}
+    for p in listing.get("items", []):
+        name = p.get("canonicalName", "")
+        by_name[name] = p["placeId"]
+
+    routes: list[dict] = []
+    place_ids = []
+    for city in cities:
+        pid = by_name.get(city)
+        if pid:
+            place_ids.append(pid)
+
+    if len(place_ids) < 2:
+        print(
+            f"[routes] only {len(place_ids)} cities resolved; "
+            "using all place pairs as fallback",
+            flush=True,
+        )
+        place_ids = [p["placeId"] for p in listing.get("items", []) if p.get("placeId")]
+
+    # Probe search to find bookable pairs
+    probe_tvl = None
+    for a in place_ids:
+        for b in place_ids:
+            if a == b:
+                continue
+            try:
+                if probe_tvl is None:
+                    _, t = await api.request(
+                        "POST", "traveler-profile", "/api/v1/travelers",
+                        {"accountId": f"acc-{uuid7()}", "travelerType": "ADULT",
+                         "givenName": "Probe", "familyName": "Driver"},
+                        step="probe-traveler",
+                    )
+                    probe_tvl = t["travelerId"]
+                _, res = await api.request(
+                    "POST", "trip-planning", "/api/v1/itineraries/search",
+                    {"originRef": a, "destinationRef": b,
+                     "departureDate": date, "travelerRefs": [probe_tvl],
+                     "channel": "WEB"}, ok=(200,), step="probe-search",
+                )
+                if any(_bookable(i) for i in res.get("itineraries") or []):
+                    routes.append({"origin": a, "destination": b, "date": date})
+                    if target_segments and len(routes) >= target_segments:
+                        return routes
+            except StepFailed:
+                continue
+
+    if not routes:
+        print("[routes] WARNING: no bookable routes found; chains will fail", flush=True)
+    else:
+        print(f"[routes] discovered {len(routes)} bookable route(s)", flush=True)
+    return routes
+
+
+# ---------------------------------------------------------------------------
+# Main driver
+# ---------------------------------------------------------------------------
+
+
+class StressDriver:
+    def __init__(self, cfg: dict, report_path: str | None):
+        self.cfg = cfg
+        self.report_path = report_path
+        self.latency = LatencyTracker()
+        self.api = ApiClient(cfg, self.latency)
+        self.state = SharedState()
+        self.rng = random.Random(cfg.get("seed", {}).get("seed"))
+        self.results: dict[str, int] = Counter()
+        self.chain_latencies: dict[str, list[float]] = defaultdict(list)
+        self.start_time = 0.0
+        self.end_time = 0.0
+        self.total_dispatched = 0
+        self.total_errors = 0
+
+    async def run(self) -> dict:
+        load = self.cfg.get("load", {})
+        model = load.get("model", "closed")
+        workers = int(load.get("workers", 100))
+        duration = float(load.get("duration_seconds", 120))
+        rps = load.get("rps")
+
+        routes = await resolve_routes(self.api, self.cfg, self.rng)
+        if not routes:
+            return self._build_report()
+
+        mix = self.cfg.get("mix", {"purchase": 1.0})
+        # Normalize mix weights
+        total_weight = sum(float(v) for v in mix.values() if float(v) > 0)
+        if total_weight == 0:
+            total_weight = 1.0
+        norm_mix = {k: float(v) / total_weight for k, v in mix.items() if float(v) > 0}
+
+        stop = asyncio.Event()
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, stop.set)
+        if duration > 0:
+            loop.call_later(duration, stop.set)
+
+        # Staff workers
+        staff_cfg = self.cfg.get("staff", {})
+        staff_count = int(staff_cfg.get("workers", 2))
+        staff_sim = StaffSim(self.cfg, self.api, self.state, self.rng)
+        staff_tasks = [
+            asyncio.create_task(staff_sim.worker(stop)) for _ in range(staff_count)
+        ]
+
+        self.start_time = time.time()
+
+        if model == "open" and rps:
+            bucket = TokenBucket(rate=float(rps), burst=max(1, int(float(rps) / 2)))
+            sem = asyncio.Semaphore(workers)
+
+            # Start staircase controller if configured
+            staircase_task = asyncio.create_task(
+                staircase_controller(self.cfg, bucket, stop)
+            )
+
+            dispatch_task = asyncio.create_task(
+                self._open_loop_dispatch(bucket, sem, stop, routes, norm_mix)
+            )
+            await stop.wait()
+            dispatch_task.cancel()
+            staircase_task.cancel()
+            # Let in-flight chains drain (bounded by semaphore)
+            await asyncio.sleep(2)
+        else:
+            # Closed-loop: fixed number of workers, each fires as fast as possible
+            chain_tasks = [
+                asyncio.create_task(
+                    self._closed_loop_worker(i, stop, routes, norm_mix)
+                )
+                for i in range(workers)
+            ]
+            await stop.wait()
+            await asyncio.gather(*chain_tasks, return_exceptions=True)
+
+        self.end_time = time.time()
+
+        # Clean up staff
+        stop.set()
+        await asyncio.gather(*staff_tasks, return_exceptions=True)
+        await self.api.close()
+
+        report = self._build_report()
+        if self.report_path:
+            with open(self.report_path, "w") as f:
+                json.dump(report, f, indent=2)
+            print(f"[report] written to {self.report_path}", flush=True)
+
+        return report
+
+    async def _open_loop_dispatch(
+        self,
+        bucket: TokenBucket,
+        sem: asyncio.Semaphore,
+        stop: asyncio.Event,
+        routes: list[dict],
+        mix: dict[str, float],
+    ) -> None:
+        """Dispatch chains at the token-bucket rate, bounded by the semaphore."""
+        while not stop.is_set():
+            await bucket.acquire()
+            if stop.is_set():
+                break
+            await sem.acquire()
+            chain_type = self._pick_chain(mix)
+            route = self.rng.choice(routes)
+            asyncio.create_task(
+                self._run_chain_with_sem(sem, chain_type, route)
+            )
+
+    async def _run_chain_with_sem(
+        self, sem: asyncio.Semaphore, chain_type: str, route: dict
+    ) -> None:
+        try:
+            await self._run_chain(chain_type, route)
+        finally:
+            sem.release()
+
+    async def _closed_loop_worker(
+        self,
+        idx: int,
+        stop: asyncio.Event,
+        routes: list[dict],
+        mix: dict[str, float],
+    ) -> None:
+        while not stop.is_set():
+            chain_type = self._pick_chain(mix)
+            route = self.rng.choice(routes)
+            await self._run_chain(chain_type, route)
+
+    def _pick_chain(self, mix: dict[str, float]) -> str:
+        r = self.rng.random()
+        cumulative = 0.0
+        for name, weight in mix.items():
+            cumulative += weight
+            if r <= cumulative:
+                return name
+        return list(mix.keys())[-1]
+
+    async def _run_chain(self, chain_type: str, route: dict) -> None:
+        self.total_dispatched += 1
+        t0 = time.monotonic()
+        try:
+            if chain_type == "purchase":
+                await purchase_chain(
+                    self.api, self.cfg, self.state, self.rng, route, self.results
+                )
+            elif chain_type == "refund":
+                await refund_chain(self.api, self.state, self.rng, self.results)
+            elif chain_type == "browse":
+                await browse_chain(self.api, self.rng, route, self.results)
+            else:
+                self.results[f"unknown_chain:{chain_type}"] += 1
+        except StepFailed as exc:
+            self.total_errors += 1
+            self.results[f"failed:{chain_type}:{exc.step}"] += 1
+        except Exception as exc:
+            self.total_errors += 1
+            self.results[f"crashed:{chain_type}:{type(exc).__name__}"] += 1
+        finally:
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            self.chain_latencies[chain_type].append(elapsed_ms)
+
+    def _build_report(self) -> dict:
+        elapsed = max(self.end_time - self.start_time, 0.001)
+
+        chain_summary: dict[str, Any] = {}
+        for chain_type, vals in self.chain_latencies.items():
+            if not vals:
+                continue
+            s = sorted(vals)
+            chain_summary[chain_type] = {
+                "count": len(s),
+                "p50_ms": round(s[len(s) // 2], 2),
+                "p95_ms": round(s[max(0, int(len(s) * 0.95) - 1)], 2),
+                "p99_ms": round(s[max(0, int(len(s) * 0.99) - 1)], 2),
+                "max_ms": round(s[-1], 2),
+            }
+
+        return {
+            "scenario": self.cfg.get("name", "unknown"),
+            "timestamp": now_iso(),
+            "duration_seconds": round(elapsed, 2),
+            "total_dispatched": self.total_dispatched,
+            "total_errors": self.total_errors,
+            "effective_rps": round(self.total_dispatched / elapsed, 2),
+            "results": dict(self.results),
+            "chain_latencies": chain_summary,
+            "endpoint_latencies": self.latency.summary(),
+            "http_status_counts": dict(self.api.status_counts),
+            "error_counts": dict(self.api.error_counts),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Periodic stats printer
+# ---------------------------------------------------------------------------
+
+
+async def periodic_stats(driver: StressDriver, stop: asyncio.Event) -> None:
+    while not stop.is_set():
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=15.0)
+        except asyncio.TimeoutError:
+            pass
+        elapsed = time.time() - driver.start_time if driver.start_time else 0
+        print(
+            f"[stats] t={elapsed:.0f}s dispatched={driver.total_dispatched} "
+            f"errors={driver.total_errors} results={dict(driver.results)}",
+            flush=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Open-loop stress test driver for train-ticket"
+    )
+    parser.add_argument(
+        "--scenario", required=True, help="Path to scenario YAML file"
+    )
+    parser.add_argument(
+        "--report", default=None, help="Path to write JSON report"
+    )
+    parser.add_argument(
+        "--rps", type=float, default=None, help="Override RPS from scenario"
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=None,
+        help="Override duration_seconds from scenario",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=None,
+        help="Override worker count from scenario",
+    )
+    return parser.parse_args()
+
+
+async def async_main() -> None:
+    args = parse_args()
+
+    with open(args.scenario) as f:
+        cfg = yaml.safe_load(f)
+
+    # CLI overrides
+    if args.rps is not None:
+        cfg.setdefault("load", {})["rps"] = args.rps
+        cfg["load"]["model"] = "open"
+    if args.duration is not None:
+        cfg.setdefault("load", {})["duration_seconds"] = args.duration
+    if args.workers is not None:
+        cfg.setdefault("load", {})["workers"] = args.workers
+
+    report_path = args.report
+    if report_path is None:
+        name = cfg.get("name", "stress")
+        report_path = f"/tmp/{name}-report.json"
+
+    driver = StressDriver(cfg, report_path)
+
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, stop.set)
+
+    stats_task = asyncio.create_task(periodic_stats(driver, stop))
+
+    try:
+        report = await driver.run()
+    finally:
+        stop.set()
+        stats_task.cancel()
+
+    # Print summary
+    print("\n" + "=" * 60, flush=True)
+    print(f"Scenario:    {report.get('scenario')}", flush=True)
+    print(f"Duration:    {report.get('duration_seconds')}s", flush=True)
+    print(f"Dispatched:  {report.get('total_dispatched')}", flush=True)
+    print(f"Errors:      {report.get('total_errors')}", flush=True)
+    print(f"Eff. RPS:    {report.get('effective_rps')}", flush=True)
+    print(f"Results:     {json.dumps(report.get('results', {}), indent=2)}", flush=True)
+    print(f"Report:      {report_path}", flush=True)
+    print("=" * 60, flush=True)
+
+
+def main() -> None:
+    asyncio.run(async_main())
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/stress/scenarios/s1-rush.yaml
+++ b/deploy/stress/scenarios/s1-rush.yaml
@@ -1,0 +1,47 @@
+# S1 — Rush scenario: N buyers competing for K seats on the same segment.
+#
+# All workers target the same origin/destination/date, so the underlying
+# inventory (target_capacity seats) is the bottleneck.  The auditor uses
+# `constraints` to verify that exactly K orders succeed and the rest get
+# clean contractual rejections.
+
+name: s1-rush
+description: "N buyers competing for K seats on same segment"
+
+load:
+  model: closed          # closed-loop: workers fire as fast as possible
+  workers: 200           # concurrent coroutines
+  duration_seconds: 120
+  rps: null              # null = max speed (closed-loop)
+
+target:
+  base_url_template: "http://{service}:8080"
+  redis_url: "redis://redis:6379"
+  request_timeout_seconds: 15
+
+mix:
+  purchase: 1.0          # 100 % purchase — pure contention test
+  refund: 0.0
+  browse: 0.0
+
+constraints:
+  target_segments: 1     # all workers target the same segment
+  target_capacity: 50    # expected K seats available
+  # Auditor uses these to assert:
+  #   confirmed_orders <= target_capacity
+  #   failed_orders    >= workers - target_capacity  (roughly)
+
+seed:
+  cities: ["Beijing", "Shanghai"]
+  departure_date: "2026-09-01"
+
+# Polling tuning for saga / order-status checks.
+polling:
+  attempts: 12
+  interval_seconds: 3
+
+staff:
+  workers: 4
+  think_time_seconds: {min: 0.2, max: 1.0}
+  queue_poll_seconds: 0.3
+  p_risk_approve: 1.0     # approve everything — rush test, not risk test

--- a/deploy/stress/scenarios/s2-staircase.yaml
+++ b/deploy/stress/scenarios/s2-staircase.yaml
@@ -1,0 +1,56 @@
+# S2 — Staircase scenario: steady-state load with stepped RPS increases.
+#
+# Open-loop driver ramps RPS through a staircase of levels, holding each
+# step for `step_duration_seconds`.  The mix includes purchases and refunds
+# to exercise the full lifecycle under sustained, predictable throughput.
+
+name: s2-staircase
+description: "Steady-state staircase: step RPS every N seconds"
+
+load:
+  model: open            # open-loop: token bucket controls arrival rate
+  workers: 300           # max concurrent coroutines (back-pressure ceiling)
+  duration_seconds: 600  # total test duration
+  rps: 10                # initial requests per second
+
+  # Staircase profile: list of (rps, hold_seconds) steps.
+  # After the last step the test continues at that RPS until duration expires.
+  staircase:
+    - {rps: 10,  hold_seconds: 60}
+    - {rps: 25,  hold_seconds: 60}
+    - {rps: 50,  hold_seconds: 60}
+    - {rps: 75,  hold_seconds: 60}
+    - {rps: 100, hold_seconds: 60}
+    - {rps: 125, hold_seconds: 60}
+    - {rps: 150, hold_seconds: 60}
+    - {rps: 100, hold_seconds: 60}   # cool-down step
+    - {rps: 50,  hold_seconds: 60}
+    - {rps: 25,  hold_seconds: 60}
+
+target:
+  base_url_template: "http://{service}:8080"
+  redis_url: "redis://redis:6379"
+  request_timeout_seconds: 15
+
+mix:
+  purchase: 0.60
+  refund: 0.15
+  browse: 0.25
+
+constraints:
+  target_segments: null  # spread across available inventory
+  target_capacity: null
+
+seed:
+  cities: ["Beijing", "Shanghai", "Guangzhou", "Hangzhou"]
+  departure_date: "2026-09-01"
+
+polling:
+  attempts: 10
+  interval_seconds: 3
+
+staff:
+  workers: 6
+  think_time_seconds: {min: 0.3, max: 1.5}
+  queue_poll_seconds: 0.3
+  p_risk_approve: 0.90


### PR DESCRIPTION
## Summary
- `deploy/stress/driver.py` (1096 lines): open-loop stress driver with TokenBucket arrival rate control, per-endpoint latency tracking (p50/p95/p99/max), JSON report output
- `deploy/stress/auditor.py` (585 lines): 6 hard correctness assertions — inventory conservation, seat uniqueness, fund conservation, no stuck orders, idempotent single-effect, clean losers
- `deploy/stress/scenarios/s1-rush.yaml`: ticket rush storm (N>>K same segment)
- `deploy/stress/scenarios/s2-staircase.yaml`: steady-state RPS staircase
- `deploy/stress/README.md`: usage instructions

## Test plan
- [x] `ast.parse` + `yaml.safe_load` syntax checks pass
- [ ] S1 scenario dry run on kind cluster
- [ ] Auditor queries validated against actual schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)