### PR TITLE
REQ-309 enrich loyalty membership points and tiers

### DIFF
--- a/services/loyalty-membership/migrations/001_loyalty_membership.sql
+++ b/services/loyalty-membership/migrations/001_loyalty_membership.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS members (
   member_id text PRIMARY KEY,
   account_id text NOT NULL UNIQUE,
-  tier text NOT NULL CHECK (tier IN ('BASIC', 'SILVER', 'GOLD', 'PLATINUM')),
+  tier text NOT NULL CHECK (tier IN ('SILVER', 'GOLD', 'PLATINUM', 'DIAMOND')),
   status text NOT NULL CHECK (status IN ('ACTIVE', 'SUSPENDED', 'CLOSED')),
   redeemable_points integer NOT NULL CHECK (redeemable_points >= 0),
   tier_points integer NOT NULL CHECK (tier_points >= 0),
@@ -14,10 +14,26 @@ CREATE TABLE IF NOT EXISTS members (
 CREATE INDEX IF NOT EXISTS idx_members_account_id ON members (account_id);
 CREATE INDEX IF NOT EXISTS idx_members_tier ON members (tier);
 
+CREATE TABLE IF NOT EXISTS order_account_refs (
+  order_id text PRIMARY KEY,
+  account_id text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS membership_years (
+  member_id text NOT NULL REFERENCES members(member_id) ON DELETE CASCADE,
+  membership_year integer NOT NULL,
+  qualifying_points integer NOT NULL CHECK (qualifying_points >= 0),
+  trip_count integer NOT NULL CHECK (trip_count >= 0),
+  current_tier text NOT NULL CHECK (current_tier IN ('SILVER', 'GOLD', 'PLATINUM', 'DIAMOND')),
+  evaluation_date timestamptz,
+  PRIMARY KEY (member_id, membership_year)
+);
+
 CREATE TABLE IF NOT EXISTS points_ledger (
   entry_id text PRIMARY KEY,
   member_id text NOT NULL REFERENCES members(member_id) ON DELETE CASCADE,
-  entry_type text NOT NULL CHECK (entry_type IN ('ACCRUAL', 'REDEMPTION', 'REVERSAL')),
+  entry_type text NOT NULL CHECK (entry_type IN ('EARNED', 'REDEEMED', 'EXPIRED', 'ADJUSTED')),
   points integer NOT NULL,
   source_event_id text NOT NULL,
   source_event_type text NOT NULL,
@@ -45,6 +61,8 @@ CREATE TABLE IF NOT EXISTS outbox (
   published_at timestamptz,
   created_at timestamptz NOT NULL DEFAULT now()
 );
+
+CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq ON outbox (seq) WHERE published_at IS NULL;
 
 CREATE TABLE IF NOT EXISTS processed_events (
   event_id text PRIMARY KEY,

--- a/services/loyalty-membership/src/app.test.ts
+++ b/services/loyalty-membership/src/app.test.ts
@@ -33,16 +33,16 @@ describe("loyalty membership HTTP API", () => {
 
     const get = await app.inject(`/members/${member.memberId}`);
     assert.equal(get.statusCode, 200);
-    assert.equal(get.json().redeemablePoints, 10);
+    assert.equal(get.json().redeemablePoints, 1000);
 
     const redeem = await app.inject({
       method: "POST",
       url: `/members/${member.memberId}/redeem`,
       headers: { "idempotency-key": "0194f2e0-7b3e-7610-8284-5c26e8b0c001" },
-      payload: { points: 4, redemptionId: "red-http" },
+      payload: { points: 500, redemptionId: "red-http" },
     });
     assert.equal(redeem.statusCode, 200);
-    assert.equal(redeem.json().balanceAfter, 6);
+    assert.equal(redeem.json().balanceAfter, 500);
     assert.equal(publisher.findByEventType("PointsRedeemed").length, 1);
   });
 });

--- a/services/loyalty-membership/src/app.ts
+++ b/services/loyalty-membership/src/app.ts
@@ -202,6 +202,56 @@ export function createApp(options: AppOptions | InstrumentationHooks = {}): Fast
     });
   });
 
+
+  app.post("/members/:id/redeem-ticket", async (request, reply) => {
+    await handleIdempotency({
+      key: headerValue(request.headers["idempotency-key"]),
+      store: idempotencyStore,
+      fingerprint: requestFingerprint(request.method, request.url.split("?")[0] ?? request.url, request.body ?? null),
+      context: requestContext(request),
+      reply,
+      operation: async () => {
+        const body = objectBody(request.body);
+        const result = await runWithService((application) => application.redeemTicketPoints({
+          memberId: memberIdParam(request),
+          orderId: requiredString(body.orderId, "orderId"),
+          pointsToRedeem: requiredInteger(body.pointsToRedeem, "pointsToRedeem"),
+          fareAmountMinor: requiredNonNegativeInteger(body.fareAmountMinor, "fareAmountMinor"),
+          redemptionId: optionalString(body.redemptionId, "redemptionId"),
+          correlationId: requestContext(request).correlationId,
+          causationId: headerValue(request.headers["idempotency-key"]),
+        }));
+        return { statusCode: 200, body: result };
+      },
+    });
+  });
+
+  app.post("/members/:id/expire-points", async (request, reply) => {
+    try {
+      const result = await runWithService((application) => application.expirePoints({
+        memberId: memberIdParam(request),
+        correlationId: requestContext(request).correlationId,
+      }));
+      return result;
+    } catch (error) {
+      sendApplicationError(reply, mapError(error), requestContext(request));
+    }
+  });
+
+  app.post("/members/:id/evaluate-tier", async (request, reply) => {
+    try {
+      const body = objectBody(request.body);
+      const result = await runWithService((application) => application.evaluateTier({
+        memberId: memberIdParam(request),
+        evaluationYear: requiredNonNegativeInteger(body.evaluationYear, "evaluationYear"),
+        correlationId: requestContext(request).correlationId,
+      }));
+      return result;
+    } catch (error) {
+      sendApplicationError(reply, mapError(error), requestContext(request));
+    }
+  });
+
   app.setNotFoundHandler((request, reply) => {
     sendError(reply, 404, "NOT_FOUND", `Route ${request.method} ${request.url} was not found`, requestContext(request));
   });
@@ -275,9 +325,21 @@ function requiredInteger(value: unknown, field: string): number {
 }
 
 function assertOptionalString(value: unknown, field: string): void {
+  optionalString(value, field);
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
   if (value !== undefined && typeof value !== "string") {
     throw new ApplicationError("VALIDATION_FAILED", `${field} must be a string`, 400, { field });
   }
+  return value as string | undefined;
+}
+
+function requiredNonNegativeInteger(value: unknown, field: string): number {
+  if (!Number.isInteger(value) || (value as number) < 0) {
+    throw new ApplicationError("VALIDATION_FAILED", `${field} must be a non-negative integer`, 400, { field });
+  }
+  return value as number;
 }
 
 function sendApplicationError(reply: FastifyReply, error: ApplicationError, context: RequestContext): void {

--- a/services/loyalty-membership/src/application.ts
+++ b/services/loyalty-membership/src/application.ts
@@ -221,13 +221,32 @@ export class LoyaltyMembershipApplicationService {
     return memberDetails(updated.toSnapshot());
   }
 
-  async deductQualifyingPointsForRefund(command: { accountId: string; occurredAt: Date; qualifyingPoints: number }): Promise<MemberDetailsDto> {
-    const member = await this.repository.findByAccountId(command.accountId);
-    if (!member) {
-      throw new ApplicationError("NOT_FOUND", `No member found for account ${command.accountId}`, 404);
+  async deductQualifyingPointsForRefund(command: { orderId: string; occurredAt: Date; qualifyingPoints?: number }): Promise<MemberDetailsDto | undefined> {
+    const accountId = await this.repository.findAccountIdByOrderId(command.orderId);
+    if (!accountId) {
+      return undefined;
     }
-    const updated = member.adjustQualifyingPointsForRefund({ occurredAt: command.occurredAt, qualifyingPoints: command.qualifyingPoints });
+    const member = await this.repository.findByAccountId(accountId);
+    if (!member) {
+      return undefined;
+    }
+    const qualifyingPoints = command.qualifyingPoints ?? member.qualifyingPointsForOrder(command.orderId);
+    if (qualifyingPoints === 0) {
+      return memberDetails(member.toSnapshot());
+    }
+    const updated = member.adjustQualifyingPointsForRefund({ occurredAt: command.occurredAt, qualifyingPoints });
     await this.repository.save(updated);
+    return memberDetails(updated.toSnapshot());
+  }
+
+  async restoreRedeemedPointsForCancelledOrder(command: { orderId: string; accountId: string; sourceEventId: string; cancelledAt: Date; correlationId: string; causationId?: string }): Promise<MemberDetailsDto> {
+    await this.repository.saveOrderAccountRef(command.orderId, command.accountId);
+    const member = (await this.repository.findByAccountId(command.accountId)) ?? Member.enroll({ accountId: command.accountId });
+    const { member: updated, events } = member.restoreRedeemedTicketPoints({ orderId: command.orderId, sourceEventId: command.sourceEventId, cancelledAt: command.cancelledAt, correlationId: command.correlationId });
+    await this.repository.save(updated);
+    for (const event of events) {
+      await this.publish(event, command.correlationId, command.causationId);
+    }
     return memberDetails(updated.toSnapshot());
   }
 

--- a/services/loyalty-membership/src/application.ts
+++ b/services/loyalty-membership/src/application.ts
@@ -7,8 +7,8 @@ import {
   type MemberId,
   type MemberSnapshot,
   type Money,
-  type PointsAccrued,
   type PointsRedeemed,
+  type SeatClass,
 } from "./domain.js";
 import { toEventEnvelope, type EventPublisher } from "./ports.js";
 
@@ -32,6 +32,8 @@ export type MemberDetailsDto = Readonly<{
     reasonCode: string;
     referenceId: string;
   }>[];
+  expiringBatches: readonly Readonly<{ batchId: string; pointsAmount: number; expiryDate: string }>[];
+  membershipYears: readonly Readonly<{ year: number; qualifyingPoints: number; tripCount: number; currentTier: string; evaluationDate?: string }>[];
 }>;
 
 export type RedemptionDto = Readonly<{
@@ -39,17 +41,22 @@ export type RedemptionDto = Readonly<{
   redemptionId: string;
   points: number;
   balanceAfter: number;
+  discountAmountMinor?: number;
+  remainingBalance?: number;
 }>;
 
 export type MemberRepository = Readonly<{
   findByMemberId(memberId: MemberId): Promise<Member | undefined>;
   findByAccountId(accountId: AccountId): Promise<Member | undefined>;
+  findAccountIdByOrderId(orderId: string): Promise<AccountId | undefined>;
+  saveOrderAccountRef(orderId: string, accountId: AccountId): Promise<void>;
   save(member: Member): Promise<void>;
 }>;
 
 export class InMemoryMemberRepository implements MemberRepository {
   private readonly byMemberId = new Map<MemberId, Member>();
   private readonly accountIndex = new Map<AccountId, MemberId>();
+  private readonly orderAccountIndex = new Map<string, AccountId>();
 
   async findByMemberId(memberId: MemberId): Promise<Member | undefined> {
     return this.byMemberId.get(memberId);
@@ -58,6 +65,14 @@ export class InMemoryMemberRepository implements MemberRepository {
   async findByAccountId(accountId: AccountId): Promise<Member | undefined> {
     const memberId = this.accountIndex.get(accountId);
     return memberId ? this.byMemberId.get(memberId) : undefined;
+  }
+
+  async findAccountIdByOrderId(orderId: string): Promise<AccountId | undefined> {
+    return this.orderAccountIndex.get(orderId);
+  }
+
+  async saveOrderAccountRef(orderId: string, accountId: AccountId): Promise<void> {
+    this.orderAccountIndex.set(orderId, accountId);
   }
 
   async save(member: Member): Promise<void> {
@@ -94,6 +109,22 @@ export class LoyaltyMembershipApplicationService {
     return { member: memberDetails(member.toSnapshot()), created: true };
   }
 
+  async redeemTicketPoints(command: {
+    memberId: string;
+    orderId: string;
+    pointsToRedeem: number;
+    fareAmountMinor: number;
+    redemptionId?: string;
+    correlationId: string;
+    causationId?: string;
+  }): Promise<RedemptionDto> {
+    const member = await this.requireMember(command.memberId);
+    const { member: updated, event } = member.redeemForTicket(command);
+    await this.repository.save(updated);
+    await this.publish(event, command.correlationId, command.causationId);
+    return redemptionDetails(event);
+  }
+
   async redeemPoints(command: {
     memberId: string;
     points: number;
@@ -109,6 +140,28 @@ export class LoyaltyMembershipApplicationService {
     return redemptionDetails(event);
   }
 
+  async accrueFromPaymentCaptured(command: {
+    orderId: string;
+    accountId?: string;
+    ticketPrice: Money;
+    sourceEventId: string;
+    confirmedAt: Date;
+    correlationId: string;
+    causationId?: string;
+    seatClass?: SeatClass;
+    travelDate?: Date;
+    routeCode?: string;
+    routeName?: string;
+    isHoliday?: boolean;
+    memberBirthDate?: Date;
+  }): Promise<MemberDetailsDto> {
+    const accountId = command.accountId ?? await this.repository.findAccountIdByOrderId(command.orderId);
+    if (!accountId) {
+      throw new ApplicationError("OUT_OF_ORDER_EVENT", `No account reference found for order ${command.orderId}`, 409);
+    }
+    return this.accrueFromJourneyOrderConfirmed({ ...command, accountId, sourceStream: "events:payment", sourceEventType: "PAYMENT_CAPTURED" });
+  }
+
   async accrueFromJourneyOrderConfirmed(command: {
     orderId: string;
     accountId: string;
@@ -117,13 +170,64 @@ export class LoyaltyMembershipApplicationService {
     confirmedAt: Date;
     correlationId: string;
     causationId?: string;
+    seatClass?: SeatClass;
+    travelDate?: Date;
+    routeCode?: string;
+    routeName?: string;
+    isHoliday?: boolean;
+    memberBirthDate?: Date;
+    tripCount?: number;
+    sourceStream?: string;
+    sourceEventType?: string;
   }): Promise<MemberDetailsDto> {
+    await this.repository.saveOrderAccountRef(command.orderId, command.accountId);
     const member = (await this.repository.findByAccountId(command.accountId)) ?? Member.enroll({ accountId: command.accountId });
     const { member: updated, events } = member.accrueFromConfirmedOrder(command);
     await this.repository.save(updated);
     for (const event of events) {
       await this.publish(event, command.correlationId, command.causationId);
     }
+    return memberDetails(updated.toSnapshot());
+  }
+
+  async expirePoints(command: { memberId: string; now?: Date; correlationId: string; causationId?: string }): Promise<MemberDetailsDto> {
+    const member = await this.requireMember(command.memberId);
+    const { member: updated, events } = member.expirePoints(command.now ?? new Date(), command.correlationId);
+    await this.repository.save(updated);
+    for (const event of events) {
+      await this.publish(event, command.correlationId, command.causationId);
+    }
+    return memberDetails(updated.toSnapshot());
+  }
+
+  async evaluateTier(command: { memberId: string; evaluationYear: number; now?: Date; correlationId: string; causationId?: string }): Promise<MemberDetailsDto> {
+    const member = await this.requireMember(command.memberId);
+    const { member: updated, events } = member.evaluateTierAtYearEnd(command.evaluationYear, command.now ?? new Date(), command.correlationId);
+    await this.repository.save(updated);
+    for (const event of events) {
+      await this.publish(event, command.correlationId, command.causationId);
+    }
+    return memberDetails(updated.toSnapshot());
+  }
+
+  async recordTripFromJourneyOrderCreated(command: { orderId: string; accountId: string; occurredAt: Date; trips?: number; correlationId: string; causationId?: string }): Promise<MemberDetailsDto> {
+    await this.repository.saveOrderAccountRef(command.orderId, command.accountId);
+    const member = (await this.repository.findByAccountId(command.accountId)) ?? Member.enroll({ accountId: command.accountId });
+    const { member: updated, events } = member.recordTrip({ occurredAt: command.occurredAt, trips: command.trips, correlationId: command.correlationId });
+    await this.repository.save(updated);
+    for (const event of events) {
+      await this.publish(event, command.correlationId, command.causationId);
+    }
+    return memberDetails(updated.toSnapshot());
+  }
+
+  async deductQualifyingPointsForRefund(command: { accountId: string; occurredAt: Date; qualifyingPoints: number }): Promise<MemberDetailsDto> {
+    const member = await this.repository.findByAccountId(command.accountId);
+    if (!member) {
+      throw new ApplicationError("NOT_FOUND", `No member found for account ${command.accountId}`, 404);
+    }
+    const updated = member.adjustQualifyingPointsForRefund({ occurredAt: command.occurredAt, qualifyingPoints: command.qualifyingPoints });
+    await this.repository.save(updated);
     return memberDetails(updated.toSnapshot());
   }
 
@@ -157,7 +261,7 @@ export function mapError(error: unknown): ApplicationError {
     return error;
   }
   if (error instanceof DomainError) {
-    if (error.code === "MISSING_REQUIRED_FIELD" || error.code === "INVALID_AMOUNT" || error.code === "INVALID_POINTS") {
+    if (["MISSING_REQUIRED_FIELD", "INVALID_AMOUNT", "INVALID_POINTS", "REDEMPTION_BELOW_MINIMUM", "REDEMPTION_CAP_BELOW_MINIMUM"].includes(error.code)) {
       return new ApplicationError("VALIDATION_FAILED", error.message, 400, { domainCode: error.code });
     }
     if (error.code === "INSUFFICIENT_POINTS") {
@@ -187,6 +291,18 @@ function memberDetails(snapshot: MemberSnapshot): MemberDetailsDto {
       reasonCode: entry.businessReason.reasonCode,
       referenceId: entry.businessReason.referenceId,
     })),
+    expiringBatches: Member.fromSnapshot(snapshot).getExpiringWithin(30).map((batch) => ({
+      batchId: batch.batchId,
+      pointsAmount: batch.pointsAmount,
+      expiryDate: batch.expiryDate.toISOString(),
+    })),
+    membershipYears: (snapshot.membershipYears ?? []).map((year) => ({
+      year: year.year,
+      qualifyingPoints: year.qualifyingPoints,
+      tripCount: year.tripCount,
+      currentTier: year.currentTier,
+      evaluationDate: year.evaluationDate?.toISOString(),
+    })),
   };
 }
 
@@ -196,5 +312,7 @@ function redemptionDetails(event: PointsRedeemed): RedemptionDto {
     redemptionId: event.redemptionId,
     points: event.points,
     balanceAfter: event.balanceAfter,
+    discountAmountMinor: event.discountAmountMinor,
+    remainingBalance: event.remainingBalance,
   };
 }

--- a/services/loyalty-membership/src/bootstrap.ts
+++ b/services/loyalty-membership/src/bootstrap.ts
@@ -6,10 +6,12 @@ import type { Pool } from "pg";
 
 import { createApp, opentelemetryInstrumentationFromEnv, type InstrumentationHooks } from "./app.js";
 import { InMemoryMemberRepository, LoyaltyMembershipApplicationService, type MemberRepository } from "./application.js";
-import { Member, type MemberSnapshot } from "./domain.js";
+import { Member, type MemberSnapshot, type SeatClass } from "./domain.js";
 import { type EventEnvelope, type EventPublisher } from "./ports.js";
 import {
   MigrationRunner,
+  OutboxAppender,
+  OutboxRelay,
   PostgresIdempotencyStore,
   RedisStreamEventPublisher,
   RedisStreamEventSubscriber,
@@ -20,6 +22,7 @@ import {
 
 export const JOURNEY_ORDER_STREAM = "events:journey-order";
 export const PAYMENT_STREAM = "events:payment";
+export const POST_SALES_STREAM = "events:post-sales";
 
 export type BootstrapOptions = Readonly<{
   host?: string;
@@ -69,13 +72,18 @@ async function startSubscriber(application: LoyaltyMembershipApplicationService)
   }
   const subscriber = new RedisStreamEventSubscriber(undefined, undefined, { thrownHandlerErrors: "dlq" });
   try {
-    await subscriber.subscribe([JOURNEY_ORDER_STREAM, PAYMENT_STREAM], "loyalty-membership", consumerName(), async (envelope) => {
+    await subscriber.subscribe([JOURNEY_ORDER_STREAM, PAYMENT_STREAM, POST_SALES_STREAM], "loyalty-membership", consumerName(), async (envelope) => {
+      if (envelope.eventType === "JourneyOrderCreated") {
+        await handleJourneyOrderCreated(application, envelope);
+      }
       if (envelope.eventType === "JourneyOrderConfirmed") {
         await handleJourneyOrderConfirmed(application, envelope);
       }
       if (envelope.eventType === "PaymentCaptured") {
-        // Payment spend tracking will share the same inbox boundary. The current
-        // foundation intentionally keeps accrual tied to JourneyOrderConfirmed per REQ-210.
+        await handlePaymentCaptured(application, envelope);
+      }
+      if (envelope.eventType === "PostSalesApplied") {
+        await handlePostSalesApplied(application, envelope);
       }
       return { ok: true };
     });
@@ -91,6 +99,54 @@ async function startSubscriber(application: LoyaltyMembershipApplicationService)
     });
     return undefined;
   }
+}
+
+export async function handleJourneyOrderCreated(application: LoyaltyMembershipApplicationService, envelope: EventEnvelope): Promise<void> {
+  const payload = envelope.payload;
+  await application.recordTripFromJourneyOrderCreated({
+    orderId: stringField(payload.orderId, "orderId"),
+    accountId: stringField(payload.accountId, "accountId"),
+    occurredAt: new Date(typeof payload.createdAt === "string" ? payload.createdAt : envelope.occurredAt),
+    trips: 1,
+    correlationId: envelope.correlationId,
+    causationId: envelope.eventId,
+  });
+}
+
+export async function handlePostSalesApplied(application: LoyaltyMembershipApplicationService, envelope: EventEnvelope): Promise<void> {
+  const payload = envelope.payload;
+  const qualifyingPoints = typeof payload.qualifyingPoints === "number" ? payload.qualifyingPoints : 0;
+  if (qualifyingPoints === 0) {
+    return;
+  }
+  await application.deductQualifyingPointsForRefund({
+    accountId: stringField(payload.accountId, "accountId"),
+    occurredAt: new Date(typeof payload.appliedAt === "string" ? payload.appliedAt : envelope.occurredAt),
+    qualifyingPoints,
+  });
+}
+
+export async function handlePaymentCaptured(application: LoyaltyMembershipApplicationService, envelope: EventEnvelope): Promise<void> {
+  const payload = envelope.payload;
+  const orderId = stringField(payload.businessRef ?? payload.orderId, "businessRef");
+  const accountId = optionalStringField(payload.accountId);
+  const capturedAmount = objectField(payload.capturedAmount ?? payload.amount, "capturedAmount");
+  const minorUnits = integerField(capturedAmount.minorUnits, "capturedAmount.minorUnits");
+  const currency = stringField(capturedAmount.currency, "capturedAmount.currency");
+  const capturedAt = new Date(typeof payload.capturedAt === "string" ? payload.capturedAt : envelope.occurredAt);
+  await application.accrueFromPaymentCaptured({
+    orderId,
+    accountId,
+    ticketPrice: { currency, minorUnits },
+    sourceEventId: envelope.eventId,
+    confirmedAt: capturedAt,
+    correlationId: envelope.correlationId,
+    causationId: envelope.eventId,
+    seatClass: optionalSeatClass(payload.seatClass),
+    routeCode: optionalStringField(payload.routeCode),
+    routeName: optionalStringField(payload.routeName),
+    isHoliday: typeof payload.isHoliday === "boolean" ? payload.isHoliday : undefined,
+  });
 }
 
 export async function handleJourneyOrderConfirmed(application: LoyaltyMembershipApplicationService, envelope: EventEnvelope): Promise<void> {
@@ -110,6 +166,8 @@ export async function handleJourneyOrderConfirmed(application: LoyaltyMembership
     confirmedAt,
     correlationId: envelope.correlationId,
     causationId: envelope.eventId,
+    sourceStream: "events:journey-order",
+    sourceEventType: "JOURNEY_ORDER_CONFIRMED",
   });
 }
 
@@ -127,7 +185,9 @@ export async function startLoyaltyStorage(pool: Pool = createPostgresPool()): Pr
   await migrations.apply();
   const redis = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", { lazyConnect: true });
   const repository = new PostgresMemberRepository(pool);
-  const publisher = new RedisStreamEventPublisher(redis);
+  const publisher = new TransactionalOutboxPublisher(new OutboxAppender(pool));
+  const relay = new OutboxRelay(pool, redis, { onFailure: (error: unknown) => console.warn({ service: "loyalty-membership", dependency: "outbox", errorName: error instanceof Error ? error.name : "UnknownError" }) });
+  relay.start();
   const idempotencyStore = new PostgresIdempotencyStore(pool);
   return {
     repository,
@@ -136,10 +196,19 @@ export async function startLoyaltyStorage(pool: Pool = createPostgresPool()): Pr
     ready: () => checkPostgresReadiness(pool),
     runCommand: async (operation) => operation(new LoyaltyMembershipApplicationService(repository, publisher)),
     stop: async () => {
-      await publisher.close();
+      await relay.stop();
+      await redis.quit();
       await pool.end();
     },
   };
+}
+
+class TransactionalOutboxPublisher implements EventPublisher {
+  constructor(private readonly appender: OutboxAppender) {}
+
+  async publish(envelope: EventEnvelope): Promise<void> {
+    await this.appender.append(envelope);
+  }
 }
 
 export class PostgresMemberRepository implements MemberRepository {
@@ -153,6 +222,19 @@ export class PostgresMemberRepository implements MemberRepository {
   async findByAccountId(accountId: string): Promise<Member | undefined> {
     const result = await this.pool.query("SELECT snapshot FROM members WHERE account_id = $1", [accountId]);
     return rowToMember(result.rows[0]);
+  }
+
+  async findAccountIdByOrderId(orderId: string): Promise<string | undefined> {
+    const result = await this.pool.query("SELECT account_id FROM order_account_refs WHERE order_id = $1", [orderId]);
+    return result.rows[0]?.account_id as string | undefined;
+  }
+
+  async saveOrderAccountRef(orderId: string, accountId: string): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO order_account_refs (order_id, account_id) VALUES ($1, $2)
+       ON CONFLICT (order_id) DO UPDATE SET account_id = EXCLUDED.account_id`,
+      [orderId, accountId],
+    );
   }
 
   async save(member: Member): Promise<void> {
@@ -195,6 +277,21 @@ function stringField(value: unknown, field: string): string {
     throw new Error(`${field} is required`);
   }
   return value;
+}
+
+function optionalStringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function optionalSeatClass(value: unknown): SeatClass | undefined {
+  const seatClass = optionalStringField(value);
+  if (!seatClass) {
+    return undefined;
+  }
+  if (["SECOND_CLASS", "FIRST_CLASS", "BUSINESS_CLASS", "二等座", "一等座", "商务座"].includes(seatClass)) {
+    return seatClass as SeatClass;
+  }
+  throw new Error("seatClass is invalid");
 }
 
 function integerField(value: unknown, field: string): number {

--- a/services/loyalty-membership/src/bootstrap.ts
+++ b/services/loyalty-membership/src/bootstrap.ts
@@ -76,8 +76,8 @@ async function startSubscriber(application: LoyaltyMembershipApplicationService)
       if (envelope.eventType === "JourneyOrderCreated") {
         await handleJourneyOrderCreated(application, envelope);
       }
-      if (envelope.eventType === "JourneyOrderConfirmed") {
-        await handleJourneyOrderConfirmed(application, envelope);
+      if (envelope.eventType === "JourneyOrderCancelled") {
+        await handleJourneyOrderCancelled(application, envelope);
       }
       if (envelope.eventType === "PaymentCaptured") {
         await handlePaymentCaptured(application, envelope);
@@ -115,14 +115,20 @@ export async function handleJourneyOrderCreated(application: LoyaltyMembershipAp
 
 export async function handlePostSalesApplied(application: LoyaltyMembershipApplicationService, envelope: EventEnvelope): Promise<void> {
   const payload = envelope.payload;
-  const qualifyingPoints = typeof payload.qualifyingPoints === "number" ? payload.qualifyingPoints : 0;
-  if (qualifyingPoints === 0) {
+  const orderId = stringField(payload.orderId, "orderId");
+  const caseId = optionalStringField(payload.caseId) ?? optionalStringField(payload.postSalesCaseId);
+  if (!caseId) {
+    throw new Error("caseId is required");
+  }
+  const resultSummary = optionalObjectField(payload.resultSummary);
+  const refundDecision = optionalObjectField(payload.refundDecision);
+  if (!postSalesAppliedRefunded(resultSummary, refundDecision)) {
     return;
   }
   await application.deductQualifyingPointsForRefund({
-    accountId: stringField(payload.accountId, "accountId"),
-    occurredAt: new Date(typeof payload.appliedAt === "string" ? payload.appliedAt : envelope.occurredAt),
-    qualifyingPoints,
+    orderId,
+    occurredAt: new Date(envelope.occurredAt),
+    qualifyingPoints: optionalNonNegativeInteger(resultSummary?.qualifyingPoints ?? refundDecision?.qualifyingPoints, "qualifyingPoints"),
   });
 }
 
@@ -151,23 +157,25 @@ export async function handlePaymentCaptured(application: LoyaltyMembershipApplic
 
 export async function handleJourneyOrderConfirmed(application: LoyaltyMembershipApplicationService, envelope: EventEnvelope): Promise<void> {
   const payload = envelope.payload;
-  const orderId = stringField(payload.orderId, "orderId");
-  const accountId = stringField(payload.accountId, "accountId");
-  const monetarySummary = objectField(payload.monetarySummary, "monetarySummary");
-  const total = objectField(monetarySummary.total, "monetarySummary.total");
-  const minorUnits = integerField(total.minorUnits, "monetarySummary.total.minorUnits");
-  const currency = stringField(total.currency ?? monetarySummary.currency, "currency");
-  const confirmedAt = new Date(stringField(payload.confirmedAt, "confirmedAt"));
-  await application.accrueFromJourneyOrderConfirmed({
-    orderId,
-    accountId,
-    ticketPrice: { currency, minorUnits },
-    sourceEventId: envelope.eventId,
-    confirmedAt,
+  await application.recordTripFromJourneyOrderCreated({
+    orderId: stringField(payload.orderId, "orderId"),
+    accountId: stringField(payload.accountId, "accountId"),
+    occurredAt: new Date(typeof payload.confirmedAt === "string" ? payload.confirmedAt : envelope.occurredAt),
+    trips: 0,
     correlationId: envelope.correlationId,
     causationId: envelope.eventId,
-    sourceStream: "events:journey-order",
-    sourceEventType: "JOURNEY_ORDER_CONFIRMED",
+  });
+}
+
+export async function handleJourneyOrderCancelled(application: LoyaltyMembershipApplicationService, envelope: EventEnvelope): Promise<void> {
+  const payload = envelope.payload;
+  await application.restoreRedeemedPointsForCancelledOrder({
+    orderId: stringField(payload.orderId, "orderId"),
+    accountId: stringField(payload.accountId, "accountId"),
+    sourceEventId: envelope.eventId,
+    cancelledAt: new Date(typeof payload.cancelledAt === "string" ? payload.cancelledAt : envelope.occurredAt),
+    correlationId: envelope.correlationId,
+    causationId: envelope.eventId,
   });
 }
 
@@ -281,6 +289,35 @@ function stringField(value: unknown, field: string): string {
 
 function optionalStringField(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function optionalObjectField(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+}
+
+function optionalNonNegativeInteger(value: unknown, field: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = integerField(value, field);
+  if (parsed < 0) {
+    throw new Error(`${field} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function postSalesAppliedRefunded(resultSummary?: Record<string, unknown>, refundDecision?: Record<string, unknown>): boolean {
+  if (refundDecision) {
+    if (typeof refundDecision.refunded === "boolean") return refundDecision.refunded;
+    if (typeof refundDecision.eligible === "boolean") return refundDecision.eligible;
+    if (typeof refundDecision.kind === "string") return refundDecision.kind.toUpperCase().includes("REFUND");
+  }
+  if (!resultSummary) {
+    return true;
+  }
+  if (typeof resultSummary.refund === "boolean") return resultSummary.refund;
+  if (typeof resultSummary.refunded === "boolean") return resultSummary.refunded;
+  return true;
 }
 
 function optionalSeatClass(value: unknown): SeatClass | undefined {

--- a/services/loyalty-membership/src/domain.test.ts
+++ b/services/loyalty-membership/src/domain.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { DomainError, Member, PointsLedger, Tier, pointsForTicketPrice } from "./domain.js";
+import { DomainError, Member, PointsCalculator, PointsLedger, RedemptionPolicy, Tier, TierEvaluator, pointsForTicketPrice } from "./domain.js";
 
 function expectDomainError(fn: () => unknown, code: string): void {
   assert.throws(fn, (error: unknown) => error instanceof DomainError && error.code === code);
@@ -16,100 +16,129 @@ const confirmedOrder = {
   correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
 };
 
+describe("points calculation", () => {
+  it("calculates Gold business-class weekend earning for 500 CNY as 1800 points", () => {
+    assert.equal(PointsCalculator.calculate({
+      fare: { currency: "CNY", minorUnits: 50_000 },
+      seatClass: "BUSINESS_CLASS",
+      travelDate: new Date("2026-07-11T10:00:00.000Z"),
+      memberTier: "GOLD",
+    }), 1_800);
+  });
+
+  it("keeps the backward-compatible helper as one point per CNY", () => {
+    assert.equal(pointsForTicketPrice({ currency: "CNY", minorUnits: 0 }), 0);
+    assert.equal(pointsForTicketPrice({ currency: "CNY", minorUnits: 100 }), 1);
+    assert.equal(pointsForTicketPrice({ currency: "CNY", minorUnits: 200 }), 2);
+  });
+
+  it("rejects unsupported currencies", () => {
+    expectDomainError(() => pointsForTicketPrice({ currency: "USD", minorUnits: 10_000 }), "UNSUPPORTED_CURRENCY");
+  });
+});
+
 describe("Tier value object", () => {
-  it("maps rolling tier points to the baseline tiers", () => {
-    assert.equal(Tier.fromTierPoints(0).name, "BASIC");
-    assert.equal(Tier.fromTierPoints(5_000).name, "SILVER");
-    assert.equal(Tier.fromTierPoints(20_000).name, "GOLD");
-    assert.equal(Tier.fromTierPoints(50_000).name, "PLATINUM");
+  it("maps annual qualifying points and trips to tiers", () => {
+    assert.equal(Tier.fromTierPoints(0).name, "SILVER");
+    assert.equal(TierEvaluator.evaluate(3_000, 0), "GOLD");
+    assert.equal(TierEvaluator.evaluate(0, 30), "PLATINUM");
+    assert.equal(TierEvaluator.evaluate(25_000, 0), "DIAMOND");
   });
 });
 
 describe("PointsLedger", () => {
   it("accrues immutable points lots and rejects duplicate source facts", () => {
     const ledger = PointsLedger.empty();
-    const sourceFactRef = {
-      stream: "events:journey-order",
-      eventType: "JOURNEY_ORDER_CONFIRMED",
-      eventId: "evt-1",
-      aggregateId: "ord-1",
-      occurredAt: new Date("2026-07-10T10:00:00.000Z"),
-    };
+    const sourceFactRef = { stream: "events:payment", eventType: "PAYMENT_CAPTURED", eventId: "evt-1", aggregateId: "ord-1", occurredAt: new Date("2026-07-10T10:00:00.000Z") };
     const result = ledger.accrue({
       memberId: "mem-1",
       points: 10,
       sourceFactRef,
-      businessReason: { reasonType: "ORDER_ACCRUAL", reasonCode: "JOURNEY_ORDER_CONFIRMED", referenceType: "JOURNEY_ORDER", referenceId: "ord-1" },
+      businessReason: { reasonType: "ORDER_ACCRUAL", reasonCode: "TICKET_PURCHASE_CAPTURED", referenceType: "JOURNEY_ORDER", referenceId: "ord-1" },
       idempotencyKey: "mem-1:evt-1",
       occurredAt: sourceFactRef.occurredAt,
     });
 
     assert.equal(result.ledger.balance, 10);
     assert.equal(result.lot.remainingPoints, 10);
-    expectDomainError(
-      () => result.ledger.accrue({
-        memberId: "mem-1",
-        points: 10,
-        sourceFactRef,
-        businessReason: { reasonType: "ORDER_ACCRUAL", reasonCode: "JOURNEY_ORDER_CONFIRMED", referenceType: "JOURNEY_ORDER", referenceId: "ord-1" },
-        idempotencyKey: "mem-1:evt-1",
-        occurredAt: sourceFactRef.occurredAt,
-      }),
-      "POINTS_ALREADY_ACCRUED",
-    );
+    expectDomainError(() => result.ledger.accrue({ memberId: "mem-1", points: 10, sourceFactRef, businessReason: { reasonType: "ORDER_ACCRUAL", reasonCode: "TICKET_PURCHASE_CAPTURED", referenceType: "JOURNEY_ORDER", referenceId: "ord-1" }, idempotencyKey: "mem-1:evt-1", occurredAt: sourceFactRef.occurredAt }), "POINTS_ALREADY_ACCRUED");
+  });
+});
+
+describe("redemption policy", () => {
+  it("redeems 1000 points for a 10 CNY discount on a 200 CNY fare", () => {
+    assert.deepEqual(RedemptionPolicy.standard.apply({ memberId: "mem-1", orderId: "ord-1", pointsToRedeem: 1_000, fareAmountMinor: 20_000 }, 2_000), {
+      pointsDeducted: 1_000,
+      discountAmountMinor: 1_000,
+      remainingBalance: 1_000,
+    });
+  });
+
+  it("caps redemption at 50% of fare", () => {
+    assert.deepEqual(RedemptionPolicy.standard.apply({ memberId: "mem-1", orderId: "ord-1", pointsToRedeem: 20_000, fareAmountMinor: 20_000 }, 20_000), {
+      pointsDeducted: 10_000,
+      discountAmountMinor: 10_000,
+      remainingBalance: 10_000,
+    });
   });
 });
 
 describe("Member aggregate", () => {
-  it("accrues one point per 100 CNY from confirmed ticket price", () => {
+  it("accrues points from confirmed ticket price and emits PointsEarned", () => {
     const member = Member.enroll({ accountId: "acct-001", memberId: "mem-001", now: new Date("2026-07-10T09:00:00.000Z") });
 
     const { member: updated, events } = member.accrueFromConfirmedOrder(confirmedOrder, new Date("2026-07-10T10:01:00.000Z"));
 
-    assert.equal(updated.redeemablePoints, 5);
-    assert.equal(updated.tier, "BASIC");
-    assert.equal(events[0].type, "PointsAccrued");
-    assert.equal(events[0].points, 5);
-    assert.equal(events[0].sourceFactRef.eventType, "JOURNEY_ORDER_CONFIRMED");
-    assert.equal(events[0].sourceFactRef.aggregateId, "ord-001");
+    assert.equal(updated.redeemablePoints, 500);
+    assert.equal(updated.tier, "SILVER");
+    const earned = events[0];
+    assert.equal(earned.type, "PointsEarned");
+    if (earned.type !== "PointsEarned") throw new Error("expected PointsEarned");
+    assert.equal(earned.points, 500);
+    assert.equal(earned.sourceFactRef.eventType, "PAYMENT_CAPTURED");
+    assert.equal(earned.sourceFactRef.aggregateId, "ord-001");
   });
 
-  it("upgrades tier immediately when accrual crosses a threshold", () => {
-    let member = Member.enroll({ accountId: "acct-002", memberId: "mem-002" });
-    ({ member } = member.accrueFromConfirmedOrder({ ...confirmedOrder, accountId: "acct-002", sourceEventId: "evt-large", ticketPrice: { currency: "CNY", minorUnits: 50_000_000 } }));
+  it("upgrades immediately to PLATINUM when annual points reach 10000", () => {
+    const member = Member.enroll({ accountId: "acct-002", memberId: "mem-002" });
+    const { member: updated, events } = member.accrueFromConfirmedOrder({ ...confirmedOrder, accountId: "acct-002", sourceEventId: "evt-large", ticketPrice: { currency: "CNY", minorUnits: 1_000_000 } });
 
-    assert.equal(member.tier, "SILVER");
+    assert.equal(updated.tier, "PLATINUM");
+    assert.ok(events.some((event) => event.type === "MemberTierUpgraded"));
   });
 
-  it("redeems available points without making the balance negative", () => {
-    const member = Member.enroll({ accountId: "acct-003", memberId: "mem-003" });
-    const { member: accrued } = member.accrueFromConfirmedOrder({ ...confirmedOrder, accountId: "acct-003", sourceEventId: "evt-redeem", ticketPrice: { currency: "CNY", minorUnits: 100_000 } });
+  it("downgrades to SILVER at year end when not re-qualified", () => {
+    const platinum = Member.fromSnapshot({ ...Member.enroll({ accountId: "acct-003", memberId: "mem-003", now: new Date("2026-01-01T00:00:00.000Z") }).toSnapshot(), tier: "PLATINUM", membershipYears: [{ year: 2026, qualifyingPoints: 2_999, tripCount: 11, currentTier: "PLATINUM" }] });
 
-    const { member: redeemed, event } = accrued.redeem({ memberId: accrued.id, points: 6, redemptionId: "red-001" });
+    const { member: evaluated, events } = platinum.evaluateTierAtYearEnd(2026, new Date("2027-04-01T00:00:00.000Z"));
 
-    assert.equal(redeemed.redeemablePoints, 4);
-    assert.equal(event.type, "PointsRedeemed");
-    assert.equal(event.balanceAfter, 4);
+    assert.equal(evaluated.tier, "SILVER");
+    assert.ok(events.some((event) => event.type === "MemberTierDowngraded"));
+  });
+
+  it("redeems ticket points and reduces balance", () => {
+    const member = Member.enroll({ accountId: "acct-004", memberId: "mem-004" });
+    const { member: accrued } = member.accrueFromConfirmedOrder({ ...confirmedOrder, accountId: "acct-004", sourceEventId: "evt-redeem", ticketPrice: { currency: "CNY", minorUnits: 100_000 } });
+
+    const { member: redeemed, result } = accrued.redeemForTicket({ memberId: accrued.id, orderId: "ord-ticket", pointsToRedeem: 1_000, fareAmountMinor: 20_000, redemptionId: "red-001" });
+
+    assert.equal(result.discountAmountMinor, 1_000);
+    assert.equal(redeemed.redeemablePoints, 0);
     expectDomainError(() => redeemed.redeem({ memberId: redeemed.id, points: 5 }), "INSUFFICIENT_POINTS");
   });
 
+  it("expires points earned 25 months ago in monthly batch", () => {
+    const member = Member.enroll({ accountId: "acct-005", memberId: "mem-005" });
+    const { member: accrued } = member.accrueFromConfirmedOrder({ ...confirmedOrder, accountId: "acct-005", sourceEventId: "evt-expire", confirmedAt: new Date("2024-01-01T00:00:00.000Z"), ticketPrice: { currency: "CNY", minorUnits: 100_000 } });
+
+    const { member: expired, events } = accrued.expirePoints(new Date("2026-02-01T00:00:00.000Z"));
+
+    assert.equal(expired.redeemablePoints, 0);
+    assert.equal(events[0]?.type, "PointsExpired");
+  });
+
   it("keeps snapshots immutable", () => {
-    const member = Member.enroll({ accountId: "acct-004", memberId: "mem-004" });
-    const snapshot = member.toSnapshot();
-    assert.throws(() => {
-      (snapshot as { tier: string }).tier = "GOLD";
-    }, TypeError);
-  });
-});
-
-describe("points calculation", () => {
-  it("rounds down to one point per 100 CNY", () => {
-    assert.equal(pointsForTicketPrice({ currency: "CNY", minorUnits: 9_999 }), 0);
-    assert.equal(pointsForTicketPrice({ currency: "CNY", minorUnits: 10_000 }), 1);
-    assert.equal(pointsForTicketPrice({ currency: "CNY", minorUnits: 19_999 }), 1);
-  });
-
-  it("rejects unsupported currencies", () => {
-    expectDomainError(() => pointsForTicketPrice({ currency: "USD", minorUnits: 10_000 }), "UNSUPPORTED_CURRENCY");
+    const snapshot = Member.enroll({ accountId: "acct-006", memberId: "mem-006" }).toSnapshot();
+    assert.throws(() => { (snapshot as { tier: string }).tier = "GOLD"; }, TypeError);
   });
 });

--- a/services/loyalty-membership/src/domain.test.ts
+++ b/services/loyalty-membership/src/domain.test.ts
@@ -91,6 +91,7 @@ describe("Member aggregate", () => {
 
     assert.equal(updated.redeemablePoints, 500);
     assert.equal(updated.tier, "SILVER");
+    assert.equal(updated.toSnapshot().membershipYears?.[0]?.tripCount, 0);
     const earned = events[0];
     assert.equal(earned.type, "PointsEarned");
     if (earned.type !== "PointsEarned") throw new Error("expected PointsEarned");
@@ -116,7 +117,7 @@ describe("Member aggregate", () => {
     assert.ok(events.some((event) => event.type === "MemberTierDowngraded"));
   });
 
-  it("redeems ticket points and reduces balance", () => {
+  it("redeems ticket points and restores them when the order is cancelled", () => {
     const member = Member.enroll({ accountId: "acct-004", memberId: "mem-004" });
     const { member: accrued } = member.accrueFromConfirmedOrder({ ...confirmedOrder, accountId: "acct-004", sourceEventId: "evt-redeem", ticketPrice: { currency: "CNY", minorUnits: 100_000 } });
 
@@ -125,6 +126,12 @@ describe("Member aggregate", () => {
     assert.equal(result.discountAmountMinor, 1_000);
     assert.equal(redeemed.redeemablePoints, 0);
     expectDomainError(() => redeemed.redeem({ memberId: redeemed.id, points: 5 }), "INSUFFICIENT_POINTS");
+
+    const { member: restored, events } = redeemed.restoreRedeemedTicketPoints({ orderId: "ord-ticket", sourceEventId: "evt-cancel", cancelledAt: new Date("2026-07-10T10:05:00.000Z") });
+
+    assert.equal(restored.redeemablePoints, 1_000);
+    assert.equal(events[0]?.type, "PointsRestored");
+    assert.equal(restored.redeemedTicketPointsForOrder("ord-ticket"), 0);
   });
 
   it("expires points earned 25 months ago in monthly batch", () => {

--- a/services/loyalty-membership/src/domain.ts
+++ b/services/loyalty-membership/src/domain.ts
@@ -110,6 +110,20 @@ export type PointsExpired = Readonly<{
   correlationId?: string;
 }>;
 
+
+export type PointsRestored = Readonly<{
+  type: "PointsRestored";
+  occurredAt: Date;
+  memberId: MemberId;
+  accountId: AccountId;
+  points: number;
+  orderId: string;
+  sourceFactRef: SourceFactRef;
+  businessReason: BusinessReason;
+  balanceAfter: number;
+  correlationId?: string;
+}>;
+
 export type MemberTierUpgraded = Readonly<{
   type: "MemberTierUpgraded";
   occurredAt: Date;
@@ -146,7 +160,7 @@ export type TierEvaluationCompleted = Readonly<{
   correlationId?: string;
 }>;
 
-export type LoyaltyDomainEvent = PointsEarned | PointsRedeemed | PointsExpired | MemberTierUpgraded | MemberTierDowngraded | TierEvaluationCompleted;
+export type LoyaltyDomainEvent = PointsEarned | PointsRedeemed | PointsRestored | PointsExpired | MemberTierUpgraded | MemberTierDowngraded | TierEvaluationCompleted;
 
 export type AccruePointsCommand = Readonly<{
   orderId: string;
@@ -267,6 +281,15 @@ export class PointsLedger {
     return { ledger: new PointsLedger([...this.entries, entry], consumeLots(this.lots, input.points)), entry };
   }
 
+  restore(input: { memberId: MemberId; points: number; sourceFactRef: SourceFactRef; businessReason: BusinessReason; idempotencyKey: string; occurredAt: Date; expiresAt?: Date }): { ledger: PointsLedger; entry: PointsLedgerEntrySnapshot; lot: PointsLotSnapshot } {
+    assertPositiveInteger(input.points, "points");
+    if (this.hasSourceFact(input.sourceFactRef.eventId) || this.entries.some((entry) => entry.idempotencyKey === input.idempotencyKey)) throw new DomainError("POINTS_ALREADY_RESTORED", "Source fact has already restored redeemed points");
+    const expiresAt = input.expiresAt ?? addUtcMonths(input.occurredAt, 24);
+    const entry: PointsLedgerEntrySnapshot = freeze({ entryId: newLedgerEntryId(), memberId: input.memberId, type: "ADJUSTED", points: input.points, sourceFactRef: cloneSourceFact(input.sourceFactRef), businessReason: input.businessReason, idempotencyKey: input.idempotencyKey, occurredAt: new Date(input.occurredAt), expiresAt });
+    const lot: PointsLotSnapshot = freeze({ lotId: newPointsLotId(), memberId: input.memberId, sourceEntryId: entry.entryId, originalPoints: input.points, remainingPoints: input.points, tierEligiblePoints: 0, validFrom: new Date(input.occurredAt), expiresAt });
+    return { ledger: new PointsLedger([...this.entries, entry], [...this.lots, lot]), entry, lot };
+  }
+
   expirePoints(memberId: MemberId, now: Date): { ledger: PointsLedger; expired: readonly ExpiredBatch[] } {
     const expiredLots = this.lots.filter((lot) => lot.remainingPoints > 0 && lot.expiresAt <= now);
     if (expiredLots.length === 0) return { ledger: this, expired: [] };
@@ -310,7 +333,7 @@ export class Member {
     const businessReason = freeze({ reasonType: "ORDER_ACCRUAL" as const, reasonCode: command.sourceEventType ?? "PAYMENT_CAPTURED", referenceType: "JOURNEY_ORDER", referenceId: command.orderId });
     const { ledger: accruedLedger, lot } = ledger.accrue({ memberId: this.id, points, tierEligiblePoints: points, sourceFactRef, businessReason, idempotencyKey: `${this.id}:${command.sourceEventId}`, occurredAt: command.confirmedAt, expiresAt: addUtcMonths(command.confirmedAt, this.snapshot.tier === "DIAMOND" ? 36 : 24) });
     const year = command.confirmedAt.getUTCFullYear();
-    const membershipYears = upsertMembershipYear(this.membershipYears(), year, (membershipYear) => freeze({ ...membershipYear, qualifyingPoints: membershipYear.qualifyingPoints + points, tripCount: membershipYear.tripCount + (command.tripCount ?? 1) }));
+    const membershipYears = upsertMembershipYear(this.membershipYears(), year, (membershipYear) => freeze({ ...membershipYear, qualifyingPoints: membershipYear.qualifyingPoints + points, tripCount: membershipYear.tripCount + (command.tripCount ?? 0) }));
     const currentYear = membershipYears.find((membershipYear) => membershipYear.year === year) ?? newMembershipYear(year, this.snapshot.tier);
     const targetTier = Tier.of(TierEvaluator.evaluate(currentYear.qualifyingPoints, currentYear.tripCount));
     const currentTier = Tier.of(this.snapshot.tier);
@@ -338,6 +361,24 @@ export class Member {
     return { member: new Member(freeze({ ...this.snapshot, tier: nextTier, updatedAt: now, membershipYears: nextMembershipYears })), events };
   }
 
+  qualifyingPointsForOrder(orderId: string): number {
+    required(orderId, "orderId");
+    return this.snapshot.ledger
+      .filter((entry) => entry.type === "EARNED" && entry.businessReason.referenceType === "JOURNEY_ORDER" && entry.businessReason.referenceId === orderId)
+      .reduce((total, entry) => total + Math.max(0, entry.points), 0);
+  }
+
+  redeemedTicketPointsForOrder(orderId: string): number {
+    required(orderId, "orderId");
+    const ticketRedemptions = this.snapshot.ledger
+      .filter((entry) => entry.type === "REDEEMED" && entry.businessReason.referenceType === "JOURNEY_ORDER" && entry.businessReason.referenceId === orderId)
+      .reduce((total, entry) => total + Math.max(0, -entry.points), 0);
+    const restoredRedemptions = this.snapshot.ledger
+      .filter((entry) => entry.type === "ADJUSTED" && entry.businessReason.reasonCode === "ORDER_CANCELLED_POINTS_RESTORED" && entry.businessReason.referenceType === "JOURNEY_ORDER" && entry.businessReason.referenceId === orderId)
+      .reduce((total, entry) => total + Math.max(0, entry.points), 0);
+    return Math.max(0, ticketRedemptions - restoredRedemptions);
+  }
+
   adjustQualifyingPointsForRefund(input: { occurredAt: Date; qualifyingPoints: number }, now = new Date()): Member {
     this.assertActive();
     assertWholeNonNegative(input.qualifyingPoints, "qualifyingPoints");
@@ -345,6 +386,22 @@ export class Member {
     const membershipYears = upsertMembershipYear(this.membershipYears(), year, (membershipYear) => freeze({ ...membershipYear, qualifyingPoints: Math.max(0, membershipYear.qualifyingPoints - input.qualifyingPoints) }));
     const currentYear = membershipYears.find((membershipYear) => membershipYear.year === year) ?? newMembershipYear(year, this.snapshot.tier);
     return new Member(freeze({ ...this.snapshot, tierPoints: currentYear.qualifyingPoints, updatedAt: now, membershipYears }));
+  }
+
+  restoreRedeemedTicketPoints(input: { orderId: string; sourceEventId: string; cancelledAt: Date; correlationId?: string; sourceStream?: string; sourceEventType?: string }, now = new Date()): { member: Member; events: readonly PointsRestored[] } {
+    this.assertActive();
+    const orderId = required(input.orderId, "orderId");
+    const sourceEventId = required(input.sourceEventId, "sourceEventId");
+    const ledger = PointsLedger.fromSnapshots(this.snapshot.ledger, this.snapshot.lots);
+    if (ledger.hasSourceFact(sourceEventId)) return { member: this, events: [] };
+    const points = this.redeemedTicketPointsForOrder(orderId);
+    if (points === 0) return { member: this, events: [] };
+    const sourceFactRef = freeze({ stream: input.sourceStream ?? "events:journey-order", eventType: input.sourceEventType ?? "JOURNEY_ORDER_CANCELLED", eventId: sourceEventId, aggregateId: orderId, occurredAt: input.cancelledAt });
+    const businessReason = freeze({ reasonType: "REVERSAL" as const, reasonCode: "ORDER_CANCELLED_POINTS_RESTORED", referenceType: "JOURNEY_ORDER", referenceId: orderId });
+    const { ledger: restoredLedger } = ledger.restore({ memberId: this.id, points, sourceFactRef, businessReason, idempotencyKey: `${this.id}:restore:${orderId}:${sourceEventId}`, occurredAt: input.cancelledAt, expiresAt: addUtcMonths(input.cancelledAt, this.snapshot.tier === "DIAMOND" ? 36 : 24) });
+    const ledgerSnapshot = restoredLedger.toSnapshot();
+    const nextSnapshot = freeze({ ...this.snapshot, redeemablePoints: restoredLedger.balance, lifetimePoints: restoredLedger.lifetimePoints, updatedAt: now, ledger: ledgerSnapshot.entries, lots: ledgerSnapshot.lots });
+    return { member: new Member(nextSnapshot), events: [freeze({ type: "PointsRestored", occurredAt: now, memberId: this.id, accountId: this.accountId, points, orderId, sourceFactRef, businessReason, balanceAfter: restoredLedger.balance, correlationId: input.correlationId })] };
   }
 
   redeem(command: RedeemPointsCommand, now = new Date()): { member: Member; event: PointsRedeemed } {

--- a/services/loyalty-membership/src/domain.ts
+++ b/services/loyalty-membership/src/domain.ts
@@ -7,34 +7,21 @@ export type PointsLotId = string;
 export type RedemptionId = string;
 
 export type MembershipStatus = "ACTIVE" | "SUSPENDED" | "CLOSED";
-export type TierName = "BASIC" | "SILVER" | "GOLD" | "PLATINUM";
-export type LedgerEntryType = "ACCRUAL" | "REDEMPTION" | "REVERSAL";
+export type TierName = "SILVER" | "GOLD" | "PLATINUM" | "DIAMOND";
+export type SeatClass = "SECOND_CLASS" | "FIRST_CLASS" | "BUSINESS_CLASS" | "二等座" | "一等座" | "商务座";
+export type LedgerEntryType = "EARNED" | "REDEEMED" | "EXPIRED" | "ADJUSTED";
 
 export class DomainError extends Error {
-  constructor(
-    public readonly code: string,
-    message: string,
-  ) {
+  constructor(public readonly code: string, message: string) {
     super(message);
     this.name = "DomainError";
   }
 }
 
-export type Money = Readonly<{
-  currency: string;
-  minorUnits: number;
-}>;
-
-export type SourceFactRef = Readonly<{
-  stream: string;
-  eventType: string;
-  eventId: string;
-  aggregateId: string;
-  occurredAt: Date;
-}>;
-
+export type Money = Readonly<{ currency: string; minorUnits: number }>;
+export type SourceFactRef = Readonly<{ stream: string; eventType: string; eventId: string; aggregateId: string; occurredAt: Date }>;
 export type BusinessReason = Readonly<{
-  reasonType: "ORDER_ACCRUAL" | "REDEMPTION" | "REVERSAL";
+  reasonType: "ORDER_ACCRUAL" | "REDEMPTION" | "REVERSAL" | "EXPIRY" | "REFUND_ADJUSTMENT" | "TRIP_COUNT";
   reasonCode: string;
   referenceType: string;
   referenceId: string;
@@ -64,6 +51,8 @@ export type PointsLotSnapshot = Readonly<{
   expiresAt: Date;
 }>;
 
+export type MembershipYearSnapshot = Readonly<{ year: number; qualifyingPoints: number; tripCount: number; currentTier: TierName; evaluationDate?: Date }>;
+
 export type MemberSnapshot = Readonly<{
   memberId: MemberId;
   accountId: AccountId;
@@ -76,20 +65,22 @@ export type MemberSnapshot = Readonly<{
   updatedAt: Date;
   ledger: readonly PointsLedgerEntrySnapshot[];
   lots: readonly PointsLotSnapshot[];
+  membershipYears?: readonly MembershipYearSnapshot[];
 }>;
 
-export type PointsAccrued = Readonly<{
-  type: "PointsAccrued";
+export type PointsEarned = Readonly<{
+  type: "PointsEarned";
   occurredAt: Date;
   memberId: MemberId;
   accountId: AccountId;
   points: number;
-  tierPoints: number;
-  balanceAfter: number;
+  sourceRef: string;
   sourceFactRef: SourceFactRef;
   businessReason: BusinessReason;
   lotId: PointsLotId;
   expiresAt: Date;
+  balanceAfter: number;
+  qualifyingPoints: number;
   correlationId?: string;
 }>;
 
@@ -100,24 +91,62 @@ export type PointsRedeemed = Readonly<{
   accountId: AccountId;
   redemptionId: RedemptionId;
   points: number;
+  orderId?: string;
+  discountAmountMinor?: number;
+  remainingBalance: number;
   balanceAfter: number;
   businessReason: BusinessReason;
   correlationId?: string;
 }>;
 
-export type MembershipTierChanged = Readonly<{
-  type: "MembershipTierChanged";
+export type PointsExpired = Readonly<{
+  type: "PointsExpired";
   occurredAt: Date;
   memberId: MemberId;
   accountId: AccountId;
-  fromTier: TierName;
-  toTier: TierName;
-  tierPoints: number;
-  reason: "ACCRUAL" | "EVALUATION" | "MANUAL_OVERRIDE";
+  points: number;
+  batchId: PointsLotId;
+  balanceAfter: number;
   correlationId?: string;
 }>;
 
-export type LoyaltyDomainEvent = PointsAccrued | PointsRedeemed | MembershipTierChanged;
+export type MemberTierUpgraded = Readonly<{
+  type: "MemberTierUpgraded";
+  occurredAt: Date;
+  memberId: MemberId;
+  accountId: AccountId;
+  oldTier: TierName;
+  newTier: TierName;
+  qualifyingPoints: number;
+  trips: number;
+  correlationId?: string;
+}>;
+
+export type MemberTierDowngraded = Readonly<{
+  type: "MemberTierDowngraded";
+  occurredAt: Date;
+  memberId: MemberId;
+  accountId: AccountId;
+  oldTier: TierName;
+  newTier: TierName;
+  qualifyingPoints: number;
+  trips: number;
+  correlationId?: string;
+}>;
+
+export type TierEvaluationCompleted = Readonly<{
+  type: "TierEvaluationCompleted";
+  occurredAt: Date;
+  memberId: MemberId;
+  accountId: AccountId;
+  evaluationYear: number;
+  resultingTier: TierName;
+  qualifyingPoints: number;
+  trips: number;
+  correlationId?: string;
+}>;
+
+export type LoyaltyDomainEvent = PointsEarned | PointsRedeemed | PointsExpired | MemberTierUpgraded | MemberTierDowngraded | TierEvaluationCompleted;
 
 export type AccruePointsCommand = Readonly<{
   orderId: string;
@@ -125,415 +154,280 @@ export type AccruePointsCommand = Readonly<{
   ticketPrice: Money;
   sourceEventId: string;
   confirmedAt: Date;
+  seatClass?: SeatClass;
+  travelDate?: Date;
+  routeCode?: string;
+  routeName?: string;
+  isHoliday?: boolean;
+  memberBirthDate?: Date;
+  tripCount?: number;
+  sourceStream?: string;
+  sourceEventType?: string;
   correlationId?: string;
 }>;
 
-export type RedeemPointsCommand = Readonly<{
-  memberId: MemberId;
-  points: number;
-  redemptionId?: RedemptionId;
-  reasonCode?: string;
-  correlationId?: string;
-}>;
+export type RedeemPointsCommand = Readonly<{ memberId: MemberId; points: number; redemptionId?: RedemptionId; reasonCode?: string; correlationId?: string }>;
+export type RedemptionRequest = Readonly<{ memberId: MemberId; orderId: string; pointsToRedeem: number; fareAmountMinor: number }>;
+export type RedemptionResult = Readonly<{ pointsDeducted: number; discountAmountMinor: number; remainingBalance: number }>;
+export type ExpiredBatch = Readonly<{ batchId: PointsLotId; points: number; earnedAt: Date; expiresAt: Date }>;
+export type ExpiringBatch = Readonly<{ batchId: PointsLotId; pointsAmount: number; expiryDate: Date }>;
+export type PointsEarningRule = Readonly<{ seatClassMultiplier: number; bonusConditions: readonly Readonly<{ name: string; multiplier: number }>[]; tierMultiplier: number }>;
+export type PointsCalculationInput = Readonly<{ fare: Money; seatClass: SeatClass; travelDate: Date; memberTier: TierName; routeCode?: string; routeName?: string; isHoliday?: boolean; memberBirthDate?: Date }>;
+export type TierPolicy = Readonly<{ tierName: TierName; minQualifyingPoints: number; minTrips: number; benefits: readonly string[] }>;
+export type RedemptionPolicySnapshot = Readonly<{ pointsToCurrencyRate: number; minRedemption: number; maxFarePercentage: number }>;
 
-const TIER_ORDER: readonly TierName[] = ["BASIC", "SILVER", "GOLD", "PLATINUM"];
-const TIER_THRESHOLDS: Readonly<Record<TierName, number>> = {
-  BASIC: 0,
-  SILVER: 5_000,
-  GOLD: 20_000,
-  PLATINUM: 50_000,
-};
+const TIER_ORDER: readonly TierName[] = ["SILVER", "GOLD", "PLATINUM", "DIAMOND"];
+const TIER_POLICIES: readonly TierPolicy[] = [
+  { tierName: "SILVER", minQualifyingPoints: 0, minTrips: 0, benefits: ["base earning"] },
+  { tierName: "GOLD", minQualifyingPoints: 3_000, minTrips: 12, benefits: ["1.2x points"] },
+  { tierName: "PLATINUM", minQualifyingPoints: 10_000, minTrips: 30, benefits: ["1.5x points"] },
+  { tierName: "DIAMOND", minQualifyingPoints: 25_000, minTrips: 60, benefits: ["2x points", "36 month points expiry"] },
+];
 
 export class Tier {
   private constructor(public readonly name: TierName) {}
-
   static of(name: TierName): Tier {
-    if (!TIER_ORDER.includes(name)) {
-      throw new DomainError("INVALID_TIER", `Unsupported membership tier ${name}`);
-    }
+    if (!TIER_ORDER.includes(name)) throw new DomainError("INVALID_TIER", `Unsupported membership tier ${name}`);
     return new Tier(name);
   }
+  static fromTierPoints(tierPoints: number): Tier { return new Tier(TierEvaluator.evaluate(tierPoints, 0)); }
+  isHigherThan(other: Tier): boolean { return TIER_ORDER.indexOf(this.name) > TIER_ORDER.indexOf(other.name); }
+  isLowerThan(other: Tier): boolean { return TIER_ORDER.indexOf(this.name) < TIER_ORDER.indexOf(other.name); }
+}
 
-  static fromTierPoints(tierPoints: number): Tier {
-    assertWholeNonNegative(tierPoints, "tierPoints");
-    if (tierPoints >= TIER_THRESHOLDS.PLATINUM) return new Tier("PLATINUM");
-    if (tierPoints >= TIER_THRESHOLDS.GOLD) return new Tier("GOLD");
-    if (tierPoints >= TIER_THRESHOLDS.SILVER) return new Tier("SILVER");
-    return new Tier("BASIC");
+export class TierEvaluator {
+  static evaluate(yearlyQualifyingPoints: number, yearlyTrips: number): TierName {
+    assertWholeNonNegative(yearlyQualifyingPoints, "yearlyQualifyingPoints");
+    assertWholeNonNegative(yearlyTrips, "yearlyTrips");
+    for (const policy of [...TIER_POLICIES].reverse()) {
+      if (yearlyQualifyingPoints >= policy.minQualifyingPoints || yearlyTrips >= policy.minTrips) return policy.tierName;
+    }
+    return "SILVER";
   }
+  static policies(): readonly TierPolicy[] { return TIER_POLICIES.map((policy) => freeze({ ...policy, benefits: [...policy.benefits] })); }
+}
 
-  isHigherThan(other: Tier): boolean {
-    return TIER_ORDER.indexOf(this.name) > TIER_ORDER.indexOf(other.name);
+export class PointsCalculator {
+  static calculate(input: PointsCalculationInput): number { return calculatePoints(input).points; }
+  static earningRule(input: Omit<PointsCalculationInput, "fare">): PointsEarningRule {
+    return freeze({ seatClassMultiplier: seatClassMultiplier(input.seatClass), bonusConditions: bonusMultipliers(input), tierMultiplier: tierMultiplier(input.memberTier) });
   }
 }
 
+export class RedemptionPolicy {
+  static readonly standard = new RedemptionPolicy({ pointsToCurrencyRate: 100, minRedemption: 500, maxFarePercentage: 0.5 });
+  constructor(private readonly snapshot: RedemptionPolicySnapshot) {}
+  maxRedeemablePoints(fareAmountMinor: number, availableBalance = Number.MAX_SAFE_INTEGER): number {
+    assertWholeNonNegative(fareAmountMinor, "fareAmountMinor");
+    assertWholeNonNegative(availableBalance, "availableBalance");
+    return Math.min(Math.floor((Math.floor(fareAmountMinor * this.snapshot.maxFarePercentage) / 100) * this.snapshot.pointsToCurrencyRate), availableBalance);
+  }
+  apply(request: RedemptionRequest, availableBalance: number): RedemptionResult {
+    required(request.memberId, "memberId");
+    required(request.orderId, "orderId");
+    assertPositiveInteger(request.pointsToRedeem, "pointsToRedeem");
+    assertWholeNonNegative(request.fareAmountMinor, "fareAmountMinor");
+    assertWholeNonNegative(availableBalance, "availableBalance");
+    if (request.pointsToRedeem < this.snapshot.minRedemption) throw new DomainError("REDEMPTION_BELOW_MINIMUM", `At least ${this.snapshot.minRedemption} points must be redeemed`);
+    if (availableBalance < this.snapshot.minRedemption) throw new DomainError("INSUFFICIENT_POINTS", "Available points cannot cover minimum redemption");
+    const pointsDeducted = Math.min(request.pointsToRedeem, this.maxRedeemablePoints(request.fareAmountMinor, availableBalance));
+    if (pointsDeducted < this.snapshot.minRedemption) throw new DomainError("REDEMPTION_CAP_BELOW_MINIMUM", "Fare cap is below the minimum redemption amount");
+    return freeze({ pointsDeducted, discountAmountMinor: this.pointsToCurrencyMinor(pointsDeducted), remainingBalance: availableBalance - pointsDeducted });
+  }
+  pointsToCurrencyMinor(points: number): number { assertWholeNonNegative(points, "points"); return Math.floor((points / this.snapshot.pointsToCurrencyRate) * 100); }
+  toSnapshot(): RedemptionPolicySnapshot { return freeze({ ...this.snapshot }); }
+}
+
 export class PointsLedger {
-  private constructor(
-    private readonly entries: readonly PointsLedgerEntrySnapshot[],
-    private readonly lots: readonly PointsLotSnapshot[],
-  ) {}
+  private constructor(private readonly entries: readonly PointsLedgerEntrySnapshot[], private readonly lots: readonly PointsLotSnapshot[]) {}
+  static empty(): PointsLedger { return new PointsLedger([], []); }
+  static fromSnapshots(entries: readonly PointsLedgerEntrySnapshot[], lots: readonly PointsLotSnapshot[]): PointsLedger { return new PointsLedger(entries.map(cloneLedgerEntry), lots.map(cloneLot)); }
+  get balance(): number { return this.lots.reduce((total, lot) => total + lot.remainingPoints, 0); }
+  get lifetimePoints(): number { return this.entries.filter((entry) => entry.type === "EARNED").reduce((total, entry) => total + entry.points, 0); }
+  tierPoints(at: Date = new Date()): number { return this.yearlyQualifyingPoints(at.getUTCFullYear()); }
+  yearlyQualifyingPoints(year: number): number { return this.lots.filter((lot) => lot.validFrom.getUTCFullYear() === year).reduce((total, lot) => total + lot.tierEligiblePoints, 0); }
+  hasSourceFact(sourceEventId: string): boolean { return this.entries.some((entry) => entry.sourceFactRef.eventId === sourceEventId); }
 
-  static empty(): PointsLedger {
-    return new PointsLedger([], []);
-  }
-
-  static fromSnapshots(entries: readonly PointsLedgerEntrySnapshot[], lots: readonly PointsLotSnapshot[]): PointsLedger {
-    return new PointsLedger(entries.map(cloneLedgerEntry), lots.map(cloneLot));
-  }
-
-  get balance(): number {
-    return this.lots.reduce((total, lot) => total + lot.remainingPoints, 0);
-  }
-
-  get lifetimePoints(): number {
-    return this.entries.filter((entry) => entry.type === "ACCRUAL").reduce((total, entry) => total + entry.points, 0);
-  }
-
-  tierPoints(at: Date = new Date()): number {
-    const windowStart = new Date(at);
-    windowStart.setUTCFullYear(windowStart.getUTCFullYear() - 1);
-    return this.lots
-      .filter((lot) => lot.validFrom >= windowStart && lot.validFrom <= at)
-      .reduce((total, lot) => total + lot.tierEligiblePoints, 0);
-  }
-
-  hasSourceFact(sourceEventId: string): boolean {
-    return this.entries.some((entry) => entry.sourceFactRef.eventId === sourceEventId);
-  }
-
-  accrue(input: {
-    memberId: MemberId;
-    points: number;
-    sourceFactRef: SourceFactRef;
-    businessReason: BusinessReason;
-    idempotencyKey: string;
-    occurredAt: Date;
-    expiresAt?: Date;
-  }): { ledger: PointsLedger; entry: PointsLedgerEntrySnapshot; lot: PointsLotSnapshot } {
+  accrue(input: { memberId: MemberId; points: number; tierEligiblePoints?: number; sourceFactRef: SourceFactRef; businessReason: BusinessReason; idempotencyKey: string; occurredAt: Date; expiresAt?: Date }): { ledger: PointsLedger; entry: PointsLedgerEntrySnapshot; lot: PointsLotSnapshot } {
     assertPositiveInteger(input.points, "points");
-    if (this.hasSourceFact(input.sourceFactRef.eventId) || this.entries.some((entry) => entry.idempotencyKey === input.idempotencyKey)) {
-      throw new DomainError("POINTS_ALREADY_ACCRUED", "Source fact has already produced a ledger entry");
-    }
-    const expiresAt = input.expiresAt ?? addUtcYears(input.occurredAt, 2);
-    const entry: PointsLedgerEntrySnapshot = freeze({
-      entryId: newLedgerEntryId(),
-      memberId: input.memberId,
-      type: "ACCRUAL",
-      points: input.points,
-      sourceFactRef: cloneSourceFact(input.sourceFactRef),
-      businessReason: input.businessReason,
-      idempotencyKey: input.idempotencyKey,
-      occurredAt: new Date(input.occurredAt),
-      expiresAt,
-    });
-    const lot: PointsLotSnapshot = freeze({
-      lotId: newPointsLotId(),
-      memberId: input.memberId,
-      sourceEntryId: entry.entryId,
-      originalPoints: input.points,
-      remainingPoints: input.points,
-      tierEligiblePoints: input.points,
-      validFrom: new Date(input.occurredAt),
-      expiresAt,
-    });
+    if (this.hasSourceFact(input.sourceFactRef.eventId) || this.entries.some((entry) => entry.idempotencyKey === input.idempotencyKey)) throw new DomainError("POINTS_ALREADY_ACCRUED", "Source fact has already produced a ledger entry");
+    const tierEligiblePoints = input.tierEligiblePoints ?? input.points;
+    assertWholeNonNegative(tierEligiblePoints, "tierEligiblePoints");
+    const expiresAt = input.expiresAt ?? addUtcMonths(input.occurredAt, 24);
+    const entry: PointsLedgerEntrySnapshot = freeze({ entryId: newLedgerEntryId(), memberId: input.memberId, type: "EARNED", points: input.points, sourceFactRef: cloneSourceFact(input.sourceFactRef), businessReason: input.businessReason, idempotencyKey: input.idempotencyKey, occurredAt: new Date(input.occurredAt), expiresAt });
+    const lot: PointsLotSnapshot = freeze({ lotId: newPointsLotId(), memberId: input.memberId, sourceEntryId: entry.entryId, originalPoints: input.points, remainingPoints: input.points, tierEligiblePoints, validFrom: new Date(input.occurredAt), expiresAt });
     return { ledger: new PointsLedger([...this.entries, entry], [...this.lots, lot]), entry, lot };
   }
 
-  redeem(input: {
-    memberId: MemberId;
-    points: number;
-    redemptionId: RedemptionId;
-    businessReason: BusinessReason;
-    occurredAt: Date;
-  }): { ledger: PointsLedger; entry: PointsLedgerEntrySnapshot } {
+  redeem(input: { memberId: MemberId; points: number; redemptionId: RedemptionId; businessReason: BusinessReason; occurredAt: Date }): { ledger: PointsLedger; entry: PointsLedgerEntrySnapshot } {
     assertPositiveInteger(input.points, "points");
-    if (input.points > this.balance) {
-      throw new DomainError("INSUFFICIENT_POINTS", "Available points cannot cover redemption");
-    }
-    const sourceFactRef: SourceFactRef = freeze({
-      stream: "commands:loyalty-membership",
-      eventType: "POINTS_REDEMPTION_REQUESTED",
-      eventId: input.redemptionId,
-      aggregateId: input.memberId,
-      occurredAt: new Date(input.occurredAt),
-    });
-    const entry: PointsLedgerEntrySnapshot = freeze({
-      entryId: newLedgerEntryId(),
-      memberId: input.memberId,
-      type: "REDEMPTION",
-      points: -input.points,
-      sourceFactRef,
-      businessReason: input.businessReason,
-      idempotencyKey: `${input.memberId}:${input.redemptionId}`,
-      occurredAt: new Date(input.occurredAt),
-    });
+    if (input.points > this.balance) throw new DomainError("INSUFFICIENT_POINTS", "Available points cannot cover redemption");
+    const sourceFactRef: SourceFactRef = freeze({ stream: "commands:loyalty-membership", eventType: "POINTS_REDEMPTION_REQUESTED", eventId: input.redemptionId, aggregateId: input.memberId, occurredAt: new Date(input.occurredAt) });
+    const entry: PointsLedgerEntrySnapshot = freeze({ entryId: newLedgerEntryId(), memberId: input.memberId, type: "REDEEMED", points: -input.points, sourceFactRef, businessReason: input.businessReason, idempotencyKey: `${input.memberId}:${input.redemptionId}`, occurredAt: new Date(input.occurredAt) });
     return { ledger: new PointsLedger([...this.entries, entry], consumeLots(this.lots, input.points)), entry };
   }
 
-  toSnapshot(): Readonly<{ entries: readonly PointsLedgerEntrySnapshot[]; lots: readonly PointsLotSnapshot[] }> {
-    return freeze({
-      entries: this.entries.map(cloneLedgerEntry),
-      lots: this.lots.map(cloneLot),
-    });
+  expirePoints(memberId: MemberId, now: Date): { ledger: PointsLedger; expired: readonly ExpiredBatch[] } {
+    const expiredLots = this.lots.filter((lot) => lot.remainingPoints > 0 && lot.expiresAt <= now);
+    if (expiredLots.length === 0) return { ledger: this, expired: [] };
+    const entries = expiredLots.map((lot) => freeze({ entryId: newLedgerEntryId(), memberId, type: "EXPIRED" as const, points: -lot.remainingPoints, sourceFactRef: freeze({ stream: "batch:loyalty-membership", eventType: "POINTS_EXPIRY_BATCH", eventId: `${lot.lotId}:${now.toISOString()}`, aggregateId: memberId, occurredAt: new Date(now) }), businessReason: freeze({ reasonType: "EXPIRY" as const, reasonCode: "POINTS_EXPIRED", referenceType: "POINTS_LOT", referenceId: lot.lotId }), idempotencyKey: `${memberId}:expire:${lot.lotId}:${now.toISOString()}`, occurredAt: new Date(now) }));
+    const expired = expiredLots.map((lot) => freeze({ batchId: lot.lotId, points: lot.remainingPoints, earnedAt: lot.validFrom, expiresAt: lot.expiresAt }));
+    const expiredIds = new Set(expiredLots.map((lot) => lot.lotId));
+    const lots = this.lots.map((lot) => expiredIds.has(lot.lotId) ? freeze({ ...lot, remainingPoints: 0 }) : cloneLot(lot));
+    return { ledger: new PointsLedger([...this.entries, ...entries], lots), expired };
   }
+
+  getExpiringWithin(days: number, now = new Date()): readonly ExpiringBatch[] {
+    assertWholeNonNegative(days, "days");
+    const until = new Date(now); until.setUTCDate(until.getUTCDate() + days);
+    return this.lots.filter((lot) => lot.remainingPoints > 0 && lot.expiresAt > now && lot.expiresAt <= until).sort((left, right) => left.expiresAt.getTime() - right.expiresAt.getTime()).map((lot) => freeze({ batchId: lot.lotId, pointsAmount: lot.remainingPoints, expiryDate: new Date(lot.expiresAt) }));
+  }
+
+  toSnapshot(): Readonly<{ entries: readonly PointsLedgerEntrySnapshot[]; lots: readonly PointsLotSnapshot[] }> { return freeze({ entries: this.entries.map(cloneLedgerEntry), lots: this.lots.map(cloneLot) }); }
 }
 
 export class Member {
   private constructor(private readonly snapshot: MemberSnapshot) {}
-
   static enroll(input: { accountId: AccountId; memberId?: MemberId; now?: Date }): Member {
     const now = input.now ?? new Date();
-    const accountId = required(input.accountId, "accountId");
-    return new Member(freeze({
-      memberId: input.memberId ?? newMemberId(),
-      accountId,
-      status: "ACTIVE",
-      tier: "BASIC",
-      redeemablePoints: 0,
-      lifetimePoints: 0,
-      tierPoints: 0,
-      createdAt: now,
-      updatedAt: now,
-      ledger: [],
-      lots: [],
-    }));
+    return new Member(freeze({ memberId: input.memberId ?? newMemberId(), accountId: required(input.accountId, "accountId"), status: "ACTIVE", tier: "SILVER", redeemablePoints: 0, lifetimePoints: 0, tierPoints: 0, createdAt: now, updatedAt: now, ledger: [], lots: [], membershipYears: [newMembershipYear(now.getUTCFullYear(), "SILVER")] }));
   }
-
   static fromSnapshot(snapshot: MemberSnapshot): Member {
-    return new Member(freeze({
-      ...snapshot,
-      createdAt: new Date(snapshot.createdAt),
-      updatedAt: new Date(snapshot.updatedAt),
-      ledger: snapshot.ledger.map(cloneLedgerEntry),
-      lots: snapshot.lots.map(cloneLot),
-    }));
+    const tier = normalizeTier(snapshot.tier as string);
+    return new Member(freeze({ ...snapshot, tier, createdAt: new Date(snapshot.createdAt), updatedAt: new Date(snapshot.updatedAt), ledger: snapshot.ledger.map(cloneLedgerEntry), lots: snapshot.lots.map(cloneLot), membershipYears: normalizeMembershipYears(snapshot.membershipYears, tier, snapshot.createdAt) }));
   }
-
-  get id(): MemberId {
-    return this.snapshot.memberId;
-  }
-
-  get accountId(): AccountId {
-    return this.snapshot.accountId;
-  }
-
-  get tier(): TierName {
-    return this.snapshot.tier;
-  }
-
-  get redeemablePoints(): number {
-    return this.snapshot.redeemablePoints;
-  }
+  get id(): MemberId { return this.snapshot.memberId; }
+  get accountId(): AccountId { return this.snapshot.accountId; }
+  get tier(): TierName { return this.snapshot.tier; }
+  get redeemablePoints(): number { return this.snapshot.redeemablePoints; }
 
   accrueFromConfirmedOrder(command: AccruePointsCommand, now = new Date()): { member: Member; events: LoyaltyDomainEvent[] } {
     this.assertActive();
-    const points = pointsForTicketPrice(command.ticketPrice);
-    if (points === 0) {
-      throw new DomainError("NO_POINTS_TO_ACCRUE", "Ticket price is too small to accrue points");
-    }
+    const points = PointsCalculator.calculate({ fare: command.ticketPrice, seatClass: command.seatClass ?? "SECOND_CLASS", travelDate: command.travelDate ?? command.confirmedAt, memberTier: this.snapshot.tier, routeCode: command.routeCode, routeName: command.routeName, isHoliday: command.isHoliday, memberBirthDate: command.memberBirthDate });
+    if (points === 0) throw new DomainError("NO_POINTS_TO_ACCRUE", "Ticket price is too small to accrue points");
     const ledger = PointsLedger.fromSnapshots(this.snapshot.ledger, this.snapshot.lots);
-    const sourceFactRef: SourceFactRef = freeze({
-      stream: "events:journey-order",
-      eventType: "JOURNEY_ORDER_CONFIRMED",
-      eventId: required(command.sourceEventId, "sourceEventId"),
-      aggregateId: required(command.orderId, "orderId"),
-      occurredAt: command.confirmedAt,
-    });
-    const businessReason: BusinessReason = freeze({
-      reasonType: "ORDER_ACCRUAL",
-      reasonCode: "JOURNEY_ORDER_CONFIRMED",
-      referenceType: "JOURNEY_ORDER",
-      referenceId: command.orderId,
-    });
-    const { ledger: accruedLedger, lot } = ledger.accrue({
-      memberId: this.id,
-      points,
-      sourceFactRef,
-      businessReason,
-      idempotencyKey: `${this.id}:${command.sourceEventId}`,
-      occurredAt: command.confirmedAt,
-    });
-    const ledgerSnapshot = accruedLedger.toSnapshot();
-    const tierPoints = accruedLedger.tierPoints(now);
+    const sourceFactRef = freeze({ stream: command.sourceStream ?? "events:payment", eventType: command.sourceEventType ?? "PAYMENT_CAPTURED", eventId: required(command.sourceEventId, "sourceEventId"), aggregateId: required(command.orderId, "orderId"), occurredAt: command.confirmedAt });
+    const businessReason = freeze({ reasonType: "ORDER_ACCRUAL" as const, reasonCode: command.sourceEventType ?? "PAYMENT_CAPTURED", referenceType: "JOURNEY_ORDER", referenceId: command.orderId });
+    const { ledger: accruedLedger, lot } = ledger.accrue({ memberId: this.id, points, tierEligiblePoints: points, sourceFactRef, businessReason, idempotencyKey: `${this.id}:${command.sourceEventId}`, occurredAt: command.confirmedAt, expiresAt: addUtcMonths(command.confirmedAt, this.snapshot.tier === "DIAMOND" ? 36 : 24) });
+    const year = command.confirmedAt.getUTCFullYear();
+    const membershipYears = upsertMembershipYear(this.membershipYears(), year, (membershipYear) => freeze({ ...membershipYear, qualifyingPoints: membershipYear.qualifyingPoints + points, tripCount: membershipYear.tripCount + (command.tripCount ?? 1) }));
+    const currentYear = membershipYears.find((membershipYear) => membershipYear.year === year) ?? newMembershipYear(year, this.snapshot.tier);
+    const targetTier = Tier.of(TierEvaluator.evaluate(currentYear.qualifyingPoints, currentYear.tripCount));
     const currentTier = Tier.of(this.snapshot.tier);
-    const targetTier = Tier.fromTierPoints(tierPoints);
     const nextTier = targetTier.isHigherThan(currentTier) ? targetTier.name : currentTier.name;
-    const nextSnapshot = freeze({
-      ...this.snapshot,
-      tier: nextTier,
-      redeemablePoints: accruedLedger.balance,
-      lifetimePoints: accruedLedger.lifetimePoints,
-      tierPoints,
-      updatedAt: now,
-      ledger: ledgerSnapshot.entries,
-      lots: ledgerSnapshot.lots,
-    });
-    const accrued: PointsAccrued = freeze({
-      type: "PointsAccrued",
-      occurredAt: now,
-      memberId: this.id,
-      accountId: this.accountId,
-      points,
-      tierPoints: points,
-      balanceAfter: accruedLedger.balance,
-      sourceFactRef,
-      businessReason,
-      lotId: lot.lotId,
-      expiresAt: lot.expiresAt,
-      correlationId: command.correlationId,
-    });
-    const events: LoyaltyDomainEvent[] = [accrued];
-    if (nextTier !== this.snapshot.tier) {
-      events.push(freeze({
-        type: "MembershipTierChanged",
-        occurredAt: now,
-        memberId: this.id,
-        accountId: this.accountId,
-        fromTier: this.snapshot.tier,
-        toTier: nextTier,
-        tierPoints,
-        reason: "ACCRUAL" as const,
-        correlationId: command.correlationId,
-      }));
-    }
+    const nextMembershipYears = membershipYears.map((membershipYear) => membershipYear.year === year ? freeze({ ...membershipYear, currentTier: nextTier }) : membershipYear);
+    const ledgerSnapshot = accruedLedger.toSnapshot();
+    const nextSnapshot = freeze({ ...this.snapshot, tier: nextTier, redeemablePoints: accruedLedger.balance, lifetimePoints: accruedLedger.lifetimePoints, tierPoints: currentYear.qualifyingPoints, updatedAt: now, ledger: ledgerSnapshot.entries, lots: ledgerSnapshot.lots, membershipYears: nextMembershipYears });
+    const events: LoyaltyDomainEvent[] = [freeze({ type: "PointsEarned", occurredAt: now, memberId: this.id, accountId: this.accountId, points, sourceRef: command.orderId, sourceFactRef, businessReason, lotId: lot.lotId, expiresAt: lot.expiresAt, balanceAfter: accruedLedger.balance, qualifyingPoints: points, correlationId: command.correlationId })];
+    if (nextTier !== this.snapshot.tier) events.push(freeze({ type: "MemberTierUpgraded", occurredAt: now, memberId: this.id, accountId: this.accountId, oldTier: this.snapshot.tier, newTier: nextTier, qualifyingPoints: currentYear.qualifyingPoints, trips: currentYear.tripCount, correlationId: command.correlationId }));
     return { member: new Member(nextSnapshot), events };
   }
 
-  redeem(command: RedeemPointsCommand, now = new Date()): { member: Member; event: PointsRedeemed } {
+
+  recordTrip(input: { occurredAt: Date; trips?: number; correlationId?: string }, now = new Date()): { member: Member; events: LoyaltyDomainEvent[] } {
     this.assertActive();
+    const year = input.occurredAt.getUTCFullYear();
+    const membershipYears = upsertMembershipYear(this.membershipYears(), year, (membershipYear) => freeze({ ...membershipYear, tripCount: membershipYear.tripCount + (input.trips ?? 1) }));
+    const currentYear = membershipYears.find((membershipYear) => membershipYear.year === year) ?? newMembershipYear(year, this.snapshot.tier);
+    const targetTier = Tier.of(TierEvaluator.evaluate(currentYear.qualifyingPoints, currentYear.tripCount));
+    const currentTier = Tier.of(this.snapshot.tier);
+    const nextTier = targetTier.isHigherThan(currentTier) ? targetTier.name : currentTier.name;
+    const nextMembershipYears = membershipYears.map((membershipYear) => membershipYear.year === year ? freeze({ ...membershipYear, currentTier: nextTier }) : membershipYear);
+    const events: LoyaltyDomainEvent[] = [];
+    if (nextTier !== this.snapshot.tier) events.push(freeze({ type: "MemberTierUpgraded", occurredAt: now, memberId: this.id, accountId: this.accountId, oldTier: this.snapshot.tier, newTier: nextTier, qualifyingPoints: currentYear.qualifyingPoints, trips: currentYear.tripCount, correlationId: input.correlationId }));
+    return { member: new Member(freeze({ ...this.snapshot, tier: nextTier, updatedAt: now, membershipYears: nextMembershipYears })), events };
+  }
+
+  adjustQualifyingPointsForRefund(input: { occurredAt: Date; qualifyingPoints: number }, now = new Date()): Member {
+    this.assertActive();
+    assertWholeNonNegative(input.qualifyingPoints, "qualifyingPoints");
+    const year = input.occurredAt.getUTCFullYear();
+    const membershipYears = upsertMembershipYear(this.membershipYears(), year, (membershipYear) => freeze({ ...membershipYear, qualifyingPoints: Math.max(0, membershipYear.qualifyingPoints - input.qualifyingPoints) }));
+    const currentYear = membershipYears.find((membershipYear) => membershipYear.year === year) ?? newMembershipYear(year, this.snapshot.tier);
+    return new Member(freeze({ ...this.snapshot, tierPoints: currentYear.qualifyingPoints, updatedAt: now, membershipYears }));
+  }
+
+  redeem(command: RedeemPointsCommand, now = new Date()): { member: Member; event: PointsRedeemed } {
     const redemptionId = command.redemptionId ?? newRedemptionId();
-    const businessReason: BusinessReason = freeze({
-      reasonType: "REDEMPTION",
-      reasonCode: command.reasonCode ?? "CATALOG_REDEMPTION",
-      referenceType: "POINTS_REDEMPTION",
-      referenceId: redemptionId,
-    });
-    const ledger = PointsLedger.fromSnapshots(this.snapshot.ledger, this.snapshot.lots);
-    const { ledger: redeemedLedger } = ledger.redeem({ memberId: this.id, points: command.points, redemptionId, businessReason, occurredAt: now });
+    return this.redeemInternal(command.points, redemptionId, freeze({ reasonType: "REDEMPTION", reasonCode: command.reasonCode ?? "CATALOG_REDEMPTION", referenceType: "POINTS_REDEMPTION", referenceId: redemptionId }), now, command.correlationId);
+  }
+
+  redeemForTicket(command: RedemptionRequest & Readonly<{ redemptionId?: RedemptionId; correlationId?: string }>, now = new Date()): { member: Member; event: PointsRedeemed; result: RedemptionResult } {
+    const result = RedemptionPolicy.standard.apply(command, this.snapshot.redeemablePoints);
+    const redemptionId = command.redemptionId ?? newRedemptionId();
+    const { member, event } = this.redeemInternal(result.pointsDeducted, redemptionId, freeze({ reasonType: "REDEMPTION", reasonCode: "TICKET_PARTIAL_PAYMENT", referenceType: "JOURNEY_ORDER", referenceId: command.orderId }), now, command.correlationId, command.orderId, result.discountAmountMinor, result.remainingBalance);
+    return { member, event, result };
+  }
+
+  expirePoints(now = new Date(), correlationId?: string): { member: Member; events: readonly PointsExpired[] } {
+    const { ledger: expiredLedger, expired } = PointsLedger.fromSnapshots(this.snapshot.ledger, this.snapshot.lots).expirePoints(this.id, now);
+    if (expired.length === 0) return { member: this, events: [] };
+    const ledgerSnapshot = expiredLedger.toSnapshot();
+    const events = expired.map((batch) => freeze({ type: "PointsExpired" as const, occurredAt: now, memberId: this.id, accountId: this.accountId, points: batch.points, batchId: batch.batchId, balanceAfter: expiredLedger.balance, correlationId }));
+    return { member: new Member(freeze({ ...this.snapshot, redeemablePoints: expiredLedger.balance, lifetimePoints: expiredLedger.lifetimePoints, updatedAt: now, ledger: ledgerSnapshot.entries, lots: ledgerSnapshot.lots })), events };
+  }
+
+  evaluateTierAtYearEnd(evaluationYear: number, now = new Date(), correlationId?: string): { member: Member; events: LoyaltyDomainEvent[] } {
+    assertWholeNonNegative(evaluationYear, "evaluationYear");
+    if (now < new Date(Date.UTC(evaluationYear + 1, 3, 1))) throw new DomainError("TIER_GRACE_PERIOD_ACTIVE", "Downgrade evaluation is available after the three month grace period");
+    const membershipYear = this.membershipYears().find((year) => year.year === evaluationYear) ?? newMembershipYear(evaluationYear, this.snapshot.tier);
+    const resultingTier = TierEvaluator.evaluate(membershipYear.qualifyingPoints, membershipYear.tripCount);
+    const events: LoyaltyDomainEvent[] = [freeze({ type: "TierEvaluationCompleted", occurredAt: now, memberId: this.id, accountId: this.accountId, evaluationYear, resultingTier, qualifyingPoints: membershipYear.qualifyingPoints, trips: membershipYear.tripCount, correlationId })];
+    if (Tier.of(resultingTier).isLowerThan(Tier.of(this.snapshot.tier))) events.push(freeze({ type: "MemberTierDowngraded", occurredAt: now, memberId: this.id, accountId: this.accountId, oldTier: this.snapshot.tier, newTier: resultingTier, qualifyingPoints: membershipYear.qualifyingPoints, trips: membershipYear.tripCount, correlationId }));
+    const years = upsertMembershipYear(this.membershipYears(), evaluationYear, (year) => freeze({ ...year, currentTier: resultingTier, evaluationDate: now }));
+    return { member: new Member(freeze({ ...this.snapshot, tier: resultingTier, updatedAt: now, membershipYears: years })), events };
+  }
+
+  getExpiringWithin(days: number, now = new Date()): readonly ExpiringBatch[] { return PointsLedger.fromSnapshots(this.snapshot.ledger, this.snapshot.lots).getExpiringWithin(days, now); }
+  toSnapshot(): MemberSnapshot { return freeze({ ...this.snapshot, createdAt: new Date(this.snapshot.createdAt), updatedAt: new Date(this.snapshot.updatedAt), ledger: this.snapshot.ledger.map(cloneLedgerEntry), lots: this.snapshot.lots.map(cloneLot), membershipYears: this.membershipYears() }); }
+  private membershipYears(): readonly MembershipYearSnapshot[] { return normalizeMembershipYears(this.snapshot.membershipYears, this.snapshot.tier, this.snapshot.createdAt); }
+  private redeemInternal(points: number, redemptionId: RedemptionId, businessReason: BusinessReason, now: Date, correlationId?: string, orderId?: string, discountAmountMinor?: number, remainingBalance?: number): { member: Member; event: PointsRedeemed } {
+    this.assertActive();
+    const { ledger: redeemedLedger } = PointsLedger.fromSnapshots(this.snapshot.ledger, this.snapshot.lots).redeem({ memberId: this.id, points, redemptionId, businessReason, occurredAt: now });
     const ledgerSnapshot = redeemedLedger.toSnapshot();
-    const nextSnapshot = freeze({
-      ...this.snapshot,
-      redeemablePoints: redeemedLedger.balance,
-      lifetimePoints: redeemedLedger.lifetimePoints,
-      tierPoints: redeemedLedger.tierPoints(now),
-      updatedAt: now,
-      ledger: ledgerSnapshot.entries,
-      lots: ledgerSnapshot.lots,
-    });
-    return {
-      member: new Member(nextSnapshot),
-      event: freeze({
-        type: "PointsRedeemed",
-        occurredAt: now,
-        memberId: this.id,
-        accountId: this.accountId,
-        redemptionId,
-        points: command.points,
-        balanceAfter: redeemedLedger.balance,
-        businessReason,
-        correlationId: command.correlationId,
-      }),
-    };
+    const nextSnapshot = freeze({ ...this.snapshot, redeemablePoints: redeemedLedger.balance, lifetimePoints: redeemedLedger.lifetimePoints, updatedAt: now, ledger: ledgerSnapshot.entries, lots: ledgerSnapshot.lots });
+    return { member: new Member(nextSnapshot), event: freeze({ type: "PointsRedeemed", occurredAt: now, memberId: this.id, accountId: this.accountId, redemptionId, points, orderId, discountAmountMinor, remainingBalance: remainingBalance ?? redeemedLedger.balance, balanceAfter: redeemedLedger.balance, businessReason, correlationId }) };
   }
-
-  toSnapshot(): MemberSnapshot {
-    return freeze({
-      ...this.snapshot,
-      createdAt: new Date(this.snapshot.createdAt),
-      updatedAt: new Date(this.snapshot.updatedAt),
-      ledger: this.snapshot.ledger.map(cloneLedgerEntry),
-      lots: this.snapshot.lots.map(cloneLot),
-    });
-  }
-
-  private assertActive(): void {
-    if (this.snapshot.status !== "ACTIVE") {
-      throw new DomainError("MEMBERSHIP_NOT_ACTIVE", "Only active memberships can accrue or redeem points");
-    }
-  }
+  private assertActive(): void { if (this.snapshot.status !== "ACTIVE") throw new DomainError("MEMBERSHIP_NOT_ACTIVE", "Only active memberships can accrue or redeem points"); }
 }
 
-export function pointsForTicketPrice(price: Money): number {
-  if (price.currency !== "CNY") {
-    throw new DomainError("UNSUPPORTED_CURRENCY", "Loyalty accrual currently supports CNY only");
-  }
-  assertWholeNonNegative(price.minorUnits, "minorUnits");
-  return Math.floor(price.minorUnits / 10_000);
+export function pointsForTicketPrice(price: Money): number { return PointsCalculator.calculate({ fare: price, seatClass: "SECOND_CLASS", travelDate: new Date("2026-07-10T00:00:00.000Z"), memberTier: "SILVER" }); }
+export function calculatePoints(input: PointsCalculationInput): Readonly<{ points: number; rule: PointsEarningRule }> {
+  if (input.fare.currency !== "CNY") throw new DomainError("UNSUPPORTED_CURRENCY", "Loyalty accrual currently supports CNY only");
+  assertWholeNonNegative(input.fare.minorUnits, "minorUnits");
+  const rule = PointsCalculator.earningRule(input);
+  const bonus = rule.bonusConditions.reduce((multiplier, condition) => multiplier * condition.multiplier, 1);
+  return freeze({ points: Math.floor((input.fare.minorUnits / 100) * rule.seatClassMultiplier * bonus * rule.tierMultiplier), rule });
 }
 
-function consumeLots(lots: readonly PointsLotSnapshot[], points: number): PointsLotSnapshot[] {
-  let remainingToConsume = points;
-  return [...lots]
-    .sort((left, right) => left.expiresAt.getTime() - right.expiresAt.getTime())
-    .map((lot) => {
-      if (remainingToConsume === 0 || lot.remainingPoints === 0) {
-        return cloneLot(lot);
-      }
-      const consumed = Math.min(lot.remainingPoints, remainingToConsume);
-      remainingToConsume -= consumed;
-      return freeze({ ...lot, remainingPoints: lot.remainingPoints - consumed });
-    });
+function seatClassMultiplier(seatClass: SeatClass): number { if (seatClass === "FIRST_CLASS" || seatClass === "一等座") return 1.5; if (seatClass === "BUSINESS_CLASS" || seatClass === "商务座") return 2; return 1; }
+function tierMultiplier(tier: TierName): number { return { SILVER: 1, GOLD: 1.2, PLATINUM: 1.5, DIAMOND: 2 }[tier]; }
+function bonusMultipliers(input: Omit<PointsCalculationInput, "fare">): readonly Readonly<{ name: string; multiplier: number }>[] {
+  const conditions: Readonly<{ name: string; multiplier: number }>[] = [];
+  const weekday = input.travelDate.getUTCDay();
+  if (weekday === 0 || weekday === 6) conditions.push(freeze({ name: "WEEKEND_TRAVEL", multiplier: 1.5 }));
+  if (input.isHoliday === true || isPublicHoliday(input.travelDate)) conditions.push(freeze({ name: "HOLIDAY_TRAVEL", multiplier: 2 }));
+  if (isBonusRoute(input.routeCode, input.routeName)) conditions.push(freeze({ name: "BONUS_ROUTE", multiplier: 1.2 }));
+  if (input.memberBirthDate && input.memberBirthDate.getUTCMonth() === input.travelDate.getUTCMonth()) conditions.push(freeze({ name: "BIRTHDAY_MONTH", multiplier: 2 }));
+  return conditions;
 }
-
-function assertPositiveInteger(value: number, field: string): void {
-  if (!Number.isInteger(value) || value <= 0) {
-    throw new DomainError("INVALID_POINTS", `${field} must be a positive integer`);
-  }
-}
-
-function assertWholeNonNegative(value: number, field: string): void {
-  if (!Number.isInteger(value) || value < 0) {
-    throw new DomainError("INVALID_AMOUNT", `${field} must be a non-negative integer`);
-  }
-}
-
-function required(value: string, field: string): string {
-  if (value.trim().length === 0) {
-    throw new DomainError("MISSING_REQUIRED_FIELD", `${field} is required`);
-  }
-  return value;
-}
-
-function addUtcYears(date: Date, years: number): Date {
-  const copy = new Date(date);
-  copy.setUTCFullYear(copy.getUTCFullYear() + years);
-  return copy;
-}
-
-function cloneLedgerEntry(entry: PointsLedgerEntrySnapshot): PointsLedgerEntrySnapshot {
-  return freeze({
-    ...entry,
-    sourceFactRef: cloneSourceFact(entry.sourceFactRef),
-    businessReason: freeze({ ...entry.businessReason }),
-    occurredAt: new Date(entry.occurredAt),
-    expiresAt: entry.expiresAt ? new Date(entry.expiresAt) : undefined,
-  });
-}
-
-function cloneSourceFact(source: SourceFactRef): SourceFactRef {
-  return freeze({ ...source, occurredAt: new Date(source.occurredAt) });
-}
-
-function cloneLot(lot: PointsLotSnapshot): PointsLotSnapshot {
-  return freeze({ ...lot, validFrom: new Date(lot.validFrom), expiresAt: new Date(lot.expiresAt) });
-}
-
-function freeze<T extends object>(value: T): Readonly<T> {
-  return Object.freeze(value);
-}
-
-function newMemberId(): MemberId {
-  return `mem_${randomUUID()}`;
-}
-
-function newLedgerEntryId(): PointsLedgerEntryId {
-  return `ple_${randomUUID()}`;
-}
-
-function newPointsLotId(): PointsLotId {
-  return `lot_${randomUUID()}`;
-}
-
-function newRedemptionId(): RedemptionId {
-  return `red_${randomUUID()}`;
-}
+function isPublicHoliday(date: Date): boolean { return ["01-01", "05-01", "10-01", "10-02", "10-03"].includes(`${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`); }
+function isBonusRoute(routeCode?: string, routeName?: string): boolean { const value = `${routeCode ?? ""} ${routeName ?? ""}`.toUpperCase(); return value.includes("JINGHU") || value.includes("JINGGUANG") || value.includes("京沪") || value.includes("京广"); }
+function consumeLots(lots: readonly PointsLotSnapshot[], points: number): PointsLotSnapshot[] { let remainingToConsume = points; return [...lots].sort((left, right) => left.expiresAt.getTime() - right.expiresAt.getTime()).map((lot) => { if (remainingToConsume === 0 || lot.remainingPoints === 0) return cloneLot(lot); const consumed = Math.min(lot.remainingPoints, remainingToConsume); remainingToConsume -= consumed; return freeze({ ...lot, remainingPoints: lot.remainingPoints - consumed }); }); }
+function upsertMembershipYear(years: readonly MembershipYearSnapshot[], year: number, update: (year: MembershipYearSnapshot) => MembershipYearSnapshot): readonly MembershipYearSnapshot[] { const existing = years.find((membershipYear) => membershipYear.year === year); const next = update(existing ?? newMembershipYear(year, "SILVER")); return freeze([...years.filter((membershipYear) => membershipYear.year !== year), next].sort((left, right) => left.year - right.year)); }
+function normalizeMembershipYears(years: readonly MembershipYearSnapshot[] | undefined, tier: TierName, createdAt: Date): readonly MembershipYearSnapshot[] { if (years && years.length > 0) return freeze(years.map((year) => freeze({ ...year, currentTier: normalizeTier(year.currentTier as string), evaluationDate: year.evaluationDate ? new Date(year.evaluationDate) : undefined }))); return freeze([newMembershipYear(createdAt.getUTCFullYear(), tier)]); }
+function newMembershipYear(year: number, tier: TierName): MembershipYearSnapshot { return freeze({ year, qualifyingPoints: 0, tripCount: 0, currentTier: tier }); }
+function normalizeTier(tier: string): TierName { if (tier === "BASIC") return "SILVER"; return Tier.of(tier as TierName).name; }
+function assertPositiveInteger(value: number, field: string): void { if (!Number.isInteger(value) || value <= 0) throw new DomainError("INVALID_POINTS", `${field} must be a positive integer`); }
+function assertWholeNonNegative(value: number, field: string): void { if (!Number.isInteger(value) || value < 0) throw new DomainError("INVALID_AMOUNT", `${field} must be a non-negative integer`); }
+function required(value: string, field: string): string { if (value.trim().length === 0) throw new DomainError("MISSING_REQUIRED_FIELD", `${field} is required`); return value; }
+function addUtcMonths(date: Date, months: number): Date { const copy = new Date(date); copy.setUTCMonth(copy.getUTCMonth() + months); return copy; }
+function cloneLedgerEntry(entry: PointsLedgerEntrySnapshot): PointsLedgerEntrySnapshot { return freeze({ ...entry, type: normalizeLedgerType(entry.type as string), sourceFactRef: cloneSourceFact(entry.sourceFactRef), businessReason: freeze({ ...entry.businessReason }), occurredAt: new Date(entry.occurredAt), expiresAt: entry.expiresAt ? new Date(entry.expiresAt) : undefined }); }
+function normalizeLedgerType(type: string): LedgerEntryType { if (type === "ACCRUAL") return "EARNED"; if (type === "REDEMPTION") return "REDEEMED"; if (type === "REVERSAL") return "ADJUSTED"; return type as LedgerEntryType; }
+function cloneSourceFact(source: SourceFactRef): SourceFactRef { return freeze({ ...source, occurredAt: new Date(source.occurredAt) }); }
+function cloneLot(lot: PointsLotSnapshot): PointsLotSnapshot { return freeze({ ...lot, validFrom: new Date(lot.validFrom), expiresAt: new Date(lot.expiresAt) }); }
+function freeze<T extends object>(value: T): Readonly<T> { return Object.freeze(value); }
+function newMemberId(): MemberId { return `mem_${randomUUID()}`; }
+function newLedgerEntryId(): PointsLedgerEntryId { return `ple_${randomUUID()}`; }
+function newPointsLotId(): PointsLotId { return `lot_${randomUUID()}`; }
+function newRedemptionId(): RedemptionId { return `red_${randomUUID()}`; }

--- a/services/loyalty-membership/src/index.ts
+++ b/services/loyalty-membership/src/index.ts
@@ -1,7 +1,7 @@
 export { createApp, health, metadata, opentelemetryInstrumentationFromEnv, type AppOptions } from "./app.js";
-export { bootstrap, handleJourneyOrderConfirmed, runtimeHost, runtimePort, type BootstrapOptions } from "./bootstrap.js";
+export { bootstrap, handleJourneyOrderConfirmed, handleJourneyOrderCreated, handlePaymentCaptured, handlePostSalesApplied, runtimeHost, runtimePort, type BootstrapOptions } from "./bootstrap.js";
 export { InMemoryEventPublisher, InMemoryMemberRepository, LoyaltyMembershipApplicationService } from "./application.js";
 export { InMemoryIdempotencyStore } from "@trainticket/ts-kit";
 export type { EventEnvelope, EventPublisher, EventSubscriber, HandlerResult } from "./ports.js";
-export { DomainError, Member, PointsLedger, Tier, pointsForTicketPrice, type LoyaltyDomainEvent, type MemberSnapshot, type TierName } from "./domain.js";
+export { DomainError, Member, PointsCalculator, PointsLedger, RedemptionPolicy, Tier, TierEvaluator, pointsForTicketPrice, type LoyaltyDomainEvent, type MemberSnapshot, type TierName } from "./domain.js";
 export { serviceProfile, type ServiceProfile } from "./profile.js";

--- a/services/loyalty-membership/src/messaging.test.ts
+++ b/services/loyalty-membership/src/messaging.test.ts
@@ -2,11 +2,11 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { InMemoryEventPublisher, InMemoryMemberRepository, LoyaltyMembershipApplicationService } from "./application.js";
-import { handleJourneyOrderConfirmed, handlePaymentCaptured } from "./bootstrap.js";
+import { handleJourneyOrderCancelled, handleJourneyOrderConfirmed, handlePaymentCaptured, handlePostSalesApplied } from "./bootstrap.js";
 import { createEventEnvelope } from "@trainticket/ts-kit";
 
 describe("journey-order event consumption", () => {
-  it("accrues points from JourneyOrderConfirmed monetary summary", async () => {
+  it("does not accrue points from JourneyOrderConfirmed", async () => {
     const repository = new InMemoryMemberRepository();
     const publisher = new InMemoryEventPublisher();
     const service = new LoyaltyMembershipApplicationService(repository, publisher);
@@ -16,10 +16,7 @@ describe("journey-order event consumption", () => {
       payload: {
         orderId: "ord-msg",
         accountId: "acct-msg",
-        monetarySummary: {
-          currency: "CNY",
-          total: { currency: "CNY", minorUnits: 250_000 },
-        },
+        monetarySummary: { currency: "CNY", total: { currency: "CNY", minorUnits: 250_000 } },
         confirmedAt: "2026-07-10T10:00:00.000Z",
       },
     });
@@ -28,12 +25,24 @@ describe("journey-order event consumption", () => {
 
     const member = await repository.findByAccountId("acct-msg");
     assert.ok(member);
-    assert.equal(member.redeemablePoints, 2500);
-    const accrued = publisher.findByEventType("PointsEarned")[0];
-    assert.equal(accrued.payload.points, 2500);
-    const sourceFactRef = accrued.payload.sourceFactRef as { eventType: string; aggregateId: string };
-    assert.equal(sourceFactRef.eventType, "JOURNEY_ORDER_CONFIRMED");
-    assert.equal(sourceFactRef.aggregateId, "ord-msg");
+    assert.equal(member.redeemablePoints, 0);
+    assert.equal(publisher.findByEventType("PointsEarned").length, 0);
+  });
+
+  it("restores ticket redemption points from JourneyOrderCancelled", async () => {
+    const repository = new InMemoryMemberRepository();
+    const publisher = new InMemoryEventPublisher();
+    const service = new LoyaltyMembershipApplicationService(repository, publisher);
+    const member = await service.enrollMember("acct-cancel-msg");
+    await service.accrueFromPaymentCaptured({ orderId: "ord-cancel-msg", accountId: "acct-cancel-msg", ticketPrice: { currency: "CNY", minorUnits: 100_000 }, sourceEventId: "evt-pay-cancel", confirmedAt: new Date("2026-07-10T10:00:00.000Z"), correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c333" });
+    await service.redeemTicketPoints({ memberId: member.member.memberId, orderId: "ord-cancel-msg", pointsToRedeem: 1_000, fareAmountMinor: 20_000, redemptionId: "red-cancel", correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c333" });
+
+    await handleJourneyOrderCancelled(service, createEventEnvelope({ eventType: "JourneyOrderCancelled", producer: "journey-order", payload: { orderId: "ord-cancel-msg", accountId: "acct-cancel-msg", reason: "USER_CANCELLED" } }));
+
+    const restored = await repository.findByAccountId("acct-cancel-msg");
+    assert.ok(restored);
+    assert.equal(restored.redeemablePoints, 1_000);
+    assert.equal(publisher.findByEventType("PointsRestored").length, 1);
   });
 });
 
@@ -66,5 +75,21 @@ describe("payment event consumption", () => {
     const sourceFactRef = earned.payload.sourceFactRef as { eventType: string; aggregateId: string };
     assert.equal(sourceFactRef.eventType, "PAYMENT_CAPTURED");
     assert.equal(sourceFactRef.aggregateId, "ord-pay-msg");
+  });
+});
+
+
+describe("post-sales event consumption", () => {
+  it("deducts qualifying points for contract-shaped PostSalesApplied refund", async () => {
+    const repository = new InMemoryMemberRepository();
+    const publisher = new InMemoryEventPublisher();
+    const service = new LoyaltyMembershipApplicationService(repository, publisher);
+    await service.accrueFromPaymentCaptured({ orderId: "ord-refund-msg", accountId: "acct-refund-msg", ticketPrice: { currency: "CNY", minorUnits: 100_000 }, sourceEventId: "evt-pay-refund", confirmedAt: new Date("2026-07-10T10:00:00.000Z"), correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c444" });
+
+    await handlePostSalesApplied(service, createEventEnvelope({ eventType: "PostSalesApplied", producer: "post-sales", payload: { caseId: "psc-refund", orderId: "ord-refund-msg", resultSummary: { description: "refund applied" } } }));
+
+    const member = await repository.findByAccountId("acct-refund-msg");
+    assert.ok(member);
+    assert.equal(member.toSnapshot().membershipYears?.find((year) => year.year === 2026)?.qualifyingPoints, 0);
   });
 });

--- a/services/loyalty-membership/src/messaging.test.ts
+++ b/services/loyalty-membership/src/messaging.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { InMemoryEventPublisher, InMemoryMemberRepository, LoyaltyMembershipApplicationService } from "./application.js";
-import { handleJourneyOrderConfirmed } from "./bootstrap.js";
+import { handleJourneyOrderConfirmed, handlePaymentCaptured } from "./bootstrap.js";
 import { createEventEnvelope } from "@trainticket/ts-kit";
 
 describe("journey-order event consumption", () => {
@@ -28,11 +28,43 @@ describe("journey-order event consumption", () => {
 
     const member = await repository.findByAccountId("acct-msg");
     assert.ok(member);
-    assert.equal(member.redeemablePoints, 25);
-    const accrued = publisher.findByEventType("PointsAccrued")[0];
-    assert.equal(accrued.payload.points, 25);
+    assert.equal(member.redeemablePoints, 2500);
+    const accrued = publisher.findByEventType("PointsEarned")[0];
+    assert.equal(accrued.payload.points, 2500);
     const sourceFactRef = accrued.payload.sourceFactRef as { eventType: string; aggregateId: string };
     assert.equal(sourceFactRef.eventType, "JOURNEY_ORDER_CONFIRMED");
     assert.equal(sourceFactRef.aggregateId, "ord-msg");
+  });
+});
+
+
+
+describe("payment event consumption", () => {
+  it("accrues points from PaymentCaptured captured amount", async () => {
+    const repository = new InMemoryMemberRepository();
+    const publisher = new InMemoryEventPublisher();
+    const service = new LoyaltyMembershipApplicationService(repository, publisher);
+    const envelope = createEventEnvelope({
+      eventType: "PaymentCaptured",
+      producer: "payment",
+      payload: {
+        paymentIntentId: "pi-msg",
+        businessRef: "ord-pay-msg",
+        accountId: "acct-pay-msg",
+        capturedAmount: { currency: "CNY", minorUnits: 50_000 },
+        capturedAt: "2026-07-10T10:00:00.000Z",
+        seatClass: "BUSINESS_CLASS",
+      },
+    });
+
+    await handlePaymentCaptured(service, envelope);
+
+    const member = await repository.findByAccountId("acct-pay-msg");
+    assert.ok(member);
+    assert.equal(member.redeemablePoints, 1000);
+    const earned = publisher.findByEventType("PointsEarned")[0];
+    const sourceFactRef = earned.payload.sourceFactRef as { eventType: string; aggregateId: string };
+    assert.equal(sourceFactRef.eventType, "PAYMENT_CAPTURED");
+    assert.equal(sourceFactRef.aggregateId, "ord-pay-msg");
   });
 });

--- a/services/loyalty-membership/src/ports.ts
+++ b/services/loyalty-membership/src/ports.ts
@@ -18,17 +18,18 @@ export function toEventEnvelope(event: LoyaltyDomainEvent, correlationId: string
 
 function eventPayload(event: LoyaltyDomainEvent): Record<string, unknown> {
   switch (event.type) {
-    case "PointsAccrued":
+    case "PointsEarned":
       return {
         memberId: event.memberId,
         accountId: event.accountId,
         points: event.points,
-        tierPoints: event.tierPoints,
-        balanceAfter: event.balanceAfter,
+        sourceRef: event.sourceRef,
         sourceFactRef: sourceFactPayload(event.sourceFactRef),
         businessReason: event.businessReason,
         lotId: event.lotId,
         expiresAt: event.expiresAt.toISOString(),
+        balanceAfter: event.balanceAfter,
+        qualifyingPoints: event.qualifyingPoints,
       };
     case "PointsRedeemed":
       return {
@@ -36,18 +37,20 @@ function eventPayload(event: LoyaltyDomainEvent): Record<string, unknown> {
         accountId: event.accountId,
         redemptionId: event.redemptionId,
         points: event.points,
+        orderId: event.orderId,
+        discountAmountMinor: event.discountAmountMinor,
+        remainingBalance: event.remainingBalance,
         balanceAfter: event.balanceAfter,
         businessReason: event.businessReason,
       };
-    case "MembershipTierChanged":
-      return {
-        memberId: event.memberId,
-        accountId: event.accountId,
-        fromTier: event.fromTier,
-        toTier: event.toTier,
-        tierPoints: event.tierPoints,
-        reason: event.reason,
-      };
+    case "PointsExpired":
+      return { memberId: event.memberId, accountId: event.accountId, points: event.points, batchId: event.batchId, balanceAfter: event.balanceAfter };
+    case "MemberTierUpgraded":
+      return { memberId: event.memberId, accountId: event.accountId, oldTier: event.oldTier, newTier: event.newTier, qualifyingPoints: event.qualifyingPoints, trips: event.trips };
+    case "MemberTierDowngraded":
+      return { memberId: event.memberId, accountId: event.accountId, oldTier: event.oldTier, newTier: event.newTier, qualifyingPoints: event.qualifyingPoints, trips: event.trips };
+    case "TierEvaluationCompleted":
+      return { memberId: event.memberId, accountId: event.accountId, evaluationYear: event.evaluationYear, resultingTier: event.resultingTier, qualifyingPoints: event.qualifyingPoints, trips: event.trips };
   }
 }
 

--- a/services/loyalty-membership/src/ports.ts
+++ b/services/loyalty-membership/src/ports.ts
@@ -43,6 +43,16 @@ function eventPayload(event: LoyaltyDomainEvent): Record<string, unknown> {
         balanceAfter: event.balanceAfter,
         businessReason: event.businessReason,
       };
+    case "PointsRestored":
+      return {
+        memberId: event.memberId,
+        accountId: event.accountId,
+        points: event.points,
+        orderId: event.orderId,
+        sourceFactRef: sourceFactPayload(event.sourceFactRef),
+        businessReason: event.businessReason,
+        balanceAfter: event.balanceAfter,
+      };
     case "PointsExpired":
       return { memberId: event.memberId, accountId: event.accountId, points: event.points, batchId: event.batchId, balanceAfter: event.balanceAfter };
     case "MemberTierUpgraded":

--- a/services/loyalty-membership/src/profile.ts
+++ b/services/loyalty-membership/src/profile.ts
@@ -21,6 +21,6 @@ export const serviceProfile: ServiceProfile = {
     "Points ledger entries and lots",
     "Tier upgrade and downgrade rules",
   ],
-  consumes: ["JourneyOrderConfirmed", "PaymentCaptured"],
-  publishes: ["PointsEarned", "PointsRedeemed", "PointsExpired", "MemberTierUpgraded", "MemberTierDowngraded", "TierEvaluationCompleted"],
+  consumes: ["JourneyOrderCreated", "JourneyOrderCancelled", "PaymentCaptured", "PostSalesApplied"],
+  publishes: ["PointsEarned", "PointsRedeemed", "PointsRestored", "PointsExpired", "MemberTierUpgraded", "MemberTierDowngraded", "TierEvaluationCompleted"],
 };

--- a/services/loyalty-membership/src/profile.ts
+++ b/services/loyalty-membership/src/profile.ts
@@ -13,8 +13,8 @@ export const serviceProfile: ServiceProfile = {
   serviceId: "loyalty-membership",
   domain: "Loyalty Membership",
   language: "typescript",
-  phase: "phase-1-loyalty-membership-service-foundation",
-  requirement: "REQ-210-Loyalty-membership-service-foundation",
+  phase: "domain-enrichment-loyalty-membership",
+  requirement: "REQ-309-loyalty-membership-points-and-tiers",
   owns: [
     "Membership tier state",
     "Redeemable points balance",
@@ -22,5 +22,5 @@ export const serviceProfile: ServiceProfile = {
     "Tier upgrade and downgrade rules",
   ],
   consumes: ["JourneyOrderConfirmed", "PaymentCaptured"],
-  publishes: ["MembershipTierChanged", "PointsAccrued", "PointsRedeemed"],
+  publishes: ["PointsEarned", "PointsRedeemed", "PointsExpired", "MemberTierUpgraded", "MemberTierDowngraded", "TierEvaluationCompleted"],
 };


### PR DESCRIPTION
## Summary
- Adds production-style points earning, redemption caps, annual tier evaluation, and FIFO expiry domain logic for loyalty-membership.
- Wires new API/application flows plus PaymentCaptured/JourneyOrderCreated/PostSalesApplied consumption and outbox-backed publication for PostgreSQL runtime.
- Updates persistence schema, events, service profile, and focused domain/API/messaging tests.

## Validation
- npm --prefix services/loyalty-membership run build
- npm --prefix services/loyalty-membership test