### PR TITLE
REQ-215 add corporate travel service foundation

### DIFF
--- a/services/corporate-travel/pyproject.toml
+++ b/services/corporate-travel/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
   "train-ticket-platform",
   "psycopg[binary]>=3.2.0",
   "psycopg-pool>=3.2.0",
+  "uvicorn>=0.30.0",
 ]
 
 [dependency-groups]

--- a/services/corporate-travel/src/corporate_travel/application.py
+++ b/services/corporate-travel/src/corporate_travel/application.py
@@ -55,6 +55,9 @@ class InMemoryCorporateTravelRepository:
     billing_periods: dict[str, BillingPeriod] = field(default_factory=dict)
     processed_event_ids: set[str] = field(default_factory=set)
     open_period_by_agreement: dict[tuple[str, str], str] = field(default_factory=dict)
+    order_confirmations: dict[str, EventEnvelope] = field(default_factory=dict)
+    payment_captures_by_order: dict[str, list[EventEnvelope]] = field(default_factory=dict)
+    billed_payment_event_ids: set[str] = field(default_factory=set)
 
     def save_agreement(self, agreement: CorporateAgreement) -> None:
         self.agreements[agreement.agreement_id] = agreement
@@ -84,6 +87,27 @@ class InMemoryCorporateTravelRepository:
             return False
         self.processed_event_ids.add(event_id)
         return True
+
+    def remember_order_confirmed(self, order_id: str, envelope: EventEnvelope) -> None:
+        self.order_confirmations[order_id] = envelope
+
+    def order_confirmed(self, order_id: str) -> bool:
+        return order_id in self.order_confirmations
+
+    def remember_payment_capture(self, order_id: str, envelope: EventEnvelope) -> None:
+        captures = self.payment_captures_by_order.setdefault(order_id, [])
+        if all(capture.eventId != envelope.eventId for capture in captures):
+            captures.append(envelope)
+
+    def unbilled_payment_captures(self, order_id: str) -> tuple[EventEnvelope, ...]:
+        return tuple(
+            capture
+            for capture in self.payment_captures_by_order.get(order_id, ())
+            if capture.eventId not in self.billed_payment_event_ids
+        )
+
+    def mark_payment_billed(self, event_id: str) -> None:
+        self.billed_payment_event_ids.add(event_id)
 
 
 @dataclass(slots=True)
@@ -185,6 +209,24 @@ class CorporateTravelService:
             return
         if not self.repository.try_mark_processed(envelope.eventId):
             return
+
+        order_id = order_id_from_event(envelope)
+        if order_id is None:
+            return
+
+        if envelope.eventType == "JourneyOrderConfirmed":
+            self.repository.remember_order_confirmed(order_id, envelope)
+        else:
+            self.repository.remember_payment_capture(order_id, envelope)
+
+        if not self.repository.order_confirmed(order_id):
+            return
+
+        for payment in self.repository.unbilled_payment_captures(order_id):
+            self._attach_captured_payment(payment)
+            self.repository.mark_payment_billed(payment.eventId)
+
+    def _attach_captured_payment(self, envelope: EventEnvelope) -> None:
         line = line_from_event(envelope)
         agreement = self.repository.get_agreement(str(envelope.payload["agreementId"]))
         billing_period = str(envelope.payload.get("billingPeriod") or agreement.billing_calendar.period)
@@ -228,15 +270,16 @@ class CorporateTravelService:
 
 
 def line_from_event(envelope: EventEnvelope) -> StatementLine:
+    if envelope.eventType != "PaymentCaptured":
+        raise ValueError("only PaymentCaptured events create corporate billing statement lines")
     payload = envelope.payload
-    amount = money_from_mapping(payload.get("amount") or payload.get("capturedAmount") or {})
-    order_id = _optional_text(payload.get("orderId"))
+    amount = money_from_mapping(payload["capturedAmount"])
+    order_id = order_id_from_event(envelope)
     payment_id = _optional_text(payload.get("paymentIntentId"))
-    source = StatementLineSource.JOURNEY_ORDER_CONFIRMED if envelope.eventType == "JourneyOrderConfirmed" else StatementLineSource.PAYMENT_CAPTURED
     source_ref = payment_id or order_id or envelope.eventId
     return StatementLine(
         line_id=deterministic_prefixed_id("line", envelope.eventId),
-        source_type=source,
+        source_type=StatementLineSource.PAYMENT_CAPTURED,
         source_business_ref=source_ref,
         order_id=order_id,
         payment_intent_id=payment_id,
@@ -245,6 +288,11 @@ def line_from_event(envelope: EventEnvelope) -> StatementLine:
         source_event_id=envelope.eventId,
         occurred_at=parse_rfc3339(envelope.occurredAt) if isinstance(envelope.occurredAt, str) else envelope.occurredAt,
     )
+
+
+def order_id_from_event(envelope: EventEnvelope) -> str | None:
+    payload = envelope.payload
+    return _optional_text(payload.get("orderId") or payload.get("businessRef"))
 
 
 def money_from_mapping(value: Mapping[str, Any]) -> Money:

--- a/services/corporate-travel/tests/test_application.py
+++ b/services/corporate-travel/tests/test_application.py
@@ -30,7 +30,7 @@ def test_service_creates_active_agreement_and_publishes_activation() -> None:
     assert publisher.envelopes[1].payload["monthlyCreditLimit"] == {"currency": "USD", "minorUnits": 100000}
 
 
-def test_service_authorizes_and_closes_billing_period_from_events() -> None:
+def test_service_authorizes_and_closes_billing_period_after_order_and_payment_facts() -> None:
     publisher = InMemoryEventPublisher()
     service = CorporateTravelService(publisher=publisher)
     agreement = service.create_agreement(**agreement_payload()).agreement
@@ -49,11 +49,14 @@ def test_service_authorizes_and_closes_billing_period_from_events() -> None:
                 "agreementId": agreement.agreement_id,
                 "billingPeriod": "2026-01",
                 "orderId": "order-1",
-                "amount": {"currency": "USD", "minorUnits": 2500},
+                "monetarySummary": {"total": {"currency": "USD", "minorUnits": 2500}},
                 "authorizationSnapshotRef": auth.snapshot_ref(),
             },
         )
     )
+
+    assert service.repository.find_open_period(agreement.agreement_id, "2026-01") is None
+
     service.handle_event(
         EventEnvelope(
             eventId="evt-pay-1",
@@ -66,7 +69,7 @@ def test_service_authorizes_and_closes_billing_period_from_events() -> None:
             payload={
                 "agreementId": agreement.agreement_id,
                 "billingPeriod": "2026-01",
-                "orderId": "order-1",
+                "businessRef": "order-1",
                 "paymentIntentId": "pay-1",
                 "capturedAmount": {"currency": "USD", "minorUnits": 2500},
                 "authorizationSnapshotRef": auth.snapshot_ref(),
@@ -77,6 +80,58 @@ def test_service_authorizes_and_closes_billing_period_from_events() -> None:
     closed = service.close_billing_period(agreement_id=agreement.agreement_id, billing_period="2026-01").billing_period
 
     assert closed.status.value == "CLOSED"
-    assert closed.total_amount.minor_units == 5000
+    assert len(closed.lines) == 1
+    assert closed.lines[0].source_type.value == "PAYMENT_CAPTURED"
+    assert closed.total_amount.minor_units == 2500
     assert publisher.envelopes[-1].eventType == "CorporateBillingPeriodClosed"
     assert publisher.envelopes[-1].payload["statementHash"] == closed.statement_hash
+
+
+def test_service_waits_for_order_confirmation_before_billing_payment_capture() -> None:
+    service = CorporateTravelService()
+    agreement = service.create_agreement(**agreement_payload()).agreement
+
+    service.handle_event(
+        EventEnvelope(
+            eventId="evt-pay-early",
+            eventType="PaymentCaptured",
+            occurredAt="2026-01-10T00:05:00Z",
+            correlationId="corr-test",
+            causationId="cmd-test",
+            producer="payment",
+            schemaVersion=1,
+            payload={
+                "agreementId": agreement.agreement_id,
+                "billingPeriod": "2026-01",
+                "businessRef": "order-early",
+                "paymentIntentId": "pay-early",
+                "capturedAmount": {"currency": "USD", "minorUnits": 1200},
+            },
+        )
+    )
+
+    assert service.repository.find_open_period(agreement.agreement_id, "2026-01") is None
+
+    service.handle_event(
+        EventEnvelope(
+            eventId="evt-order-early",
+            eventType="JourneyOrderConfirmed",
+            occurredAt="2026-01-10T00:00:00Z",
+            correlationId="corr-test",
+            causationId="cmd-test",
+            producer="journey-order",
+            schemaVersion=1,
+            payload={
+                "agreementId": agreement.agreement_id,
+                "billingPeriod": "2026-01",
+                "orderId": "order-early",
+                "monetarySummary": {"total": {"currency": "USD", "minorUnits": 1200}},
+            },
+        )
+    )
+
+    period = service.repository.find_open_period(agreement.agreement_id, "2026-01")
+
+    assert period is not None
+    assert len(period.lines) == 1
+    assert period.total_amount.minor_units == 1200

--- a/services/corporate-travel/uv.lock
+++ b/services/corporate-travel/uv.lock
@@ -57,6 +57,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -73,6 +85,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary"] },
     { name = "psycopg-pool" },
     { name = "train-ticket-platform" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -86,6 +99,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "psycopg-pool", specifier = ">=3.2.0" },
     { name = "train-ticket-platform", editable = "../../platform/python-kit" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -730,6 +744,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/b7/4c0f736ca824b3a25b15e8213d1bcfc15f8ac2ae48d1b445b310892dc4da/uuid6-2025.0.1.tar.gz", hash = "sha256:cd0af94fa428675a44e32c5319ec5a3485225ba2179eefcf4c3f205ae30a81bd", size = 13932, upload-time = "2025-07-04T18:30:35.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/b2/93faaab7962e2aa8d6e174afb6f76be2ca0ce89fde14d3af835acebcaa59/uuid6-2025.0.1-py3-none-any.whl", hash = "sha256:80530ce4d02a93cdf82e7122ca0da3ebbbc269790ec1cb902481fa3e9cc9ff99", size = 6979, upload-time = "2025-07-04T18:30:34.001Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.51.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/ec/dbb7e5a6b91f86bfb9eb7d2988a2730907b6a729875b949c7f022e8b88fa/uvicorn-0.51.0-py3-none-any.whl", hash = "sha256:5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b", size = 73219, upload-time = "2026-07-08T10:59:04.44Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add Python corporate-travel bounded context with domain aggregates, application service, FastAPI endpoints, migrations, and unit tests.
- Add Dockerfile, image build registration, and Kubernetes deployment/service manifest.

## Validation
- cd services/corporate-travel && uv run python -m pytest
- Service start check: uv run --with "uvicorn[standard]" uvicorn corporate_travel.api:create_app --factory --host 127.0.0.1 --port 18082, then GET /health returned 200.