### PR TITLE
REQ-306 identity verification enrichment

### DIFF
--- a/services/identity-verification/migrations/003_identity_enrichment.sql
+++ b/services/identity-verification/migrations/003_identity_enrichment.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS identity_blacklist_snapshots (
+  id text PRIMARY KEY,
+  version bigint NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_identity_blacklist_document
+  ON identity_blacklist_snapshots ((data->>'documentNumber'), (data->>'blacklistType'));
+
+CREATE TABLE IF NOT EXISTS active_ticket_snapshots (
+  id text PRIMARY KEY,
+  version bigint NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_active_ticket_duplicate
+  ON active_ticket_snapshots ((data->>'documentNumber'), (data->>'segmentRef'), (data->>'departureDate'))
+  WHERE data->>'status' = 'ACTIVE';
+CREATE INDEX IF NOT EXISTS idx_active_ticket_order
+  ON active_ticket_snapshots ((data->>'orderId'));
+
+CREATE TABLE IF NOT EXISTS verification_cache_snapshots (
+  id text PRIMARY KEY,
+  version bigint NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_verification_cache_traveler_document
+  ON verification_cache_snapshots ((data->>'travelerId'), (data->>'documentNumber'));

--- a/services/identity-verification/src/identity_verification/adapters/storage/postgres.py
+++ b/services/identity-verification/src/identity_verification/adapters/storage/postgres.py
@@ -297,6 +297,12 @@ class PostgresIdentityVerificationStore(InMemoryStore):
             self._active_tickets.save(conn, ticket_id, ticket_to_json(ticket), expected)
         self._with_conn(write)
 
+    def list_active_tickets_for_order(self, order_id: str) -> tuple[ActiveTicket, ...]:
+        def read(conn: Any) -> tuple[ActiveTicket, ...]:
+            rows = conn.execute("SELECT id, version, data FROM active_ticket_snapshots WHERE data->>'orderId'=%s AND data->>'status'='ACTIVE'", (order_id,)).fetchall()
+            return tuple(ticket_from_json(row[2]) for row in rows)
+        return self._with_conn(read)
+
     def release_active_tickets_for_order(self, order_id: str) -> None:
         def write(conn: Any) -> None:
             rows = conn.execute("SELECT id, version, data FROM active_ticket_snapshots WHERE data->>'orderId'=%s", (order_id,)).fetchall()
@@ -316,6 +322,18 @@ class PostgresIdentityVerificationStore(InMemoryStore):
             return (verified_at, expires_at) if expires_at > at else None
         return self._with_conn(read)
 
+    def find_cached_document_for_traveler(self, traveler_id: str, at: datetime) -> str | None:
+        def read(conn: Any) -> str | None:
+            rows = conn.execute("SELECT id, version, data FROM verification_cache_snapshots WHERE data->>'travelerId'=%s ORDER BY data->>'expiresAt' DESC", (traveler_id,)).fetchall()
+            for row in rows:
+                data = dict(row[2])
+                expires_at = _parse_dt(str(data.get("expiresAt") or ""))
+                if expires_at is not None and expires_at > at:
+                    self._remember("verification-cache", str(row[0]), int(row[1]))
+                    return str(data["documentNumber"])
+            return None
+        return self._with_conn(read)
+
     def save_cached_verification(self, traveler_id: str, document_number: str, verified_at: datetime, expires_at: datetime) -> None:
         cache_id = f"vcache-{traveler_id}-{document_number}"
         data = {"travelerId": traveler_id, "documentNumber": document_number, "verifiedAt": _dt(verified_at), "expiresAt": _dt(expires_at)}
@@ -331,6 +349,33 @@ class PostgresIdentityVerificationStore(InMemoryStore):
         def write(conn: Any) -> None:
             conn.execute("INSERT INTO traveler_snapshot_links(traveler_id, snapshot_version, data) VALUES (%s,%s,%s) ON CONFLICT (traveler_id) DO UPDATE SET snapshot_version=EXCLUDED.snapshot_version, data=EXCLUDED.data, updated_at=now()", (traveler_id, str(data.get("snapshotVersion") or data.get("profileSnapshotVersion") or ""), json.dumps(dict(data))))
         self._with_conn(write)
+
+    def find_reserved_pre_order_check_for_order_event(self, account_id: str, traveler_ids: tuple[str, ...], segment_refs: tuple[str, ...]) -> dict[str, Any] | None:
+        def read(conn: Any) -> dict[str, Any] | None:
+            rows = conn.execute(
+                """
+                SELECT id, version, data
+                  FROM pre_order_check_snapshots
+                 WHERE data->>'status'='RESERVED'
+                   AND data->'body'->>'result'='PASS'
+                   AND data->'body'->>'accountId'=%s
+                 ORDER BY data->'body'->>'evaluatedAt' DESC
+                """,
+                (account_id,),
+            ).fetchall()
+            traveler_set = set(traveler_ids)
+            segment_set = set(segment_refs)
+            for row in rows:
+                data = dict(row[2])
+                body = dict(data.get("body") or {})
+                if set(str(item) for item in body.get("travelerRefs") or ()) != traveler_set:
+                    continue
+                if set(str(item) for item in body.get("segmentRefs") or ()) != segment_set:
+                    continue
+                self._remember("pre-order", str(row[0]), int(row[1]))
+                return data
+            return None
+        return self._with_conn(read)
 
     def append_outbox(self, envelopes: Iterable[Any]) -> None:
         def write(conn: Any) -> None:

--- a/services/identity-verification/src/identity_verification/adapters/storage/postgres.py
+++ b/services/identity-verification/src/identity_verification/adapters/storage/postgres.py
@@ -11,7 +11,7 @@ from typing import Any
 from train_ticket_platform.storage import OutboxAppender, ProcessedEventsGuard, SnapshotRepository
 
 from identity_verification.application.service import InMemoryStore, NotFoundError
-from identity_verification.domain import CredentialRecord, CredentialStatus, EligibilityCertificate, CertificateStatus, PurchaseLimitFact, SimOutcome, VerificationCase, VerificationStatus
+from identity_verification.domain import ActiveTicket, BlacklistEntry, BlacklistType, CredentialRecord, CredentialStatus, EligibilityCertificate, CertificateStatus, PurchaseLimitFact, SimOutcome, VerificationCase, VerificationStatus
 
 
 def _dt(value: datetime | None) -> str | None:
@@ -26,6 +26,24 @@ def _parse_dt(value: str | None) -> datetime | None:
 
 def _json(data: Mapping[str, Any] | str) -> Mapping[str, Any]:
     return json.loads(data) if isinstance(data, str) else data
+
+
+def blacklist_entry_to_json(entry: BlacklistEntry) -> dict[str, Any]:
+    return {"documentNumber": entry.documentNumber, "blacklistType": entry.blacklistType.value, "reason": entry.reason, "effectiveFrom": _dt(entry.effectiveFrom), "effectiveUntil": _dt(entry.effectiveUntil)}
+
+
+def blacklist_entry_from_json(data: Mapping[str, Any] | str) -> BlacklistEntry:
+    d = _json(data)
+    return BlacklistEntry(str(d["documentNumber"]), BlacklistType(str(d["blacklistType"])), str(d.get("reason") or ""), _parse_dt(str(d["effectiveFrom"])) or datetime.now(UTC), _parse_dt(d.get("effectiveUntil")))
+
+
+def ticket_to_json(ticket: ActiveTicket) -> dict[str, Any]:
+    return {"documentNumber": ticket.documentNumber, "segmentRef": ticket.segmentRef, "departureDate": ticket.departureDate, "orderId": ticket.orderId, "status": ticket.status}
+
+
+def ticket_from_json(data: Mapping[str, Any] | str) -> ActiveTicket:
+    d = _json(data)
+    return ActiveTicket(str(d["documentNumber"]), str(d["segmentRef"]), str(d["departureDate"]), str(d["orderId"]), str(d.get("status") or "ACTIVE"))
 
 
 def credential_to_json(c: CredentialRecord) -> dict[str, Any]:
@@ -91,6 +109,9 @@ class PostgresIdentityVerificationStore(InMemoryStore):
         self._certificates = SnapshotRepository("eligibility_certificate_snapshots")
         self._facts = SnapshotRepository("purchase_limit_fact_snapshots")
         self._pre_orders = SnapshotRepository("pre_order_check_snapshots")
+        self._blacklist = SnapshotRepository("identity_blacklist_snapshots")
+        self._active_tickets = SnapshotRepository("active_ticket_snapshots")
+        self._verification_cache = SnapshotRepository("verification_cache_snapshots")
         self._processed = ProcessedEventsGuard()
 
     @contextmanager
@@ -241,6 +262,70 @@ class PostgresIdentityVerificationStore(InMemoryStore):
             if not row: return None
             self._remember("pre-order", str(row[0]), int(row[1])); return dict(row[2])
         return self._with_conn(read)
+
+    def add_blacklist_entry(self, entry: BlacklistEntry) -> None:
+        record_id = f"blk-{entry.documentNumber}-{entry.blacklistType.value}"
+        def write(conn: Any) -> None:
+            snap = self._blacklist.get(conn, record_id)
+            expected = int(snap[0]) if snap is not None else None
+            self._blacklist.save(conn, record_id, blacklist_entry_to_json(entry), expected)
+        self._with_conn(write)
+
+    def list_blacklist_entries(self, document_number: str) -> tuple[BlacklistEntry, ...]:
+        def read(conn: Any) -> tuple[BlacklistEntry, ...]:
+            rows = conn.execute("SELECT id, version, data FROM identity_blacklist_snapshots WHERE data->>'documentNumber'=%s", (document_number,)).fetchall()
+            return tuple(blacklist_entry_from_json(row[2]) for row in rows)
+        return self._with_conn(read)
+
+    def find_active_ticket(self, document_number: str, segment_ref: str, departure_date: str) -> ActiveTicket | None:
+        ticket_id = f"act-{document_number}-{segment_ref}-{departure_date}"
+        def read(conn: Any) -> ActiveTicket | None:
+            snap = self._active_tickets.get(conn, ticket_id)
+            if snap is None: return None
+            version, data = snap; self._remember("active-ticket", ticket_id, version)
+            ticket = ticket_from_json(data)
+            return ticket if ticket.status == "ACTIVE" else None
+        return self._with_conn(read)
+
+    def save_active_ticket(self, ticket: ActiveTicket) -> None:
+        ticket_id = f"act-{ticket.documentNumber}-{ticket.segmentRef}-{ticket.departureDate}"
+        def write(conn: Any) -> None:
+            expected = self._take("active-ticket", ticket_id)
+            if expected is None:
+                snap = self._active_tickets.get(conn, ticket_id)
+                expected = int(snap[0]) if snap is not None else None
+            self._active_tickets.save(conn, ticket_id, ticket_to_json(ticket), expected)
+        self._with_conn(write)
+
+    def release_active_tickets_for_order(self, order_id: str) -> None:
+        def write(conn: Any) -> None:
+            rows = conn.execute("SELECT id, version, data FROM active_ticket_snapshots WHERE data->>'orderId'=%s", (order_id,)).fetchall()
+            for row in rows:
+                data = dict(row[2]); data["status"] = "CANCELLED"
+                self._active_tickets.save(conn, str(row[0]), data, int(row[1]))
+        self._with_conn(write)
+
+    def get_cached_verification(self, traveler_id: str, document_number: str, at: datetime) -> tuple[datetime, datetime] | None:
+        cache_id = f"vcache-{traveler_id}-{document_number}"
+        def read(conn: Any) -> tuple[datetime, datetime] | None:
+            snap = self._verification_cache.get(conn, cache_id)
+            if snap is None: return None
+            version, data = snap; self._remember("verification-cache", cache_id, version)
+            verified_at = _parse_dt(str(data["verifiedAt"])) or datetime.now(UTC)
+            expires_at = _parse_dt(str(data["expiresAt"])) or datetime.now(UTC)
+            return (verified_at, expires_at) if expires_at > at else None
+        return self._with_conn(read)
+
+    def save_cached_verification(self, traveler_id: str, document_number: str, verified_at: datetime, expires_at: datetime) -> None:
+        cache_id = f"vcache-{traveler_id}-{document_number}"
+        data = {"travelerId": traveler_id, "documentNumber": document_number, "verifiedAt": _dt(verified_at), "expiresAt": _dt(expires_at)}
+        def write(conn: Any) -> None:
+            expected = self._take("verification-cache", cache_id)
+            if expected is None:
+                snap = self._verification_cache.get(conn, cache_id)
+                expected = int(snap[0]) if snap is not None else None
+            self._verification_cache.save(conn, cache_id, data, expected)
+        self._with_conn(write)
 
     def save_traveler_snapshot(self, traveler_id: str, data: Mapping[str, Any]) -> None:
         def write(conn: Any) -> None:

--- a/services/identity-verification/src/identity_verification/api.py
+++ b/services/identity-verification/src/identity_verification/api.py
@@ -14,11 +14,14 @@ from train_ticket_platform.storage import DatabaseConfig, DatabasePool, OutboxRe
 from train_ticket_platform.ids import new_uuid7
 
 from .adapters.messaging import TRAVELER_PROFILE_STREAM
+
+JOURNEY_ORDER_STREAM = "events:journey-order"
+RISK_COMPLIANCE_STREAM = "events:risk-compliance"
 from .adapters.storage.postgres import PostgresIdentityVerificationStore
 from .application.service import DeterministicSimGateway, IdentityVerificationService, InMemoryStore
 from .runtime import health, profile
 from .web.errors import register_exception_handlers
-from .web.handlers import router as identity_router
+from .web.handlers import compatibility_router, router as identity_router
 
 REQUEST_ID_HEADER = "X-Request-ID"
 CORRELATION_ID_HEADER = "X-Correlation-Id"
@@ -102,8 +105,9 @@ def configure_identity_routes(app: FastAPI, store: Any | None = None, idempotenc
         async def identity_unit_of_work_middleware(request: Request, call_next: Any):
             with unit_of_work(): return await call_next(request)
     app.state.identity_verification_service = service; app.state.identity_verification_store = store
-    configure_idempotency_middleware(app, idempotency_store or BoundedInMemoryIdempotencyStore(), require_key=True, include_path_prefixes=("/api/v1/identity-verification/credentials", "/api/v1/identity-verification/verification-cases", "/api/v1/identity-verification/eligibility-certificates", "/api/v1/identity-verification/pre-order-checks", "/api/v1/identity-verification/purchase-limit-facts"))
+    configure_idempotency_middleware(app, idempotency_store or BoundedInMemoryIdempotencyStore(), require_key=True, include_path_prefixes=("/api/v1/identity-verification/credentials", "/api/v1/identity-verification/verification-cases", "/api/v1/identity-verification/eligibility-certificates", "/api/v1/identity-verification/pre-order-checks", "/api/v1/identity-verification/purchase-limit-facts", "/api/v1/identity-verification/verifications", "/api/v1/verifications"))
     for route in identity_router.routes: app.router.routes.append(route)
+    for route in compatibility_router.routes: app.router.routes.append(route)
 
 
 def _postgres_store_from_env(app: FastAPI) -> tuple[Any, IdempotencyStore | None]:
@@ -115,8 +119,15 @@ def _postgres_store_from_env(app: FastAPI) -> tuple[Any, IdempotencyStore | None
     run_migrations(pool, migrations_dir, readiness)
     store = PostgresIdentityVerificationStore(pool); relay = OutboxRelay(pool); relay.start()
     subscriber = RedisEventSubscriber(); holder: dict[str, Any] = {}
-    def handle(envelope: Any) -> None: holder["service"].handle_traveler_snapshot_updated(envelope, TRAVELER_PROFILE_STREAM)
-    thread = subscriber.start_in_background((TRAVELER_PROFILE_STREAM,), "identity-verification", handle)
+    def handle(envelope: Any) -> None:
+        service = holder["service"]
+        if envelope.eventType in {"JourneyOrderCreated", "JourneyOrderCancelled"}:
+            service.handle_journey_order_event(envelope, JOURNEY_ORDER_STREAM)
+        elif envelope.eventType == "RiskAlertRaised":
+            service.handle_risk_alert_raised(envelope, RISK_COMPLIANCE_STREAM)
+        else:
+            service.handle_traveler_snapshot_updated(envelope, TRAVELER_PROFILE_STREAM)
+    thread = subscriber.start_in_background((TRAVELER_PROFILE_STREAM, JOURNEY_ORDER_STREAM, RISK_COMPLIANCE_STREAM), "identity-verification", handle)
     app.state.outbox_relay = relay; app.state.event_subscriber = subscriber; app.state.event_subscriber_thread = thread; app.state._identity_service_holder = holder
     return store, PostgresIdempotencyStore(pool)
 

--- a/services/identity-verification/src/identity_verification/application/service.py
+++ b/services/identity-verification/src/identity_verification/application/service.py
@@ -11,15 +11,25 @@ from uuid import UUID
 from train_ticket_platform.events import EventEnvelope, canonical_correlation_id, rfc3339_utc
 
 from identity_verification.domain import (
+    ActiveTicket,
+    BlacklistChecker,
+    BlacklistEntry,
+    BlacklistType,
+    DuplicateTicketCheck,
     CredentialRecord,
     CredentialStatus,
     DomainError,
+    ExpiredDocumentError,
     EligibilityCertificate,
     PreOrderResult,
     PreconditionFailed,
     PurchaseLimitFact,
     SimOutcome,
+    VerificationCache,
     VerificationCase,
+    VerificationRequest,
+    VerificationResult,
+    VerificationResultStatus,
     VerificationStatus,
     now_utc,
 )
@@ -96,6 +106,9 @@ class InMemoryStore:
         self.pre_order_checks: dict[str, dict[str, Any]] = {}
         self.pre_order_duplicate_index: dict[str, str] = {}
         self.traveler_snapshots: dict[str, dict[str, Any]] = {}
+        self.blacklist_entries: list[BlacklistEntry] = []
+        self.active_tickets: dict[tuple[str, str, str], ActiveTicket] = {}
+        self.verification_cache = VerificationCache()
         self._outbox: list[EventEnvelope] = []
         self.processed_events: set[str] = set()
 
@@ -192,6 +205,30 @@ class InMemoryStore:
         return self.get_pre_order_check(cid) if cid else None
 
 
+    def add_blacklist_entry(self, entry: BlacklistEntry) -> None:
+        self.blacklist_entries.append(entry)
+
+    def list_blacklist_entries(self, document_number: str) -> tuple[BlacklistEntry, ...]:
+        return tuple(entry for entry in self.blacklist_entries if entry.documentNumber == document_number)
+
+    def find_active_ticket(self, document_number: str, segment_ref: str, departure_date: str) -> ActiveTicket | None:
+        return self.active_tickets.get((document_number, segment_ref, departure_date))
+
+    def save_active_ticket(self, ticket: ActiveTicket) -> None:
+        self.active_tickets[ticket.key] = ticket
+
+    def release_active_tickets_for_order(self, order_id: str) -> None:
+        for key, ticket in list(self.active_tickets.items()):
+            if ticket.orderId == order_id:
+                self.active_tickets.pop(key, None)
+
+    def get_cached_verification(self, traveler_id: str, document_number: str, at: datetime) -> tuple[datetime, datetime] | None:
+        return self.verification_cache.get_valid(traveler_id, document_number, at)
+
+    def save_cached_verification(self, traveler_id: str, document_number: str, verified_at: datetime, expires_at: datetime) -> None:
+        self.verification_cache.record(traveler_id, document_number, verified_at, expires_at)
+
+
 class DeterministicSimGateway:
     def __init__(self, seed: str = "sim-tail-v1") -> None:
         self.seed = seed
@@ -225,6 +262,76 @@ class IdentityVerificationService:
     def _append(self, envelopes: tuple[EventEnvelope, ...]) -> None:
         append = getattr(self.store, "append_outbox", None)
         if callable(append): append(envelopes)
+
+    def verify_identity(self, data: Mapping[str, Any], correlation_id: str, causation_id: str | None) -> dict[str, Any]:
+        with self.transaction():
+            at = now_utc()
+            request = VerificationRequest.from_mapping(data)
+            duplicate_check = DuplicateTicketCheck.PASS
+            envelopes: list[EventEnvelope] = []
+            try:
+                request.validate(at)
+            except ExpiredDocumentError:
+                result = VerificationResult(VerificationResultStatus.EXPIRED, "EXPIRED_DOCUMENT", None, None, duplicateTicketCheck=duplicate_check)
+                envelopes.append(self._identity_rejected_event(request.travelerId, "EXPIRED_DOCUMENT", corr=correlation_id, cause=causation_id, at=at))
+                self._append(tuple(envelopes))
+                return self._verification_response(request, result)
+
+            if request.segmentRef and request.departureDate:
+                existing_ticket = self.store.find_active_ticket(request.documentNumber, request.segmentRef, request.departureDate)
+                if existing_ticket is not None:
+                    duplicate_check = DuplicateTicketCheck.FAIL
+                    result = VerificationResult(VerificationResultStatus.REJECTED, "DUPLICATE_TICKET", None, None, duplicateTicketCheck=duplicate_check)
+                    envelopes.append(self._identity_rejected_event(request.travelerId, "DUPLICATE_TICKET", corr=correlation_id, cause=causation_id, at=at))
+                    self._append(tuple(envelopes))
+                    return self._verification_response(request, result)
+
+            blacklist_hit = self._blacklist_hit(request, at)
+            if blacklist_hit is not None:
+                entry, status, reason, restrictions = blacklist_hit
+                result = VerificationResult(status, reason, None, None, restrictions=restrictions, duplicateTicketCheck=duplicate_check)
+                envelopes.append(self._blacklist_hit_event(entry, corr=correlation_id, cause=causation_id, at=at))
+                envelopes.append(self._identity_rejected_event(request.travelerId, reason, corr=correlation_id, cause=causation_id, at=at))
+                self._append(tuple(envelopes))
+                return self._verification_response(request, result)
+
+            cache_lookup = self.store.get_cached_verification(request.travelerId, request.documentNumber, at)
+            cached = None if request.bookingValueMinor > 500_000 else cache_lookup
+            if cached is not None:
+                verified_at, expires_at = cached
+                result = VerificationResult(VerificationResultStatus.VERIFIED, None, verified_at, expires_at, duplicateTicketCheck=duplicate_check, cacheHit=True)
+                return self._verification_response(request, result)
+
+            expires_at = at + timedelta(days=request.documentType.validity_days)
+            result = VerificationResult(VerificationResultStatus.VERIFIED, None, at, expires_at, duplicateTicketCheck=duplicate_check)
+            self.store.save_cached_verification(request.travelerId, request.documentNumber, at, expires_at)
+            envelopes.append(self._identity_verified_event(request, expires_at, correlation_id, causation_id, at))
+            self._append(tuple(envelopes))
+            return self._verification_response(request, result)
+
+    def _blacklist_hit(self, request: VerificationRequest, at: datetime) -> tuple[BlacklistEntry, VerificationResultStatus, str, tuple[str, ...]] | None:
+        hit = BlacklistChecker(self.store.list_blacklist_entries(request.documentNumber)).check(request.documentNumber, request.seatClass, at)
+        if hit is None:
+            return None
+        entry, (status, reason, restrictions) = hit
+        return entry, status, reason, restrictions
+
+    def _verification_response(self, request: VerificationRequest, result: VerificationResult) -> dict[str, Any]:
+        return {"travelerId": request.travelerId, "documentType": request.documentType.value, **result.to_json()}
+
+    def _identity_verified_event(self, request: VerificationRequest, expires_at: datetime, corr: str, cause: str | None, at: datetime) -> EventEnvelope:
+        payload = {"travelerId": request.travelerId, "documentType": request.documentType.value, "verifiedAt": rfc3339_utc(at), "expiresAt": rfc3339_utc(expires_at)}
+        version = int(at.timestamp() * 1_000_000)
+        return _envelope("IdentityVerified", f"{request.travelerId}:{request.documentNumber}", version, payload, corr, cause, at)
+
+    def _identity_rejected_event(self, traveler_id: str, reason: str, corr: str, cause: str | None, at: datetime) -> EventEnvelope:
+        version = int(at.timestamp() * 1_000_000)
+        return _envelope("IdentityRejected", traveler_id, version, {"travelerId": traveler_id, "reason": reason, "rejectedAt": rfc3339_utc(at)}, corr, cause, at)
+
+    def _blacklist_hit_event(self, entry: BlacklistEntry, corr: str, cause: str | None, at: datetime) -> EventEnvelope:
+        payload = {"documentNumber": entry.documentNumber, "blacklistType": entry.blacklistType.value, "reason": entry.reason, "hitAt": rfc3339_utc(at)}
+        version = int(at.timestamp() * 1_000_000)
+        return _envelope("BlacklistHit", entry.documentNumber, version, payload, corr, cause, at)
 
     def register_credential(self, data: Mapping[str, Any], correlation_id: str, causation_id: str | None) -> dict[str, Any]:
         with self.transaction():
@@ -470,3 +577,47 @@ class IdentityVerificationService:
             traveler_id = str(payload.get("travelerId") or "")
             if traveler_id:
                 self.store.save_traveler_snapshot(traveler_id, payload)
+
+
+    def handle_journey_order_event(self, envelope: EventEnvelope, stream: str = "events:journey-order") -> None:
+        with self.transaction():
+            if not self.store.mark_processed(envelope.eventId, stream):
+                return
+            payload = dict(envelope.payload)
+            if envelope.eventType == "JourneyOrderCancelled":
+                order_id = str(payload.get("orderId") or "")
+                if order_id:
+                    self.store.release_active_tickets_for_order(order_id)
+                return
+            if envelope.eventType != "JourneyOrderCreated":
+                return
+            order_id = str(payload.get("orderId") or "")
+            departure_date = str(payload.get("departureDate") or payload.get("journeyDate") or payload.get("createdAt", "")[:10])
+            for traveler in payload.get("travelerRefs") or []:
+                document_number = self._document_number_from_traveler_ref(traveler)
+                if not document_number:
+                    continue
+                for segment_ref in payload.get("segmentRefs") or []:
+                    self.store.save_active_ticket(ActiveTicket(document_number, str(segment_ref), departure_date, order_id))
+
+    def handle_risk_alert_raised(self, envelope: EventEnvelope, stream: str = "events:risk-compliance") -> None:
+        with self.transaction():
+            if not self.store.mark_processed(envelope.eventId, stream):
+                return
+            if envelope.eventType != "RiskAlertRaised":
+                return
+            payload = dict(envelope.payload)
+            document_number = payload.get("documentNumber") or payload.get("documentNo")
+            if not document_number:
+                return
+            self.store.add_blacklist_entry(BlacklistEntry(str(document_number), BlacklistType.FRAUD_FLAGGED, str(payload.get("reason") or "risk alert"), now_utc()))
+
+    @staticmethod
+    def _document_number_from_traveler_ref(traveler: Any) -> str | None:
+        if isinstance(traveler, str):
+            return None
+        if isinstance(traveler, Mapping):
+            for key in ("documentNumber", "documentNo", "identityDocumentNumber"):
+                if traveler.get(key):
+                    return str(traveler[key]).upper()
+        return None

--- a/services/identity-verification/src/identity_verification/application/service.py
+++ b/services/identity-verification/src/identity_verification/application/service.py
@@ -317,7 +317,7 @@ class IdentityVerificationService:
                 entry, status, reason, restrictions = blacklist_hit
                 result = VerificationResult(status, reason, None, None, restrictions=restrictions, duplicateTicketCheck=duplicate_check)
                 envelopes.append(self._blacklist_hit_event(entry, corr=correlation_id, cause=causation_id, at=at))
-                envelopes.append(self._identity_rejected_event(request.travelerId, reason, corr=correlation_id, cause=causation_id, at=at))
+                envelopes.append(self._identity_rejected_event(request.travelerId, "BLACKLISTED", corr=correlation_id, cause=causation_id, at=at))
                 self._append(tuple(envelopes))
                 return self._verification_response(request, result)
 

--- a/services/identity-verification/src/identity_verification/application/service.py
+++ b/services/identity-verification/src/identity_verification/application/service.py
@@ -212,18 +212,44 @@ class InMemoryStore:
         return tuple(entry for entry in self.blacklist_entries if entry.documentNumber == document_number)
 
     def find_active_ticket(self, document_number: str, segment_ref: str, departure_date: str) -> ActiveTicket | None:
-        return self.active_tickets.get((document_number, segment_ref, departure_date))
+        ticket = self.active_tickets.get((document_number, segment_ref, departure_date))
+        return ticket if ticket is not None and ticket.status == "ACTIVE" else None
 
     def save_active_ticket(self, ticket: ActiveTicket) -> None:
         self.active_tickets[ticket.key] = ticket
 
+    def list_active_tickets_for_order(self, order_id: str) -> tuple[ActiveTicket, ...]:
+        return tuple(ticket for ticket in self.active_tickets.values() if ticket.orderId == order_id and ticket.status == "ACTIVE")
+
     def release_active_tickets_for_order(self, order_id: str) -> None:
         for key, ticket in list(self.active_tickets.items()):
             if ticket.orderId == order_id:
-                self.active_tickets.pop(key, None)
+                self.active_tickets[key] = ActiveTicket(ticket.documentNumber, ticket.segmentRef, ticket.departureDate, ticket.orderId, "CANCELLED")
+
+    def find_reserved_pre_order_check_for_order_event(self, account_id: str, traveler_ids: tuple[str, ...], segment_refs: tuple[str, ...]) -> dict[str, Any] | None:
+        traveler_set = set(traveler_ids)
+        segment_set = set(segment_refs)
+        candidates = []
+        for record in self.pre_order_checks.values():
+            body = dict(record.get("body") or {})
+            if record.get("status") != "RESERVED" or body.get("result") != PreOrderResult.PASS.value:
+                continue
+            if body.get("accountId") != account_id:
+                continue
+            if set(str(item) for item in body.get("travelerRefs") or ()) != traveler_set:
+                continue
+            if set(str(item) for item in body.get("segmentRefs") or ()) != segment_set:
+                continue
+            candidates.append(record)
+        if not candidates:
+            return None
+        return dict(max(candidates, key=lambda item: str((item.get("body") or {}).get("evaluatedAt") or "")))
 
     def get_cached_verification(self, traveler_id: str, document_number: str, at: datetime) -> tuple[datetime, datetime] | None:
         return self.verification_cache.get_valid(traveler_id, document_number, at)
+
+    def find_cached_document_for_traveler(self, traveler_id: str, at: datetime) -> str | None:
+        return self.verification_cache.find_valid_document_for_traveler(traveler_id, at)
 
     def save_cached_verification(self, traveler_id: str, document_number: str, verified_at: datetime, expires_at: datetime) -> None:
         self.verification_cache.record(traveler_id, document_number, verified_at, expires_at)
@@ -592,13 +618,23 @@ class IdentityVerificationService:
             if envelope.eventType != "JourneyOrderCreated":
                 return
             order_id = str(payload.get("orderId") or "")
-            departure_date = str(payload.get("departureDate") or payload.get("journeyDate") or payload.get("createdAt", "")[:10])
-            for traveler in payload.get("travelerRefs") or []:
-                document_number = self._document_number_from_traveler_ref(traveler)
-                if not document_number:
+            account_id = str(payload.get("accountId") or "")
+            segment_refs = tuple(str(item) for item in payload.get("segmentRefs") or () if str(item))
+            traveler_ids = self._traveler_ids_from_refs(payload.get("travelerRefs") or ())
+            pre_order = self.store.find_reserved_pre_order_check_for_order_event(account_id, traveler_ids, segment_refs)
+            if not order_id or pre_order is None:
+                return
+            body = dict(pre_order.get("body") or {})
+            departure_date = str(body.get("journeyDate") or "")
+            if not departure_date:
+                return
+            for fact_id in pre_order.get("purchaseLimitFactIds") or ():
+                fact = self.store.get_fact(str(fact_id))
+                document_number = self.store.find_cached_document_for_traveler(fact.travelerId, now_utc())
+                if document_number is None:
                     continue
-                for segment_ref in payload.get("segmentRefs") or []:
-                    self.store.save_active_ticket(ActiveTicket(document_number, str(segment_ref), departure_date, order_id))
+                for segment_ref in fact.segmentRefs:
+                    self.store.save_active_ticket(ActiveTicket(document_number, segment_ref, departure_date, order_id))
 
     def handle_risk_alert_raised(self, envelope: EventEnvelope, stream: str = "events:risk-compliance") -> None:
         with self.transaction():
@@ -607,17 +643,30 @@ class IdentityVerificationService:
             if envelope.eventType != "RiskAlertRaised":
                 return
             payload = dict(envelope.payload)
-            document_number = payload.get("documentNumber") or payload.get("documentNo")
-            if not document_number:
+            order_id = str(payload.get("orderId") or "")
+            if not order_id:
                 return
-            self.store.add_blacklist_entry(BlacklistEntry(str(document_number), BlacklistType.FRAUD_FLAGGED, str(payload.get("reason") or "risk alert"), now_utc()))
+            reason = self._risk_alert_reason(payload)
+            at = _parse_dt(str(payload.get("raisedAt") or "")) or now_utc()
+            for ticket in self.store.list_active_tickets_for_order(order_id):
+                self.store.add_blacklist_entry(BlacklistEntry(ticket.documentNumber, BlacklistType.FRAUD_FLAGGED, reason, at))
 
     @staticmethod
-    def _document_number_from_traveler_ref(traveler: Any) -> str | None:
-        if isinstance(traveler, str):
-            return None
-        if isinstance(traveler, Mapping):
-            for key in ("documentNumber", "documentNo", "identityDocumentNumber"):
-                if traveler.get(key):
-                    return str(traveler[key]).upper()
-        return None
+    def _traveler_ids_from_refs(traveler_refs: Any) -> tuple[str, ...]:
+        traveler_ids: list[str] = []
+        for traveler in traveler_refs:
+            if isinstance(traveler, str):
+                traveler_ids.append(traveler)
+            elif isinstance(traveler, Mapping) and traveler.get("travelerId"):
+                traveler_ids.append(str(traveler["travelerId"]))
+        return tuple(traveler_ids)
+
+    @staticmethod
+    def _risk_alert_reason(payload: Mapping[str, Any]) -> str:
+        triggered_rules = payload.get("triggeredRules")
+        if isinstance(triggered_rules, list) and triggered_rules:
+            rule_ids = [str(rule.get("ruleId") or rule.get("id")) for rule in triggered_rules if isinstance(rule, Mapping) and (rule.get("ruleId") or rule.get("id"))]
+            if rule_ids:
+                return "risk alert: " + ",".join(rule_ids)
+        verdict = str(payload.get("verdict") or "").strip()
+        return f"risk alert: {verdict}" if verdict else "risk alert"

--- a/services/identity-verification/src/identity_verification/domain.py
+++ b/services/identity-verification/src/identity_verification/domain.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
-from typing import Any, Self
+import re
+from typing import Any, Mapping, Self
 
 from train_ticket_platform.events import rfc3339_utc
 
@@ -58,6 +59,227 @@ class PreOrderResult(StrEnum):
     DEGRADED = "DEGRADED"
 
 
+class DocumentType(StrEnum):
+    ID_CARD = "ID_CARD"
+    PASSPORT = "PASSPORT"
+    HK_MACAU_PERMIT = "HK_MACAU_PERMIT"
+    TW_PERMIT = "TW_PERMIT"
+    RESIDENCE_PERMIT = "RESIDENCE_PERMIT"
+
+    @property
+    def validity_days(self) -> int:
+        if self is DocumentType.ID_CARD:
+            return 30
+        if self is DocumentType.PASSPORT:
+            return 7
+        return 14
+
+    def validate_number(self, document_number: str) -> bool:
+        value = document_number.strip().upper()
+        patterns = {
+            DocumentType.ID_CARD: r"^[1-9]\d{5}(18|19|20)\d{2}(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01])\d{3}[0-9X]$",
+            DocumentType.PASSPORT: r"^[A-Z0-9]{5,17}$",
+            DocumentType.HK_MACAU_PERMIT: r"^[HMhm][0-9]{8,10}$",
+            DocumentType.TW_PERMIT: r"^[Tt][0-9]{8,10}$",
+            DocumentType.RESIDENCE_PERMIT: r"^[A-Z]{3}[0-9]{12}$",
+        }
+        if re.fullmatch(patterns[self], value) is None:
+            return False
+        return self is not DocumentType.ID_CARD or _valid_chinese_id_checksum(value)
+
+    def names_match(self, submitted: str, registered: str | None = None) -> bool:
+        if registered is None:
+            return True
+        submitted_norm = _normalize_name(submitted)
+        registered_norm = _normalize_name(registered)
+        if self is DocumentType.PASSPORT:
+            return submitted_norm == registered_norm or submitted_norm.replace(" ", "") == registered_norm.replace(" ", "")
+        return submitted.strip() == registered.strip()
+
+
+def _valid_chinese_id_checksum(value: str) -> bool:
+    weights = (7, 9, 10, 5, 8, 4, 2, 1, 6, 3, 7, 9, 10, 5, 8, 4, 2)
+    checks = "10X98765432"
+    total = sum(int(value[index]) * weight for index, weight in enumerate(weights))
+    return checks[total % 11] == value[-1].upper()
+
+
+def _normalize_name(value: str) -> str:
+    return " ".join(value.strip().upper().replace(",", " ").split())
+
+
+class VerificationResultStatus(StrEnum):
+    VERIFIED = "VERIFIED"
+    REJECTED = "REJECTED"
+    EXPIRED = "EXPIRED"
+    BLACKLISTED = "BLACKLISTED"
+    CHALLENGE = "CHALLENGE"
+
+
+class DuplicateTicketCheck(StrEnum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+
+
+class BlacklistType(StrEnum):
+    CREDIT_DEFAULT = "CREDIT_DEFAULT"
+    SECURITY_BAN = "SECURITY_BAN"
+    FRAUD_FLAGGED = "FRAUD_FLAGGED"
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationRequest:
+    travelerId: str
+    documentType: DocumentType
+    documentNumber: str
+    holderName: str
+    expiryDate: datetime | None = None
+    segmentRef: str | None = None
+    departureDate: str | None = None
+    seatClass: str | None = None
+    bookingValueMinor: int = 0
+    expectedHolderName: str | None = None
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "VerificationRequest":
+        doc_type = DocumentType(str(data["documentType"]))
+        expiry = data.get("expiryDate")
+        if isinstance(expiry, str):
+            expiry = datetime.fromisoformat(expiry.replace("Z", "+00:00")).astimezone(UTC)
+        return cls(
+            travelerId=require_text(data.get("travelerId"), "travelerId"),
+            documentType=doc_type,
+            documentNumber=require_text(data.get("documentNumber"), "documentNumber").upper(),
+            holderName=require_text(data.get("holderName"), "holderName"),
+            expiryDate=expiry,
+            segmentRef=str(data["segmentRef"]) if data.get("segmentRef") else None,
+            departureDate=str(data["departureDate"]) if data.get("departureDate") else None,
+            seatClass=str(data["seatClass"]) if data.get("seatClass") else None,
+            bookingValueMinor=int(data.get("bookingValueMinor") or 0),
+            expectedHolderName=str(data["expectedHolderName"]) if data.get("expectedHolderName") else None,
+        )
+
+    def validate(self, at: datetime) -> None:
+        if not self.documentType.validate_number(self.documentNumber):
+            raise DomainError("documentNumber format is invalid")
+        if not self.documentType.names_match(self.holderName, self.expectedHolderName):
+            raise DomainError("holderName does not match document")
+        if self.documentType is not DocumentType.ID_CARD:
+            if self.expiryDate is None:
+                raise DomainError("expiryDate is required for this documentType")
+            if self.expiryDate <= at:
+                raise ExpiredDocumentError("document is expired")
+
+
+class ExpiredDocumentError(DomainError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationResult:
+    status: VerificationResultStatus
+    reason: str | None
+    verifiedAt: datetime | None
+    expiresAt: datetime | None
+    restrictions: tuple[str, ...] = ()
+    duplicateTicketCheck: DuplicateTicketCheck = DuplicateTicketCheck.PASS
+    cacheHit: bool = False
+
+    def to_json(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "status": self.status.value,
+            "restrictions": list(self.restrictions),
+            "duplicateTicketCheck": self.duplicateTicketCheck.value,
+            "cacheHit": self.cacheHit,
+        }
+        if self.reason: data["reason"] = self.reason
+        if self.verifiedAt: data["verifiedAt"] = rfc3339_utc(self.verifiedAt)
+        if self.expiresAt: data["expiresAt"] = rfc3339_utc(self.expiresAt)
+        return data
+
+
+@dataclass(frozen=True, slots=True)
+class BlacklistEntry:
+    documentNumber: str
+    blacklistType: BlacklistType
+    reason: str
+    effectiveFrom: datetime
+    effectiveUntil: datetime | None = None
+
+    def active_at(self, at: datetime) -> bool:
+        return self.effectiveFrom <= at and (self.effectiveUntil is None or self.effectiveUntil > at)
+
+    def restriction_for(self, seat_class: str | None) -> tuple[VerificationResultStatus, str, tuple[str, ...]] | None:
+        seat = (seat_class or "SECOND_CLASS").upper()
+        if self.blacklistType is BlacklistType.SECURITY_BAN:
+            return VerificationResultStatus.BLACKLISTED, "BLACKLISTED", ("TRAVEL_BAN",)
+        if self.blacklistType is BlacklistType.CREDIT_DEFAULT and seat not in {"SECOND_CLASS", "SECOND"}:
+            return VerificationResultStatus.BLACKLISTED, "CREDIT_DEFAULT_RESTRICTED_CLASS", ("SECOND_CLASS_ONLY",)
+        if self.blacklistType is BlacklistType.CREDIT_DEFAULT:
+            return None
+        return VerificationResultStatus.CHALLENGE, "FRAUD_FLAGGED", ("MANUAL_REVIEW_REQUIRED",)
+
+
+class BlacklistChecker:
+    def __init__(self, entries: tuple[BlacklistEntry, ...] = ()) -> None:
+        self._entries = entries
+
+    def check(self, document_number: str, seat_class: str | None, at: datetime) -> tuple[BlacklistEntry, tuple[VerificationResultStatus, str, tuple[str, ...]]] | None:
+        for entry in self._entries:
+            if entry.documentNumber == document_number and entry.active_at(at):
+                restriction = entry.restriction_for(seat_class)
+                if restriction is not None:
+                    return entry, restriction
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class ActiveTicket:
+    documentNumber: str
+    segmentRef: str
+    departureDate: str
+    orderId: str
+    status: str = "ACTIVE"
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        return (self.documentNumber, self.segmentRef, self.departureDate)
+
+
+class ActiveTicketRegistry:
+    def __init__(self, tickets: tuple[ActiveTicket, ...] = ()) -> None:
+        self._tickets = {ticket.key: ticket for ticket in tickets if ticket.status == "ACTIVE"}
+
+    def checkDuplicateTicket(self, documentNumber: str, segmentRef: str, departureDate: str) -> bool:
+        return (documentNumber, segmentRef, departureDate) in self._tickets
+
+    def record_created(self, documentNumber: str, segmentRef: str, departureDate: str, orderId: str) -> None:
+        self._tickets[(documentNumber, segmentRef, departureDate)] = ActiveTicket(documentNumber, segmentRef, departureDate, orderId)
+
+    def record_cancelled(self, orderId: str) -> None:
+        for key, ticket in list(self._tickets.items()):
+            if ticket.orderId == orderId:
+                self._tickets.pop(key, None)
+
+
+class VerificationCache:
+    def __init__(self, entries: Mapping[tuple[str, str], tuple[datetime, datetime]] | None = None) -> None:
+        self._entries = dict(entries or {})
+
+    def record(self, travelerId: str, documentNumber: str, verifiedAt: datetime, expiresAt: datetime) -> None:
+        self._entries[(travelerId, documentNumber)] = (verifiedAt, expiresAt)
+
+    def get_valid(self, travelerId: str, documentNumber: str, at: datetime) -> tuple[datetime, datetime] | None:
+        entry = self._entries.get((travelerId, documentNumber))
+        if entry is None:
+            return None
+        return entry if entry[1] > at else None
+
+    def needsReverification(self, travelerId: str, documentNumber: str, bookingValueMinor: int, at: datetime | None = None) -> bool:
+        if bookingValueMinor > 500_000:
+            return True
+        return self.get_valid(travelerId, documentNumber, at or now_utc()) is None
+
 def now_utc() -> datetime:
     return datetime.now(UTC)
 
@@ -94,7 +316,7 @@ class CredentialRecord:
 
     @classmethod
     def register(cls, *, credential_id: str, traveler_id: str, profile_snapshot_version: str, document_type: str, masked_document_no: str, document_hash: str, material_fingerprint: str, canonical_name_hash: str, birth_date_hash: str | None, valid_until: datetime | None, evidence_hash: str | None, identity_cluster_id: str, at: datetime) -> "CredentialRecord":
-        if document_type not in {"ID_CARD", "PASSPORT"}:
+        if document_type not in {item.value for item in DocumentType}:
             raise DomainError("documentType is invalid")
         if valid_until is not None and valid_until <= at:
             raise DomainError("validUntil must be in the future")

--- a/services/identity-verification/src/identity_verification/domain.py
+++ b/services/identity-verification/src/identity_verification/domain.py
@@ -275,6 +275,16 @@ class VerificationCache:
             return None
         return entry if entry[1] > at else None
 
+    def find_valid_document_for_traveler(self, travelerId: str, at: datetime) -> str | None:
+        candidates = [
+            (document_number, expires_at)
+            for (cached_traveler_id, document_number), (_verified_at, expires_at) in self._entries.items()
+            if cached_traveler_id == travelerId and expires_at > at
+        ]
+        if not candidates:
+            return None
+        return max(candidates, key=lambda item: item[1])[0]
+
     def needsReverification(self, travelerId: str, documentNumber: str, bookingValueMinor: int, at: datetime | None = None) -> bool:
         if bookingValueMinor > 500_000:
             return True

--- a/services/identity-verification/src/identity_verification/web/handlers.py
+++ b/services/identity-verification/src/identity_verification/web/handlers.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from identity_verification.application.service import IdentityVerificationService
 
 router = APIRouter(prefix="/api/v1/identity-verification")
+compatibility_router = APIRouter(prefix="/api/v1")
 
 
 class LooseModel(BaseModel):
@@ -22,6 +23,18 @@ class RegisterCredentialRequest(LooseModel):
     birthDateHash: str | None = None
     validUntil: str | None = None
     evidenceHash: str | None = None
+
+
+class RealNameVerificationRequest(LooseModel):
+    travelerId: str
+    documentType: str
+    documentNumber: str
+    holderName: str
+    expiryDate: str | None = None
+    segmentRef: str | None = None
+    departureDate: str | None = None
+    seatClass: str | None = None
+    bookingValueMinor: int = 0
 
 
 class StartVerificationRequest(LooseModel):
@@ -97,6 +110,20 @@ def _cause(request: Request) -> str:
 @router.post("/credentials", status_code=201)
 def register_credential(body: RegisterCredentialRequest, request: Request) -> dict[str, Any]:
     return _service(request).register_credential(body.model_dump(exclude_none=True), _corr(request), _cause(request))
+
+
+def _verify_identity_response(body: RealNameVerificationRequest, request: Request) -> dict[str, Any]:
+    return _service(request).verify_identity(body.model_dump(exclude_none=True), _corr(request), _cause(request))
+
+
+@router.post("/verifications", status_code=201)
+def verify_identity(body: RealNameVerificationRequest, request: Request) -> dict[str, Any]:
+    return _verify_identity_response(body, request)
+
+
+@compatibility_router.post("/verifications", status_code=201)
+def verify_identity_compatibility(body: RealNameVerificationRequest, request: Request) -> dict[str, Any]:
+    return _verify_identity_response(body, request)
 
 
 @router.post("/verification-cases", status_code=201)

--- a/services/identity-verification/tests/test_api.py
+++ b/services/identity-verification/tests/test_api.py
@@ -149,3 +149,23 @@ def test_credential_status_uses_store_interface_not_cases_attribute():
     response = client.get(f"/api/v1/identity-verification/credentials/{cred['credentialRecordId']}/verification-status")
     assert response.status_code == 200
     assert response.json()["verificationStatus"] == "PASSED"
+
+
+def test_real_name_verification_api_contract_and_events():
+    store = InMemoryStore(); client = TestClient(create_app(store=store))
+    response = client.post("/api/v1/identity-verification/verifications", json={"travelerId": "tvl-api", "documentType": "ID_CARD", "documentNumber": "11010519491231002X", "holderName": "张三", "segmentRef": "seg-api", "departureDate": "2026-02-01", "seatClass": "SECOND_CLASS", "bookingValueMinor": 10000}, headers={"Idempotency-Key": key(90)})
+    assert response.status_code == 201
+    body = response.json()
+    assert body["status"] == "VERIFIED"
+    assert body["restrictions"] == []
+    assert body["duplicateTicketCheck"] == "PASS"
+    assert store.take_outbox()[0].eventType == "IdentityVerified"
+    compat = client.post("/api/v1/verifications", json={"travelerId": "tvl-api-compat", "documentType": "ID_CARD", "documentNumber": "110105199001010010", "holderName": "张三", "segmentRef": "seg-api-compat", "departureDate": "2026-02-01", "seatClass": "SECOND_CLASS", "bookingValueMinor": 10000}, headers={"Idempotency-Key": key(92)})
+    assert compat.status_code == 201
+    assert compat.json()["status"] == "VERIFIED"
+
+    store.save_active_ticket(__import__("identity_verification.domain", fromlist=["ActiveTicket"]).ActiveTicket("11010519491231002X", "seg-api", "2026-02-01", "ord-api"))
+    rejected = client.post("/api/v1/identity-verification/verifications", json={"travelerId": "tvl-api-2", "documentType": "ID_CARD", "documentNumber": "11010519491231002X", "holderName": "张三", "segmentRef": "seg-api", "departureDate": "2026-02-01", "seatClass": "SECOND_CLASS", "bookingValueMinor": 10000}, headers={"Idempotency-Key": key(91)})
+    assert rejected.status_code == 201
+    assert rejected.json()["reason"] == "DUPLICATE_TICKET"
+    assert rejected.json()["duplicateTicketCheck"] == "FAIL"

--- a/services/identity-verification/tests/test_domain.py
+++ b/services/identity-verification/tests/test_domain.py
@@ -87,6 +87,8 @@ def test_real_name_duplicate_blacklist_expiry_and_cache():
     first_class = service.verify_identity({**request, "documentNumber": credit_doc, "travelerId": "tvl-credit", "segmentRef": "seg-credit", "seatClass": "FIRST_CLASS"}, "corr-real", "cmd-real-5")
     assert first_class["status"] == "BLACKLISTED"
     assert first_class["reason"] == "CREDIT_DEFAULT_RESTRICTED_CLASS"
+    rejection_events = [event for event in store.take_outbox() if event.eventType == "IdentityRejected"]
+    assert rejection_events[-1].payload["reason"] == "BLACKLISTED"
     second_class = service.verify_identity({**request, "documentNumber": credit_doc, "travelerId": "tvl-credit", "segmentRef": "seg-credit-2", "seatClass": "SECOND_CLASS"}, "corr-real", "cmd-real-6")
     assert second_class["status"] == "VERIFIED"
 
@@ -116,3 +118,5 @@ def test_journey_order_and_risk_events_maintain_registries():
     assert result["status"] == "CHALLENGE"
     assert result["reason"] == "FRAUD_FLAGGED"
     assert result["restrictions"] == ["MANUAL_REVIEW_REQUIRED"]
+    rejection_events = [event for event in store.take_outbox() if event.eventType == "IdentityRejected"]
+    assert rejection_events[-1].payload["reason"] == "BLACKLISTED"

--- a/services/identity-verification/tests/test_domain.py
+++ b/services/identity-verification/tests/test_domain.py
@@ -101,12 +101,17 @@ def test_journey_order_and_risk_events_maintain_registries():
 
     store = InMemoryStore()
     service = IdentityVerificationService(store)
-    service.handle_journey_order_event(EventEnvelope(eventId="evt-journey-created", eventType="JourneyOrderCreated", producer="journey-order", payload={"orderId": "ord-reg", "segmentRefs": ["seg-reg"], "departureDate": "2026-02-01", "travelerRefs": [{"travelerId": "tvl-reg", "documentNumber": "11010519491231002X"}]}))
+    service.verify_identity({"travelerId": "tvl-reg", "documentType": "ID_CARD", "documentNumber": "11010519491231002X", "holderName": "张三"}, "corr-risk", "cmd-verify")
+    service.register_credential({"travelerId": "tvl-reg", "profileSnapshotVersion": "snap-reg", "documentType": "ID_CARD", "maskedDocumentNo": "110105********002X", "documentHash": "doc-reg-0", "canonicalNameHash": "name-reg"}, "corr-risk", "cmd-cred")
+    credential = store.credentials_for_traveler("tvl-reg")[0]
+    store.save_credential(credential.mark_verified("ivc-reg", at=datetime(2026, 1, 1, tzinfo=UTC)))
+    service.pre_order_check({"orderIntentId": "oint-reg", "accountId": "acct-reg", "travelerRefs": ["tvl-reg"], "segmentRefs": ["seg-reg"], "journeyDate": "2026-02-01", "productCode": "TRAIN", "requestedEligibilityTypes": [], "limitPolicyVersion": "limit-v1"}, "corr-risk", "cmd-pre")
+    service.handle_journey_order_event(EventEnvelope(eventId="evt-journey-created", eventType="JourneyOrderCreated", producer="journey-order", payload={"orderId": "ord-reg", "accountId": "acct-reg", "offerId": "off-reg", "monetarySummary": {"total": {"currency": "CNY", "amount": "100.00"}, "currency": "CNY"}, "segmentRefs": ["seg-reg"], "travelerRefs": [{"travelerId": "tvl-reg", "travelerType": "ADULT", "maskedDocumentNo": "110105********002X"}], "createdAt": "2026-01-01T00:00:00Z"}))
     assert store.find_active_ticket("11010519491231002X", "seg-reg", "2026-02-01") is not None
-    service.handle_journey_order_event(EventEnvelope(eventId="evt-journey-cancelled", eventType="JourneyOrderCancelled", producer="journey-order", payload={"orderId": "ord-reg", "reason": "USER_CANCELLED"}))
+    service.handle_risk_alert_raised(EventEnvelope(eventId="evt-risk-alert", eventType="RiskAlertRaised", producer="risk-compliance", payload={"evaluationId": "rsk-reg", "orderId": "ord-reg", "accountId": "acct-reg", "score": 80, "verdict": "CHALLENGE", "triggeredRules": [{"ruleId": "velocity"}], "raisedAt": "2026-01-01T00:05:00Z"}))
+    service.handle_journey_order_event(EventEnvelope(eventId="evt-journey-cancelled", eventType="JourneyOrderCancelled", producer="journey-order", payload={"orderId": "ord-reg", "accountId": "acct-reg", "reason": "USER_CANCELLED"}))
     assert store.find_active_ticket("11010519491231002X", "seg-reg", "2026-02-01") is None
 
-    service.handle_risk_alert_raised(EventEnvelope(eventId="evt-risk-alert", eventType="RiskAlertRaised", producer="risk-compliance", payload={"documentNumber": "11010519491231002X", "reason": "fraud pattern"}))
     result = service.verify_identity({"travelerId": "tvl-risk", "documentType": "ID_CARD", "documentNumber": "11010519491231002X", "holderName": "张三", "seatClass": "SECOND_CLASS"}, "corr-risk", "cmd-risk")
     assert result["status"] == "CHALLENGE"
     assert result["reason"] == "FRAUD_FLAGGED"

--- a/services/identity-verification/tests/test_domain.py
+++ b/services/identity-verification/tests/test_domain.py
@@ -48,3 +48,66 @@ def test_purchase_limit_fact_missed_and_failed_transitions():
     assert failed.status == "FAILED"
     assert failed.version == 2
     assert failed.failureCode == "LEDGER_CONFLICT"
+
+
+def test_real_name_duplicate_blacklist_expiry_and_cache():
+    from identity_verification.application.service import IdentityVerificationService, InMemoryStore
+    from identity_verification.domain import ActiveTicket, BlacklistEntry, BlacklistType
+
+    at = datetime(2026, 1, 1, tzinfo=UTC)
+    store = InMemoryStore()
+    service = IdentityVerificationService(store)
+    doc = "11010519491231002X"
+    request = {"travelerId": "tvl-real", "documentType": "ID_CARD", "documentNumber": doc, "holderName": "张三", "segmentRef": "seg-1", "departureDate": "2026-02-01", "seatClass": "SECOND_CLASS", "bookingValueMinor": 10000}
+    first = service.verify_identity(request, "corr-real", "cmd-real")
+    assert first["status"] == "VERIFIED"
+    assert first["duplicateTicketCheck"] == "PASS"
+    assert first["cacheHit"] is False
+    assert [event.eventType for event in store.take_outbox()] == ["IdentityVerified"]
+
+    cached = service.verify_identity(request, "corr-real", "cmd-real-2")
+    assert cached["status"] == "VERIFIED"
+    assert cached["cacheHit"] is True
+    assert store.take_outbox() == ()
+
+    store.save_active_ticket(ActiveTicket(doc, "seg-1", "2026-02-01", "ord-1"))
+    duplicate = service.verify_identity({**request, "travelerId": "tvl-other"}, "corr-real", "cmd-real-3")
+    assert duplicate["status"] == "REJECTED"
+    assert duplicate["reason"] == "DUPLICATE_TICKET"
+    assert duplicate["duplicateTicketCheck"] == "FAIL"
+
+    security_doc = "110105194912310038"
+    store.add_blacklist_entry(BlacklistEntry(security_doc, BlacklistType.SECURITY_BAN, "security", at))
+    security = service.verify_identity({**request, "documentNumber": security_doc, "travelerId": "tvl-ban", "segmentRef": "seg-ban"}, "corr-real", "cmd-real-4")
+    assert security["status"] == "BLACKLISTED"
+    assert security["restrictions"] == ["TRAVEL_BAN"]
+
+    credit_doc = "110105194912310046"
+    store.add_blacklist_entry(BlacklistEntry(credit_doc, BlacklistType.CREDIT_DEFAULT, "credit", at))
+    first_class = service.verify_identity({**request, "documentNumber": credit_doc, "travelerId": "tvl-credit", "segmentRef": "seg-credit", "seatClass": "FIRST_CLASS"}, "corr-real", "cmd-real-5")
+    assert first_class["status"] == "BLACKLISTED"
+    assert first_class["reason"] == "CREDIT_DEFAULT_RESTRICTED_CLASS"
+    second_class = service.verify_identity({**request, "documentNumber": credit_doc, "travelerId": "tvl-credit", "segmentRef": "seg-credit-2", "seatClass": "SECOND_CLASS"}, "corr-real", "cmd-real-6")
+    assert second_class["status"] == "VERIFIED"
+
+    expired = service.verify_identity({"travelerId": "tvl-passport", "documentType": "PASSPORT", "documentNumber": "E12345678", "holderName": "LI SI", "expiryDate": "2020-01-01T00:00:00Z"}, "corr-real", "cmd-real-7")
+    assert expired["status"] == "EXPIRED"
+    assert expired["reason"] == "EXPIRED_DOCUMENT"
+
+
+def test_journey_order_and_risk_events_maintain_registries():
+    from identity_verification.application.service import IdentityVerificationService, InMemoryStore
+    from train_ticket_platform.events import EventEnvelope
+
+    store = InMemoryStore()
+    service = IdentityVerificationService(store)
+    service.handle_journey_order_event(EventEnvelope(eventId="evt-journey-created", eventType="JourneyOrderCreated", producer="journey-order", payload={"orderId": "ord-reg", "segmentRefs": ["seg-reg"], "departureDate": "2026-02-01", "travelerRefs": [{"travelerId": "tvl-reg", "documentNumber": "11010519491231002X"}]}))
+    assert store.find_active_ticket("11010519491231002X", "seg-reg", "2026-02-01") is not None
+    service.handle_journey_order_event(EventEnvelope(eventId="evt-journey-cancelled", eventType="JourneyOrderCancelled", producer="journey-order", payload={"orderId": "ord-reg", "reason": "USER_CANCELLED"}))
+    assert store.find_active_ticket("11010519491231002X", "seg-reg", "2026-02-01") is None
+
+    service.handle_risk_alert_raised(EventEnvelope(eventId="evt-risk-alert", eventType="RiskAlertRaised", producer="risk-compliance", payload={"documentNumber": "11010519491231002X", "reason": "fraud pattern"}))
+    result = service.verify_identity({"travelerId": "tvl-risk", "documentType": "ID_CARD", "documentNumber": "11010519491231002X", "holderName": "张三", "seatClass": "SECOND_CLASS"}, "corr-risk", "cmd-risk")
+    assert result["status"] == "CHALLENGE"
+    assert result["reason"] == "FRAUD_FLAGGED"
+    assert result["restrictions"] == ["MANUAL_REVIEW_REQUIRED"]


### PR DESCRIPTION
## Summary
- add real-name verification endpoint with multi-document validation, duplicate ticket checks, blacklist restrictions, and verification cache
- persist blacklist, active ticket registry, and verification cache snapshots with outbox events for IdentityVerified/IdentityRejected/BlacklistHit
- consume journey-order/risk-compliance events to maintain registries

## Validation
- services/identity-verification: uv run pytest