### PR TITLE
REQ-302 add capacity overbooking snapshots

### DIFF
--- a/services/capacity-availability/src/adapters/storage/mod.rs
+++ b/services/capacity-availability/src/adapters/storage/mod.rs
@@ -193,6 +193,7 @@ impl PostgresCapacityService {
         let interval = StationInterval::new(0, 1).map_err(to_internal)?;
         let unit_ref = pool
             .find_available_unit(&interval, now)
+            .or_else(|| pool.capacity_unit_refs().into_iter().next())
             .ok_or_else(|| AppError::Unavailable("No capacity units available in pool".into()))?;
         let hold = CapacityHold::request(
             HoldId::new(&hold_id).map_err(to_internal)?,
@@ -214,13 +215,13 @@ impl PostgresCapacityService {
             now + 300_000,
         )
         .map_err(to_internal)?;
-        let event = pool.request_hold(hold, now).map_err(|error| match error {
+        let events = pool.request_hold(hold, now).map_err(|error| match error {
             DomainError::IdempotencyConflict { .. } => AppError::IdempotencyKeyReused(
                 "Idempotency-Key was reused with a different request body".into(),
             ),
             error => AppError::DomainRuleViolation(error.to_string()),
         })?;
-        let envelope = domain_event_to_wire(&event, correlation_id)?;
+        let envelopes = domain_events_to_wire(&events, correlation_id)?;
         self.inventory_repo
             .save(
                 &mut tx,
@@ -242,13 +243,23 @@ impl PostgresCapacityService {
             )
             .await
             .map_err(to_app_storage)?;
-        OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &envelope)
-            .await
-            .map_err(to_app_storage)?;
+        for envelope in envelopes {
+            OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &envelope)
+                .await
+                .map_err(to_app_storage)?;
+        }
+        let status = if events
+            .iter()
+            .any(|event| matches!(event, DomainEvent::CapacityHeld(_)))
+        {
+            "HELD"
+        } else {
+            "WAITLISTED"
+        };
         let response = HoldCapacityResponse {
             hold_id,
             segment_ref: req.segment_ref.clone(),
-            status: "HELD".to_string(),
+            status: status.to_string(),
             held_until: unix_millis_to_rfc3339(now + 300_000),
         };
         self.finish_idempotency(
@@ -358,8 +369,8 @@ impl PostgresCapacityService {
     ) -> Result<T, AppError>
     where
         T: Serialize + for<'de> Deserialize<'de>,
-        M: Fn(&mut InventoryPool, u64) -> Result<DomainEvent, AppError>,
-        R: Fn(&DomainEvent) -> T,
+        M: Fn(&mut InventoryPool, u64) -> Result<Vec<DomainEvent>, AppError>,
+        R: Fn(&[DomainEvent]) -> T,
     {
         for attempt in 0..MAX_RETRIES {
             let result = async {
@@ -383,8 +394,8 @@ impl PostgresCapacityService {
                     .map_err(to_app_storage)?
                     .ok_or_else(|| AppError::NotFound("hold not found".into()))?;
                 let mut pool = loaded_pool.data.try_into_domain()?;
-                let event = mutate(&mut pool, now_millis())?;
-                let envelope = domain_event_to_wire(&event, correlation_id)?;
+                let events = mutate(&mut pool, now_millis())?;
+                let envelopes = domain_events_to_wire(&events, correlation_id)?;
                 self.inventory_repo
                     .save(
                         &mut tx,
@@ -398,10 +409,12 @@ impl PostgresCapacityService {
                     .hold(&HoldId::new(hold_id).map_err(to_internal)?)
                     .ok_or_else(|| AppError::NotFound("hold not found".into()))?;
                 self.upsert_hold_snapshot(&mut tx, hold_id, hold).await?;
-                OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &envelope)
-                    .await
-                    .map_err(to_app_storage)?;
-                let resp = response(&event);
+                for envelope in envelopes {
+                    OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &envelope)
+                        .await
+                        .map_err(to_app_storage)?;
+                }
+                let resp = response(&events);
                 self.finish_idempotency(
                     &mut tx,
                     idempotency_key,
@@ -818,13 +831,13 @@ impl PostgresCapacityService {
             now + 300_000,
         )
         .map_err(inbound_fatal)?;
-        let event = pool.request_hold(hold, now).map_err(|error| match error {
+        let events = pool.request_hold(hold, now).map_err(|error| match error {
             DomainError::IdempotencyConflict { .. } => {
                 InboundEventError::Fatal("IDEMPOTENCY_KEY_REUSED".into())
             }
             error => InboundEventError::Fatal(error.to_string()),
         })?;
-        let outbound = domain_event_to_wire(&event, &envelope.correlation_id)
+        let outbound = domain_events_to_wire(&events, &envelope.correlation_id)
             .map_err(inbound_from_app_error)?;
         self.inventory_repo
             .save(
@@ -847,13 +860,23 @@ impl PostgresCapacityService {
             )
             .await
             .map_err(inbound_transient)?;
-        OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &outbound)
-            .await
-            .map_err(inbound_transient)?;
+        for envelope in outbound {
+            OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &envelope)
+                .await
+                .map_err(inbound_transient)?;
+        }
+        let status = if events
+            .iter()
+            .any(|event| matches!(event, DomainEvent::CapacityHeld(_)))
+        {
+            "HELD"
+        } else {
+            "WAITLISTED"
+        };
         let response = HoldCapacityResponse {
             hold_id,
             segment_ref: req.segment_ref.clone(),
-            status: "HELD".to_string(),
+            status: status.to_string(),
             held_until: unix_millis_to_rfc3339(now + 300_000),
         };
         self.finish_idempotency(
@@ -1040,11 +1063,11 @@ impl PostgresCapacityService {
             tx.commit().await.map_err(inbound_transient)?;
             return Ok(());
         }
-        let event = pool
+        let events = pool
             .confirm_hold(&hold_id_value, now_millis())
             .map_err(map_hold_mutation_error)
             .map_err(inbound_from_app_error)?;
-        let outbound = domain_event_to_wire(&event, &envelope.correlation_id)
+        let outbound = domain_events_to_wire(&events, &envelope.correlation_id)
             .map_err(inbound_from_app_error)?;
         self.inventory_repo
             .save(
@@ -1061,9 +1084,11 @@ impl PostgresCapacityService {
         self.upsert_hold_snapshot(&mut tx, &hold_id, hold)
             .await
             .map_err(inbound_from_app_error)?;
-        OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &outbound)
-            .await
-            .map_err(inbound_transient)?;
+        for envelope in outbound {
+            OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &envelope)
+                .await
+                .map_err(inbound_transient)?;
+        }
         let resp = ConfirmHoldResponse {
             hold_id,
             status: "CONFIRMED".to_string(),
@@ -1280,11 +1305,11 @@ impl PostgresCapacityService {
             tx.commit().await.map_err(inbound_transient)?;
             return Ok(());
         }
-        let event = pool
+        let events = pool
             .release_hold(&hold_id_value, now_millis(), release_reason)
             .map_err(map_hold_mutation_error)
             .map_err(inbound_from_app_error)?;
-        let outbound = domain_event_to_wire(&event, &envelope.correlation_id)
+        let outbound = domain_events_to_wire(&events, &envelope.correlation_id)
             .map_err(inbound_from_app_error)?;
         self.inventory_repo
             .save(
@@ -1301,9 +1326,11 @@ impl PostgresCapacityService {
         self.upsert_hold_snapshot(&mut tx, &hold_id, hold)
             .await
             .map_err(inbound_from_app_error)?;
-        OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &outbound)
-            .await
-            .map_err(inbound_transient)?;
+        for envelope in outbound {
+            OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &envelope)
+                .await
+                .map_err(inbound_transient)?;
+        }
         let resp = ReleaseHoldResponse {
             hold_id,
             status: "RELEASED".to_string(),
@@ -1334,8 +1361,8 @@ impl PostgresCapacityService {
     ) -> Result<(), InboundEventError>
     where
         T: Serialize + for<'de> Deserialize<'de>,
-        M: Fn(&mut InventoryPool, u64) -> Result<DomainEvent, AppError>,
-        R: Fn(&DomainEvent) -> T,
+        M: Fn(&mut InventoryPool, u64) -> Result<Vec<DomainEvent>, AppError>,
+        R: Fn(&[DomainEvent]) -> T,
     {
         let stream = stream_for_producer(&envelope.producer);
         for attempt in 0..MAX_RETRIES {
@@ -1380,8 +1407,8 @@ impl PostgresCapacityService {
     ) -> Result<(), InboundEventError>
     where
         T: Serialize + for<'de> Deserialize<'de>,
-        M: Fn(&mut InventoryPool, u64) -> Result<DomainEvent, AppError>,
-        R: Fn(&DomainEvent) -> T,
+        M: Fn(&mut InventoryPool, u64) -> Result<Vec<DomainEvent>, AppError>,
+        R: Fn(&[DomainEvent]) -> T,
     {
         let mut tx = self.pool().begin().await.map_err(inbound_transient)?;
         if !mark_event_processing(&mut tx, &envelope.event_id, stream)
@@ -1423,15 +1450,15 @@ impl PostgresCapacityService {
             .data
             .try_into_domain()
             .map_err(inbound_from_app_error)?;
-        let event = match mutate(&mut pool, now_millis()) {
-            Ok(event) => event,
+        let events = match mutate(&mut pool, now_millis()) {
+            Ok(events) => events,
             Err(AppError::NotFound(_)) | Err(AppError::PreconditionFailed(_)) => {
                 tx.commit().await.map_err(inbound_transient)?;
                 return Ok(());
             }
             Err(error) => return Err(inbound_from_app_error(error)),
         };
-        let outbound = domain_event_to_wire(&event, &envelope.correlation_id)
+        let outbound = domain_events_to_wire(&events, &envelope.correlation_id)
             .map_err(inbound_from_app_error)?;
         self.inventory_repo
             .save(
@@ -1448,10 +1475,12 @@ impl PostgresCapacityService {
         self.upsert_hold_snapshot(&mut tx, hold_id, hold)
             .await
             .map_err(inbound_from_app_error)?;
-        OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &outbound)
-            .await
-            .map_err(inbound_transient)?;
-        let resp = response(&event);
+        for envelope in outbound {
+            OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &envelope)
+                .await
+                .map_err(inbound_transient)?;
+        }
+        let resp = response(&events);
         self.finish_idempotency(
             &mut tx,
             idempotency_key,
@@ -1498,6 +1527,7 @@ struct InventoryPoolSnapshot {
     identity: InventoryPoolIdentitySnapshot,
     capacity_units: Vec<String>,
     holds: Vec<CapacityHoldSnapshot>,
+    overbooking_policy: Option<OverbookingPolicy>,
 }
 
 impl InventoryPoolSnapshot {
@@ -1518,6 +1548,7 @@ impl InventoryPoolSnapshot {
             identity: InventoryPoolIdentitySnapshot::from_domain(&pool.identity),
             capacity_units,
             holds,
+            overbooking_policy: Some(pool.overbooking_policy()),
         }
     }
 
@@ -1531,6 +1562,9 @@ impl InventoryPoolSnapshot {
                 .map_err(to_internal)?,
         )
         .map_err(to_internal)?;
+        if let Some(policy) = self.overbooking_policy {
+            pool.set_overbooking_policy(policy);
+        }
         for hold in self.holds {
             pool.restore_hold(hold.try_into_domain()?)
                 .map_err(to_internal)?;
@@ -1708,11 +1742,19 @@ fn new_pool(pool_id: &str, req: &HoldCapacityRequest) -> Result<InventoryPool, A
         "v1",
     )
     .map_err(to_internal)?;
-    let units = (0..req.quantity.max(10))
+    let units = (0..req.quantity.max(100))
         .map(|i| CapacityUnitRef::new(format!("{:02}{}", (i / 4) + 1, ['A', 'B', 'C', 'D'][i % 4])))
         .collect::<Result<Vec<_>, _>>()
         .map_err(to_internal)?;
-    InventoryPool::new(identity, units).map_err(to_internal)
+    InventoryPool::new(identity, units)
+        .map(|pool| {
+            pool.with_overbooking_policy(OverbookingPolicy {
+                max_overbooking_pct: 5.0,
+                no_show_rate: 3.0,
+                safety_margin_pct: 1.0,
+            })
+        })
+        .map_err(to_internal)
 }
 
 fn validate_hold_request(req: &HoldCapacityRequest) -> Result<(), AppError> {
@@ -1759,6 +1801,16 @@ fn replay_capacity_held_envelope(
         }),
     )
     .map_err(inbound_fatal)
+}
+
+fn domain_events_to_wire(
+    events: &[DomainEvent],
+    correlation_id: &str,
+) -> Result<Vec<WireEnvelope>, AppError> {
+    events
+        .iter()
+        .map(|event| domain_event_to_wire(event, correlation_id))
+        .collect()
 }
 
 fn domain_event_to_wire(
@@ -1830,6 +1882,35 @@ fn domain_event_to_wire(
             }
             ("CapacityHoldFailed", payload)
         }
+        DomainEvent::CapacitySnapshotUpdated(e) => (
+            "CapacitySnapshotUpdated",
+            capacity_snapshot_payload(&e.snapshot),
+        ),
+        DomainEvent::OverbookingThresholdReached(e) => (
+            "OverbookingThresholdReached",
+            json!({
+                "poolId": e.pool_id.to_string(),
+                "physicalCapacity": e.physical_capacity,
+                "confirmedCount": e.confirmed_count,
+                "overbookingPct": e.overbooking_pct,
+            }),
+        ),
+        DomainEvent::WaitlistActivated(e) => (
+            "WaitlistActivated",
+            json!({
+                "segmentRef": e.segment_ref,
+                "departureDate": e.departure_date,
+                "queuePosition": e.queue_position,
+            }),
+        ),
+        DomainEvent::WaitlistCapacityFreed(e) => (
+            "WaitlistCapacityFreed",
+            json!({
+                "segmentRef": e.segment_ref,
+                "departureDate": e.departure_date,
+                "freedSlots": e.freed_slots,
+            }),
+        ),
     };
     WireEnvelope::try_new(
         event_type,
@@ -1840,6 +1921,33 @@ fn domain_event_to_wire(
         payload,
     )
     .map_err(|error| AppError::Internal(error.to_string()))
+}
+
+fn capacity_snapshot_payload(snapshot: &CapacitySnapshot) -> Value {
+    json!({
+        "segmentRef": snapshot.segment_ref,
+        "departureDate": snapshot.departure_date,
+        "totalCapacity": snapshot.total_capacity,
+        "remainingCapacity": snapshot.remaining_capacity,
+        "physicalCapacity": snapshot.physical_capacity,
+        "holdCount": snapshot.hold_count,
+        "confirmedCount": snapshot.confirmed_count,
+        "utilizationPct": snapshot.utilization_pct,
+        "snapshotVersion": snapshot.snapshot_version,
+        "classes": snapshot.classes.iter().map(|class| json!({
+            "classRef": class.class_ref,
+            "physicalCapacity": class.physical_capacity,
+            "effectiveCapacity": class.effective_capacity,
+            "holdCount": class.hold_count,
+            "confirmedCount": class.confirmed_count,
+            "remainingCapacity": class.remaining_capacity,
+            "overbookingPolicy": {
+                "maxOverbookingPct": class.overbooking_policy.max_overbooking_pct,
+                "noShowRate": class.overbooking_policy.no_show_rate,
+                "safetyMarginPct": class.overbooking_policy.safety_margin_pct,
+            }
+        })).collect::<Vec<_>>(),
+    })
 }
 
 fn parse_state(state: &str) -> Result<CapacityHoldState, AppError> {

--- a/services/capacity-availability/src/api.rs
+++ b/services/capacity-availability/src/api.rs
@@ -5,7 +5,8 @@
 #[cfg(feature = "redis-impl")]
 use crate::adapters::storage::PostgresCapacityService;
 use crate::application::{
-    AppError, AvailabilitySnapshotResponse, CapacityService, HoldCapacityRequest,
+    AppError, AvailabilitySnapshotResponse, CapacityService, CapacitySnapshotResponse,
+    HoldCapacityRequest,
 };
 
 use axum::{
@@ -22,6 +23,11 @@ pub fn router(service: Arc<CapacityService>) -> Router {
     Router::new()
         .route("/api/v1/availability-snapshots", get(query_availability))
         .route("/api/v1/capacity-holds", post(hold_capacity))
+        .route("/api/v1/capacity/holds", post(hold_capacity))
+        .route(
+            "/api/v1/capacity/segments/{segment_ref}/snapshot",
+            get(get_capacity_snapshot),
+        )
         .route(
             "/api/v1/capacity-holds/{hold_id}/confirm",
             post(confirm_hold),
@@ -39,6 +45,7 @@ pub fn postgres_router(service: Arc<PostgresCapacityService>) -> Router {
     Router::new()
         .route("/api/v1/availability-snapshots", get(query_availability_pg))
         .route("/api/v1/capacity-holds", post(hold_capacity_pg))
+        .route("/api/v1/capacity/holds", post(hold_capacity_pg))
         .route(
             "/api/v1/capacity-holds/{hold_id}/confirm",
             post(confirm_hold_pg),
@@ -124,6 +131,48 @@ fn to_availability_json(r: AvailabilitySnapshotResponse) -> AvailabilitySnapshot
     }
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CapacitySnapshotJson {
+    pub segment_ref: String,
+    pub departure_date: String,
+    pub total_capacity: u32,
+    pub remaining_capacity: u32,
+    pub physical_capacity: u32,
+    pub hold_count: u32,
+    pub confirmed_count: u32,
+    pub utilization_pct: f64,
+    pub snapshot_version: String,
+    pub classes: Vec<crate::domain::ClassCapacity>,
+}
+
+async fn get_capacity_snapshot(
+    Extension(service): Extension<Arc<CapacityService>>,
+    Extension(context): Extension<RequestContext>,
+    axum::extract::Path(segment_ref): axum::extract::Path<String>,
+) -> Result<Json<CapacitySnapshotJson>, AppErrorResponse> {
+    let correlation_id = context.correlation_id().to_string();
+    let result = service
+        .query_capacity_snapshot(&segment_ref)
+        .map_err(|e| AppErrorResponse::new(e, correlation_id))?;
+    Ok(Json(to_capacity_snapshot_json(result)))
+}
+
+fn to_capacity_snapshot_json(r: CapacitySnapshotResponse) -> CapacitySnapshotJson {
+    CapacitySnapshotJson {
+        segment_ref: r.segment_ref,
+        departure_date: r.departure_date,
+        total_capacity: r.total_capacity,
+        remaining_capacity: r.remaining_capacity,
+        physical_capacity: r.physical_capacity,
+        hold_count: r.hold_count,
+        confirmed_count: r.confirmed_count,
+        utilization_pct: r.utilization_pct,
+        snapshot_version: r.snapshot_version,
+        classes: r.classes,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // POST /api/v1/capacity-holds
 // ---------------------------------------------------------------------------
@@ -133,7 +182,8 @@ fn to_availability_json(r: AvailabilitySnapshotResponse) -> AvailabilitySnapshot
 pub struct HoldCapacityJson {
     pub segment_ref: String,
     pub traveler_ref: String,
-    pub class_ref: String,
+    pub class_ref: Option<String>,
+    pub seat_class: Option<String>,
     pub quantity: usize,
     pub segment_booking_id: String,
 }
@@ -165,7 +215,10 @@ async fn hold_capacity(
     let req = HoldCapacityRequest {
         segment_ref: body.segment_ref,
         traveler_ref: body.traveler_ref,
-        class_ref: body.class_ref,
+        class_ref: body
+            .class_ref
+            .or(body.seat_class)
+            .unwrap_or_else(|| "standard".to_string()),
         quantity: body.quantity,
         segment_booking_id: body.segment_booking_id,
     };
@@ -313,7 +366,10 @@ async fn hold_capacity_pg(
             HoldCapacityRequest {
                 segment_ref: body.segment_ref,
                 traveler_ref: body.traveler_ref,
-                class_ref: body.class_ref,
+                class_ref: body
+                    .class_ref
+                    .or(body.seat_class)
+                    .unwrap_or_else(|| "standard".to_string()),
                 quantity: body.quantity,
                 segment_booking_id: body.segment_booking_id,
             },

--- a/services/capacity-availability/src/application.rs
+++ b/services/capacity-availability/src/application.rs
@@ -338,20 +338,28 @@ impl CapacityService {
                 "v1",
             )
             .unwrap();
-            // Create some capacity units based on quantity
-            let units: Vec<CapacityUnitRef> = (0..req.quantity.max(10))
+            // Create a default segment/class pool; each class is isolated by pool_key.
+            let units: Vec<CapacityUnitRef> = (0..req.quantity.max(100))
                 .map(|i| {
                     let seat = format!("{:02}{}", ((i / 4) + 1), ['A', 'B', 'C', 'D'][i % 4]);
                     CapacityUnitRef::new(seat).unwrap()
                 })
                 .collect();
-            InventoryPool::new(identity, units).unwrap()
+            InventoryPool::new(identity, units)
+                .unwrap()
+                .with_overbooking_policy(OverbookingPolicy {
+                    max_overbooking_pct: 5.0,
+                    no_show_rate: 3.0,
+                    safety_margin_pct: 1.0,
+                })
         });
 
-        // Find a unit that is actually free for the requested interval.
+        // Use a concrete unit while physical seats remain; during overbooking, reuse a
+        // stable virtual unit and let aggregate-level effective-capacity rules decide.
         let interval = StationInterval::new(0, 1).map_err(|e| AppError::Internal(e.to_string()))?;
         let unit_ref = pool
             .find_available_unit(&interval, now)
+            .or_else(|| pool.capacity_unit_refs().into_iter().next())
             .ok_or_else(|| AppError::Unavailable("No capacity units available in pool".into()))?;
 
         // Create the hold
@@ -377,13 +385,21 @@ impl CapacityService {
         .map_err(|e| AppError::Internal(e.to_string()))?;
 
         match pool.request_hold(hold, now) {
-            Ok(event) => {
-                self.publish_domain_event(&event, correlation_id)
+            Ok(events) => {
+                self.publish_domain_events(&events, correlation_id)
                     .map_err(AppError::from_publish_failed)?;
+                let status = if events
+                    .iter()
+                    .any(|event| matches!(event, DomainEvent::CapacityHeld(_)))
+                {
+                    "HELD"
+                } else {
+                    "WAITLISTED"
+                };
                 let resp = HoldCapacityResponse {
                     hold_id,
                     segment_ref: req.segment_ref.clone(),
-                    status: "HELD".to_string(),
+                    status: status.to_string(),
                     held_until: unix_millis_to_rfc3339(now + 300000),
                 };
                 self.store_idempotency_response(idempotency_key, fingerprint, &resp)?;
@@ -432,8 +448,8 @@ impl CapacityService {
                         .map_err(|_| AppError::NotFound("hold not found".into()))?,
                     now,
                 ) {
-                    Ok(event) => {
-                        self.publish_domain_event(&event, correlation_id)
+                    Ok(events) => {
+                        self.publish_domain_events(&events, correlation_id)
                             .map_err(AppError::from_publish_failed)?;
                         let resp = ConfirmHoldResponse {
                             hold_id: hold_id.to_string(),
@@ -530,8 +546,8 @@ impl CapacityService {
                     now,
                     release_reason,
                 ) {
-                    Ok(event) => {
-                        self.publish_domain_event(&event, correlation_id)
+                    Ok(events) => {
+                        self.publish_domain_events(&events, correlation_id)
                             .map_err(AppError::from_publish_failed)?;
                         let resp = ReleaseHoldResponse {
                             hold_id: hold_id.to_string(),
@@ -657,6 +673,75 @@ impl CapacityService {
         Err(AppError::NotFound("hold not found".into()))
     }
 
+    /// Query dynamic capacity snapshot for a service segment with class breakdown.
+    pub fn query_capacity_snapshot(
+        &self,
+        segment_ref: &str,
+    ) -> Result<CapacitySnapshotResponse, AppError> {
+        if segment_ref.trim().is_empty() {
+            return Err(AppError::ValidationFailed("segmentRef is required".into()));
+        }
+
+        let pools = self
+            .pools
+            .lock()
+            .map_err(|e| AppError::Internal(format!("lock error: {}", e)))?;
+        let mut snapshots: Vec<CapacitySnapshot> = pools
+            .values()
+            .filter(|pool| {
+                pool.identity.service_segment_ref == segment_ref
+                    || pool.identity.route_segment_ref == segment_ref
+            })
+            .map(InventoryPool::snapshot)
+            .collect();
+
+        if snapshots.is_empty() {
+            return Err(AppError::NotFound("capacity segment not found".into()));
+        }
+        snapshots.sort_by(|a, b| a.classes[0].class_ref.cmp(&b.classes[0].class_ref));
+
+        let total_capacity = snapshots.iter().map(|s| s.total_capacity).sum();
+        let remaining_capacity = snapshots.iter().map(|s| s.remaining_capacity).sum();
+        let physical_capacity = snapshots.iter().map(|s| s.physical_capacity).sum();
+        let hold_count = snapshots.iter().map(|s| s.hold_count).sum();
+        let confirmed_count = snapshots.iter().map(|s| s.confirmed_count).sum();
+        let utilization_pct = if total_capacity == 0 {
+            0.0
+        } else {
+            ((hold_count + confirmed_count) as f64 / total_capacity as f64) * 100.0
+        };
+        let classes = snapshots.iter().flat_map(|s| s.classes.clone()).collect();
+
+        Ok(CapacitySnapshotResponse {
+            segment_ref: segment_ref.to_string(),
+            departure_date: snapshots[0].departure_date.clone(),
+            total_capacity,
+            remaining_capacity,
+            physical_capacity,
+            hold_count,
+            confirmed_count,
+            utilization_pct,
+            snapshot_version: snapshots
+                .iter()
+                .map(|s| s.snapshot_version.as_str())
+                .max()
+                .unwrap_or("0")
+                .to_string(),
+            classes,
+        })
+    }
+
+    fn publish_domain_events(
+        &self,
+        events: &[DomainEvent],
+        correlation_id: &str,
+    ) -> Result<(), PublishFailed> {
+        for event in events {
+            self.publish_domain_event(event, correlation_id)?;
+        }
+        Ok(())
+    }
+
     fn publish_domain_event(
         &self,
         event: &DomainEvent,
@@ -726,6 +811,35 @@ impl CapacityService {
                 }
                 ("CapacityHoldFailed", payload)
             }
+            DomainEvent::CapacitySnapshotUpdated(e) => (
+                "CapacitySnapshotUpdated",
+                capacity_snapshot_payload(&e.snapshot),
+            ),
+            DomainEvent::OverbookingThresholdReached(e) => (
+                "OverbookingThresholdReached",
+                json!({
+                    "poolId": e.pool_id.to_string(),
+                    "physicalCapacity": e.physical_capacity,
+                    "confirmedCount": e.confirmed_count,
+                    "overbookingPct": e.overbooking_pct,
+                }),
+            ),
+            DomainEvent::WaitlistActivated(e) => (
+                "WaitlistActivated",
+                json!({
+                    "segmentRef": e.segment_ref,
+                    "departureDate": e.departure_date,
+                    "queuePosition": e.queue_position,
+                }),
+            ),
+            DomainEvent::WaitlistCapacityFreed(e) => (
+                "WaitlistCapacityFreed",
+                json!({
+                    "segmentRef": e.segment_ref,
+                    "departureDate": e.departure_date,
+                    "freedSlots": e.freed_slots,
+                }),
+            ),
         };
 
         let envelope = WireEnvelope::try_new(
@@ -766,6 +880,20 @@ pub struct RemainingByClass {
     pub class_ref: String,
     pub total: usize,
     pub available: usize,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CapacitySnapshotResponse {
+    pub segment_ref: String,
+    pub departure_date: String,
+    pub total_capacity: u32,
+    pub remaining_capacity: u32,
+    pub physical_capacity: u32,
+    pub hold_count: u32,
+    pub confirmed_count: u32,
+    pub utilization_pct: f64,
+    pub snapshot_version: String,
+    pub classes: Vec<ClassCapacity>,
 }
 
 #[derive(Debug, Clone)]
@@ -886,6 +1014,33 @@ impl AppError {
             AppError::Internal(m) => m,
         }
     }
+}
+
+fn capacity_snapshot_payload(snapshot: &CapacitySnapshot) -> Value {
+    json!({
+        "segmentRef": snapshot.segment_ref,
+        "departureDate": snapshot.departure_date,
+        "totalCapacity": snapshot.total_capacity,
+        "remainingCapacity": snapshot.remaining_capacity,
+        "physicalCapacity": snapshot.physical_capacity,
+        "holdCount": snapshot.hold_count,
+        "confirmedCount": snapshot.confirmed_count,
+        "utilizationPct": snapshot.utilization_pct,
+        "snapshotVersion": snapshot.snapshot_version,
+        "classes": snapshot.classes.iter().map(|class| json!({
+            "classRef": class.class_ref,
+            "physicalCapacity": class.physical_capacity,
+            "effectiveCapacity": class.effective_capacity,
+            "holdCount": class.hold_count,
+            "confirmedCount": class.confirmed_count,
+            "remainingCapacity": class.remaining_capacity,
+            "overbookingPolicy": {
+                "maxOverbookingPct": class.overbooking_policy.max_overbooking_pct,
+                "noShowRate": class.overbooking_policy.no_show_rate,
+                "safetyMarginPct": class.overbooking_policy.safety_margin_pct,
+            }
+        })).collect::<Vec<_>>(),
+    })
 }
 
 fn quantity_field(value: &Value) -> Option<usize> {

--- a/services/capacity-availability/src/domain.rs
+++ b/services/capacity-availability/src/domain.rs
@@ -476,13 +476,17 @@ impl EventEnvelope {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DomainEvent {
     CapacityHeld(CapacityHeld),
     CapacityHoldConfirmed(CapacityHoldConfirmed),
     CapacityReleased(CapacityReleased),
     CapacityHoldExpired(CapacityHoldExpired),
     CapacityHoldFailed(CapacityHoldFailed),
+    CapacitySnapshotUpdated(CapacitySnapshotUpdated),
+    OverbookingThresholdReached(OverbookingThresholdReached),
+    WaitlistActivated(WaitlistActivated),
+    WaitlistCapacityFreed(WaitlistCapacityFreed),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -577,6 +581,107 @@ impl HoldFailureReason {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OverbookingPolicy {
+    pub max_overbooking_pct: f64,
+    pub no_show_rate: f64,
+    pub safety_margin_pct: f64,
+}
+
+impl OverbookingPolicy {
+    pub fn none() -> Self {
+        Self {
+            max_overbooking_pct: 0.0,
+            no_show_rate: 0.0,
+            safety_margin_pct: 0.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WaitlistState {
+    Inactive,
+    Active { queue_size: u32 },
+}
+
+impl WaitlistState {
+    fn queue_size(&self) -> u32 {
+        match self {
+            WaitlistState::Inactive => 0,
+            WaitlistState::Active { queue_size } => *queue_size,
+        }
+    }
+
+    fn activate_next(&mut self) -> u32 {
+        let next = self.queue_size().saturating_add(1);
+        *self = WaitlistState::Active { queue_size: next };
+        next
+    }
+
+    fn is_active(&self) -> bool {
+        matches!(self, WaitlistState::Active { .. })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClassCapacity {
+    pub class_ref: String,
+    pub physical_capacity: u32,
+    pub effective_capacity: u32,
+    pub hold_count: u32,
+    pub confirmed_count: u32,
+    pub remaining_capacity: u32,
+    pub overbooking_policy: OverbookingPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CapacitySnapshot {
+    pub segment_ref: String,
+    pub departure_date: String,
+    pub total_capacity: u32,
+    pub remaining_capacity: u32,
+    pub physical_capacity: u32,
+    pub hold_count: u32,
+    pub confirmed_count: u32,
+    pub utilization_pct: f64,
+    pub snapshot_version: String,
+    pub classes: Vec<ClassCapacity>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CapacitySnapshotUpdated {
+    pub envelope: EventEnvelope,
+    pub snapshot: CapacitySnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OverbookingThresholdReached {
+    pub envelope: EventEnvelope,
+    pub pool_id: InventoryPoolId,
+    pub physical_capacity: u32,
+    pub confirmed_count: u32,
+    pub overbooking_pct: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct WaitlistActivated {
+    pub envelope: EventEnvelope,
+    pub segment_ref: String,
+    pub departure_date: String,
+    pub queue_position: u32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct WaitlistCapacityFreed {
+    pub envelope: EventEnvelope,
+    pub segment_ref: String,
+    pub departure_date: String,
+    pub freed_slots: u32,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InventoryPoolState {
     Initialized,
@@ -586,7 +691,7 @@ pub enum InventoryPoolState {
     Cancelled,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InventoryPool {
     pub identity: InventoryPoolIdentity,
     pub(crate) capacity_units: HashSet<CapacityUnitRef>,
@@ -594,6 +699,8 @@ pub struct InventoryPool {
     idempotency_index: HashMap<IdempotencyKey, HoldId>,
     version: u64,
     state: InventoryPoolState,
+    overbooking_policy: OverbookingPolicy,
+    waitlist_state: WaitlistState,
 }
 
 impl InventoryPool {
@@ -614,6 +721,8 @@ impl InventoryPool {
             idempotency_index: HashMap::new(),
             version: 1,
             state: InventoryPoolState::Initialized,
+            overbooking_policy: OverbookingPolicy::none(),
+            waitlist_state: WaitlistState::Inactive,
         })
     }
 
@@ -623,6 +732,34 @@ impl InventoryPool {
 
     pub fn state(&self) -> InventoryPoolState {
         self.state
+    }
+
+    pub fn with_overbooking_policy(mut self, policy: OverbookingPolicy) -> Self {
+        self.overbooking_policy = policy;
+        self
+    }
+
+    pub fn set_overbooking_policy(&mut self, policy: OverbookingPolicy) {
+        self.overbooking_policy = policy;
+        self.version += 1;
+    }
+
+    pub fn overbooking_policy(&self) -> OverbookingPolicy {
+        self.overbooking_policy
+    }
+
+    pub fn physical_capacity(&self) -> u32 {
+        self.capacity_units.len() as u32
+    }
+
+    pub fn effective_capacity(&self) -> u32 {
+        let physical = self.physical_capacity() as f64;
+        (physical * (1.0 + self.overbooking_policy.max_overbooking_pct.max(0.0) / 100.0)).floor()
+            as u32
+    }
+
+    pub fn waitlist_state(&self) -> &WaitlistState {
+        &self.waitlist_state
     }
 
     pub fn total_units(&self) -> usize {
@@ -649,7 +786,11 @@ impl InventoryPool {
         Ok(())
     }
 
-    pub fn request_hold(&mut self, mut hold: CapacityHold, now: u64) -> DomainResult<DomainEvent> {
+    pub fn request_hold(
+        &mut self,
+        mut hold: CapacityHold,
+        now: u64,
+    ) -> DomainResult<Vec<DomainEvent>> {
         self.ensure_unit_known(&hold.scope.capacity_unit_ref)?;
 
         if let Some(existing_hold_id) = self.idempotency_index.get(&hold.idempotency_key) {
@@ -658,7 +799,9 @@ impl InventoryPool {
                 .get(existing_hold_id)
                 .expect("idempotency index references an existing hold");
             if same_hold_request(existing, &hold) {
-                return Ok(DomainEvent::CapacityHeld(existing.to_capacity_held(true)));
+                return Ok(vec![DomainEvent::CapacityHeld(
+                    existing.to_capacity_held(true),
+                )]);
             }
             return Err(DomainError::IdempotencyConflict {
                 idempotency_key: hold.idempotency_key.to_string(),
@@ -666,34 +809,51 @@ impl InventoryPool {
             });
         }
 
-        if let Some(conflict) = self.conflicting_hold(
-            &hold.hold_id,
-            &hold.scope.capacity_unit_ref,
-            &hold.scope.station_interval,
-            now,
-        ) {
-            let event = CapacityHoldFailed {
-                envelope: EventEnvelope::new(
-                    "CapacityHoldFailed",
-                    now,
-                    &hold.scope.references.source_context,
-                    None::<String>,
-                    "capacity-availability",
-                ),
-                requested_hold_id: hold.hold_id.clone(),
-                inventory_pool_id: self.identity.pool_id.clone(),
-                capacity_unit_ref: hold.scope.capacity_unit_ref.clone(),
-                interval: hold.scope.station_interval.clone(),
-                idempotency_key: hold.idempotency_key.clone(),
-                reason: HoldFailureReason::OverlappingHold {
-                    conflicting_hold_id: conflict.hold_id.clone(),
-                },
-                references: hold.scope.references.clone(),
-            };
+        let occupied = self.occupied_count_at(&hold.scope.station_interval, now);
+        if occupied >= self.effective_capacity() {
             hold.state = CapacityHoldState::Failed;
+            let queue_position = self.waitlist_state.activate_next();
             self.holds.insert(hold.hold_id.clone(), hold);
             self.version += 1;
-            return Ok(DomainEvent::CapacityHoldFailed(event));
+            return Ok(vec![
+                self.waitlist_activated_event(now, queue_position),
+                self.snapshot_updated_event(now),
+            ]);
+        }
+
+        if occupied < self.physical_capacity() {
+            if let Some(conflict) = self.conflicting_hold(
+                &hold.hold_id,
+                &hold.scope.capacity_unit_ref,
+                &hold.scope.station_interval,
+                now,
+            ) {
+                let event = CapacityHoldFailed {
+                    envelope: EventEnvelope::new(
+                        "CapacityHoldFailed",
+                        now,
+                        &hold.scope.references.source_context,
+                        None::<String>,
+                        "capacity-availability",
+                    ),
+                    requested_hold_id: hold.hold_id.clone(),
+                    inventory_pool_id: self.identity.pool_id.clone(),
+                    capacity_unit_ref: hold.scope.capacity_unit_ref.clone(),
+                    interval: hold.scope.station_interval.clone(),
+                    idempotency_key: hold.idempotency_key.clone(),
+                    reason: HoldFailureReason::OverlappingHold {
+                        conflicting_hold_id: conflict.hold_id.clone(),
+                    },
+                    references: hold.scope.references.clone(),
+                };
+                hold.state = CapacityHoldState::Failed;
+                self.holds.insert(hold.hold_id.clone(), hold);
+                self.version += 1;
+                return Ok(vec![
+                    DomainEvent::CapacityHoldFailed(event),
+                    self.snapshot_updated_event(now),
+                ]);
+            }
         }
 
         hold.mark_held();
@@ -702,10 +862,10 @@ impl InventoryPool {
             .insert(hold.idempotency_key.clone(), hold.hold_id.clone());
         self.holds.insert(hold.hold_id.clone(), hold);
         self.version += 1;
-        Ok(event)
+        Ok(vec![event, self.snapshot_updated_event(now)])
     }
 
-    pub fn confirm_hold(&mut self, hold_id: &HoldId, now: u64) -> DomainResult<DomainEvent> {
+    pub fn confirm_hold(&mut self, hold_id: &HoldId, now: u64) -> DomainResult<Vec<DomainEvent>> {
         let event = {
             let hold = self
                 .holds
@@ -729,7 +889,25 @@ impl InventoryPool {
             })
         };
         self.version += 1;
-        Ok(event)
+        let mut events = vec![event, self.snapshot_updated_event(now)];
+        if self.confirmed_count() > self.physical_capacity() {
+            events.push(DomainEvent::OverbookingThresholdReached(
+                OverbookingThresholdReached {
+                    envelope: EventEnvelope::new(
+                        "OverbookingThresholdReached",
+                        now,
+                        &self.identity.service_segment_ref,
+                        None::<String>,
+                        "capacity-availability",
+                    ),
+                    pool_id: self.identity.pool_id.clone(),
+                    physical_capacity: self.physical_capacity(),
+                    confirmed_count: self.confirmed_count(),
+                    overbooking_pct: self.overbooking_policy.max_overbooking_pct,
+                },
+            ));
+        }
+        Ok(events)
     }
 
     pub fn release_hold(
@@ -737,8 +915,9 @@ impl InventoryPool {
         hold_id: &HoldId,
         now: u64,
         release_reason: impl Into<String>,
-    ) -> DomainResult<DomainEvent> {
+    ) -> DomainResult<Vec<DomainEvent>> {
         let release_reason = non_empty(release_reason, "release_reason")?;
+        let before_remaining = self.remaining_capacity();
         let event = {
             let hold = self
                 .holds
@@ -764,10 +943,17 @@ impl InventoryPool {
             })
         };
         self.version += 1;
-        Ok(event)
+        let mut events = vec![event, self.snapshot_updated_event(now)];
+        let after_remaining = self.remaining_capacity();
+        if self.waitlist_state.is_active() && after_remaining > before_remaining {
+            events
+                .push(self.waitlist_capacity_freed_event(now, after_remaining - before_remaining));
+        }
+        Ok(events)
     }
 
-    pub fn expire_hold(&mut self, hold_id: &HoldId, now: u64) -> DomainResult<DomainEvent> {
+    pub fn expire_hold(&mut self, hold_id: &HoldId, now: u64) -> DomainResult<Vec<DomainEvent>> {
+        let before_remaining = self.remaining_capacity();
         let event = {
             let hold = self
                 .holds
@@ -791,7 +977,13 @@ impl InventoryPool {
             })
         };
         self.version += 1;
-        Ok(event)
+        let mut events = vec![event, self.snapshot_updated_event(now)];
+        let after_remaining = self.remaining_capacity();
+        if self.waitlist_state.is_active() && after_remaining > before_remaining {
+            events
+                .push(self.waitlist_capacity_freed_event(now, after_remaining - before_remaining));
+        }
+        Ok(events)
     }
 
     pub fn availability_snapshot(
@@ -850,6 +1042,112 @@ impl InventoryPool {
             status,
             explanations,
         }
+    }
+
+    pub fn snapshot(&self) -> CapacitySnapshot {
+        let physical_capacity = self.physical_capacity();
+        let total_capacity = self.effective_capacity();
+        let hold_count = self.held_count();
+        let confirmed_count = self.confirmed_count();
+        let remaining_capacity = total_capacity.saturating_sub(hold_count + confirmed_count);
+        let utilization_pct = if total_capacity == 0 {
+            0.0
+        } else {
+            ((hold_count + confirmed_count) as f64 / total_capacity as f64) * 100.0
+        };
+        let class = ClassCapacity {
+            class_ref: self.identity.seat_class_or_cabin_ref.clone(),
+            physical_capacity,
+            effective_capacity: total_capacity,
+            hold_count,
+            confirmed_count,
+            remaining_capacity,
+            overbooking_policy: self.overbooking_policy,
+        };
+
+        CapacitySnapshot {
+            segment_ref: self.identity.service_segment_ref.clone(),
+            departure_date: self.identity.service_date.clone(),
+            total_capacity,
+            remaining_capacity,
+            physical_capacity,
+            hold_count,
+            confirmed_count,
+            utilization_pct,
+            snapshot_version: self.version.to_string(),
+            classes: vec![class],
+        }
+    }
+
+    pub fn remaining_capacity(&self) -> u32 {
+        self.effective_capacity()
+            .saturating_sub(self.held_count() + self.confirmed_count())
+    }
+
+    fn held_count(&self) -> u32 {
+        self.holds
+            .values()
+            .filter(|hold| matches!(hold.state, CapacityHoldState::Held))
+            .count() as u32
+    }
+
+    fn confirmed_count(&self) -> u32 {
+        self.holds
+            .values()
+            .filter(|hold| matches!(hold.state, CapacityHoldState::Confirmed))
+            .count() as u32
+    }
+
+    fn occupied_count_at(&self, interval: &StationInterval, now: u64) -> u32 {
+        self.holds
+            .values()
+            .filter(|hold| {
+                hold.is_blocking_at(now) && hold.scope.station_interval.overlaps(interval)
+            })
+            .count() as u32
+    }
+
+    fn snapshot_updated_event(&self, now: u64) -> DomainEvent {
+        DomainEvent::CapacitySnapshotUpdated(CapacitySnapshotUpdated {
+            envelope: EventEnvelope::new(
+                "CapacitySnapshotUpdated",
+                now,
+                &self.identity.service_segment_ref,
+                None::<String>,
+                "capacity-availability",
+            ),
+            snapshot: self.snapshot(),
+        })
+    }
+
+    fn waitlist_activated_event(&self, now: u64, queue_position: u32) -> DomainEvent {
+        DomainEvent::WaitlistActivated(WaitlistActivated {
+            envelope: EventEnvelope::new(
+                "WaitlistActivated",
+                now,
+                &self.identity.service_segment_ref,
+                None::<String>,
+                "capacity-availability",
+            ),
+            segment_ref: self.identity.service_segment_ref.clone(),
+            departure_date: self.identity.service_date.clone(),
+            queue_position,
+        })
+    }
+
+    fn waitlist_capacity_freed_event(&self, now: u64, freed_slots: u32) -> DomainEvent {
+        DomainEvent::WaitlistCapacityFreed(WaitlistCapacityFreed {
+            envelope: EventEnvelope::new(
+                "WaitlistCapacityFreed",
+                now,
+                &self.identity.service_segment_ref,
+                None::<String>,
+                "capacity-availability",
+            ),
+            segment_ref: self.identity.service_segment_ref.clone(),
+            departure_date: self.identity.service_date.clone(),
+            freed_slots,
+        })
     }
 
     fn ensure_unit_known(&self, unit: &CapacityUnitRef) -> DomainResult<()> {
@@ -1163,15 +1461,13 @@ mod tests {
     fn overlapping_holds_on_same_unit_are_rejected() {
         let mut pool = pool();
         let first = request("hold-1", "01A", 1, 3, "idem-1", 10, 70);
-        assert!(matches!(
-            pool.request_hold(first, 10).unwrap(),
-            DomainEvent::CapacityHeld(_)
-        ));
+        let events = pool.request_hold(first, 10).unwrap();
+        assert!(matches!(events.first(), Some(DomainEvent::CapacityHeld(_))));
 
         let overlap = request("hold-2", "01A", 2, 4, "idem-2", 11, 71);
         let failed = pool.request_hold(overlap, 11).unwrap();
-        match failed {
-            DomainEvent::CapacityHoldFailed(event) => assert!(matches!(
+        match failed.first() {
+            Some(DomainEvent::CapacityHoldFailed(event)) => assert!(matches!(
                 event.reason,
                 HoldFailureReason::OverlappingHold { .. }
             )),
@@ -1197,18 +1493,27 @@ mod tests {
         pool.request_hold(request("hold-1", "01A", 1, 3, "idem-1", 10, 70), 10)
             .unwrap();
         let confirmed = pool.confirm_hold(&hold_id("hold-1"), 20).unwrap();
-        assert!(matches!(confirmed, DomainEvent::CapacityHoldConfirmed(_)));
+        assert!(matches!(
+            confirmed.first(),
+            Some(DomainEvent::CapacityHoldConfirmed(_))
+        ));
         assert!(pool.expire_hold(&hold_id("hold-1"), 80).is_err());
         let released = pool
             .release_hold(&hold_id("hold-1"), 90, "post-sales-void")
             .unwrap();
-        assert!(matches!(released, DomainEvent::CapacityReleased(_)));
+        assert!(matches!(
+            released.first(),
+            Some(DomainEvent::CapacityReleased(_))
+        ));
 
         pool.request_hold(request("hold-2", "01A", 1, 3, "idem-2", 100, 110), 100)
             .unwrap();
         assert!(pool.expire_hold(&hold_id("hold-2"), 109).is_err());
         let expired = pool.expire_hold(&hold_id("hold-2"), 110).unwrap();
-        assert!(matches!(expired, DomainEvent::CapacityHoldExpired(_)));
+        assert!(matches!(
+            expired.first(),
+            Some(DomainEvent::CapacityHoldExpired(_))
+        ));
     }
 
     #[test]
@@ -1217,8 +1522,8 @@ mod tests {
         let first = request("hold-1", "01A", 1, 3, "idem-1", 10, 70);
         pool.request_hold(first.clone(), 10).unwrap();
         let replay = pool.request_hold(first, 11).unwrap();
-        match replay {
-            DomainEvent::CapacityHeld(event) => assert!(event.idempotent_replay),
+        match replay.first() {
+            Some(DomainEvent::CapacityHeld(event)) => assert!(event.idempotent_replay),
             _ => panic!("expected held replay"),
         }
 
@@ -1248,6 +1553,130 @@ mod tests {
         assert_eq!(after_expiry.available_count, 2);
     }
 
+    fn large_pool(size: u32, overbooking_pct: f64) -> InventoryPool {
+        let units = (0..size)
+            .map(|i| unit(&format!("{:03}", i)))
+            .collect::<Vec<_>>();
+        InventoryPool::new(identity(), units)
+            .unwrap()
+            .with_overbooking_policy(OverbookingPolicy {
+                max_overbooking_pct: overbooking_pct,
+                no_show_rate: 3.0,
+                safety_margin_pct: 1.0,
+            })
+    }
+
+    #[test]
+    fn overbooking_limit_accepts_105th_and_waitlists_106th_for_100_seats() {
+        let mut pool = large_pool(100, 5.0);
+        for i in 0..105 {
+            let seat = format!("{:03}", i.min(99));
+            let events = pool
+                .request_hold(
+                    request(
+                        &format!("hold-{i}"),
+                        &seat,
+                        1,
+                        2,
+                        &format!("idem-{i}"),
+                        10 + i as u64,
+                        1_000 + i as u64,
+                    ),
+                    10 + i as u64,
+                )
+                .unwrap();
+            assert!(matches!(events[0], DomainEvent::CapacityHeld(_)));
+        }
+        assert_eq!(pool.snapshot().remaining_capacity, 0);
+
+        let waitlisted = pool
+            .request_hold(
+                request("hold-106", "099", 1, 2, "idem-106", 200, 1_200),
+                200,
+            )
+            .unwrap();
+        assert!(
+            waitlisted
+                .iter()
+                .any(|event| matches!(event, DomainEvent::WaitlistActivated(_)))
+        );
+        assert!(matches!(
+            pool.waitlist_state(),
+            WaitlistState::Active { queue_size: 1 }
+        ));
+    }
+
+    #[test]
+    fn snapshot_updated_emitted_with_correct_counts_on_mutations() {
+        let mut pool = large_pool(2, 0.0);
+        let events = pool
+            .request_hold(request("hold-snap", "000", 1, 2, "idem-snap", 10, 20), 10)
+            .unwrap();
+        let snapshot = events
+            .iter()
+            .find_map(|event| match event {
+                DomainEvent::CapacitySnapshotUpdated(event) => Some(&event.snapshot),
+                _ => None,
+            })
+            .expect("snapshot event");
+        assert_eq!(snapshot.total_capacity, 2);
+        assert_eq!(snapshot.remaining_capacity, 1);
+        assert_eq!(snapshot.hold_count, 1);
+        assert_eq!(snapshot.confirmed_count, 0);
+
+        let events = pool.confirm_hold(&hold_id("hold-snap"), 11).unwrap();
+        let snapshot = events
+            .iter()
+            .find_map(|event| match event {
+                DomainEvent::CapacitySnapshotUpdated(event) => Some(&event.snapshot),
+                _ => None,
+            })
+            .expect("snapshot event");
+        assert_eq!(snapshot.remaining_capacity, 1);
+        assert_eq!(snapshot.hold_count, 0);
+        assert_eq!(snapshot.confirmed_count, 1);
+
+        let events = pool
+            .release_hold(&hold_id("hold-snap"), 12, "test-release")
+            .unwrap();
+        let snapshot = events
+            .iter()
+            .find_map(|event| match event {
+                DomainEvent::CapacitySnapshotUpdated(event) => Some(&event.snapshot),
+                _ => None,
+            })
+            .expect("snapshot event");
+        assert_eq!(snapshot.remaining_capacity, 2);
+        assert_eq!(snapshot.hold_count, 0);
+        assert_eq!(snapshot.confirmed_count, 0);
+    }
+
+    #[test]
+    fn overbooking_threshold_and_waitlist_freed_are_emitted() {
+        let mut pool = large_pool(1, 100.0);
+        pool.request_hold(request("hold-a", "000", 1, 2, "idem-a", 10, 50), 10)
+            .unwrap();
+        pool.request_hold(request("hold-b", "000", 1, 2, "idem-b", 11, 51), 11)
+            .unwrap();
+        pool.request_hold(request("hold-c", "000", 1, 2, "idem-c", 12, 52), 12)
+            .unwrap();
+
+        pool.confirm_hold(&hold_id("hold-a"), 20).unwrap();
+        let events = pool.confirm_hold(&hold_id("hold-b"), 21).unwrap();
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, DomainEvent::OverbookingThresholdReached(_)))
+        );
+        let events = pool
+            .release_hold(&hold_id("hold-a"), 30, "test-release")
+            .unwrap();
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, DomainEvent::WaitlistCapacityFreed(_)))
+        );
+    }
     #[test]
     fn unix_millis_to_rfc3339_round_trip() {
         // Known timestamp: 2027-01-01T00:00:00.000Z


### PR DESCRIPTION
## Summary
- add overbooking policies, effective capacity snapshots, waitlist, and overbooking domain events
- emit snapshot/threshold/waitlist events through in-memory and postgres application paths
- add capacity segment snapshot endpoint and optional seatClass hold request support

## Validation
- cd services/capacity-availability && cargo test