### PR TITLE
fix: PG connection pool health checks (all 3 kits)

### DIFF
--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/persistence/DataSources.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/persistence/DataSources.java
@@ -14,9 +14,14 @@ public final class DataSources {
         config.setJdbcUrl(parsed.jdbcUrl());
         config.setUsername(parsed.username());
         config.setPassword(parsed.password());
-        config.setMaximumPoolSize(10);
+        config.setMaximumPoolSize(Integer.parseInt(
+            System.getenv().getOrDefault("HIKARI_MAX_POOL_SIZE", "10")));
         config.setMinimumIdle(1);
         config.setPoolName("platform-java-kit-postgres");
+        config.setKeepaliveTime(30_000);
+        config.setMaxLifetime(600_000);
+        config.setConnectionTimeout(5_000);
+        config.setValidationTimeout(3_000);
         return new HikariDataSource(config);
     }
 }

--- a/platform/python-kit/src/train_ticket_platform/storage.py
+++ b/platform/python-kit/src/train_ticket_platform/storage.py
@@ -62,7 +62,12 @@ class DatabasePool:
             from psycopg_pool import ConnectionPool as PsycopgConnectionPool
         except ImportError as exc:  # pragma: no cover - optional dependency
             raise StorageError("psycopg_pool is not installed") from exc
-        self._pool = PsycopgConnectionPool(self.config.url, min_size=min_size, max_size=max_size, open=open)
+        import os
+        pool_max = int(os.environ.get("PG_MAX_POOL_SIZE", str(max_size)))
+        self._pool = PsycopgConnectionPool(
+            self.config.url, min_size=min_size, max_size=pool_max, open=open,
+            max_idle=300.0, max_lifetime=600.0, check=PsycopgConnectionPool.check_connection,
+        )
 
     def connection(self) -> Any:
         return self._pool.connection()

--- a/platform/rust-kit/src/storage.rs
+++ b/platform/rust-kit/src/storage.rs
@@ -73,9 +73,14 @@ impl Storage {
         let options: PgConnectOptions = database_url
             .parse()
             .map_err(|error| StorageError::Config(format!("invalid DATABASE_URL: {error}")))?;
+        let max_conn: u32 = std::env::var("PG_MAX_POOL_SIZE")
+            .ok().and_then(|v| v.parse().ok()).unwrap_or(10);
         let pool = PgPoolOptions::new()
-            .max_connections(10)
+            .max_connections(max_conn)
             .acquire_timeout(Duration::from_secs(5))
+            .idle_timeout(Duration::from_secs(300))
+            .max_lifetime(Duration::from_secs(600))
+            .test_before_acquire(true)
             .connect_with(options)
             .await?;
         Ok(Self {


### PR DESCRIPTION
Adds keepalive, max_lifetime, test_before_acquire across Java/Rust/Python kits. Prevents stale connections after PG restart.