### PR TITLE
perf: ts-kit batch read 50x + risk scalper detection

### DIFF
--- a/platform/ts-kit/src/messaging.ts
+++ b/platform/ts-kit/src/messaging.ts
@@ -231,8 +231,8 @@ export class InMemoryEventSubscriber implements EventSubscriber {
   }
 }
 
-const READ_BLOCK_MS = 2_000;
-const READ_COUNT = 10;
+const READ_BLOCK_MS = 1_000;
+const READ_COUNT = 50;
 const CLAIM_MIN_IDLE_MS = 60_000;
 const MAX_DELIVERIES = 5;
 const STREAM_MAXLEN = 100_000;

--- a/services/risk-compliance/src/risk_compliance/application.py
+++ b/services/risk-compliance/src/risk_compliance/application.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -26,8 +27,8 @@ from .domain import BlockScope, Decision, PolicyVersionRef, RiskAssessment, Risk
 PRODUCER = "risk-compliance"
 SCHEMA_VERSION = 1
 DEFAULT_POLICY_VERSION = PolicyVersionRef(policy_set_id="risk-rules", version="1.0.0")
-FREQUENCY_WINDOW = timedelta(minutes=10)
-FREQUENCY_THRESHOLD = 3
+FREQUENCY_WINDOW = timedelta(minutes=int(os.environ.get("RISK_FREQUENCY_WINDOW_MINUTES", "5")))
+FREQUENCY_THRESHOLD = int(os.environ.get("RISK_FREQUENCY_THRESHOLD", "2"))
 BLOCKING_DECISIONS = {Decision.DENY, Decision.CHALLENGE}
 BLOCKING_DECISION_VALUES = {decision.value for decision in BLOCKING_DECISIONS}
 RiskScenario: TypeAlias = str


### PR DESCRIPTION
ts-kit subscriber 10→50 batch read for offer throughput. Risk threshold 3→2 in 5m window to catch scalper rotation.