### PR TITLE
REQ-303 Implement post-sales refund and change policy engine

### DIFF
--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryPostSalesPolicyContextStore.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryPostSalesPolicyContextStore.java
@@ -1,0 +1,21 @@
+package com.trainticket.postsales.application;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryPostSalesPolicyContextStore implements PostSalesPolicyContextStore {
+    private final ConcurrentMap<String, PostSalesPolicyContext> byOrderId = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<PostSalesPolicyContext> findByOrderId(String journeyOrderId) {
+        return Optional.ofNullable(byOrderId.get(journeyOrderId));
+    }
+
+    @Override
+    public void save(PostSalesPolicyContext context) {
+        byOrderId.put(context.journeyOrderId(), context);
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryPostSalesRepository.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryPostSalesRepository.java
@@ -66,6 +66,7 @@ public class InMemoryPostSalesRepository implements PostSalesRepository {
     private static boolean isActive(PostSalesCase postSalesCase) {
         return postSalesCase.status() != PostSalesCaseStatus.REJECTED
             && postSalesCase.status() != PostSalesCaseStatus.CANCELLED
-            && postSalesCase.status() != PostSalesCaseStatus.FAILED;
+            && postSalesCase.status() != PostSalesCaseStatus.FAILED
+            && postSalesCase.status() != PostSalesCaseStatus.APPLIED;
     }
 }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
@@ -1,15 +1,21 @@
 package com.trainticket.postsales.application;
 
 import com.trainticket.postsales.domain.AmountDecisionSnapshot;
+import com.trainticket.postsales.domain.ChangeAssessment;
 import com.trainticket.postsales.domain.ChangeFinancialAction;
 import com.trainticket.postsales.domain.ChangeFlowSnapshot;
+import com.trainticket.postsales.domain.ChangePolicyEngine;
 import com.trainticket.postsales.domain.DecisionKind;
 import com.trainticket.postsales.domain.Money;
 import com.trainticket.postsales.domain.PostSalesCase;
 import com.trainticket.postsales.domain.PostSalesCaseType;
 import com.trainticket.postsales.domain.PostSalesCaseStatus;
 import com.trainticket.postsales.domain.PostSalesDecision;
+import com.trainticket.postsales.domain.RefundAssessment;
+import com.trainticket.postsales.domain.RefundClassification;
+import com.trainticket.postsales.domain.RefundPolicyEngine;
 import com.trainticket.postsales.domain.PostSalesEvent;
+import com.trainticket.postsales.domain.RefundWaterfall;
 import com.trainticket.postsales.domain.PostSalesScope;
 import com.trainticket.postsales.domain.RuleEvaluationSnapshot;
 import com.trainticket.platformkit.persistence.OptimisticConcurrencyException;
@@ -27,6 +33,8 @@ public class PostSalesApplicationService {
     private final EventPublisher eventPublisher;
     private final AdjustmentQuotePort adjustmentQuotePort;
     private final Clock clock;
+    private final RefundPolicyEngine refundPolicyEngine = new RefundPolicyEngine();
+    private final ChangePolicyEngine changePolicyEngine = new ChangePolicyEngine();
 
     public PostSalesApplicationService(PostSalesRepository repository, EventPublisher eventPublisher,
             AdjustmentQuotePort adjustmentQuotePort, Clock clock) {
@@ -164,23 +172,61 @@ public class PostSalesApplicationService {
         String explanation = quote
             .map(q -> "fare-pricing adjustment quote " + q.adjustmentQuoteId())
             .orElse("fare-pricing unavailable; zero-amount fallback");
-        AmountDecisionSnapshot amount = switch (kind) {
-            case REFUND, CANCELLATION, COMPENSATION -> AmountDecisionSnapshot.refund(zero, refundable, explanation);
-            case CHANGE -> amountDue.isZero() && !refundable.isZero()
-                ? AmountDecisionSnapshot.refund(zero, refundable, explanation)
-                : AmountDecisionSnapshot.extraCharge(zero, amountDue, explanation);
-        };
-        ChangeFlowSnapshot changeFlowSnapshot = kind == DecisionKind.CHANGE
-            ? new ChangeFlowSnapshot(
+        if (kind == DecisionKind.COMPENSATION) {
+            AmountDecisionSnapshot amount = AmountDecisionSnapshot.refund(zero, refundable, explanation);
+            return new PostSalesDecision(postSalesCase.caseId(), 1, kind, true, "ELIGIBLE", ruleSnapshot, amount, null, null, null, now, now.plusSeconds(900));
+        }
+
+        if (kind == DecisionKind.CHANGE) {
+            Money originalFare = refundable.isZero() ? amountDue : refundable;
+            Money newFare = amountDue.isZero() ? originalFare : originalFare.add(amountDue);
+            ChangeAssessment assessment = changePolicyEngine.evaluateChange(originalFare, newFare, now, now.plusSeconds(60 * 60 * 24 * 20), 0);
+            AmountDecisionSnapshot amount = assessment.netPayable().isZero() && !assessment.netRefundable().isZero()
+                ? AmountDecisionSnapshot.refund(assessment.changeFee(), assessment.netRefundable(), assessment.explanation())
+                : AmountDecisionSnapshot.extraCharge(assessment.changeFee(), assessment.netPayable(), assessment.explanation());
+            ChangeFinancialAction financialAction = assessment.netPayable().isZero()
+                ? (assessment.netRefundable().isZero() ? ChangeFinancialAction.NONE : ChangeFinancialAction.REQUEST_ASYNC_REFUND)
+                : ChangeFinancialAction.COLLECT_DIFFERENCE_PAYMENT;
+            ChangeFlowSnapshot changeFlowSnapshot = new ChangeFlowSnapshot(
                 "change-offer-" + postSalesCase.caseId(),
                 "capacity-hold-" + postSalesCase.caseId(),
-                ChangeFinancialAction.NONE,
+                financialAction,
                 "void-old-entitlement-" + postSalesCase.caseId(),
                 "issue-new-entitlement-" + postSalesCase.caseId(),
                 "release-old-capacity-" + postSalesCase.caseId()
-            )
-            : null;
-        return new PostSalesDecision(postSalesCase.caseId(), 1, kind, true, "ELIGIBLE", ruleSnapshot, amount, changeFlowSnapshot, now, now.plusSeconds(900));
+            );
+            return PostSalesDecision.change(postSalesCase.caseId(), true, "ELIGIBLE", ruleSnapshot, amount, changeFlowSnapshot, assessment, now, now.plusSeconds(900));
+        }
+
+        Money penaltyBase = refundable.isZero() ? zero : refundable;
+        RefundAssessment assessment = refundPolicyEngine.evaluateRefund(
+            RefundWaterfall.simple(penaltyBase),
+            penaltyBase,
+            now,
+            now.plusSeconds(60 * 60 * 24 * 20),
+            classify(postSalesCase.reasonCode()),
+            "ADULT",
+            Math.max(1, postSalesCase.scope().travelerRefs().size())
+        );
+        AmountDecisionSnapshot amount = AmountDecisionSnapshot.refund(assessment.penaltyAmount(), assessment.refundableAmount(), assessment.explanation(), assessment.componentDecisions());
+        return PostSalesDecision.refund(postSalesCase.caseId(), true, "ELIGIBLE", ruleSnapshot, amount, assessment, now, now.plusSeconds(900));
+    }
+
+    private static RefundClassification classify(String reasonCode) {
+        String reason = reasonCode == null ? "" : reasonCode.toUpperCase(java.util.Locale.ROOT);
+        if (reason.contains("CARRIER") || reason.contains("TRAIN_CANCEL") || reason.contains("TRAIN_CANCELLED")) {
+            return RefundClassification.INVOLUNTARY_CARRIER;
+        }
+        if (reason.contains("DELAY")) {
+            return RefundClassification.INVOLUNTARY_DELAY;
+        }
+        if (reason.contains("FORCE") || reason.contains("MAJEURE")) {
+            return RefundClassification.INVOLUNTARY_FORCE_MAJEURE;
+        }
+        if (reason.contains("PLATFORM") || reason.contains("ERROR")) {
+            return RefundClassification.INVOLUNTARY_PLATFORM;
+        }
+        return RefundClassification.VOLUNTARY;
     }
 
     /**

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
@@ -15,7 +15,6 @@ import com.trainticket.postsales.domain.RefundAssessment;
 import com.trainticket.postsales.domain.RefundClassification;
 import com.trainticket.postsales.domain.RefundPolicyEngine;
 import com.trainticket.postsales.domain.PostSalesEvent;
-import com.trainticket.postsales.domain.RefundWaterfall;
 import com.trainticket.postsales.domain.PostSalesScope;
 import com.trainticket.postsales.domain.RuleEvaluationSnapshot;
 import com.trainticket.platformkit.persistence.OptimisticConcurrencyException;
@@ -32,15 +31,17 @@ public class PostSalesApplicationService {
     private final PostSalesRepository repository;
     private final EventPublisher eventPublisher;
     private final AdjustmentQuotePort adjustmentQuotePort;
+    private final PostSalesPolicyContextStore policyContextStore;
     private final Clock clock;
     private final RefundPolicyEngine refundPolicyEngine = new RefundPolicyEngine();
     private final ChangePolicyEngine changePolicyEngine = new ChangePolicyEngine();
 
     public PostSalesApplicationService(PostSalesRepository repository, EventPublisher eventPublisher,
-            AdjustmentQuotePort adjustmentQuotePort, Clock clock) {
+            AdjustmentQuotePort adjustmentQuotePort, PostSalesPolicyContextStore policyContextStore, Clock clock) {
         this.repository = repository;
         this.eventPublisher = eventPublisher;
         this.adjustmentQuotePort = adjustmentQuotePort;
+        this.policyContextStore = policyContextStore;
         this.clock = clock;
     }
 
@@ -86,6 +87,11 @@ public class PostSalesApplicationService {
             postSalesCase = get(caseId);
         }
         postSalesCase.approve("http-approval", clock.instant(), sourceCommandId, sourceCommandId, correlationId);
+        if (postSalesCase.caseType() == PostSalesCaseType.CHANGE) {
+            policyContextStore.findByOrderId(postSalesCase.journeyOrderId())
+                .map(PostSalesPolicyContext::incrementAppliedChangeCount)
+                .ifPresent(policyContextStore::save);
+        }
         repository.save(postSalesCase);
         publishNewEvents(postSalesCase);
         return postSalesCase;
@@ -177,10 +183,17 @@ public class PostSalesApplicationService {
             return new PostSalesDecision(postSalesCase.caseId(), 1, kind, true, "ELIGIBLE", ruleSnapshot, amount, null, null, null, now, now.plusSeconds(900));
         }
 
+        PostSalesPolicyContext policyContext = policyContextFor(postSalesCase, now, refundable);
         if (kind == DecisionKind.CHANGE) {
-            Money originalFare = refundable.isZero() ? amountDue : refundable;
+            Money originalFare = policyContext.originalFareOr(refundable.isZero() ? amountDue : refundable);
             Money newFare = amountDue.isZero() ? originalFare : originalFare.add(amountDue);
-            ChangeAssessment assessment = changePolicyEngine.evaluateChange(originalFare, newFare, now, now.plusSeconds(60 * 60 * 24 * 20), 0);
+            ChangeAssessment assessment = changePolicyEngine.evaluateChange(
+                originalFare,
+                newFare,
+                now,
+                policyContext.departureTime(),
+                policyContext.appliedChangeCount()
+            );
             AmountDecisionSnapshot amount = assessment.netPayable().isZero() && !assessment.netRefundable().isZero()
                 ? AmountDecisionSnapshot.refund(assessment.changeFee(), assessment.netRefundable(), assessment.explanation())
                 : AmountDecisionSnapshot.extraCharge(assessment.changeFee(), assessment.netPayable(), assessment.explanation());
@@ -198,18 +211,32 @@ public class PostSalesApplicationService {
             return PostSalesDecision.change(postSalesCase.caseId(), true, "ELIGIBLE", ruleSnapshot, amount, changeFlowSnapshot, assessment, now, now.plusSeconds(900));
         }
 
-        Money penaltyBase = refundable.isZero() ? zero : refundable;
+        Money penaltyBase = policyContext.originalFareOr(refundable.isZero() ? zero : refundable);
         RefundAssessment assessment = refundPolicyEngine.evaluateRefund(
-            RefundWaterfall.simple(penaltyBase),
+            policyContext.waterfallFor(penaltyBase),
             penaltyBase,
             now,
-            now.plusSeconds(60 * 60 * 24 * 20),
+            policyContext.departureTime(),
             classify(postSalesCase.reasonCode()),
-            "ADULT",
-            Math.max(1, postSalesCase.scope().travelerRefs().size())
+            policyContext.travelerType(postSalesCase.scope().travelerRefs()),
+            policyContext.groupSize()
         );
         AmountDecisionSnapshot amount = AmountDecisionSnapshot.refund(assessment.penaltyAmount(), assessment.refundableAmount(), assessment.explanation(), assessment.componentDecisions());
         return PostSalesDecision.refund(postSalesCase.caseId(), true, "ELIGIBLE", ruleSnapshot, amount, assessment, now, now.plusSeconds(900));
+    }
+
+    private PostSalesPolicyContext policyContextFor(PostSalesCase postSalesCase, Instant now, Money fallbackAmount) {
+        return policyContextStore.findByOrderId(postSalesCase.journeyOrderId())
+            .orElseGet(() -> PostSalesPolicyContext.fallback(
+                postSalesCase.journeyOrderId(),
+                now,
+                postSalesCase.scope().travelerRefs().size(),
+                fallbackAmount
+            ));
+    }
+
+    public void recordPolicyContext(PostSalesPolicyContext context) {
+        policyContextStore.save(context);
     }
 
     private static RefundClassification classify(String reasonCode) {

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesEventHandler.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesEventHandler.java
@@ -55,7 +55,11 @@ public class PostSalesEventHandler {
             if (!consumedEventLog.recordIfFirstSeen(envelope.eventId())) {
                 return EventSubscriber.HandlerResult.SUCCESS;
             }
-            if ("CapacityReleased".equals(envelope.eventType())) {
+            if ("JourneyOrderCreated".equals(envelope.eventType()) || "JourneyOrderConfirmed".equals(envelope.eventType())) {
+                policyContext(envelope.payload()).ifPresent(applicationService::recordPolicyContext);
+            } else if ("JourneyOrderPostSalesAdjusted".equals(envelope.eventType())) {
+                policyContext(envelope.payload()).ifPresent(applicationService::recordPolicyContext);
+            } else if ("CapacityReleased".equals(envelope.eventType())) {
                 String segmentBookingRef = segmentBookingRef(envelope.payload());
                 if (segmentBookingRef != null) {
                     applicationService.applyForSegmentBooking(segmentBookingRef, envelope.eventId(), envelope.correlationId());
@@ -68,6 +72,13 @@ public class PostSalesEventHandler {
             }
             return EventSubscriber.HandlerResult.TRANSIENT_FAILURE;
         }
+    }
+
+    private static Optional<PostSalesPolicyContext> policyContext(Object payload) {
+        if (!(payload instanceof Map<?, ?> map)) {
+            return Optional.empty();
+        }
+        return PostSalesPolicyContextMapper.fromEventPayload(map);
     }
 
     private static String segmentBookingRef(Object payload) {

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesMapper.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesMapper.java
@@ -7,6 +7,9 @@ import com.trainticket.postsales.domain.DecisionKind;
 import com.trainticket.postsales.domain.EventMetadata;
 import com.trainticket.postsales.domain.Money;
 import com.trainticket.postsales.domain.ChangeApplied;
+import com.trainticket.postsales.domain.ChangeFeeAssessed;
+import com.trainticket.postsales.domain.RefundComponentDecision;
+import com.trainticket.postsales.domain.RefundFeeAssessed;
 import com.trainticket.postsales.domain.PostSalesApplied;
 import com.trainticket.postsales.domain.PostSalesApproved;
 import com.trainticket.postsales.domain.PostSalesCase;
@@ -147,6 +150,16 @@ public final class PostSalesMapper {
             payload.put("decisionKind", quoted.decisionKind().name());
             payload.put("eligible", quoted.eligible());
             payload.put("ruleSnapshotRef", quoted.ruleSnapshotRef());
+            if (quoted.refundAssessment() != null) {
+                payload.put("refundAssessment", refundAssessment(quoted.refundAssessment()));
+            }
+            if (quoted.changeAssessment() != null) {
+                payload.put("changeAssessment", changeAssessment(quoted.changeAssessment()));
+            }
+        } else if (event instanceof RefundFeeAssessed assessed) {
+            payload.put("refundAssessment", refundAssessment(assessed.assessment()));
+        } else if (event instanceof ChangeFeeAssessed assessed) {
+            payload.put("changeAssessment", changeAssessment(assessed.assessment()));
         } else if (event instanceof PostSalesApproved approved) {
             payload.put("orderId", approved.journeyOrderId());
             payload.put("approvedActions", approvedActions(approved, sourceCase));
@@ -231,8 +244,47 @@ public final class PostSalesMapper {
         body.put("adjustmentQuoteId", decision.ruleSnapshot().farePricingEvaluationRef());
         body.put("refundableAmount", money(amount.refundAmount()));
         body.put("amountDue", money(amount.extraChargeAmount()));
+        if (decision.refundAssessment() != null) {
+            body.put("refundAssessment", refundAssessment(decision.refundAssessment()));
+        }
+        if (decision.changeAssessment() != null) {
+            body.put("changeAssessment", changeAssessment(decision.changeAssessment()));
+        }
         body.put("quotedAt", decision.quotedAt().toString());
         body.put("expiresAt", decision.expiresAt().toString());
+        return body;
+    }
+
+    private static Map<String, Object> refundAssessment(com.trainticket.postsales.domain.RefundAssessment assessment) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("refundableAmount", money(assessment.refundableAmount()));
+        body.put("penaltyAmount", money(assessment.penaltyAmount()));
+        body.put("penaltyPct", assessment.penaltyPct().toPlainString());
+        body.put("tierApplied", assessment.tierApplied());
+        body.put("classification", assessment.classification().name());
+        body.put("explanation", assessment.explanation());
+        body.put("components", assessment.componentDecisions().stream().map(PostSalesMapper::componentDecision).toList());
+        return body;
+    }
+
+    private static Map<String, Object> componentDecision(RefundComponentDecision decision) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("componentType", decision.componentType());
+        body.put("originalAmount", money(decision.originalAmount()));
+        body.put("refundableAmount", money(decision.refundableAmount()));
+        body.put("retainedAmount", money(decision.retainedAmount()));
+        body.put("refundable", decision.refundable());
+        body.put("retainReason", decision.retainReason());
+        return body;
+    }
+
+    private static Map<String, Object> changeAssessment(com.trainticket.postsales.domain.ChangeAssessment assessment) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("changeFee", money(assessment.changeFee()));
+        body.put("fareDifference", money(assessment.fareDifference()));
+        body.put("netPayable", money(assessment.netPayable()));
+        body.put("netRefundable", money(assessment.netRefundable()));
+        body.put("explanation", assessment.explanation());
         return body;
     }
 

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesPolicyContext.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesPolicyContext.java
@@ -1,0 +1,141 @@
+package com.trainticket.postsales.application;
+
+import com.trainticket.postsales.domain.Money;
+import com.trainticket.postsales.domain.RefundWaterfall;
+import java.time.Instant;
+import java.util.Currency;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public record PostSalesPolicyContext(
+    String journeyOrderId,
+    Instant departureTime,
+    Map<String, String> travelerTypesByRef,
+    int groupSize,
+    int appliedChangeCount,
+    Money originalFare,
+    RefundWaterfallComponents refundComponents
+) {
+    public PostSalesPolicyContext {
+        journeyOrderId = requireText(journeyOrderId, "journeyOrderId");
+        Objects.requireNonNull(departureTime, "departureTime is required");
+        travelerTypesByRef = Map.copyOf(Objects.requireNonNull(travelerTypesByRef, "travelerTypesByRef is required"));
+        if (groupSize < 1) {
+            throw new IllegalArgumentException("groupSize must be positive");
+        }
+        if (appliedChangeCount < 0) {
+            throw new IllegalArgumentException("appliedChangeCount must not be negative");
+        }
+        originalFare = Objects.requireNonNull(originalFare, "originalFare is required");
+        refundComponents = Objects.requireNonNull(refundComponents, "refundComponents is required");
+    }
+
+    public static PostSalesPolicyContext fallback(String journeyOrderId, Instant requestTime, int scopedTravelerCount, Money amount) {
+        int groupSize = Math.max(1, scopedTravelerCount);
+        return new PostSalesPolicyContext(
+            journeyOrderId,
+            requestTime,
+            Map.of(),
+            groupSize,
+            0,
+            amount,
+            RefundWaterfallComponents.empty(amount.currency())
+        );
+    }
+
+    public String travelerType(List<String> scopedTravelerRefs) {
+        for (String travelerRef : scopedTravelerRefs) {
+            String travelerType = travelerTypesByRef.get(travelerRef);
+            if (travelerType != null && !travelerType.isBlank()) {
+                return travelerType;
+            }
+        }
+        return travelerTypesByRef.values().stream()
+            .filter(value -> value != null && !value.isBlank())
+            .findFirst()
+            .orElse("UNKNOWN");
+    }
+
+    public Money originalFareOr(Money fallback) {
+        return originalFare.isZero() ? fallback : originalFare;
+    }
+
+    public RefundWaterfall waterfallFor(Money penaltyBase) {
+        return refundComponents.toWaterfall(penaltyBase);
+    }
+
+    public PostSalesPolicyContext incrementAppliedChangeCount() {
+        return new PostSalesPolicyContext(
+            journeyOrderId,
+            departureTime,
+            travelerTypesByRef,
+            groupSize,
+            appliedChangeCount + 1,
+            originalFare,
+            refundComponents
+        );
+    }
+
+    public record RefundWaterfallComponents(
+        Money baseFare,
+        Money taxes,
+        Money platformServiceFee,
+        Money supplierServiceFee,
+        Money ancillary,
+        Money discounts,
+        boolean ancillaryUsed
+    ) {
+        public RefundWaterfallComponents {
+            baseFare = Objects.requireNonNull(baseFare, "baseFare is required");
+            taxes = sameCurrency(taxes, baseFare, "taxes");
+            platformServiceFee = sameCurrency(platformServiceFee, baseFare, "platformServiceFee");
+            supplierServiceFee = sameCurrency(supplierServiceFee, baseFare, "supplierServiceFee");
+            ancillary = sameCurrency(ancillary, baseFare, "ancillary");
+            discounts = sameCurrency(discounts, baseFare, "discounts");
+        }
+
+        public static RefundWaterfallComponents empty(Currency currency) {
+            Money zero = Money.zero(currency);
+            return new RefundWaterfallComponents(zero, zero, zero, zero, zero, zero, false);
+        }
+
+        public RefundWaterfall toWaterfall(Money fallbackBaseFare) {
+            if (baseFare.isZero() && taxes.isZero() && platformServiceFee.isZero()
+                && supplierServiceFee.isZero() && ancillary.isZero() && discounts.isZero()) {
+                return RefundWaterfall.simple(fallbackBaseFare);
+            }
+            Money effectiveBaseFare = baseFare.isZero() ? fallbackBaseFare : baseFare;
+            return new RefundWaterfall(
+                effectiveBaseFare,
+                convertIfZeroCurrency(taxes, effectiveBaseFare),
+                convertIfZeroCurrency(platformServiceFee, effectiveBaseFare),
+                convertIfZeroCurrency(supplierServiceFee, effectiveBaseFare),
+                convertIfZeroCurrency(ancillary, effectiveBaseFare),
+                convertIfZeroCurrency(discounts, effectiveBaseFare),
+                ancillaryUsed
+            );
+        }
+
+        private static Money convertIfZeroCurrency(Money value, Money base) {
+            return value.isZero() && !value.currency().equals(base.currency()) ? Money.zero(base.currency()) : value;
+        }
+
+        private static Money sameCurrency(Money value, Money base, String name) {
+            Objects.requireNonNull(value, name + " is required").compareTo(base);
+            return value;
+        }
+    }
+
+    static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value;
+    }
+
+    public static Optional<Instant> earliest(List<Instant> instants) {
+        return instants.stream().min(Instant::compareTo);
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesPolicyContextMapper.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesPolicyContextMapper.java
@@ -1,0 +1,244 @@
+package com.trainticket.postsales.application;
+
+import com.trainticket.postsales.application.PostSalesPolicyContext.RefundWaterfallComponents;
+import com.trainticket.postsales.domain.Money;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+final class PostSalesPolicyContextMapper {
+    private static final String DEFAULT_CURRENCY = "CNY";
+
+    private PostSalesPolicyContextMapper() {
+    }
+
+    static Optional<PostSalesPolicyContext> fromEventPayload(Map<?, ?> payload) {
+        String journeyOrderId = text(payload, "orderId")
+            .or(() -> text(payload, "journeyOrderId"))
+            .orElse(null);
+        if (journeyOrderId == null) {
+            return Optional.empty();
+        }
+        String currency = currency(payload);
+        List<Map<?, ?>> segmentPayloads = mapList(payload.get("segments"));
+        Optional<Instant> departureTime = earliestDeparture(payload, segmentPayloads);
+        if (departureTime.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Map<String, String> travelerTypes = travelerTypes(payload.get("travelerRefs"));
+        int groupSize = travelerTypes.isEmpty() ? Math.max(1, textList(payload.get("travelerRefs")).size()) : travelerTypes.size();
+        RefundWaterfallComponents components = refundComponents(payload, currency);
+        Money originalFare = components.baseFare().isZero() ? totalMoney(payload, currency) : components.baseFare();
+        int appliedChangeCount = integer(payload, "appliedChangeCount")
+            .or(() -> integer(payload, "changeCount"))
+            .or(() -> countAppliedChangeEvents(payload.get("postSalesAdjustments")))
+            .or(() -> countAppliedChangeEvents(payload.get("adjustments")))
+            .orElse(0);
+
+        return Optional.of(new PostSalesPolicyContext(
+            journeyOrderId,
+            departureTime.get(),
+            travelerTypes,
+            groupSize,
+            appliedChangeCount,
+            originalFare,
+            components
+        ));
+    }
+
+    private static Optional<Instant> earliestDeparture(Map<?, ?> payload, List<Map<?, ?>> segments) {
+        List<Instant> candidates = new ArrayList<>();
+        for (String field : List.of("departureTime", "departureAt")) {
+            text(payload, field).map(Instant::parse).ifPresent(candidates::add);
+        }
+        for (Map<?, ?> segment : segments) {
+            for (String field : List.of("departureTime", "departureAt")) {
+                text(segment, field).map(Instant::parse).ifPresent(candidates::add);
+            }
+        }
+        return PostSalesPolicyContext.earliest(candidates);
+    }
+
+    private static Map<String, String> travelerTypes(Object travelerRefsValue) {
+        Map<String, String> travelerTypes = new LinkedHashMap<>();
+        if (travelerRefsValue instanceof List<?> values) {
+            for (Object value : values) {
+                if (value instanceof Map<?, ?> traveler) {
+                    String travelerId = text(traveler, "travelerId")
+                        .or(() -> text(traveler, "travelerRef"))
+                        .orElse(null);
+                    String travelerType = text(traveler, "travelerType")
+                        .or(() -> text(traveler, "documentType"))
+                        .orElse("UNKNOWN");
+                    if (travelerId != null) {
+                        travelerTypes.put(travelerId, travelerType);
+                    }
+                } else if (value instanceof String travelerId && !travelerId.isBlank()) {
+                    travelerTypes.put(travelerId, "UNKNOWN");
+                }
+            }
+        }
+        return travelerTypes;
+    }
+
+    private static RefundWaterfallComponents refundComponents(Map<?, ?> payload, String currency) {
+        List<Map<?, ?>> items = mapList(payload.get("orderItems"));
+        if (items.isEmpty()) {
+            items = mapList(payload.get("lineItems"));
+        }
+        Money zero = Money.zero(currency);
+        Money baseFare = zero;
+        Money taxes = zero;
+        Money platformServiceFee = zero;
+        Money supplierServiceFee = zero;
+        Money ancillary = zero;
+        Money discounts = zero;
+        for (Map<?, ?> item : items) {
+            Money amount = amount(item, currency).orElse(zero);
+            String type = text(item, "type")
+                .or(() -> text(item, "itemType"))
+                .or(() -> text(item, "kind"))
+                .orElse("")
+                .toUpperCase(Locale.ROOT);
+            if (type.contains("TAX")) {
+                taxes = taxes.add(amount);
+            } else if (type.contains("PLATFORM") && type.contains("FEE")) {
+                platformServiceFee = platformServiceFee.add(amount);
+            } else if (type.contains("SUPPLIER") && type.contains("FEE")) {
+                supplierServiceFee = supplierServiceFee.add(amount);
+            } else if (type.contains("SERVICE") && type.contains("FEE")) {
+                platformServiceFee = platformServiceFee.add(amount);
+            } else if (type.contains("ANCILLARY") || type.contains("INSURANCE") || type.contains("MEAL") || type.contains("UPGRADE")) {
+                ancillary = ancillary.add(amount);
+            } else if (type.contains("DISCOUNT")) {
+                discounts = discounts.add(amount);
+            } else {
+                baseFare = baseFare.add(amount);
+            }
+        }
+        if (items.isEmpty()) {
+            baseFare = moneyAt(payload, List.of("monetarySummary", "subtotal"), currency)
+                .or(() -> moneyAt(payload, List.of("monetarySummary", "total"), currency))
+                .orElse(zero);
+        }
+        boolean ancillaryUsed = booleanValue(payload.get("ancillaryUsed"));
+        return new RefundWaterfallComponents(baseFare, taxes, platformServiceFee, supplierServiceFee, ancillary, discounts, ancillaryUsed);
+    }
+
+    private static Money totalMoney(Map<?, ?> payload, String currency) {
+        return moneyAt(payload, List.of("monetarySummary", "total"), currency)
+            .or(() -> moneyAt(payload, List.of("monetarySummary", "subtotal"), currency))
+            .orElse(Money.zero(currency));
+    }
+
+    private static String currency(Map<?, ?> payload) {
+        Object monetarySummary = nested(payload, List.of("monetarySummary")).orElse(Map.of());
+        return monetarySummary instanceof Map<?, ?> map ? text(map, "currency").orElse(DEFAULT_CURRENCY) : DEFAULT_CURRENCY;
+    }
+
+    private static Optional<Money> amount(Map<?, ?> item, String currency) {
+        return moneyAt(item, List.of("amount"), currency)
+            .or(() -> moneyAt(item, List.of("price"), currency))
+            .or(() -> moneyAt(item, List.of("total"), currency));
+    }
+
+    private static Optional<Money> moneyAt(Map<?, ?> payload, List<String> path, String fallbackCurrency) {
+        Optional<Object> value = nested(payload, path);
+        if (value.isEmpty()) {
+            return Optional.empty();
+        }
+        Object raw = value.get();
+        if (raw instanceof Map<?, ?> map) {
+            String currency = text(map, "currency").orElse(fallbackCurrency);
+            Optional<Integer> minorUnits = integer(map, "minorUnits");
+            if (minorUnits.isPresent()) {
+                return Optional.of(Money.fromMinorUnits(minorUnits.get().longValue(), currency));
+            }
+            Optional<String> amount = text(map, "amount");
+            if (amount.isPresent()) {
+                return Optional.of(Money.of(amount.get(), currency));
+            }
+        }
+        if (raw instanceof Number number) {
+            return Optional.of(Money.fromMinorUnits(number.longValue(), fallbackCurrency));
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Object> nested(Map<?, ?> payload, List<String> path) {
+        Object current = payload;
+        for (String field : path) {
+            if (!(current instanceof Map<?, ?> map) || !map.containsKey(field)) {
+                return Optional.empty();
+            }
+            current = map.get(field);
+        }
+        return Optional.ofNullable(current);
+    }
+
+    private static Optional<String> text(Map<?, ?> payload, String field) {
+        Object value = payload.get(field);
+        return value instanceof String text && !text.isBlank() ? Optional.of(text) : Optional.empty();
+    }
+
+    private static Optional<Integer> integer(Map<?, ?> payload, String field) {
+        Object value = payload.get(field);
+        if (value instanceof Number number) {
+            return Optional.of(number.intValue());
+        }
+        if (value instanceof String text && !text.isBlank()) {
+            return Optional.of(Integer.parseInt(text));
+        }
+        return Optional.empty();
+    }
+
+    private static boolean booleanValue(Object value) {
+        return value instanceof Boolean bool && bool;
+    }
+
+    private static Optional<Integer> countAppliedChangeEvents(Object value) {
+        if (!(value instanceof List<?> values)) {
+            return Optional.empty();
+        }
+        int count = 0;
+        for (Object item : values) {
+            if (item instanceof Map<?, ?> map) {
+                String type = text(map, "caseType").or(() -> text(map, "type")).orElse("");
+                String status = text(map, "status").orElse("APPLIED");
+                if (type.equalsIgnoreCase("CHANGE") && status.equalsIgnoreCase("APPLIED")) {
+                    count++;
+                }
+            }
+        }
+        return Optional.of(count);
+    }
+
+    private static List<Map<?, ?>> mapList(Object value) {
+        if (!(value instanceof List<?> values)) {
+            return List.of();
+        }
+        List<Map<?, ?>> maps = new ArrayList<>();
+        for (Object item : values) {
+            if (item instanceof Map<?, ?> map) {
+                maps.add(map);
+            }
+        }
+        return maps;
+    }
+
+    private static List<String> textList(Object value) {
+        if (!(value instanceof List<?> values)) {
+            return List.of();
+        }
+        return values.stream()
+            .filter(String.class::isInstance)
+            .map(String.class::cast)
+            .filter(text -> !text.isBlank())
+            .toList();
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesPolicyContextStore.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesPolicyContextStore.java
@@ -1,0 +1,9 @@
+package com.trainticket.postsales.application;
+
+import java.util.Optional;
+
+public interface PostSalesPolicyContextStore {
+    Optional<PostSalesPolicyContext> findByOrderId(String journeyOrderId);
+
+    void save(PostSalesPolicyContext context);
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/AmountDecisionSnapshot.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/AmountDecisionSnapshot.java
@@ -1,18 +1,21 @@
 package com.trainticket.postsales.domain;
 
+import java.util.List;
 import java.util.Objects;
 
 public record AmountDecisionSnapshot(
     Money feeAmount,
     Money refundAmount,
     Money extraChargeAmount,
-    String explanation
+    String explanation,
+    List<RefundComponentDecision> componentDecisions
 ) {
     public AmountDecisionSnapshot {
         Objects.requireNonNull(feeAmount, "feeAmount is required");
         Objects.requireNonNull(refundAmount, "refundAmount is required");
         Objects.requireNonNull(extraChargeAmount, "extraChargeAmount is required");
         explanation = PostSalesScope.requireText(explanation, "explanation");
+        componentDecisions = componentDecisions == null ? List.of() : List.copyOf(componentDecisions);
         feeAmount.compareTo(refundAmount);
         feeAmount.compareTo(extraChargeAmount);
         if (!refundAmount.isZero() && !extraChargeAmount.isZero()) {
@@ -20,11 +23,19 @@ public record AmountDecisionSnapshot(
         }
     }
 
+    public AmountDecisionSnapshot(Money feeAmount, Money refundAmount, Money extraChargeAmount, String explanation) {
+        this(feeAmount, refundAmount, extraChargeAmount, explanation, List.of());
+    }
+
     public static AmountDecisionSnapshot refund(Money feeAmount, Money refundAmount, String explanation) {
-        return new AmountDecisionSnapshot(feeAmount, refundAmount, Money.zero(refundAmount.currency()), explanation);
+        return refund(feeAmount, refundAmount, explanation, List.of());
+    }
+
+    public static AmountDecisionSnapshot refund(Money feeAmount, Money refundAmount, String explanation, List<RefundComponentDecision> componentDecisions) {
+        return new AmountDecisionSnapshot(feeAmount, refundAmount, Money.zero(refundAmount.currency()), explanation, componentDecisions);
     }
 
     public static AmountDecisionSnapshot extraCharge(Money feeAmount, Money extraChargeAmount, String explanation) {
-        return new AmountDecisionSnapshot(feeAmount, Money.zero(extraChargeAmount.currency()), extraChargeAmount, explanation);
+        return new AmountDecisionSnapshot(feeAmount, Money.zero(extraChargeAmount.currency()), extraChargeAmount, explanation, List.of());
     }
 }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/ChangeAssessment.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/ChangeAssessment.java
@@ -1,0 +1,25 @@
+package com.trainticket.postsales.domain;
+
+import java.util.Objects;
+
+public record ChangeAssessment(
+    Money changeFee,
+    Money fareDifference,
+    Money netPayable,
+    Money netRefundable,
+    String explanation
+) {
+    public ChangeAssessment {
+        Objects.requireNonNull(changeFee, "changeFee is required");
+        Objects.requireNonNull(fareDifference, "fareDifference is required");
+        Objects.requireNonNull(netPayable, "netPayable is required");
+        Objects.requireNonNull(netRefundable, "netRefundable is required");
+        explanation = PostSalesScope.requireText(explanation, "explanation");
+        changeFee.compareTo(fareDifference);
+        changeFee.compareTo(netPayable);
+        changeFee.compareTo(netRefundable);
+        if (!netPayable.isZero() && !netRefundable.isZero()) {
+            throw new DomainRuleViolation("a change assessment cannot be both payable and refundable");
+        }
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/ChangeFeeAssessed.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/ChangeFeeAssessed.java
@@ -1,0 +1,7 @@
+package com.trainticket.postsales.domain;
+
+public record ChangeFeeAssessed(
+    String caseId,
+    ChangeAssessment assessment,
+    EventMetadata metadata
+) implements PostSalesEvent { }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/ChangePolicyEngine.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/ChangePolicyEngine.java
@@ -1,0 +1,39 @@
+package com.trainticket.postsales.domain;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+public final class ChangePolicyEngine {
+    private static final BigDecimal TWENTY_PCT = new BigDecimal("0.20");
+
+    public ChangeAssessment evaluateChange(
+        Money originalFare,
+        Money newFare,
+        Instant requestTime,
+        Instant departureTime,
+        int changeCount
+    ) {
+        Objects.requireNonNull(originalFare, "originalFare is required");
+        Objects.requireNonNull(newFare, "newFare is required").compareTo(originalFare);
+        Objects.requireNonNull(requestTime, "requestTime is required");
+        Objects.requireNonNull(departureTime, "departureTime is required");
+        if (changeCount < 0) {
+            throw new DomainRuleViolation("changeCount must not be negative");
+        }
+
+        boolean freeFirstChange = changeCount == 0 && Duration.between(requestTime, departureTime).compareTo(Duration.ofHours(48)) > 0;
+        Money changeFee = freeFirstChange ? Money.zero(originalFare.currency()) : RefundWaterfall.percent(originalFare, TWENTY_PCT);
+        Money fareIncrease = newFare.compareTo(originalFare) > 0 ? RefundWaterfall.subtract(newFare, originalFare) : Money.zero(originalFare.currency());
+        Money fareDecrease = originalFare.compareTo(newFare) > 0 ? RefundWaterfall.subtract(originalFare, newFare) : Money.zero(originalFare.currency());
+        Money grossPayable = changeFee.add(fareIncrease);
+        Money netPayable = grossPayable.compareTo(fareDecrease) > 0 ? RefundWaterfall.subtract(grossPayable, fareDecrease) : Money.zero(originalFare.currency());
+        Money netRefundable = fareDecrease.compareTo(grossPayable) > 0 ? RefundWaterfall.subtract(fareDecrease, grossPayable) : Money.zero(originalFare.currency());
+        Money fareDifference = fareIncrease.isZero() ? fareDecrease : fareIncrease;
+        String explanation = freeFirstChange
+            ? "first change more than 48 hours before departure has no change fee; fare difference netted"
+            : "20% change fee applied; fare difference netted";
+        return new ChangeAssessment(changeFee, fareDifference, netPayable, netRefundable, explanation);
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesCase.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesCase.java
@@ -160,8 +160,15 @@ public final class PostSalesCase {
             throw new DomainRuleViolation("decision kind must match post-sales case type");
         }
         this.decision = decision;
+        EventMetadata quoteMetadata = metadata(occurredAt, sourceCommandId, causationId, correlationId, PostSalesCaseStatus.ELIGIBILITY_CHECKING);
         domainEvents.add(new PostSalesDecisionQuoted(caseId, decision.kind(), decision.eligible(), decision.ruleSnapshot().farePricingEvaluationRef(),
-            metadata(occurredAt, sourceCommandId, causationId, correlationId, PostSalesCaseStatus.ELIGIBILITY_CHECKING)));
+            decision.refundAssessment(), decision.changeAssessment(), quoteMetadata));
+        if (decision.refundAssessment() != null) {
+            domainEvents.add(new RefundFeeAssessed(caseId, decision.refundAssessment(), quoteMetadata));
+        }
+        if (decision.changeAssessment() != null) {
+            domainEvents.add(new ChangeFeeAssessed(caseId, decision.changeAssessment(), quoteMetadata));
+        }
         if (!decision.eligible()) {
             reject(decision.reasonCode(), occurredAt, sourceCommandId, causationId, correlationId);
             return;

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesDecision.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesDecision.java
@@ -12,6 +12,8 @@ public record PostSalesDecision(
     RuleEvaluationSnapshot ruleSnapshot,
     AmountDecisionSnapshot amountSnapshot,
     ChangeFlowSnapshot changeFlowSnapshot,
+    RefundAssessment refundAssessment,
+    ChangeAssessment changeAssessment,
     Instant quotedAt,
     Instant expiresAt
 ) {
@@ -29,6 +31,18 @@ public record PostSalesDecision(
         if (!expiresAt.isAfter(quotedAt)) {
             throw new DomainRuleViolation("decision quote must expire after quotedAt");
         }
+        if (kind == DecisionKind.REFUND && refundAssessment == null) {
+            throw new DomainRuleViolation("refund decisions must include a refund assessment");
+        }
+        if (kind != DecisionKind.REFUND && refundAssessment != null) {
+            throw new DomainRuleViolation("only refund decisions may include a refund assessment");
+        }
+        if (kind == DecisionKind.CHANGE && changeAssessment == null) {
+            throw new DomainRuleViolation("change decisions must include a change assessment");
+        }
+        if (kind != DecisionKind.CHANGE && changeAssessment != null) {
+            throw new DomainRuleViolation("only change decisions may include a change assessment");
+        }
         if (kind == DecisionKind.CHANGE && changeFlowSnapshot == null) {
             throw new DomainRuleViolation("change decisions must include a conservative change flow snapshot");
         }
@@ -38,10 +52,20 @@ public record PostSalesDecision(
     }
 
     public static PostSalesDecision refund(String caseId, boolean eligible, String reasonCode, RuleEvaluationSnapshot ruleSnapshot, AmountDecisionSnapshot amountSnapshot, Instant quotedAt, Instant expiresAt) {
-        return new PostSalesDecision(caseId, 1, DecisionKind.REFUND, eligible, reasonCode, ruleSnapshot, amountSnapshot, null, quotedAt, expiresAt);
+        RefundAssessment assessment = new RefundAssessment(amountSnapshot.refundAmount(), amountSnapshot.feeAmount(), java.math.BigDecimal.ZERO, "LEGACY", amountSnapshot.explanation(), RefundClassification.VOLUNTARY, amountSnapshot.componentDecisions());
+        return refund(caseId, eligible, reasonCode, ruleSnapshot, amountSnapshot, assessment, quotedAt, expiresAt);
+    }
+
+    public static PostSalesDecision refund(String caseId, boolean eligible, String reasonCode, RuleEvaluationSnapshot ruleSnapshot, AmountDecisionSnapshot amountSnapshot, RefundAssessment refundAssessment, Instant quotedAt, Instant expiresAt) {
+        return new PostSalesDecision(caseId, 1, DecisionKind.REFUND, eligible, reasonCode, ruleSnapshot, amountSnapshot, null, refundAssessment, null, quotedAt, expiresAt);
     }
 
     public static PostSalesDecision change(String caseId, boolean eligible, String reasonCode, RuleEvaluationSnapshot ruleSnapshot, AmountDecisionSnapshot amountSnapshot, ChangeFlowSnapshot changeFlowSnapshot, Instant quotedAt, Instant expiresAt) {
-        return new PostSalesDecision(caseId, 1, DecisionKind.CHANGE, eligible, reasonCode, ruleSnapshot, amountSnapshot, changeFlowSnapshot, quotedAt, expiresAt);
+        ChangeAssessment assessment = new ChangeAssessment(amountSnapshot.feeAmount(), amountSnapshot.extraChargeAmount().isZero() ? amountSnapshot.refundAmount() : amountSnapshot.extraChargeAmount(), amountSnapshot.extraChargeAmount(), amountSnapshot.refundAmount(), amountSnapshot.explanation());
+        return change(caseId, eligible, reasonCode, ruleSnapshot, amountSnapshot, changeFlowSnapshot, assessment, quotedAt, expiresAt);
+    }
+
+    public static PostSalesDecision change(String caseId, boolean eligible, String reasonCode, RuleEvaluationSnapshot ruleSnapshot, AmountDecisionSnapshot amountSnapshot, ChangeFlowSnapshot changeFlowSnapshot, ChangeAssessment changeAssessment, Instant quotedAt, Instant expiresAt) {
+        return new PostSalesDecision(caseId, 1, DecisionKind.CHANGE, eligible, reasonCode, ruleSnapshot, amountSnapshot, changeFlowSnapshot, null, changeAssessment, quotedAt, expiresAt);
     }
 }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesDecisionQuoted.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesDecisionQuoted.java
@@ -5,5 +5,7 @@ public record PostSalesDecisionQuoted(
     DecisionKind decisionKind,
     boolean eligible,
     String ruleSnapshotRef,
+    RefundAssessment refundAssessment,
+    ChangeAssessment changeAssessment,
     EventMetadata metadata
 ) implements PostSalesEvent { }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesEvent.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesEvent.java
@@ -1,6 +1,6 @@
 package com.trainticket.postsales.domain;
 
-public sealed interface PostSalesEvent permits PostSalesRequested, PostSalesCaseOpened, PostSalesEligibilityEvaluated, PostSalesDecisionQuoted, PostSalesApproved, PostSalesRejected, PostSalesExecutionRequested, PostSalesExecutionStarted, PostSalesStepSucceeded, PostSalesStepFailed, PostSalesManualReviewRequired, PostSalesApplied, PostSalesFailed, ChangeApplied {
+public sealed interface PostSalesEvent permits PostSalesRequested, PostSalesCaseOpened, PostSalesEligibilityEvaluated, PostSalesDecisionQuoted, RefundFeeAssessed, ChangeFeeAssessed, PostSalesApproved, PostSalesRejected, PostSalesExecutionRequested, PostSalesExecutionStarted, PostSalesStepSucceeded, PostSalesStepFailed, PostSalesManualReviewRequired, PostSalesApplied, PostSalesFailed, ChangeApplied {
     String caseId();
     EventMetadata metadata();
 }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/RefundAssessment.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/RefundAssessment.java
@@ -1,0 +1,26 @@
+package com.trainticket.postsales.domain;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
+
+public record RefundAssessment(
+    Money refundableAmount,
+    Money penaltyAmount,
+    BigDecimal penaltyPct,
+    String tierApplied,
+    String explanation,
+    RefundClassification classification,
+    List<RefundComponentDecision> componentDecisions
+) {
+    public RefundAssessment {
+        Objects.requireNonNull(refundableAmount, "refundableAmount is required");
+        Objects.requireNonNull(penaltyAmount, "penaltyAmount is required");
+        penaltyPct = Objects.requireNonNull(penaltyPct, "penaltyPct is required").stripTrailingZeros();
+        tierApplied = PostSalesScope.requireText(tierApplied, "tierApplied");
+        explanation = PostSalesScope.requireText(explanation, "explanation");
+        classification = Objects.requireNonNull(classification, "classification is required");
+        componentDecisions = List.copyOf(Objects.requireNonNull(componentDecisions, "componentDecisions are required"));
+        refundableAmount.compareTo(penaltyAmount);
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/RefundClassification.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/RefundClassification.java
@@ -1,0 +1,13 @@
+package com.trainticket.postsales.domain;
+
+public enum RefundClassification {
+    VOLUNTARY,
+    INVOLUNTARY_CARRIER,
+    INVOLUNTARY_DELAY,
+    INVOLUNTARY_FORCE_MAJEURE,
+    INVOLUNTARY_PLATFORM;
+
+    public boolean isInvoluntary() {
+        return this != VOLUNTARY;
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/RefundComponentDecision.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/RefundComponentDecision.java
@@ -1,0 +1,22 @@
+package com.trainticket.postsales.domain;
+
+import java.util.Objects;
+
+public record RefundComponentDecision(
+    String componentType,
+    Money originalAmount,
+    Money refundableAmount,
+    Money retainedAmount,
+    boolean refundable,
+    String retainReason
+) {
+    public RefundComponentDecision {
+        componentType = PostSalesScope.requireText(componentType, "componentType");
+        Objects.requireNonNull(originalAmount, "originalAmount is required");
+        Objects.requireNonNull(refundableAmount, "refundableAmount is required");
+        Objects.requireNonNull(retainedAmount, "retainedAmount is required");
+        originalAmount.compareTo(refundableAmount);
+        originalAmount.compareTo(retainedAmount);
+        retainReason = retainReason == null ? "" : retainReason;
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/RefundFeeAssessed.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/RefundFeeAssessed.java
@@ -1,0 +1,7 @@
+package com.trainticket.postsales.domain;
+
+public record RefundFeeAssessed(
+    String caseId,
+    RefundAssessment assessment,
+    EventMetadata metadata
+) implements PostSalesEvent { }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/RefundPolicyEngine.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/RefundPolicyEngine.java
@@ -1,0 +1,103 @@
+package com.trainticket.postsales.domain;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+public final class RefundPolicyEngine {
+    private static final BigDecimal ZERO_PCT = new BigDecimal("0.00");
+    private static final BigDecimal FIVE_PCT = new BigDecimal("0.05");
+    private static final BigDecimal TEN_PCT = new BigDecimal("0.10");
+    private static final BigDecimal TWENTY_PCT = new BigDecimal("0.20");
+    private static final BigDecimal FULL_PCT = new BigDecimal("1.00");
+
+    public RefundAssessment evaluateRefund(
+        Money originalFare,
+        Instant requestTime,
+        Instant departureTime,
+        boolean involuntary,
+        String travelerType,
+        int groupSize
+    ) {
+        RefundClassification classification = involuntary ? RefundClassification.INVOLUNTARY_CARRIER : RefundClassification.VOLUNTARY;
+        return evaluateRefund(RefundWaterfall.simple(originalFare), originalFare, requestTime, departureTime, classification, travelerType, groupSize);
+    }
+
+    public RefundAssessment evaluateRefund(
+        RefundWaterfall waterfall,
+        Money penaltyBase,
+        Instant requestTime,
+        Instant departureTime,
+        RefundClassification classification,
+        String travelerType,
+        int groupSize
+    ) {
+        Objects.requireNonNull(waterfall, "waterfall is required");
+        Objects.requireNonNull(penaltyBase, "penaltyBase is required");
+        Objects.requireNonNull(requestTime, "requestTime is required");
+        Objects.requireNonNull(departureTime, "departureTime is required");
+        classification = Objects.requireNonNull(classification, "classification is required");
+        if (groupSize < 1) {
+            throw new DomainRuleViolation("groupSize must be positive");
+        }
+
+        TierChoice choice = chooseTier(requestTime, departureTime, classification, travelerType, groupSize, penaltyBase);
+        Money penalty = RefundWaterfall.percent(penaltyBase, choice.penaltyPct());
+        if (!choice.minimumPenalty().isZero() && !penalty.isZero() && penalty.compareTo(choice.minimumPenalty()) < 0) {
+            penalty = choice.minimumPenalty();
+        }
+        penalty = RefundWaterfall.min(penalty, penaltyBase);
+        RefundWaterfall.RefundWaterfallResult waterfallResult = waterfall.apply(penaltyBase, penalty);
+        return new RefundAssessment(
+            waterfallResult.refundableAmount(),
+            penalty,
+            choice.penaltyPct(),
+            choice.tierApplied(),
+            choice.explanation(),
+            classification,
+            waterfallResult.componentDecisions()
+        );
+    }
+
+    private TierChoice chooseTier(
+        Instant requestTime,
+        Instant departureTime,
+        RefundClassification classification,
+        String travelerType,
+        int groupSize,
+        Money penaltyBase
+    ) {
+        if (classification.isInvoluntary()) {
+            return new TierChoice(ZERO_PCT, Money.zero(penaltyBase.currency()), "INVOLUNTARY_OVERRIDE", "involuntary refund bypasses penalty tiers");
+        }
+        Duration beforeDeparture = Duration.between(requestTime, departureTime);
+        if (beforeDeparture.isNegative() || beforeDeparture.isZero()) {
+            return new TierChoice(FULL_PCT, Money.zero(penaltyBase.currency()), "AFTER_DEPARTURE_NON_REFUNDABLE", "refund requested after departure is non-refundable");
+        }
+        if (groupSize >= 10) {
+            return new TierChoice(FIVE_PCT, Money.zero(penaltyBase.currency()), "GROUP_FLAT_5_PERCENT", "group booking refund applies flat 5% fee");
+        }
+        if (isStudent(travelerType) && beforeDeparture.compareTo(Duration.ofDays(2)) > 0) {
+            return new TierChoice(ZERO_PCT, Money.zero(penaltyBase.currency()), "STUDENT_GT_2D_FREE", "student ticket refunded more than 2 days before departure has no fee");
+        }
+        if (beforeDeparture.compareTo(Duration.ofHours(48)) < 0) {
+            return new TierChoice(FULL_PCT, Money.zero(penaltyBase.currency()), "LT_48H_NON_REFUNDABLE", "refund requested less than 48 hours before departure is non-refundable");
+        }
+        if (beforeDeparture.compareTo(Duration.ofDays(8)) < 0) {
+            return new TierChoice(TWENTY_PCT, Money.zero(penaltyBase.currency()), "TIER_2_TO_7_DAYS", "voluntary refund 2-7 days before departure applies 20% fee");
+        }
+        if (beforeDeparture.compareTo(Duration.ofDays(15)) <= 0) {
+            return new TierChoice(TEN_PCT, Money.zero(penaltyBase.currency()), "TIER_8_TO_15_DAYS", "voluntary refund 8-15 days before departure applies 10% fee");
+        }
+        return new TierChoice(FIVE_PCT, Money.of("2.00", penaltyBase.currency().getCurrencyCode()), "TIER_GT_15_DAYS", "voluntary refund more than 15 days before departure applies 5% fee");
+    }
+
+    private static boolean isStudent(String travelerType) {
+        return travelerType != null && travelerType.toUpperCase(Locale.ROOT).contains("STUDENT");
+    }
+
+    private record TierChoice(BigDecimal penaltyPct, Money minimumPenalty, String tierApplied, String explanation) { }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/RefundTier.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/RefundTier.java
@@ -1,0 +1,30 @@
+package com.trainticket.postsales.domain;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public record RefundTier(
+    Integer minDaysBefore,
+    Integer maxDaysBefore,
+    BigDecimal penaltyPct,
+    Money minimumPenalty,
+    String name
+) {
+    public RefundTier {
+        if (minDaysBefore != null && minDaysBefore < 0) {
+            throw new DomainRuleViolation("minimum days before departure must not be negative");
+        }
+        if (maxDaysBefore != null && maxDaysBefore < 0) {
+            throw new DomainRuleViolation("maximum days before departure must not be negative");
+        }
+        if (minDaysBefore != null && maxDaysBefore != null && minDaysBefore > maxDaysBefore) {
+            throw new DomainRuleViolation("minimum days before departure must be less than maximum days before departure");
+        }
+        penaltyPct = Objects.requireNonNull(penaltyPct, "penaltyPct is required").stripTrailingZeros();
+        if (penaltyPct.signum() < 0 || penaltyPct.compareTo(BigDecimal.ONE) > 0) {
+            throw new DomainRuleViolation("penaltyPct must be between 0 and 1");
+        }
+        minimumPenalty = Objects.requireNonNull(minimumPenalty, "minimumPenalty is required");
+        name = PostSalesScope.requireText(name, "name");
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/RefundWaterfall.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/RefundWaterfall.java
@@ -1,0 +1,140 @@
+package com.trainticket.postsales.domain;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Currency;
+import java.util.List;
+import java.util.Objects;
+
+public final class RefundWaterfall {
+    private final Money baseFare;
+    private final Money taxes;
+    private final Money platformServiceFee;
+    private final Money supplierServiceFee;
+    private final Money ancillary;
+    private final Money discounts;
+    private final boolean ancillaryUsed;
+
+    public RefundWaterfall(
+        Money baseFare,
+        Money taxes,
+        Money platformServiceFee,
+        Money supplierServiceFee,
+        Money ancillary,
+        Money discounts,
+        boolean ancillaryUsed
+    ) {
+        this.baseFare = Objects.requireNonNull(baseFare, "baseFare is required");
+        this.taxes = requireSameCurrency(taxes, baseFare, "taxes");
+        this.platformServiceFee = requireSameCurrency(platformServiceFee, baseFare, "platformServiceFee");
+        this.supplierServiceFee = requireSameCurrency(supplierServiceFee, baseFare, "supplierServiceFee");
+        this.ancillary = requireSameCurrency(ancillary, baseFare, "ancillary");
+        this.discounts = requireSameCurrency(discounts, baseFare, "discounts");
+        this.ancillaryUsed = ancillaryUsed;
+    }
+
+    public static RefundWaterfall simple(Money baseFare) {
+        Money zero = Money.zero(baseFare.currency());
+        return new RefundWaterfall(baseFare, zero, zero, zero, zero, zero, false);
+    }
+
+    public RefundWaterfallResult apply(Money requestedRefundable, Money penaltyAmount) {
+        Objects.requireNonNull(requestedRefundable, "requestedRefundable is required").compareTo(baseFare);
+        Objects.requireNonNull(penaltyAmount, "penaltyAmount is required").compareTo(baseFare);
+        Currency currency = baseFare.currency();
+        Money zero = Money.zero(currency);
+        List<RefundComponentDecision> decisions = new ArrayList<>();
+
+        Money ancillaryRefund = ancillaryUsed ? zero : ancillary;
+        decisions.add(new RefundComponentDecision(
+            "ANCILLARY",
+            ancillary,
+            ancillaryRefund,
+            ancillaryUsed ? ancillary : zero,
+            !ancillaryUsed,
+            ancillaryUsed ? "ancillary already used" : "unused ancillary refundable"
+        ));
+
+        decisions.add(new RefundComponentDecision(
+            "PLATFORM_SERVICE_FEE",
+            platformServiceFee,
+            zero,
+            platformServiceFee,
+            false,
+            "platform service fee retained"
+        ));
+
+        decisions.add(new RefundComponentDecision(
+            "SUPPLIER_SERVICE_FEE",
+            supplierServiceFee,
+            supplierServiceFee,
+            zero,
+            true,
+            "supplier service fee returned"
+        ));
+
+        decisions.add(new RefundComponentDecision(
+            "TAXES",
+            taxes,
+            taxes,
+            zero,
+            true,
+            "taxes fully refundable"
+        ));
+
+        Money basePenalty = min(penaltyAmount, baseFare);
+        Money baseRefund = subtract(baseFare, basePenalty);
+        decisions.add(new RefundComponentDecision(
+            "BASE_FARE",
+            baseFare,
+            baseRefund,
+            basePenalty,
+            !baseRefund.isZero(),
+            basePenalty.isZero() ? "base fare refundable" : "base fare penalty retained"
+        ));
+
+        decisions.add(new RefundComponentDecision(
+            "DISCOUNTS",
+            discounts,
+            zero,
+            discounts,
+            false,
+            discounts.isZero() ? "no discount claw back" : "discount clawed back"
+        ));
+
+        Money calculated = ancillaryRefund.add(supplierServiceFee).add(taxes).add(baseRefund);
+        Money afterDiscountClawBack = subtract(calculated, discounts);
+        return new RefundWaterfallResult(afterDiscountClawBack, decisions);
+    }
+
+    private static Money requireSameCurrency(Money money, Money base, String name) {
+        Objects.requireNonNull(money, name + " is required").compareTo(base);
+        return money;
+    }
+
+    static Money percent(Money money, BigDecimal pct) {
+        BigDecimal amount = money.amount().multiply(pct).setScale(money.currency().getDefaultFractionDigits(), RoundingMode.HALF_UP);
+        return new Money(amount, money.currency());
+    }
+
+    static Money subtract(Money left, Money right) {
+        left.compareTo(right);
+        BigDecimal result = left.amount().subtract(right.amount());
+        if (result.signum() < 0) {
+            result = BigDecimal.ZERO;
+        }
+        return new Money(result, left.currency());
+    }
+
+    static Money min(Money left, Money right) {
+        return left.compareTo(right) <= 0 ? left : right;
+    }
+
+    public record RefundWaterfallResult(Money refundableAmount, List<RefundComponentDecision> componentDecisions) {
+        public RefundWaterfallResult {
+            Objects.requireNonNull(refundableAmount, "refundableAmount is required");
+            componentDecisions = List.copyOf(Objects.requireNonNull(componentDecisions, "componentDecisions are required"));
+        }
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostgresPostSalesPolicyContextStore.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostgresPostSalesPolicyContextStore.java
@@ -1,0 +1,72 @@
+package com.trainticket.postsales.infrastructure.persistence;
+
+import com.trainticket.postsales.application.PostSalesPolicyContext;
+import com.trainticket.postsales.application.PostSalesPolicyContextStore;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Primary
+@ConditionalOnBean(DataSource.class)
+public class PostgresPostSalesPolicyContextStore implements PostSalesPolicyContextStore {
+    private final JdbcTemplate jdbc;
+    private final ObjectMapper objectMapper;
+
+    public PostgresPostSalesPolicyContextStore(DataSource dataSource, ObjectMapper objectMapper) {
+        this.jdbc = new JdbcTemplate(dataSource);
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Optional<PostSalesPolicyContext> findByOrderId(String journeyOrderId) {
+        ensureTable();
+        return jdbc.query("SELECT data FROM post_sales_policy_contexts WHERE journey_order_id = ?", rs -> {
+            if (!rs.next()) {
+                return Optional.empty();
+            }
+            return Optional.of(read(rs.getString("data")));
+        }, journeyOrderId);
+    }
+
+    @Override
+    public void save(PostSalesPolicyContext context) {
+        ensureTable();
+        jdbc.update("""
+            INSERT INTO post_sales_policy_contexts (journey_order_id, data, updated_at)
+            VALUES (?, ?::jsonb, now())
+            ON CONFLICT (journey_order_id) DO UPDATE SET data = EXCLUDED.data, updated_at = now()
+            """, context.journeyOrderId(), write(context));
+    }
+
+    private void ensureTable() {
+        jdbc.execute("""
+            CREATE TABLE IF NOT EXISTS post_sales_policy_contexts (
+                journey_order_id text PRIMARY KEY,
+                data jsonb NOT NULL,
+                updated_at timestamptz NOT NULL DEFAULT now()
+            )
+            """);
+    }
+
+    private String write(PostSalesPolicyContext context) {
+        try {
+            return objectMapper.writeValueAsString(context);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("post-sales policy context could not be encoded", exception);
+        }
+    }
+
+    private PostSalesPolicyContext read(String json) {
+        try {
+            return objectMapper.readValue(json, PostSalesPolicyContext.class);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("post-sales policy context could not be decoded", exception);
+        }
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostgresPostSalesRepository.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostgresPostSalesRepository.java
@@ -102,7 +102,8 @@ public class PostgresPostSalesRepository implements PostSalesRepository {
     private static boolean isActive(PostSalesCase postSalesCase) {
         return postSalesCase.status() != PostSalesCaseStatus.REJECTED
             && postSalesCase.status() != PostSalesCaseStatus.CANCELLED
-            && postSalesCase.status() != PostSalesCaseStatus.FAILED;
+            && postSalesCase.status() != PostSalesCaseStatus.FAILED
+            && postSalesCase.status() != PostSalesCaseStatus.APPLIED;
     }
 
     private PostSalesSnapshot readSnapshot(String json) {

--- a/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostgresPostSalesRepository.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostgresPostSalesRepository.java
@@ -126,10 +126,83 @@ public class PostgresPostSalesRepository implements PostSalesRepository {
         return PostSalesCase.rehydrate(text(r,"caseId"), text(r,"journeyOrderId"), PostSalesCaseType.valueOf(text(r,"caseType")), objectMapper.convertValue(r.path("scope"), PostSalesScope.class), text(r,"reasonCode"), text(r,"actorRef"), text(r,"idempotencyKey"), PostSalesCaseStatus.valueOf(text(r,"status")), r.path("decision").isNull()?null:decision(r.path("decision")), steps(r.path("executionPlan")), r.path("executionPlanAggregate").isNull()?null:plan(r.path("executionPlanAggregate")), r.path("terminalReason").asText(null), List.of());
     }
 
-    private ObjectNode decision(PostSalesDecision d) { ObjectNode n=objectMapper.createObjectNode(); n.put("caseId",d.caseId()); n.put("version",d.version()); n.put("kind",d.kind().name()); n.put("eligible",d.eligible()); n.put("reasonCode",d.reasonCode()); n.set("ruleSnapshot", objectMapper.valueToTree(d.ruleSnapshot())); n.set("amountSnapshot", amount(d.amountSnapshot())); if(d.changeFlowSnapshot()==null)n.putNull("changeFlowSnapshot"); else n.set("changeFlowSnapshot", objectMapper.valueToTree(d.changeFlowSnapshot())); n.put("quotedAt",d.quotedAt().toString()); n.put("expiresAt",d.expiresAt().toString()); return n; }
-    private PostSalesDecision decision(JsonNode n) { return new PostSalesDecision(text(n,"caseId"), n.path("version").asInt(), DecisionKind.valueOf(text(n,"kind")), n.path("eligible").asBoolean(), text(n,"reasonCode"), objectMapper.convertValue(n.path("ruleSnapshot"), RuleEvaluationSnapshot.class), amount(n.path("amountSnapshot")), n.path("changeFlowSnapshot").isNull()?null:objectMapper.convertValue(n.path("changeFlowSnapshot"), ChangeFlowSnapshot.class), Instant.parse(text(n,"quotedAt")), Instant.parse(text(n,"expiresAt"))); }
-    private ObjectNode amount(AmountDecisionSnapshot a){ ObjectNode n=objectMapper.createObjectNode(); n.set("feeAmount", money(a.feeAmount())); n.set("refundAmount", money(a.refundAmount())); n.set("extraChargeAmount", money(a.extraChargeAmount())); n.put("explanation", a.explanation()); return n; }
-    private AmountDecisionSnapshot amount(JsonNode n){ return new AmountDecisionSnapshot(money(n.path("feeAmount")), money(n.path("refundAmount")), money(n.path("extraChargeAmount")), text(n,"explanation")); }
+    private ObjectNode decision(PostSalesDecision decision) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("caseId", decision.caseId());
+        node.put("version", decision.version());
+        node.put("kind", decision.kind().name());
+        node.put("eligible", decision.eligible());
+        node.put("reasonCode", decision.reasonCode());
+        node.set("ruleSnapshot", objectMapper.valueToTree(decision.ruleSnapshot()));
+        node.set("amountSnapshot", amount(decision.amountSnapshot()));
+        if (decision.changeFlowSnapshot() == null) {
+            node.putNull("changeFlowSnapshot");
+        } else {
+            node.set("changeFlowSnapshot", objectMapper.valueToTree(decision.changeFlowSnapshot()));
+        }
+        if (decision.refundAssessment() == null) {
+            node.putNull("refundAssessment");
+        } else {
+            node.set("refundAssessment", objectMapper.valueToTree(decision.refundAssessment()));
+        }
+        if (decision.changeAssessment() == null) {
+            node.putNull("changeAssessment");
+        } else {
+            node.set("changeAssessment", objectMapper.valueToTree(decision.changeAssessment()));
+        }
+        node.put("quotedAt", decision.quotedAt().toString());
+        node.put("expiresAt", decision.expiresAt().toString());
+        return node;
+    }
+    private PostSalesDecision decision(JsonNode node) {
+        AmountDecisionSnapshot amount = amount(node.path("amountSnapshot"));
+        RefundAssessment refundAssessment = node.path("refundAssessment").isMissingNode() || node.path("refundAssessment").isNull()
+            ? legacyRefund(node, amount)
+            : objectMapper.convertValue(node.path("refundAssessment"), RefundAssessment.class);
+        ChangeAssessment changeAssessment = node.path("changeAssessment").isMissingNode() || node.path("changeAssessment").isNull()
+            ? legacyChange(node, amount)
+            : objectMapper.convertValue(node.path("changeAssessment"), ChangeAssessment.class);
+        return new PostSalesDecision(
+            text(node, "caseId"),
+            node.path("version").asInt(),
+            DecisionKind.valueOf(text(node, "kind")),
+            node.path("eligible").asBoolean(),
+            text(node, "reasonCode"),
+            objectMapper.convertValue(node.path("ruleSnapshot"), RuleEvaluationSnapshot.class),
+            amount,
+            node.path("changeFlowSnapshot").isNull() ? null : objectMapper.convertValue(node.path("changeFlowSnapshot"), ChangeFlowSnapshot.class),
+            refundAssessment,
+            changeAssessment,
+            Instant.parse(text(node, "quotedAt")),
+            Instant.parse(text(node, "expiresAt"))
+        );
+    }
+    private ObjectNode amount(AmountDecisionSnapshot amount) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.set("feeAmount", money(amount.feeAmount()));
+        node.set("refundAmount", money(amount.refundAmount()));
+        node.set("extraChargeAmount", money(amount.extraChargeAmount()));
+        node.put("explanation", amount.explanation());
+        node.set("componentDecisions", objectMapper.valueToTree(amount.componentDecisions()));
+        return node;
+    }
+    private AmountDecisionSnapshot amount(JsonNode node) {
+        List<RefundComponentDecision> componentDecisions = node.path("componentDecisions").isMissingNode()
+            ? List.of()
+            : objectMapper.convertValue(node.path("componentDecisions"), objectMapper.getTypeFactory().constructCollectionType(List.class, RefundComponentDecision.class));
+        return new AmountDecisionSnapshot(money(node.path("feeAmount")), money(node.path("refundAmount")), money(node.path("extraChargeAmount")), text(node, "explanation"), componentDecisions);
+    }
+    private RefundAssessment legacyRefund(JsonNode node, AmountDecisionSnapshot amount) {
+        return DecisionKind.valueOf(text(node, "kind")) == DecisionKind.REFUND
+            ? new RefundAssessment(amount.refundAmount(), amount.feeAmount(), java.math.BigDecimal.ZERO, "LEGACY", amount.explanation(), RefundClassification.VOLUNTARY, amount.componentDecisions())
+            : null;
+    }
+
+    private ChangeAssessment legacyChange(JsonNode node, AmountDecisionSnapshot amount) {
+        return DecisionKind.valueOf(text(node, "kind")) == DecisionKind.CHANGE
+            ? new ChangeAssessment(amount.feeAmount(), amount.extraChargeAmount().isZero() ? amount.refundAmount() : amount.extraChargeAmount(), amount.extraChargeAmount(), amount.refundAmount(), amount.explanation())
+            : null;
+    }
     private ObjectNode money(Money m){ ObjectNode n=objectMapper.createObjectNode(); n.put("currency", m.currency().getCurrencyCode()); n.put("minorUnits", m.toMinorUnits()); return n; }
     private Money money(JsonNode n){ return Money.fromMinorUnits(n.path("minorUnits").asLong(), text(n,"currency")); }
     private ObjectNode step(PostSalesStep s){ ObjectNode n=objectMapper.createObjectNode(); n.put("type",s.type().name()); n.put("targetContext",s.targetContext()); n.put("idempotencyKey",s.idempotencyKey()); n.put("maxRetries",s.maxRetries()); n.put("status",s.status().name()); if(s.externalRef()==null)n.putNull("externalRef"); else n.put("externalRef",s.externalRef()); if(s.failureReason()==null)n.putNull("failureReason"); else n.put("failureReason",s.failureReason()); if(s.completedAt()==null)n.putNull("completedAt"); else n.put("completedAt",s.completedAt().toString()); return n; }

--- a/services/post-sales/src/test/java/com/trainticket/postsales/application/MessagingPortsTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/application/MessagingPortsTest.java
@@ -113,7 +113,7 @@ class MessagingPortsTest {
     @Test
     void subscriberHandlerDeduplicatesDuplicateEventId() {
         RecordingConsumedEventLog log = new RecordingConsumedEventLog();
-        PostSalesEventHandler handler = new PostSalesEventHandler(log, null);
+        PostSalesEventHandler handler = new PostSalesEventHandler(log, new NoOpPostSalesApplicationService());
         EventEnvelope envelope = new EventEnvelope(
             "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d001",
             "JourneyOrderCancelled",
@@ -212,6 +212,12 @@ class MessagingPortsTest {
             if (result == EventSubscriber.HandlerResult.FATAL_FAILURE) {
                 dlq.add(envelope);
             }
+        }
+    }
+
+    private static final class NoOpPostSalesApplicationService extends PostSalesApplicationService {
+        NoOpPostSalesApplicationService() {
+            super(new InMemoryPostSalesRepository(), ignored -> { }, ignored -> java.util.Optional.empty(), new InMemoryPostSalesPolicyContextStore(), java.time.Clock.systemUTC());
         }
     }
 

--- a/services/post-sales/src/test/java/com/trainticket/postsales/application/PostSalesApplicationServicePolicyIntegrationTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/application/PostSalesApplicationServicePolicyIntegrationTest.java
@@ -1,0 +1,123 @@
+package com.trainticket.postsales.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.trainticket.postsales.domain.Money;
+import com.trainticket.postsales.domain.PostSalesCase;
+import com.trainticket.postsales.domain.PostSalesCaseType;
+import com.trainticket.postsales.domain.PostSalesScope;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class PostSalesApplicationServicePolicyIntegrationTest {
+    private static final Instant NOW = Instant.parse("2026-07-03T10:00:00Z");
+
+    @Test
+    void refundQuoteUsesStoredThreeDayDepartureContext() {
+        InMemoryPostSalesPolicyContextStore contextStore = new InMemoryPostSalesPolicyContextStore();
+        PostSalesApplicationService service = service(contextStore, quote("adjq-refund", 10_000, "CNY", 0, "CNY"));
+        service.recordPolicyContext(PostSalesPolicyContext.fallback("ord-policy-1", NOW.plusSeconds(3 * 86_400), 1, Money.of("100.00", "CNY")));
+        PostSalesCase postSalesCase = service.open(command("ord-policy-1", PostSalesCaseType.REFUND, "idem-refund-policy"));
+
+        PostSalesCase evaluated = service.evaluate("psc-" + postSalesCase.caseId(), "cmd-evaluate", "corr-policy");
+
+        assertEquals("TIER_2_TO_7_DAYS", evaluated.decision().refundAssessment().tierApplied());
+        assertEquals(2_000, evaluated.decision().refundAssessment().penaltyAmount().toMinorUnits());
+    }
+
+    @Test
+    void refundQuoteUsesInvoluntaryClassificationWithStoredDepartureContext() {
+        InMemoryPostSalesPolicyContextStore contextStore = new InMemoryPostSalesPolicyContextStore();
+        PostSalesApplicationService service = service(contextStore, quote("adjq-carrier", 10_000, "CNY", 0, "CNY"));
+        service.recordPolicyContext(PostSalesPolicyContext.fallback("ord-policy-2", NOW.plusSeconds(3 * 86_400), 1, Money.of("100.00", "CNY")));
+        PostSalesCase postSalesCase = service.open(new PostSalesApplicationService.OpenCaseCommand(
+            "ord-policy-2",
+            PostSalesCaseType.REFUND,
+            scope(),
+            "CARRIER_CANCELLED",
+            "acct-1",
+            "idem-carrier-policy",
+            "cmd-open",
+            "corr-policy"
+        ));
+
+        PostSalesCase evaluated = service.evaluate("psc-" + postSalesCase.caseId(), "cmd-evaluate", "corr-policy");
+
+        assertEquals("INVOLUNTARY_OVERRIDE", evaluated.decision().refundAssessment().tierApplied());
+        assertEquals(0, evaluated.decision().refundAssessment().penaltyAmount().toMinorUnits());
+    }
+
+    @Test
+    void secondChangeUsesPersistedChangeCountAndActualDepartureContext() {
+        InMemoryPostSalesPolicyContextStore contextStore = new InMemoryPostSalesPolicyContextStore();
+        contextStore.save(new PostSalesPolicyContext(
+            "ord-change-policy",
+            NOW.plusSeconds(20 * 86_400),
+            Map.of("tvl-1", "ADULT"),
+            1,
+            1,
+            Money.of("100.00", "CNY"),
+            PostSalesPolicyContext.RefundWaterfallComponents.empty(java.util.Currency.getInstance("CNY"))
+        ));
+        PostSalesApplicationService service = service(contextStore, quote("adjq-change", 0, "CNY", 5_000, "CNY"));
+        PostSalesCase postSalesCase = service.open(command("ord-change-policy", PostSalesCaseType.CHANGE, "idem-change-policy"));
+
+        PostSalesCase evaluated = service.evaluate("psc-" + postSalesCase.caseId(), "cmd-evaluate", "corr-policy");
+
+        assertEquals(2_000, evaluated.decision().changeAssessment().changeFee().toMinorUnits());
+        assertEquals(7_000, evaluated.decision().changeAssessment().netPayable().toMinorUnits());
+    }
+
+    private static PostSalesApplicationService service(
+        PostSalesPolicyContextStore contextStore,
+        AdjustmentQuotePort.AdjustmentQuoteResult quote
+    ) {
+        AdjustmentQuotePort quotePort = ignored -> Optional.of(quote);
+        return new PostSalesApplicationService(
+            new InMemoryPostSalesRepository(),
+            ignored -> { },
+            quotePort,
+            contextStore,
+            Clock.fixed(NOW, ZoneOffset.UTC)
+        );
+    }
+
+    private static AdjustmentQuotePort.AdjustmentQuoteResult quote(
+        String quoteId,
+        long refundableMinorUnits,
+        String refundableCurrency,
+        long amountDueMinorUnits,
+        String amountDueCurrency
+    ) {
+        return new AdjustmentQuotePort.AdjustmentQuoteResult(
+            quoteId,
+            "QUOTED",
+            refundableMinorUnits,
+            refundableCurrency,
+            amountDueMinorUnits,
+            amountDueCurrency
+        );
+    }
+
+    private static PostSalesApplicationService.OpenCaseCommand command(String orderId, PostSalesCaseType caseType, String idempotencyKey) {
+        return new PostSalesApplicationService.OpenCaseCommand(
+            orderId,
+            caseType,
+            scope(),
+            "CUSTOMER_REQUEST",
+            "acct-1",
+            idempotencyKey,
+            "cmd-open",
+            "corr-policy"
+        );
+    }
+
+    private static PostSalesScope scope() {
+        return new PostSalesScope(List.of("oi-1"), List.of("seg-1"), List.of("tvl-1"), List.of("ent-1"));
+    }
+}

--- a/services/post-sales/src/test/java/com/trainticket/postsales/domain/ChangePolicyEngineTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/domain/ChangePolicyEngineTest.java
@@ -1,0 +1,48 @@
+package com.trainticket.postsales.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class ChangePolicyEngineTest {
+    private static final Instant REQUEST = Instant.parse("2026-07-01T00:00:00Z");
+    private final ChangePolicyEngine engine = new ChangePolicyEngine();
+
+    @Test
+    void firstChangeMoreThanFortyEightHoursBeforeDepartureOnlyPaysFareIncrease() {
+        ChangeAssessment assessment = engine.evaluateChange(Money.of("200.00", "CNY"), Money.of("260.00", "CNY"), REQUEST, REQUEST.plusSeconds(3 * 86_400), 0);
+
+        assertEquals(Money.of("0.00", "CNY"), assessment.changeFee());
+        assertEquals(Money.of("60.00", "CNY"), assessment.fareDifference());
+        assertEquals(Money.of("60.00", "CNY"), assessment.netPayable());
+        assertEquals(Money.of("0.00", "CNY"), assessment.netRefundable());
+    }
+
+    @Test
+    void changeWithinFortyEightHoursPaysFareIncreasePlusChangeFee() {
+        ChangeAssessment assessment = engine.evaluateChange(Money.of("200.00", "CNY"), Money.of("260.00", "CNY"), REQUEST, REQUEST.plusSeconds(24 * 3_600), 0);
+
+        assertEquals(Money.of("40.00", "CNY"), assessment.changeFee());
+        assertEquals(Money.of("60.00", "CNY"), assessment.fareDifference());
+        assertEquals(Money.of("100.00", "CNY"), assessment.netPayable());
+    }
+
+    @Test
+    void fareDecreaseIsRefundedNetOfChangeFee() {
+        ChangeAssessment assessment = engine.evaluateChange(Money.of("200.00", "CNY"), Money.of("140.00", "CNY"), REQUEST, REQUEST.plusSeconds(24 * 3_600), 0);
+
+        assertEquals(Money.of("40.00", "CNY"), assessment.changeFee());
+        assertEquals(Money.of("60.00", "CNY"), assessment.fareDifference());
+        assertEquals(Money.of("20.00", "CNY"), assessment.netRefundable());
+        assertEquals(Money.of("0.00", "CNY"), assessment.netPayable());
+    }
+
+    @Test
+    void secondChangeAlwaysChargesTwentyPercentEvenWhenMoreThanFortyEightHoursBeforeDeparture() {
+        ChangeAssessment assessment = engine.evaluateChange(Money.of("200.00", "CNY"), Money.of("200.00", "CNY"), REQUEST, REQUEST.plusSeconds(5 * 86_400), 1);
+
+        assertEquals(Money.of("40.00", "CNY"), assessment.changeFee());
+        assertEquals(Money.of("40.00", "CNY"), assessment.netPayable());
+    }
+}

--- a/services/post-sales/src/test/java/com/trainticket/postsales/domain/RefundPolicyEngineTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/domain/RefundPolicyEngineTest.java
@@ -1,0 +1,87 @@
+package com.trainticket.postsales.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class RefundPolicyEngineTest {
+    private static final Instant REQUEST = Instant.parse("2026-07-01T00:00:00Z");
+    private final RefundPolicyEngine engine = new RefundPolicyEngine();
+
+    @Test
+    void voluntaryRefundTwentyDaysBeforeDepartureAppliesFivePercentPenalty() {
+        RefundAssessment assessment = engine.evaluateRefund(Money.of("200.00", "CNY"), REQUEST, REQUEST.plusSeconds(20 * 86_400), false, "ADULT", 1);
+
+        assertEquals(new BigDecimal("0.05"), assessment.penaltyPct());
+        assertEquals(Money.of("10.00", "CNY"), assessment.penaltyAmount());
+        assertEquals(Money.of("190.00", "CNY"), assessment.refundableAmount());
+        assertEquals("TIER_GT_15_DAYS", assessment.tierApplied());
+    }
+
+    @Test
+    void voluntaryRefundThreeDaysBeforeDepartureAppliesTwentyPercentPenalty() {
+        RefundAssessment assessment = engine.evaluateRefund(Money.of("200.00", "CNY"), REQUEST, REQUEST.plusSeconds(3 * 86_400), false, "ADULT", 1);
+
+        assertEquals(new BigDecimal("0.2"), assessment.penaltyPct());
+        assertEquals(Money.of("40.00", "CNY"), assessment.penaltyAmount());
+        assertEquals(Money.of("160.00", "CNY"), assessment.refundableAmount());
+    }
+
+    @Test
+    void involuntaryCarrierRefundBypassesPenalty() {
+        RefundAssessment assessment = engine.evaluateRefund(
+            RefundWaterfall.simple(Money.of("200.00", "CNY")),
+            Money.of("200.00", "CNY"),
+            REQUEST,
+            REQUEST.plusSeconds(3_600),
+            RefundClassification.INVOLUNTARY_CARRIER,
+            "ADULT",
+            1
+        );
+
+        assertEquals(BigDecimal.ZERO, assessment.penaltyPct());
+        assertEquals(Money.of("0.00", "CNY"), assessment.penaltyAmount());
+        assertEquals(Money.of("200.00", "CNY"), assessment.refundableAmount());
+    }
+
+    @Test
+    void specialRulesApplyForStudentAndGroupBookings() {
+        RefundAssessment student = engine.evaluateRefund(Money.of("200.00", "CNY"), REQUEST, REQUEST.plusSeconds(3 * 86_400), false, "STUDENT", 1);
+        RefundAssessment group = engine.evaluateRefund(Money.of("200.00", "CNY"), REQUEST, REQUEST.plusSeconds(3 * 86_400), false, "ADULT", 10);
+
+        assertEquals(Money.of("0.00", "CNY"), student.penaltyAmount());
+        assertEquals("STUDENT_GT_2D_FREE", student.tierApplied());
+        assertEquals(Money.of("10.00", "CNY"), group.penaltyAmount());
+        assertEquals("GROUP_FLAT_5_PERCENT", group.tierApplied());
+    }
+
+    @Test
+    void waterfallRetainsPlatformServiceFeeRefundsTaxAncillaryAndBaseFareMinusPenalty() {
+        RefundWaterfall waterfall = new RefundWaterfall(
+            Money.of("200.00", "CNY"),
+            Money.of("20.00", "CNY"),
+            Money.of("10.00", "CNY"),
+            Money.of("0.00", "CNY"),
+            Money.of("50.00", "CNY"),
+            Money.of("0.00", "CNY"),
+            false
+        );
+
+        RefundAssessment assessment = engine.evaluateRefund(
+            waterfall,
+            Money.of("200.00", "CNY"),
+            REQUEST,
+            REQUEST.plusSeconds(3 * 86_400),
+            RefundClassification.VOLUNTARY,
+            "ADULT",
+            1
+        );
+
+        assertEquals(Money.of("230.00", "CNY"), assessment.refundableAmount());
+        assertTrue(assessment.componentDecisions().stream().anyMatch(c -> c.componentType().equals("PLATFORM_SERVICE_FEE") && c.retainedAmount().equals(Money.of("10.00", "CNY"))));
+        assertTrue(assessment.componentDecisions().stream().anyMatch(c -> c.componentType().equals("TAXES") && c.refundableAmount().equals(Money.of("20.00", "CNY"))));
+    }
+}


### PR DESCRIPTION
## Summary
- Add domain refund/change policy engines, assessment records, refund waterfall, classification enum, and fee assessed events
- Integrate assessments into post-sales decisions/events and persistence snapshots
- Add unit coverage for refund tiers, involuntary override, change fee/fare-difference netting, and refund waterfall

## Validation
- javac domain compile with local stubs: passed
- Policy smoke assertions: passed
- mvn -f services/post-sales/pom.xml test: blocked by missing com.trainticket:java-kit:0.1.0-SNAPSHOT
- platform/java-kit mvn install -DskipTests: blocked by pre-existing LettuceRedisStreamOperations compile errors