### PR TITLE
Add group booking service foundation

### DIFF
--- a/deploy/k8s/services.yaml
+++ b/deploy/k8s/services.yaml
@@ -3169,7 +3169,10 @@ spec:
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
             - name: DATABASE_URL
-              value: postgresql://trainticket:trainticket-dev@postgres:5432/group_booking
+              valueFrom:
+                secretKeyRef:
+                  name: group-booking-database
+                  key: url
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://otel-collector:4317
             - name: OTEL_SERVICE_NAME

--- a/services/group-booking/src/main/java/com/trainticket/groupbooking/api/GroupBookingController.java
+++ b/services/group-booking/src/main/java/com/trainticket/groupbooking/api/GroupBookingController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/group-bookings")
+@RequestMapping({"/api/v1/group-bookings", "/group-bookings"})
 public class GroupBookingController {
     private final GroupBookingService service;
 

--- a/services/group-booking/src/main/java/com/trainticket/groupbooking/application/GroupBookingRepository.java
+++ b/services/group-booking/src/main/java/com/trainticket/groupbooking/application/GroupBookingRepository.java
@@ -6,4 +6,5 @@ import java.util.Optional;
 public interface GroupBookingRepository {
     void save(GroupBooking booking);
     Optional<GroupBooking> findById(String groupBookingId);
+    Optional<GroupBooking> findByCapacityHoldId(String capacityHoldId);
 }

--- a/services/group-booking/src/main/java/com/trainticket/groupbooking/application/GroupBookingService.java
+++ b/services/group-booking/src/main/java/com/trainticket/groupbooking/application/GroupBookingService.java
@@ -97,17 +97,20 @@ public class GroupBookingService {
             return;
         }
         Map<?, ?> payload = envelope.payload() instanceof Map<?, ?> map ? map : Map.of();
-        String groupBookingId = text(payload.get("groupBookingId"));
-        if (groupBookingId == null) {
-            groupBookingId = text(payload.get("businessRef"));
+        String holdId = text(payload.get("holdId"));
+        if (holdId == null) {
+            throw new IllegalArgumentException("CapacityHoldConfirmed requires holdId");
         }
-        String holdId = firstText(payload, "holdId", "capacityHoldId");
-        int quantity = intValue(payload.get("confirmedQuantity"), payload.get("quantity"), payload.get("heldQuantity"));
-        if (groupBookingId == null || holdId == null) {
-            throw new IllegalArgumentException("CapacityHoldConfirmed requires groupBookingId/businessRef and holdId");
+        requireText(payload, "inventoryPoolId");
+        requireText(payload, "capacityUnitRef");
+        if (!(payload.get("interval") instanceof Map<?, ?>)) {
+            throw new IllegalArgumentException("CapacityHoldConfirmed requires interval");
         }
-        GroupBooking booking = getAggregate(groupBookingId);
-        booking.recordCapacityHoldConfirmed(holdId, quantity, clock.instant());
+        requireText(payload, "confirmedAt");
+
+        GroupBooking booking = repository.findByCapacityHoldId(holdId)
+            .orElseThrow(() -> new NotFoundException("group booking not found for capacity hold: " + holdId));
+        booking.recordCapacityHoldConfirmed(holdId, clock.instant());
         repository.save(booking);
     }
 
@@ -150,22 +153,16 @@ public class GroupBookingService {
         return PrefixedIds.isCorrelationId(correlationId) ? correlationId : PrefixedIds.newCorrelationId();
     }
 
-    private static String firstText(Map<?, ?> payload, String first, String second) {
-        String value = text(payload.get(first));
-        return value == null ? text(payload.get(second)) : value;
+    private static String requireText(Map<?, ?> payload, String field) {
+        String value = text(payload.get(field));
+        if (value == null) {
+            throw new IllegalArgumentException("CapacityHoldConfirmed requires " + field);
+        }
+        return value;
     }
 
     private static String text(Object value) {
         return value instanceof String string && !string.isBlank() ? string : null;
-    }
-
-    private static int intValue(Object... values) {
-        for (Object value : values) {
-            if (value instanceof Number number) {
-                return number.intValue();
-            }
-        }
-        return 0;
     }
 
     public record CreateGroupBookingCommand(

--- a/services/group-booking/src/main/java/com/trainticket/groupbooking/application/InMemoryGroupBookingRepository.java
+++ b/services/group-booking/src/main/java/com/trainticket/groupbooking/application/InMemoryGroupBookingRepository.java
@@ -19,4 +19,14 @@ public class InMemoryGroupBookingRepository implements GroupBookingRepository {
     public Optional<GroupBooking> findById(String groupBookingId) {
         return Optional.ofNullable(bookings.get(groupBookingId));
     }
+
+    @Override
+    public Optional<GroupBooking> findByCapacityHoldId(String capacityHoldId) {
+        if (capacityHoldId == null || capacityHoldId.isBlank()) {
+            return Optional.empty();
+        }
+        return bookings.values().stream()
+            .filter(booking -> capacityHoldId.equals(booking.capacityHoldId()))
+            .findFirst();
+    }
 }

--- a/services/group-booking/src/main/java/com/trainticket/groupbooking/domain/GroupBooking.java
+++ b/services/group-booking/src/main/java/com/trainticket/groupbooking/domain/GroupBooking.java
@@ -113,18 +113,15 @@ public final class GroupBooking {
         domainEvents.add(new GroupBookingConfirmed(groupBookingId, holdId, activeCount, activeMemberIds(), Objects.requireNonNull(now, "now is required")));
     }
 
-    public void recordCapacityHoldConfirmed(String capacityHoldId, int confirmedQuantity, Instant now) {
+    public void recordCapacityHoldConfirmed(String capacityHoldId, Instant now) {
         String holdId = GroupMember.requireText(capacityHoldId, "capacityHoldId");
-        if (confirmedQuantity < MINIMUM_GROUP_SIZE) {
-            throw new DomainRuleViolation("confirmedQuantity must be at least 10 for a group booking");
-        }
-        if (confirmedQuantity < activeMemberCount()) {
-            throw new DomainRuleViolation("confirmedQuantity cannot be less than active roster size");
+        if (this.capacityHoldId == null || !this.capacityHoldId.equals(holdId)) {
+            throw new DomainRuleViolation("capacity hold confirmation does not match this group booking");
         }
         if (status == GroupBookingStatus.DRAFT) {
             status = GroupBookingStatus.HOLD_ACTIVE;
         }
-        this.capacityHoldId = holdId;
+        Objects.requireNonNull(now, "now is required");
     }
 
     public void cancel(List<String> memberIds, String reason, Instant now) {
@@ -150,13 +147,18 @@ public final class GroupBooking {
                 if (member == null) {
                     throw new DomainRuleViolation("member not found: " + memberId);
                 }
-                member.cancel();
-                cancelled.add(member.memberId());
+                if (member.active()) {
+                    cancelled.add(member.memberId());
+                }
+            }
+            int remainingActiveCount = activeMemberCount() - cancelled.size();
+            if (remainingActiveCount < MINIMUM_GROUP_SIZE && status == GroupBookingStatus.CONFIRMED) {
+                throw new DomainRuleViolation("partial cancellation would reduce confirmed group below minimum size");
+            }
+            for (String memberId : cancelled) {
+                members.get(memberId).cancel();
             }
             if (activeMemberCount() < MINIMUM_GROUP_SIZE) {
-                if (status == GroupBookingStatus.CONFIRMED) {
-                    throw new DomainRuleViolation("partial cancellation would reduce confirmed group below minimum size");
-                }
                 status = GroupBookingStatus.CANCELLED;
                 cancellationReason = "group size below minimum after partial cancellation: " + normalizedReason;
             } else {

--- a/services/group-booking/src/test/java/com/trainticket/groupbooking/api/GroupBookingControllerTest.java
+++ b/services/group-booking/src/test/java/com/trainticket/groupbooking/api/GroupBookingControllerTest.java
@@ -31,15 +31,26 @@ class GroupBookingControllerTest {
     void createValidatesMinimumGroupSize() throws Exception {
         mockMvc.perform(post("/api/v1/group-bookings")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("""
-                    {
-                      "organizerRef":"org-1",
-                      "segmentRefs":["seg-1"],
-                      "targetTravelerCount":9,
-                      "fare":{"currency":"USD","minorUnits":10000,"discountBasisPoints":0}
-                    }
-                    """))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"));
+                .content(invalidSmallGroupRequest()))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void exposesUnversionedGroupBookingEndpoint() throws Exception {
+        mockMvc.perform(post("/group-bookings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidSmallGroupRequest()))
+            .andExpect(status().isBadRequest());
+    }
+
+    private static String invalidSmallGroupRequest() {
+        return """
+            {
+              "organizerRef":"org-1",
+              "segmentRefs":["seg-1"],
+              "targetTravelerCount":9,
+              "fare":{"currency":"USD","minorUnits":10000,"discountBasisPoints":0}
+            }
+            """;
     }
 }

--- a/services/group-booking/src/test/java/com/trainticket/groupbooking/application/GroupBookingServiceTest.java
+++ b/services/group-booking/src/test/java/com/trainticket/groupbooking/application/GroupBookingServiceTest.java
@@ -35,10 +35,11 @@ class GroupBookingServiceTest {
     }
 
     @Test
-    void consumesCapacityHoldConfirmedForKnownGroupBooking() {
+    void consumesCapacityHoldConfirmedUsingDocumentedCapacityContract() {
         BookingDetail created = service.create(new GroupBookingService.CreateGroupBookingCommand(
             "org-1", List.of("seg-1"), 10, "USD", 10_000L, 0, null), PrefixedIds.newCorrelationId());
         service.addMembers(created.groupBookingId(), new GroupBookingService.AddMembersCommand(memberCommands(10)), PrefixedIds.newCorrelationId());
+        service.confirm(created.groupBookingId(), new GroupBookingService.ConfirmGroupBookingCommand("hold-1"), PrefixedIds.newCorrelationId());
 
         EventEnvelope envelope = new EventEnvelope(
             PrefixedIds.newEventId(),
@@ -48,14 +49,20 @@ class GroupBookingServiceTest {
             null,
             "capacity-availability",
             1,
-            Map.of("groupBookingId", created.groupBookingId(), "holdId", "hold-1", "confirmedQuantity", 10)
+            Map.of(
+                "holdId", "hold-1",
+                "inventoryPoolId", "pool-1",
+                "capacityUnitRef", "unit-1",
+                "interval", Map.of("fromStationRef", "sta-1", "toStationRef", "sta-2"),
+                "confirmedAt", "2026-07-10T12:01:00Z"
+            )
         );
 
         service.handleCapacityHoldConfirmed(envelope);
 
         BookingDetail detail = service.get(created.groupBookingId());
         assertThat(detail.capacityHoldId()).isEqualTo("hold-1");
-        assertThat(detail.status()).isEqualTo("HOLD_ACTIVE");
+        assertThat(detail.status()).isEqualTo("CONFIRMED");
     }
 
     private static List<GroupBookingService.MemberCommand> memberCommands(int count) {

--- a/services/group-booking/src/test/java/com/trainticket/groupbooking/domain/GroupBookingTest.java
+++ b/services/group-booking/src/test/java/com/trainticket/groupbooking/domain/GroupBookingTest.java
@@ -72,6 +72,22 @@ class GroupBookingTest {
         assertThat(booking.activeMemberCount()).isEqualTo(9);
     }
 
+    @Test
+    void invalidConfirmedPartialCancellationDoesNotMutateRoster() {
+        GroupBooking booking = GroupBooking.create("gb-1", "org-1", List.of("seg-1"), 10, fare(), NOW);
+        booking.addMembers(members(10), NOW);
+        booking.confirm("hold-1", NOW);
+        booking.pullEvents();
+
+        assertThatThrownBy(() -> booking.cancel(List.of("mem-1"), "traveler withdrew", NOW))
+            .isInstanceOf(DomainRuleViolation.class)
+            .hasMessageContaining("below minimum size");
+
+        assertThat(booking.status()).isEqualTo(GroupBookingStatus.CONFIRMED);
+        assertThat(booking.activeMemberCount()).isEqualTo(10);
+        assertThat(booking.pullEvents()).isEmpty();
+    }
+
     private static GroupFare fare() {
         return new GroupFare("USD", 12_500L, 750, "neg-1");
     }


### PR DESCRIPTION
## Summary
- add Java/Spring group-booking bounded-context service with GroupBooking aggregate, GroupMember entity, GroupFare value object, REST API, and CapacityHoldConfirmed handler
- add group-booking persistence migration, Dockerfile, and Kubernetes deployment/service entry
- cover domain, application, and API behavior with unit tests

## Validation
- mvn -q -f platform/java-kit/pom.xml install -DskipTests && cd services/group-booking && mvn test
- cd services/group-booking && mvn -q -DskipTests package && java -jar target/group-booking-0.1.0-SNAPSHOT.jar --server.port=19080; curl http://localhost:19080/health