### PR TITLE
REQ-204 parallelize Redis consumer handlers

### DIFF
--- a/deploy/k8s/services.yaml
+++ b/deploy/k8s/services.yaml
@@ -846,6 +846,8 @@ spec:
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME
               value: booking-orchestration
+            - name: CONSUMER_THREADS
+              value: "4"
             - name: OTEL_TRACES_EXPORTER
               value: otlp
             - name: OTEL_METRICS_EXPORTER

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
@@ -10,12 +10,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RedisEventSubscriber implements EventSubscriber {
     public static final int MAX_DELIVERY_ATTEMPTS = 5;
@@ -23,10 +26,13 @@ public class RedisEventSubscriber implements EventSubscriber {
     private static final long INITIAL_BACKOFF_SECONDS = 1;
     private static final long MAX_BACKOFF_SECONDS = 30;
     private static final int LAST_FAILURE_CACHE_SIZE = 1_024;
+    private static final int DEFAULT_CONSUMER_THREADS = 1;
+    private static final String CONSUMER_THREADS_ENV = "CONSUMER_THREADS";
 
     private final RedisStreamOperations streams;
     private final ObjectMapper objectMapper;
-    private final ExecutorService executor;
+    private final ExecutorService pollExecutor;
+    private final ExecutorService handlerExecutor;
     private final AtomicBoolean running = new AtomicBoolean();
     private final AutoCloseable closeable;
     private final ConsumedEventStore consumedEvents;
@@ -60,12 +66,27 @@ public class RedisEventSubscriber implements EventSubscriber {
     }
 
     RedisEventSubscriber(RedisStreamOperations streams, ObjectMapper objectMapper, AutoCloseable closeable, ConsumedEventStore consumedEvents, EventConsumerTracer eventConsumerTracer) {
+        this(streams, objectMapper, closeable, consumedEvents, eventConsumerTracer, consumerThreadsFromEnvironment());
+    }
+
+    RedisEventSubscriber(
+        RedisStreamOperations streams,
+        ObjectMapper objectMapper,
+        AutoCloseable closeable,
+        ConsumedEventStore consumedEvents,
+        EventConsumerTracer eventConsumerTracer,
+        int consumerThreads
+    ) {
+        if (consumerThreads < 1) {
+            throw new IllegalArgumentException("consumerThreads must be positive");
+        }
         this.streams = Objects.requireNonNull(streams, "streams are required");
         this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper is required");
         this.closeable = closeable;
         this.consumedEvents = Objects.requireNonNull(consumedEvents, "consumedEvents is required");
         this.eventConsumerTracer = Objects.requireNonNull(eventConsumerTracer, "eventConsumerTracer is required");
-        this.executor = Executors.newSingleThreadExecutor();
+        this.pollExecutor = Executors.newSingleThreadExecutor(namedThreadFactory("redis-subscriber-poll"));
+        this.handlerExecutor = Executors.newFixedThreadPool(consumerThreads, namedThreadFactory("redis-subscriber-handler"));
     }
 
     @Override
@@ -76,11 +97,13 @@ public class RedisEventSubscriber implements EventSubscriber {
             throw new SubscribeFailedException("at least one stream is required", null);
         }
         running.set(true);
-        executor.submit(() -> poll(streamNames, group, consumerName, handler));
+        pollExecutor.submit(() -> poll(streamNames, group, consumerName, handler));
     }
 
     public void recoverOnce(String stream, String group, String consumerName, EventHandler handler) {
-        recover(stream, group, consumerName, handler);
+        for (RedisStreamOperations.StreamEntry message : streams.autoClaim(stream, group, consumerName)) {
+            handle(stream, group, consumerName, message, handler);
+        }
     }
 
     private void poll(List<String> streamNames, String group, String consumerName, EventHandler handler) {
@@ -91,7 +114,7 @@ public class RedisEventSubscriber implements EventSubscriber {
                     streams.createGroup(stream, group);
                     recover(stream, group, consumerName, handler);
                     for (RedisStreamOperations.StreamEntry message : streams.readGroup(stream, group, consumerName)) {
-                        handle(stream, group, consumerName, message, handler, streams.deliveryCount(stream, group, message.id()));
+                        submitHandle(stream, group, consumerName, message, handler);
                     }
                     backoffSeconds = INITIAL_BACKOFF_SECONDS;
                 } catch (RuntimeException exception) {
@@ -108,11 +131,22 @@ public class RedisEventSubscriber implements EventSubscriber {
 
     private void recover(String stream, String group, String consumerName, EventHandler handler) {
         for (RedisStreamOperations.StreamEntry message : streams.autoClaim(stream, group, consumerName)) {
-            handle(stream, group, consumerName, message, handler, streams.deliveryCount(stream, group, message.id()));
+            submitHandle(stream, group, consumerName, message, handler);
         }
     }
 
-    private void handle(String stream, String group, String consumerName, RedisStreamOperations.StreamEntry message, EventHandler handler, int deliveryAttempts) {
+    private void submitHandle(String stream, String group, String consumerName, RedisStreamOperations.StreamEntry message, EventHandler handler) {
+        try {
+            handlerExecutor.submit(() -> handle(stream, group, consumerName, message, handler));
+        } catch (RejectedExecutionException exception) {
+            if (running.get()) {
+                throw exception;
+            }
+        }
+    }
+
+    private void handle(String stream, String group, String consumerName, RedisStreamOperations.StreamEntry message, EventHandler handler) {
+        int deliveryAttempts = streams.deliveryCount(stream, group, message.id());
         String json = message.envelopeJson();
         if (json == null) {
             moveToDlq(stream, group, consumerName, message.id(), "{}", "MissingEnvelope", deliveryAttempts);
@@ -168,8 +202,35 @@ public class RedisEventSubscriber implements EventSubscriber {
         }
     }
 
-    private static EventConsumerTracer defaultEventConsumerTracer() {
+    static EventConsumerTracer defaultEventConsumerTracer() {
         return new GlobalEventConsumerTracer(RedisEventSubscriber.class.getName());
+    }
+
+    private static int consumerThreadsFromEnvironment() {
+        String configured = System.getenv(CONSUMER_THREADS_ENV);
+        if (configured == null || configured.isBlank()) {
+            return DEFAULT_CONSUMER_THREADS;
+        }
+        try {
+            int threads = Integer.parseInt(configured.trim());
+            if (threads > 0) {
+                return threads;
+            }
+        } catch (NumberFormatException exception) {
+            LOGGER.warn("{}={} is not a valid positive integer; using default {}", CONSUMER_THREADS_ENV, configured, DEFAULT_CONSUMER_THREADS);
+            return DEFAULT_CONSUMER_THREADS;
+        }
+        LOGGER.warn("{}={} must be positive; using default {}", CONSUMER_THREADS_ENV, configured, DEFAULT_CONSUMER_THREADS);
+        return DEFAULT_CONSUMER_THREADS;
+    }
+
+    private static ThreadFactory namedThreadFactory(String prefix) {
+        AtomicInteger sequence = new AtomicInteger(1);
+        return runnable -> {
+            Thread thread = new Thread(runnable, prefix + "-" + sequence.getAndIncrement());
+            thread.setDaemon(true);
+            return thread;
+        };
     }
 
     private void rememberLastFailure(String stream, String messageId, RuntimeException exception) {
@@ -218,16 +279,6 @@ public class RedisEventSubscriber implements EventSubscriber {
         return value.length() <= 500 ? value : value.substring(0, 500);
     }
 
-    private static boolean isNoGroup(RuntimeException exception) {
-        for (Throwable cause = exception; cause != null; cause = cause.getCause()) {
-            String message = cause.getMessage();
-            if (message != null && message.contains("NOGROUP")) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     private static void sleepQuietly(long millis) {
         try {
             Thread.sleep(millis);
@@ -247,9 +298,11 @@ public class RedisEventSubscriber implements EventSubscriber {
     @Override
     public void close() {
         running.set(false);
-        executor.shutdown();
+        pollExecutor.shutdownNow();
+        handlerExecutor.shutdown();
         try {
-            executor.awaitTermination(5, TimeUnit.SECONDS);
+            pollExecutor.awaitTermination(5, TimeUnit.SECONDS);
+            handlerExecutor.awaitTermination(5, TimeUnit.SECONDS);
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
         }

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
@@ -9,11 +9,12 @@ import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
@@ -121,6 +122,51 @@ class RedisEventSubscriberTest {
         assertThat(reconnectLogs.get(2)).contains("reconnecting in 4s");
     }
 
+
+    @Test
+    void configuredConsumerThreadsHandleMessagesInParallel() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        List<RedisStreamOperations.StreamEntry> messages = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            EventEnvelope event = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of("id", String.valueOf(i)));
+            messages.add(new RedisStreamOperations.StreamEntry(i + "-0", objectMapper.writeValueAsString(event)));
+        }
+        FakeRedisStreams streams = new FakeRedisStreams(messages);
+        RedisEventSubscriber subscriber = new RedisEventSubscriber(
+            streams,
+            objectMapper,
+            null,
+            new InMemoryConsumedEventStore(),
+            RedisEventSubscriber.defaultEventConsumerTracer(),
+            4
+        );
+        CountDownLatch allStarted = new CountDownLatch(messages.size());
+        CountDownLatch releaseHandlers = new CountDownLatch(1);
+
+        try {
+            subscriber.subscribe(List.of("events:payment"), "journey-order", "consumer-1", envelope -> {
+                allStarted.countDown();
+                try {
+                    releaseHandlers.await(2, TimeUnit.SECONDS);
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                    return HandlerResult.TRANSIENT_FAILURE;
+                }
+                return HandlerResult.SUCCESS;
+            });
+
+            assertThat(allStarted.await(1, TimeUnit.SECONDS)).isTrue();
+            releaseHandlers.countDown();
+            for (int i = 0; i < 20 && streams.acked.size() < messages.size(); i++) {
+                Thread.sleep(50);
+            }
+        } finally {
+            releaseHandlers.countDown();
+            subscriber.close();
+        }
+        assertThat(streams.acked).containsExactlyInAnyOrder("0-0", "1-0", "2-0", "3-0");
+    }
+
     @Test
     void maxDeliveryAttemptsUsesLastRuntimeExceptionAsFailureReasonWithoutRedispatching() throws Exception {
         ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
@@ -148,7 +194,7 @@ class RedisEventSubscriberTest {
     private static final class FailThenSucceedStreams implements RedisStreamOperations {
         private final int failCount;
         private final List<StreamEntry> successBatch;
-        private final List<String> acked = new ArrayList<>();
+        private final List<String> acked = Collections.synchronizedList(new ArrayList<>());
         private int readGroupCalls;
         private boolean delivered;
 
@@ -179,7 +225,7 @@ class RedisEventSubscriberTest {
 
     private static final class FakeRedisStreams implements RedisStreamOperations {
         private final List<StreamEntry> firstBatch;
-        private final List<String> acked = new ArrayList<>();
+        private final List<String> acked = Collections.synchronizedList(new ArrayList<>());
         private boolean delivered;
         private boolean autoClaimEnabled;
         private int autoClaimCalls;


### PR DESCRIPTION
## Summary
- add configurable CONSUMER_THREADS handler pool to java-kit RedisEventSubscriber
- run Redis stream handler work on fixed pool while keeping polling on a lifecycle thread
- configure booking-orchestration deployment with CONSUMER_THREADS=4

## Validation
- mvn -q -f platform/java-kit/pom.xml test -Dtest=RedisEventSubscriberTest,EventEnvelopeTraceContextTest
- mvn -q -f platform/java-kit/pom.xml -DskipTests compile