### PR TITLE
REQ-308 transfer-management MCT enforcement and auto-rebooking

### DIFF
--- a/services/transfer-management/src/transfer_management/adapters/messaging/__init__.py
+++ b/services/transfer-management/src/transfer_management/adapters/messaging/__init__.py
@@ -1,3 +1,4 @@
 DISRUPTION_RECOVERY_STREAM = "events:disruption-recovery"
 FULFILLMENT_STREAM = "events:fulfillment"
+TRIP_PLANNING_STREAM = "events:trip-planning"
 FULFILLMENT_SEGMENT_EVENTS = ("SegmentArrived", "SegmentDelayed", "SegmentCancelled")

--- a/services/transfer-management/src/transfer_management/adapters/storage/postgres.py
+++ b/services/transfer-management/src/transfer_management/adapters/storage/postgres.py
@@ -31,6 +31,7 @@ from transfer_management.domain import (
     RiskThresholds,
     SegmentStatusReport,
     TransferCategory,
+    TransferMode,
     TransferPlan,
     TransferRiskPolicy,
     TransferPlanStatus,
@@ -80,12 +81,12 @@ def recovery_from_json(data: Mapping[str, Any] | None) -> RecoveryCaseMapping | 
 
 
 def connection_to_json(c: Connection) -> dict[str, Any]:
-    return {"connectionId": c.connectionId, "transferPlanId": c.transferPlanId, "itineraryRef": c.itineraryRef, "previousSegmentRef": c.previousSegmentRef, "nextSegmentRef": c.nextSegmentRef, "travelerRefs": list(c.travelerRefs), "fromNodeRef": c.fromNodeRef, "toNodeRef": c.toNodeRef, "fromNodeType": c.fromNodeType.value, "toNodeType": c.toNodeType.value, "transferCategory": c.transferCategory.value, "contractId": c.contractId, "contractType": c.contractType.value, "status": c.status.value, "latestEvaluation": evaluation_to_json(c.latestEvaluation), "window": c.window.to_json(), "createdAt": _dt(c.createdAt), "updatedAt": _dt(c.updatedAt), "journeyOrderId": c.journeyOrderId, "recovery": c.recovery.to_json() if c.recovery else None, "serviceDate": c.serviceDate, "scheduledServiceRef": c.scheduledServiceRef, "replacementOfConnectionId": c.replacementOfConnectionId, "replacementConnectionId": c.replacementConnectionId}
+    return {"connectionId": c.connectionId, "transferPlanId": c.transferPlanId, "itineraryRef": c.itineraryRef, "previousSegmentRef": c.previousSegmentRef, "nextSegmentRef": c.nextSegmentRef, "travelerRefs": list(c.travelerRefs), "fromNodeRef": c.fromNodeRef, "toNodeRef": c.toNodeRef, "fromNodeType": c.fromNodeType.value, "toNodeType": c.toNodeType.value, "transferCategory": c.transferCategory.value, "contractId": c.contractId, "contractType": c.contractType.value, "status": c.status.value, "latestEvaluation": evaluation_to_json(c.latestEvaluation), "window": c.window.to_json(), "createdAt": _dt(c.createdAt), "updatedAt": _dt(c.updatedAt), "journeyOrderId": c.journeyOrderId, "recovery": c.recovery.to_json() if c.recovery else None, "serviceDate": c.serviceDate, "scheduledServiceRef": c.scheduledServiceRef, "replacementOfConnectionId": c.replacementOfConnectionId, "replacementConnectionId": c.replacementConnectionId, "fromMode": c.fromMode.value, "toMode": c.toMode.value, "guaranteed": c.guaranteed, "transferInstructions": c.transferInstructions, "walkingDistanceMeters": c.walkingDistanceMeters}
 
 
 def connection_from_json(data: Mapping[str, Any] | str, version: int = 0) -> Connection:
     data = _json_obj(data)
-    return Connection(str(data["connectionId"]), str(data["transferPlanId"]), str(data["itineraryRef"]), str(data["previousSegmentRef"]), str(data["nextSegmentRef"]), tuple(data.get("travelerRefs") or ()), str(data["fromNodeRef"]), str(data["toNodeRef"]), NodeType(str(data["fromNodeType"])), NodeType(str(data["toNodeType"])), TransferCategory(str(data["transferCategory"])), str(data["contractId"]), ContractType(str(data["contractType"])), ConnectionStatus(str(data["status"])), evaluation_from_json(data["latestEvaluation"]), window_from_json(data["window"]), _parse(data.get("createdAt")) or datetime.now(UTC), _parse(data.get("updatedAt")) or datetime.now(UTC), data.get("journeyOrderId"), recovery_from_json(data.get("recovery")), data.get("serviceDate"), data.get("scheduledServiceRef"), data.get("replacementOfConnectionId"), data.get("replacementConnectionId"), version)
+    return Connection(str(data["connectionId"]), str(data["transferPlanId"]), str(data["itineraryRef"]), str(data["previousSegmentRef"]), str(data["nextSegmentRef"]), tuple(data.get("travelerRefs") or ()), str(data["fromNodeRef"]), str(data["toNodeRef"]), NodeType(str(data["fromNodeType"])), NodeType(str(data["toNodeType"])), TransferCategory(str(data["transferCategory"])), str(data["contractId"]), ContractType(str(data["contractType"])), ConnectionStatus(str(data["status"])), evaluation_from_json(data["latestEvaluation"]), window_from_json(data["window"]), _parse(data.get("createdAt")) or datetime.now(UTC), _parse(data.get("updatedAt")) or datetime.now(UTC), data.get("journeyOrderId"), recovery_from_json(data.get("recovery")), data.get("serviceDate"), data.get("scheduledServiceRef"), data.get("replacementOfConnectionId"), data.get("replacementConnectionId"), TransferMode(str(data.get("fromMode") or "TRAIN")), TransferMode(str(data.get("toMode") or "TRAIN")), bool(data.get("guaranteed") or False), data.get("transferInstructions"), data.get("walkingDistanceMeters"), version)
 
 
 def contract_to_json(c: ConnectionContract) -> dict[str, Any]:

--- a/services/transfer-management/src/transfer_management/api.py
+++ b/services/transfer-management/src/transfer_management/api.py
@@ -14,7 +14,7 @@ from train_ticket_platform.observability import init_opentelemetry
 from train_ticket_platform.storage import DatabaseConfig, DatabasePool, OutboxRelay, PostgresIdempotencyStore, ReadinessGate, run_migrations
 from train_ticket_platform.ids import new_uuid7
 
-from .adapters.messaging import DISRUPTION_RECOVERY_STREAM, FULFILLMENT_STREAM
+from .adapters.messaging import DISRUPTION_RECOVERY_STREAM, FULFILLMENT_STREAM, TRIP_PLANNING_STREAM
 from .adapters.storage.postgres import PostgresTransferManagementStore
 from .application.service import InMemoryStore, TransferManagementService
 from .downstream import DisruptionRecoveryClient, DownstreamError
@@ -161,11 +161,15 @@ def _postgres_store_from_env(app: FastAPI) -> tuple[Any, IdempotencyStore | None
     def handle(envelope: Any) -> None:
         try:
             handled_fulfillment = holder["service"].handle_fulfillment_event(envelope, FULFILLMENT_STREAM)
+            if handled_fulfillment:
+                return
+            handled_planning = holder["service"].handle_trip_planning_event(envelope, TRIP_PLANNING_STREAM)
+            if handled_planning:
+                return
+            holder["service"].handle_recovery_event(envelope, DISRUPTION_RECOVERY_STREAM)
         except DownstreamError as exc:
             raise TransientHandlerError(str(exc)) from exc
-        if not handled_fulfillment:
-            holder["service"].handle_recovery_event(envelope, DISRUPTION_RECOVERY_STREAM)
-    thread = subscriber.start_in_background((DISRUPTION_RECOVERY_STREAM, FULFILLMENT_STREAM), "transfer-management", handle)
+    thread = subscriber.start_in_background((DISRUPTION_RECOVERY_STREAM, FULFILLMENT_STREAM, TRIP_PLANNING_STREAM), "transfer-management", handle)
     app.state.outbox_relay = relay
     app.state.event_subscriber = subscriber
     app.state.event_subscriber_thread = thread

--- a/services/transfer-management/src/transfer_management/application/service.py
+++ b/services/transfer-management/src/transfer_management/application/service.py
@@ -15,17 +15,24 @@ from train_ticket_platform.ids import new_prefixed_uuid7
 from transfer_management.domain import (
     ActorRef,
     Connection,
+    ConnectionGuarantee,
+    ConnectionValidator,
+    CrossModeTransfer,
     ConnectionContract,
     ConnectionStatus,
     ConnectionWindow,
     ContractStatus,
     ContractType,
     DomainError,
+    MinimumConnectionTime,
+    MissedConnectionDetector,
     MctRule,
     MctRuleStatus,
     NodeType,
     PreconditionFailed,
     RecoveryCaseMapping,
+    RebookingRequest,
+    RebookingSuggestion,
     RecoveryTriggerStatus,
     ReportType,
     RiskEvaluation,
@@ -34,7 +41,9 @@ from transfer_management.domain import (
     RiskThresholds,
     SegmentStatusReport,
     TransferCategory,
+    TransferMode,
     TransferPlan,
+    TransferProposal,
     TransferRiskPolicy,
     TransferPlanStatus,
     now_utc,
@@ -48,6 +57,8 @@ from transfer_management.topology import PlaceNetworkClient, PlaceNetworkUnavail
 PRODUCER = "transfer-management"
 PROTECTED_TYPES = {ContractType.PROTECTED, ContractType.SUPPLIER_PROTECTED}
 FULFILLMENT_SEGMENT_EVENT_TYPES = {"SegmentArrived", "SegmentDelayed", "SegmentCancelled"}
+DISRUPTION_SEGMENT_EVENT_TYPES = {"TrainDelayed", "TrainCancelled"}
+AUTO_REBOOKING_WINDOW = timedelta(hours=4)
 LOGGER = logging.getLogger(__name__)
 
 
@@ -224,6 +235,49 @@ def _replacement_window_json(window: Mapping[str, Any]) -> dict[str, Any]:
 
 
 
+def _mode(value: Any, default: TransferMode = TransferMode.TRAIN) -> TransferMode:
+    return TransferMode(str(value or default.value).upper())
+
+
+def _same_platform(data: Mapping[str, Any], category: TransferCategory) -> bool:
+    if data.get("samePlatform") is not None:
+        return bool(data.get("samePlatform"))
+    return category is TransferCategory.IN_STATION
+
+
+def _cross_mode_from_data(data: Mapping[str, Any], from_mode: TransferMode, to_mode: TransferMode, from_node_ref: str, to_node_ref: str) -> CrossModeTransfer:
+    walking = int(data.get("walkingMinutes") if data.get("walkingMinutes") is not None else (0 if from_node_ref == to_node_ref else 10))
+    override = data.get("mctOverride")
+    return CrossModeTransfer(from_mode, to_mode, from_node_ref, to_node_ref, walking, int(override) if override is not None else None)
+
+
+def _can_use_builtin_mct(data: Mapping[str, Any], from_mode: TransferMode, to_mode: TransferMode, station_ref: str, same_platform: bool) -> bool:
+    return (
+        from_mode is not to_mode
+        or same_platform
+        or data.get("stationSize") == "SMALL_STATION"
+        or station_ref in {"北京南", "上海虹桥", "广州南", "南京南", "武汉", "成都东"}
+        or data.get("mctOverride") is not None
+    )
+
+
+def _leg_ref(leg: Mapping[str, Any], index: int) -> str:
+    return str(leg.get("serviceSegmentRef") or leg.get("segmentRef") or leg.get("servicePlanRef") or f"leg-{index}")
+
+
+def _itinerary_transfer_hint(itinerary: Mapping[str, Any], index: int) -> Mapping[str, Any]:
+    transfers = itinerary.get("transfers") or itinerary.get("transferHints") or ()
+    if isinstance(transfers, Iterable) and not isinstance(transfers, (str, bytes, Mapping)):
+        items = tuple(item for item in transfers if isinstance(item, Mapping))
+        if index - 1 < len(items):
+            return items[index - 1]
+    return {}
+
+
+def _optional_int(value: Any) -> int | None:
+    return int(value) if value is not None else None
+
+
 def segment_status_report_from_fulfillment_event(envelope: EventEnvelope) -> dict[str, Any]:
     payload = dict(envelope.payload or {})
     event_type = envelope.eventType
@@ -244,6 +298,34 @@ def segment_status_report_from_fulfillment_event(envelope: EventEnvelope) -> dic
     else:
         data["cancelledAt"] = rfc3339_utc(parse_dt(payload.get("cancelledAt"), "cancelledAt"))
     return data
+
+
+def segment_status_report_from_disruption_event(envelope: EventEnvelope) -> dict[str, Any]:
+    payload = dict(envelope.payload or {})
+    event_type = envelope.eventType
+    observed_at = payload.get("observedAt") or envelope.occurredAt
+    data: dict[str, Any] = {
+        "segmentRef": require_text(payload.get("segmentRef") or payload.get("serviceRef") or payload.get("trainRef"), "payload.segmentRef"),
+        "reportType": "DELAY" if event_type == "TrainDelayed" else "CANCELLED",
+        "reportedBy": {"actorType": "SYSTEM", "actorId": "disruption-recovery"},
+        "sourceSystem": "FULFILLMENT-EVENT",
+        "sourceRecordId": envelope.eventId,
+        "observedAt": rfc3339_utc(parse_dt(observed_at, "observedAt")),
+    }
+    if event_type == "TrainDelayed":
+        estimated = payload.get("actualArrivalAt") or payload.get("estimatedArrivalAt") or payload.get("estimatedNewArrival") or payload.get("estimatedNewDeparture")
+        if estimated is None and payload.get("delayMinutes") is not None:
+            estimated = parse_dt(observed_at, "observedAt") + timedelta(minutes=int(payload.get("delayMinutes") or 0))
+        data["estimatedArrivalAt"] = rfc3339_utc(parse_dt(estimated, "estimatedArrivalAt"))
+    else:
+        data["cancelledAt"] = rfc3339_utc(parse_dt(payload.get("cancelledAt") or observed_at, "cancelledAt"))
+    for key in ("rebookingSuggestions", "alternativeConnections"):
+        if payload.get(key):
+            data["rebookingSuggestions"] = payload[key]
+            break
+    return data
+
+
 
 class TransferManagementService:
     def __init__(self, store: Any, downstream: DisruptionRecoveryClient | None = None, topology: PlaceNetworkClient | None = None) -> None:
@@ -327,23 +409,40 @@ class TransferManagementService:
         except PlaceNetworkUnavailable:
             topology = None
             degraded_reasons = ("PLACE_NETWORK_UNAVAILABLE",)
-        rule = self._require_published_rule(from_node_type, to_node_type, TransferCategory(str(data.get("transferCategory"))), at)
+        category = TransferCategory(str(data.get("transferCategory")))
+        from_mode = _mode(data.get("fromMode"))
+        to_mode = _mode(data.get("toMode"))
+        cross_mode = _cross_mode_from_data(data, from_mode, to_mode, from_node_ref, to_node_ref)
+        override = data.get("mctOverride")
+        same_platform = _same_platform(data, category)
+        mct = MinimumConnectionTime.default_for(to_node_ref, from_mode, to_mode, same_platform, int(override) if override is not None else None)
+        rule = self._find_published_rule(from_node_type, to_node_type, category, at)
+        if rule is None:
+            if not _can_use_builtin_mct(data, from_mode, to_mode, to_node_ref, same_platform):
+                raise DomainError("NO_PUBLISHED_MCT_RULE")
+            rule = self._default_mct_rule(from_node_type, to_node_type, category, mct, at)
         window_data = dict(data.get("window") or {})
         planned = parse_dt(window_data.get("plannedArrivalAt"), "window.plannedArrivalAt")
         departure = parse_dt(window_data.get("nextDepartureAt"), "window.nextDepartureAt")
         cutoff = parse_dt(window_data.get("nextCutoffAt") or window_data.get("nextDepartureAt"), "window.nextCutoffAt")
-        window = ConnectionWindow.build(planned, departure, cutoff, int(window_data.get("mctMinutes") or rule.minimumMinutes), optional_dt(window_data.get("actualArrivalAt")))
+        requested_mct = int(window_data.get("mctMinutes") or max(mct.minutes, rule.minimumMinutes))
+        required_mct = max(requested_mct, mct.minutes, rule.minimumMinutes)
+        mct = MinimumConnectionTime(mct.stationRef, mct.fromMode, mct.toMode, required_mct)
+        validation = ConnectionValidator().ensure_valid(planned, departure, mct)
+        window = ConnectionWindow.build(planned, departure, cutoff, validation.requiredMinutes, optional_dt(window_data.get("actualArrivalAt")))
         evaluation = self._evaluate_window(window, rule, at, new_prefixed_uuid7("tre"), (), topology.placeGraphVersion if topology else None, degraded_reasons)
         contract_id = require_text(data.get("contractId"), "contractId")
         contract_type = ContractType(str(data.get("contractType")))
         status = ConnectionStatus.FEASIBLE if evaluation.riskLevel is RiskLevel.FEASIBLE else ConnectionStatus.TIGHT if evaluation.riskLevel is RiskLevel.TIGHT else ConnectionStatus.AT_RISK
-        connection = Connection(new_prefixed_uuid7("con"), plan.transferPlanId, require_text(data.get("itineraryRef"), "itineraryRef"), require_text(data.get("previousSegmentRef"), "previousSegmentRef"), require_text(data.get("nextSegmentRef"), "nextSegmentRef"), tuple(str(x) for x in data.get("travelerRefs") or []), from_node_ref, to_node_ref, from_node_type, to_node_type, TransferCategory(str(data.get("transferCategory"))), contract_id, contract_type, ConnectionStatus.PLANNED, evaluation, window, at, at, str(data.get("journeyOrderId") or plan.journeyOrderId or "").strip() or None, serviceDate=str(data.get("serviceDate") or cutoff.date().isoformat()), scheduledServiceRef=str(data.get("scheduledServiceRef") or "").strip() or None)
+        guaranteed = bool(data.get("guaranteed") if data.get("guaranteed") is not None else (contract_type in PROTECTED_TYPES and plan.itineraryRef == require_text(data.get("itineraryRef"), "itineraryRef")))
+        connection = Connection(new_prefixed_uuid7("con"), plan.transferPlanId, require_text(data.get("itineraryRef"), "itineraryRef"), require_text(data.get("previousSegmentRef"), "previousSegmentRef"), require_text(data.get("nextSegmentRef"), "nextSegmentRef"), tuple(str(x) for x in data.get("travelerRefs") or []), from_node_ref, to_node_ref, from_node_type, to_node_type, category, contract_id, contract_type, ConnectionStatus.PLANNED, evaluation, window, at, at, str(data.get("journeyOrderId") or plan.journeyOrderId or "").strip() or None, serviceDate=str(data.get("serviceDate") or cutoff.date().isoformat()), scheduledServiceRef=str(data.get("scheduledServiceRef") or "").strip() or None, fromMode=from_mode, toMode=to_mode, guaranteed=guaranteed, transferInstructions=cross_mode.instructions, walkingDistanceMeters=cross_mode.walkingDistanceMeters)
         connection = connection.transition(status, at)
         plan = plan.add_connection(connection.connectionId, at)
         self.store.save_plan(plan)
         self.store.save_connection(connection)
         events = [
             _envelope("ConnectionRegistered", connection.connectionId, 1, connection.to_json() | {"registeredAt": rfc3339_utc(at)}, correlation_id, causation_id, at),
+            _envelope("ConnectionValidated", connection.connectionId, 1, {"connection": connection.ref_json(), "validation": validation.to_json(), "minimumConnectionTime": mct.to_json(), "guarantee": ConnectionGuarantee(connection.connectionId, guaranteed, connection.itineraryRef).to_json(), "validatedAt": rfc3339_utc(at)}, correlation_id, causation_id, at),
             self._risk_event(connection, None, correlation_id, causation_id, at, None),
         ]
         self._append(events)
@@ -402,11 +501,18 @@ class TransferManagementService:
                     report = find_report(source_key) or report
             updated: list[Connection] = []
             events: list[EventEnvelope] = []
+            suggestions = self._rebooking_suggestions(data.get("rebookingSuggestions") or data.get("alternativeConnections") or ())
             for connection in self.store.list_connections_for_segment(report.segmentRef):
                 new_connection, risk_events = self._refresh_connection(connection, at, correlation_id, causation_id, report)
+                events.extend(risk_events)
+                if new_connection.status is ConnectionStatus.MISSED and suggestions and self._carrier_responsible(new_connection):
+                    new_connection, rebooked, rebooking_events = self._auto_rebook(new_connection, suggestions, at, correlation_id, causation_id)
+                    events.extend(rebooking_events)
+                    updated.extend(rebooked)
+                elif new_connection.status is ConnectionStatus.MISSED and self._carrier_responsible(new_connection):
+                    events.append(self._rebooking_failed_event(new_connection, at, correlation_id, causation_id, "NO_ALTERNATIVE_WITHIN_4_HOURS"))
                 self.store.save_connection(new_connection)
                 updated.append(new_connection)
-                events.extend(risk_events)
                 if new_connection.status is ConnectionStatus.MISSED and new_connection.recovery and new_connection.recovery.recoveryTriggerStatus is RecoveryTriggerStatus.PENDING:
                     pending_recovery_ids.append(new_connection.connectionId)
             self._append(events)
@@ -537,7 +643,27 @@ class TransferManagementService:
             LOGGER.warning("fulfillment segment event processing hit downstream error eventId=%s eventType=%s: %s", envelope.eventId, envelope.eventType, exc)
             raise
 
+    def handle_trip_planning_event(self, envelope: EventEnvelope, stream: str | None = None) -> bool:
+        if envelope.eventType != "ItineraryProposed":
+            return False
+        at = now_utc()
+        with self.transaction():
+            events = self._validate_itinerary_proposed(envelope, at)
+            mark = getattr(self.store, "mark_processed", None)
+            if callable(mark) and not mark(envelope.eventId, stream):
+                return True
+            self._append(events)
+        return True
+
     def handle_recovery_event(self, envelope: EventEnvelope, stream: str | None = None) -> bool:
+        if envelope.eventType in DISRUPTION_SEGMENT_EVENT_TYPES:
+            with self.transaction():
+                mark = getattr(self.store, "mark_processed", None)
+                if callable(mark) and not mark(envelope.eventId, stream):
+                    return True
+                report_data = segment_status_report_from_disruption_event(envelope)
+                self.report_segment_status(report_data, envelope.correlationId, envelope.eventId)
+            return True
         if envelope.eventType not in {"RecoveryCompleted", "RecoveryFailed"}:
             return False
         with self.transaction():
@@ -563,6 +689,101 @@ class TransferManagementService:
             self.store.save_connection(connection)
             self._append([event])
             return True
+
+    def _validate_itinerary_proposed(self, envelope: EventEnvelope, at: datetime) -> list[EventEnvelope]:
+        payload = dict(envelope.payload or {})
+        events: list[EventEnvelope] = []
+        intent_ref = str(payload.get("intentRef") or "") or None
+        for itinerary in payload.get("itineraries") or ():
+            if not isinstance(itinerary, Mapping):
+                continue
+            itinerary_ref = require_text(itinerary.get("itineraryRef"), "itinerary.itineraryRef")
+            traveler_refs = tuple(str(ref) for ref in itinerary.get("travelerRefs") or payload.get("travelerRefs") or ())
+            legs = tuple(leg for leg in itinerary.get("legs") or () if isinstance(leg, Mapping))
+            for index, (previous_leg, next_leg) in enumerate(zip(legs, legs[1:]), start=1):
+                previous_segment_ref = _leg_ref(previous_leg, index)
+                next_segment_ref = _leg_ref(next_leg, index + 1)
+                from_station_ref = require_text(previous_leg.get("destinationStopRef") or previous_leg.get("destinationStationRef"), "leg.destinationStopRef")
+                to_station_ref = require_text(next_leg.get("originStopRef") or next_leg.get("originStationRef"), "leg.originStopRef")
+                arrival_at = parse_dt(previous_leg.get("arrivalTime") or previous_leg.get("arrivalAt"), "leg.arrivalTime")
+                departure_at = parse_dt(next_leg.get("departureTime") or next_leg.get("departureAt"), "leg.departureTime")
+                transfer_hint = _itinerary_transfer_hint(itinerary, index)
+                from_mode = _mode(previous_leg.get("mode") or transfer_hint.get("fromMode"))
+                to_mode = _mode(next_leg.get("mode") or transfer_hint.get("toMode"))
+                same_platform = bool(transfer_hint.get("samePlatform")) if transfer_hint.get("samePlatform") is not None else False
+                override = _optional_int(transfer_hint.get("mctOverride") if transfer_hint.get("mctOverride") is not None else transfer_hint.get("mctMinutes"))
+                station_ref = to_station_ref or from_station_ref
+                category = TransferCategory(str(transfer_hint.get("transferCategory") or ("SAME_STATION" if from_station_ref == to_station_ref else "CROSS_STATION")))
+                mct = MinimumConnectionTime.default_for(station_ref, from_mode, to_mode, same_platform, override)
+                validation = ConnectionValidator().validate(arrival_at, departure_at, mct)
+                transfer_id = f"{itinerary_ref}:transfer:{index}"
+                proposal = TransferProposal(transfer_id, (validation,))
+                rejected = False
+                try:
+                    proposal.validateConnectionTimes()
+                except DomainError:
+                    rejected = True
+                connection_ref = {"connectionId": transfer_id, "itineraryRef": itinerary_ref, "previousSegmentRef": previous_segment_ref, "nextSegmentRef": next_segment_ref, "travelerRefs": list(traveler_refs)}
+                event_type = "ConnectionValidationRejected" if rejected else "ConnectionValidated"
+                event_payload: dict[str, Any] = {
+                    "connection": connection_ref,
+                    "intentRef": intent_ref,
+                    "itineraryRef": itinerary_ref,
+                    "transferIndex": index,
+                    "fromStationRef": from_station_ref,
+                    "toStationRef": to_station_ref,
+                    "fromMode": from_mode.value,
+                    "toMode": to_mode.value,
+                    "transferCategory": category.value,
+                    "validation": validation.to_json(),
+                    "minimumConnectionTime": mct.to_json(),
+                    "validatedAt": rfc3339_utc(at),
+                }
+                if rejected:
+                    event_payload["rejectionReason"] = validation.reason or "CONNECTION_VALIDATION_FAILED"
+                events.append(_envelope(event_type, transfer_id, 1, event_payload, envelope.correlationId, envelope.eventId, at))
+        return events
+
+    def _default_mct_rule(self, from_type: NodeType, to_type: NodeType, category: TransferCategory, mct: MinimumConnectionTime, at: datetime) -> MctRule:
+        return MctRule(f"mct-default-{mct.fromMode.value.lower()}-{mct.toMode.value.lower()}-{category.value.lower()}", 1, MctRuleStatus.PUBLISHED, from_type, to_type, category, mct.minutes, {"source": "BUILTIN_STATION_POLICY", "stationRef": mct.stationRef}, at, publishedAt=at)
+
+    def _carrier_responsible(self, connection: Connection) -> bool:
+        return connection.guaranteed or connection.contractType in PROTECTED_TYPES
+
+    def _rebooking_suggestions(self, raw_items: Any) -> tuple[RebookingSuggestion, ...]:
+        suggestions: list[RebookingSuggestion] = []
+        for item in raw_items or ():
+            if not isinstance(item, Mapping):
+                continue
+            segment_ref = item.get("newSegmentRef") or item.get("segmentRef") or item.get("scheduledServiceRef")
+            departure = item.get("newDepartureTime") or item.get("departureAt") or item.get("nextDepartureAt")
+            if not segment_ref or not departure:
+                continue
+            suggestions.append(RebookingSuggestion(str(segment_ref), parse_dt(departure, "rebookingSuggestion.newDepartureTime"), int(item.get("additionalCost") or 0)))
+        return tuple(suggestions)
+
+    def _auto_rebook(self, connection: Connection, suggestions: Iterable[RebookingSuggestion], at: datetime, correlation_id: str, causation_id: str) -> tuple[Connection, list[Connection], list[EventEnvelope]]:
+        actual_arrival = connection.window.actualArrivalAt or connection.window.plannedArrivalAt
+        request = RebookingRequest(connection.connectionId, connection.nextSegmentRef, AUTO_REBOOKING_WINDOW)
+        suggestion = MissedConnectionDetector().choose_rebooking(request, actual_arrival, tuple(suggestions))
+        if suggestion is None:
+            return connection, [], [self._rebooking_failed_event(connection, at, correlation_id, causation_id, "NO_ALTERNATIVE_WITHIN_4_HOURS")]
+        no_charge = replace(suggestion, additionalCost=0)
+        window = ConnectionWindow.build(actual_arrival, no_charge.newDepartureTime, no_charge.newDepartureTime, connection.window.mctMinutes)
+        evaluation = RiskEvaluation(new_prefixed_uuid7("tre"), RiskLevel.FEASIBLE if window.bufferMinutes >= 0 else RiskLevel.AT_RISK, connection.latestEvaluation.mctRuleId, connection.latestEvaluation.mctRuleVersion, window.availableMinutes, connection.latestEvaluation.requiredMinutes, ("AUTO_REBOOKING",), at, connection.latestEvaluation.riskPolicyVersion, connection.latestEvaluation.placeGraphVersion, connection.latestEvaluation.degraded, connection.latestEvaluation.degradedReasons)
+        replacement_connection = Connection(new_prefixed_uuid7("con"), connection.transferPlanId, connection.itineraryRef, connection.previousSegmentRef, no_charge.newSegmentRef, connection.travelerRefs, connection.fromNodeRef, connection.toNodeRef, connection.fromNodeType, connection.toNodeType, connection.transferCategory, connection.contractId, connection.contractType, ConnectionStatus.PLANNED, evaluation, window, at, at, connection.journeyOrderId, serviceDate=connection.serviceDate, scheduledServiceRef=no_charge.newSegmentRef, replacementOfConnectionId=connection.connectionId, fromMode=connection.fromMode, toMode=connection.toMode, guaranteed=connection.guaranteed, transferInstructions=connection.transferInstructions, walkingDistanceMeters=connection.walkingDistanceMeters).transition(ConnectionStatus.FEASIBLE if evaluation.riskLevel is RiskLevel.FEASIBLE else ConnectionStatus.AT_RISK, at)
+        plan = self.store.get_plan(connection.transferPlanId).add_connection(replacement_connection.connectionId, at)
+        recovered = connection.recover_with_replacement(replacement_connection.connectionId, at)
+        self.store.save_plan(plan)
+        self.store.save_connection(replacement_connection)
+        event = _envelope("AutoRebookingCompleted", recovered.connectionId, recovered.version + 1, {"connection": recovered.ref_json(), "rebookingRequest": request.to_json(), "rebookingSuggestion": no_charge.to_json(), "replacementConnectionId": replacement_connection.connectionId, "additionalCost": 0, "carrierResponsible": True, "completedAt": rfc3339_utc(at)}, correlation_id, causation_id, at)
+        registered = _envelope("ConnectionRegistered", replacement_connection.connectionId, 1, replacement_connection.to_json() | {"registeredAt": rfc3339_utc(at), "autoRebooking": True}, correlation_id, causation_id, at)
+        return recovered, [replacement_connection], [registered, event]
+
+    def _rebooking_failed_event(self, connection: Connection, at: datetime, correlation_id: str, causation_id: str, reason: str) -> EventEnvelope:
+        request = RebookingRequest(connection.connectionId, connection.nextSegmentRef, AUTO_REBOOKING_WINDOW)
+        payload = {"connection": connection.ref_json(), "rebookingRequest": request.to_json(), "reason": reason, "refundOffered": self._carrier_responsible(connection), "refundScope": "REMAINING_LEGS" if self._carrier_responsible(connection) else "VOLUNTARY_CHANGE_RULES", "failedAt": rfc3339_utc(at)}
+        return _envelope("RebookingFailed", connection.connectionId, connection.version + 4, payload, correlation_id, causation_id, at)
 
     def _plan_json(self, plan: TransferPlan) -> dict[str, Any]:
         connections = tuple(c.summary_json() for c in self.store.list_connections_for_plan(plan.transferPlanId))
@@ -614,7 +835,8 @@ class TransferManagementService:
                     reasons.append("PREVIOUS_SEGMENT_CANCELLED")
             elif report.segmentRef == connection.nextSegmentRef and report.reportType is ReportType.CANCELLED:
                 reasons.append("NEXT_SEGMENT_CANCELLED")
-        rule = self._require_published_rule(connection.fromNodeType, connection.toNodeType, connection.transferCategory, at)
+        mct = MinimumConnectionTime.default_for(connection.toNodeRef, connection.fromMode, connection.toMode, connection.transferCategory is TransferCategory.IN_STATION)
+        rule = self._find_published_rule(connection.fromNodeType, connection.toNodeType, connection.transferCategory, at) or self._default_mct_rule(connection.fromNodeType, connection.toNodeType, connection.transferCategory, mct, at)
         place_graph_version = connection.latestEvaluation.placeGraphVersion
         degraded_reasons: tuple[str, ...] = ()
         try:
@@ -623,6 +845,10 @@ class TransferManagementService:
                 place_graph_version = topology.placeGraphVersion
         except (PlaceNetworkUnavailable, PlaceNetworkValidationError):
             degraded_reasons = ("PLACE_NETWORK_UNAVAILABLE",)
+        actual_arrival = window.actualArrivalAt or window.plannedArrivalAt
+        effective_mct = MinimumConnectionTime(connection.toNodeRef, connection.fromMode, connection.toMode, window.mctMinutes)
+        if MissedConnectionDetector().is_missed(actual_arrival, window.nextDepartureAt, effective_mct):
+            reasons.append("MISSED_CONNECTION_MCT_VIOLATION")
         evaluation = self._evaluate_window(window, rule, at, new_prefixed_uuid7("tre"), reasons, place_graph_version, degraded_reasons)
         updated = connection.apply_evaluation(evaluation, window, at)
         events = [self._risk_event(updated, previous_status if previous_status != updated.status else None, correlation_id, causation_id, at, report.segmentStatusReportId if report else None)]

--- a/services/transfer-management/src/transfer_management/domain.py
+++ b/services/transfer-management/src/transfer_management/domain.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import Any, Iterable, Mapping
 
@@ -45,6 +45,14 @@ class ContractType(StrEnum):
     SUPPLIER_PROTECTED = "SUPPLIER_PROTECTED"
     PLATFORM_ASSISTED = "PLATFORM_ASSISTED"
     SELF_TRANSFER = "SELF_TRANSFER"
+
+
+class TransferMode(StrEnum):
+    TRAIN = "TRAIN"
+    METRO = "METRO"
+    BUS = "BUS"
+    FLIGHT = "FLIGHT"
+    TAXI = "TAXI"
 
 
 class ContractStatus(StrEnum):
@@ -169,6 +177,179 @@ def require_text(value: Any, field_name: str) -> str:
     if not text:
         raise DomainError(f"{field_name} is required")
     return text
+
+
+
+LARGE_HUB_STATIONS = frozenset({"北京南", "上海虹桥", "广州南"})
+MEDIUM_HUB_STATIONS = frozenset({"南京南", "武汉", "成都东"})
+
+
+def station_default_mct_minutes(station_ref: str) -> int:
+    station = str(station_ref or "").strip()
+    if station in LARGE_HUB_STATIONS:
+        return 25
+    if station in MEDIUM_HUB_STATIONS:
+        return 20
+    return 15
+
+
+@dataclass(frozen=True, slots=True)
+class MinimumConnectionTime:
+    stationRef: str
+    fromMode: TransferMode
+    toMode: TransferMode
+    minutes: int
+
+    def __post_init__(self) -> None:
+        require_text(self.stationRef, "stationRef")
+        if self.minutes <= 0:
+            raise DomainError("minimum connection time must be positive")
+
+    @classmethod
+    def default_for(cls, station_ref: str, from_mode: TransferMode = TransferMode.TRAIN, to_mode: TransferMode = TransferMode.TRAIN, same_platform: bool = False, override_minutes: int | None = None) -> "MinimumConnectionTime":
+        if override_minutes is not None:
+            minutes = int(override_minutes)
+        elif from_mode is TransferMode.TRAIN and to_mode is TransferMode.METRO:
+            minutes = 35
+        elif same_platform and from_mode is to_mode:
+            minutes = 10
+        else:
+            minutes = station_default_mct_minutes(station_ref)
+        return cls(station_ref, from_mode, to_mode, minutes)
+
+    def to_json(self) -> dict[str, Any]:
+        return {"stationRef": self.stationRef, "fromMode": self.fromMode.value, "toMode": self.toMode.value, "minutes": self.minutes}
+
+
+@dataclass(frozen=True, slots=True)
+class CrossModeTransfer:
+    fromMode: TransferMode
+    toMode: TransferMode
+    fromStationRef: str
+    toStationRef: str
+    walkingMinutes: int
+    mctOverride: int | None = None
+
+    def __post_init__(self) -> None:
+        require_text(self.fromStationRef, "fromStationRef")
+        require_text(self.toStationRef, "toStationRef")
+        if self.walkingMinutes < 0:
+            raise DomainError("walkingMinutes must be non-negative")
+        if self.mctOverride is not None and self.mctOverride <= 0:
+            raise DomainError("mctOverride must be positive")
+
+    @property
+    def instructions(self) -> str:
+        if self.fromMode is self.toMode:
+            return f"Remain within {self.fromStationRef} and follow signs to the connecting {self.toMode.value.lower()} service."
+        return f"Transfer from {self.fromMode.value} at {self.fromStationRef} to {self.toMode.value} at {self.toStationRef}; allow about {self.walkingMinutes} minutes for walking and wayfinding."
+
+    @property
+    def walkingDistanceMeters(self) -> int:
+        return self.walkingMinutes * 80
+
+    def minimum_connection_time(self) -> MinimumConnectionTime:
+        return MinimumConnectionTime.default_for(self.toStationRef, self.fromMode, self.toMode, self.fromStationRef == self.toStationRef, self.mctOverride)
+
+    def to_json(self) -> dict[str, Any]:
+        data = {"fromMode": self.fromMode.value, "toMode": self.toMode.value, "fromStationRef": self.fromStationRef, "toStationRef": self.toStationRef, "walkingMinutes": self.walkingMinutes, "walkingDistanceMeters": self.walkingDistanceMeters, "instructions": self.instructions}
+        if self.mctOverride is not None:
+            data["mctOverride"] = self.mctOverride
+        return data
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectionGuarantee:
+    transferId: str
+    guaranteed: bool
+    itineraryRef: str
+
+    def __post_init__(self) -> None:
+        require_text(self.transferId, "transferId")
+        require_text(self.itineraryRef, "itineraryRef")
+
+    def to_json(self) -> dict[str, Any]:
+        return {"transferId": self.transferId, "guaranteed": self.guaranteed, "itineraryRef": self.itineraryRef}
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectionValidationResult:
+    valid: bool
+    reason: str | None
+    availableMinutes: int
+    requiredMinutes: int
+
+    def to_json(self) -> dict[str, Any]:
+        data = {"valid": self.valid, "availableMinutes": self.availableMinutes, "requiredMinutes": self.requiredMinutes}
+        if self.reason:
+            data["reason"] = self.reason
+        return data
+
+
+class ConnectionValidator:
+    def validate(self, arrival_at: datetime, departure_at: datetime, minimum_connection_time: MinimumConnectionTime) -> ConnectionValidationResult:
+        available = int((departure_at - arrival_at).total_seconds() // 60)
+        if available < minimum_connection_time.minutes:
+            return ConnectionValidationResult(False, "INSUFFICIENT_CONNECTION_TIME", available, minimum_connection_time.minutes)
+        return ConnectionValidationResult(True, None, available, minimum_connection_time.minutes)
+
+    def ensure_valid(self, arrival_at: datetime, departure_at: datetime, minimum_connection_time: MinimumConnectionTime) -> ConnectionValidationResult:
+        result = self.validate(arrival_at, departure_at, minimum_connection_time)
+        if not result.valid:
+            raise DomainError(result.reason or "CONNECTION_VALIDATION_FAILED")
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class RebookingRequest:
+    originalTransferId: str
+    missedLegRef: str
+    searchWindow: timedelta
+
+    def __post_init__(self) -> None:
+        require_text(self.originalTransferId, "originalTransferId")
+        require_text(self.missedLegRef, "missedLegRef")
+        if self.searchWindow.total_seconds() <= 0:
+            raise DomainError("searchWindow must be positive")
+
+    def to_json(self) -> dict[str, Any]:
+        return {"originalTransferId": self.originalTransferId, "missedLegRef": self.missedLegRef, "searchWindowMinutes": int(self.searchWindow.total_seconds() // 60)}
+
+
+@dataclass(frozen=True, slots=True)
+class RebookingSuggestion:
+    newSegmentRef: str
+    newDepartureTime: datetime
+    additionalCost: int = 0
+
+    def __post_init__(self) -> None:
+        require_text(self.newSegmentRef, "newSegmentRef")
+        if self.additionalCost < 0:
+            raise DomainError("additionalCost must be non-negative")
+
+    def to_json(self) -> dict[str, Any]:
+        return {"newSegmentRef": self.newSegmentRef, "newDepartureTime": rfc3339_utc(self.newDepartureTime), "additionalCost": self.additionalCost}
+
+
+class MissedConnectionDetector:
+    def is_missed(self, actual_arrival_at: datetime, next_departure_at: datetime, minimum_connection_time: MinimumConnectionTime) -> bool:
+        return actual_arrival_at > next_departure_at - timedelta(minutes=minimum_connection_time.minutes)
+
+    def choose_rebooking(self, request: RebookingRequest, missed_at: datetime, suggestions: Iterable[RebookingSuggestion]) -> RebookingSuggestion | None:
+        latest = missed_at + request.searchWindow
+        feasible = [suggestion for suggestion in suggestions if missed_at <= suggestion.newDepartureTime <= latest]
+        return min(feasible, key=lambda suggestion: suggestion.newDepartureTime) if feasible else None
+
+
+@dataclass(frozen=True, slots=True)
+class TransferProposal:
+    transferId: str
+    validations: tuple[ConnectionValidationResult, ...] = ()
+
+    def validateConnectionTimes(self) -> None:
+        for validation in self.validations:
+            if not validation.valid:
+                raise DomainError(validation.reason or "CONNECTION_VALIDATION_FAILED")
 
 
 @dataclass(frozen=True, slots=True)
@@ -355,6 +536,11 @@ class Connection:
     scheduledServiceRef: str | None = None
     replacementOfConnectionId: str | None = None
     replacementConnectionId: str | None = None
+    fromMode: TransferMode = TransferMode.TRAIN
+    toMode: TransferMode = TransferMode.TRAIN
+    guaranteed: bool = False
+    transferInstructions: str | None = None
+    walkingDistanceMeters: int | None = None
     version: int = 0
 
     def transition(self, target: ConnectionStatus, at: datetime) -> "Connection":
@@ -424,6 +610,13 @@ class Connection:
             data["replacementOfConnectionId"] = self.replacementOfConnectionId
         if self.replacementConnectionId:
             data["replacementConnectionId"] = self.replacementConnectionId
+        data["fromMode"] = self.fromMode.value
+        data["toMode"] = self.toMode.value
+        data["guaranteed"] = self.guaranteed
+        if self.transferInstructions:
+            data["transferInstructions"] = self.transferInstructions
+        if self.walkingDistanceMeters is not None:
+            data["walkingDistanceMeters"] = self.walkingDistanceMeters
         if self.recovery and self.recovery.recoveryTriggerStatus is not RecoveryTriggerStatus.NOT_REQUIRED:
             data["recovery"] = self.recovery.to_json()
         return data
@@ -590,7 +783,7 @@ class TransferRiskPolicy:
 
     def classify(self, available_minutes: int, buffer_minutes: int, reasons: Iterable[str]) -> tuple[RiskLevel, tuple[str, ...]]:
         explanation = list(reasons)
-        if "NEXT_SEGMENT_CANCELLED" in explanation or "PREVIOUS_SEGMENT_CANCELLED" in explanation:
+        if "NEXT_SEGMENT_CANCELLED" in explanation or "PREVIOUS_SEGMENT_CANCELLED" in explanation or "MISSED_CONNECTION_MCT_VIOLATION" in explanation:
             return RiskLevel.MISSED, tuple(dict.fromkeys(explanation))
         if available_minutes < 0:
             explanation.append("CUTOFF_EXPIRED")

--- a/services/transfer-management/src/transfer_management/web/handlers.py
+++ b/services/transfer-management/src/transfer_management/web/handlers.py
@@ -46,6 +46,12 @@ class RegisterConnectionRequest(LooseModel):
     journeyOrderId: str | None = None
     serviceDate: str | None = None
     scheduledServiceRef: str | None = None
+    fromMode: str | None = None
+    toMode: str | None = None
+    samePlatform: bool | None = None
+    walkingMinutes: int | None = None
+    mctOverride: int | None = None
+    guaranteed: bool | None = None
 
 
 class ReaccommodateConnectionRequest(LooseModel):

--- a/services/transfer-management/tests/test_api.py
+++ b/services/transfer-management/tests/test_api.py
@@ -224,7 +224,7 @@ def test_reaccommodate_precondition_and_self_completion_skip() -> None:
     assert [e for e in store.take_outbox() if e.eventType == "ConnectionRecovered"] == []
 
 
-def test_fulfillment_segment_delayed_event_marks_connection_at_risk() -> None:
+def test_fulfillment_segment_delayed_event_marks_connection_missed_when_mct_is_violated() -> None:
     from datetime import UTC, datetime
     from train_ticket_platform.events import EventEnvelope
     from transfer_management.application.service import TransferManagementService
@@ -242,7 +242,7 @@ def test_fulfillment_segment_delayed_event_marks_connection_at_risk() -> None:
 
     assert service.handle_fulfillment_event(envelope, "events:fulfillment") is True
     updated = service.get_connection(connection["connectionId"])
-    assert updated["status"] == "AT_RISK"
+    assert updated["status"] == "MISSED"
     assert store.mark_processed(envelope.eventId, "events:fulfillment") is False
 
 
@@ -313,3 +313,48 @@ def test_failed_activation_does_not_retire_the_active_policy() -> None:
     assert res.status_code == 412, res.text
     res = client.get("/api/v1/risk-policies/active")
     assert res.json()["riskPolicyId"] == p2, res.text
+
+
+def test_connection_missed_auto_rebooks_with_no_charge() -> None:
+    client, store, downstream = setup_client()
+    con = create_plan_and_connection(client)
+    now = datetime.now(UTC).replace(microsecond=0)
+    res = client.post("/api/v1/segment-status-reports", headers={"Idempotency-Key": idem(), "X-Correlation-Id": f"corr-{idem()}"}, json={"segmentRef": "seg-a", "reportType": "DELAY", "reportedBy": {"actorType": "SYSTEM", "actorId": "sys"}, "sourceSystem": "OPERATIONS", "sourceRecordId": "r-auto", "observedAt": rfc3339_utc(now), "estimatedArrivalAt": rfc3339_utc(now + timedelta(hours=2)), "rebookingSuggestions": [{"newSegmentRef": "seg-c", "newDepartureTime": rfc3339_utc(now + timedelta(hours=3)), "additionalCost": 2500}]})
+    assert res.status_code == 202, res.text
+    updated = res.json()["updatedConnections"]
+    recovered = [item for item in updated if item["connectionId"] == con["connectionId"]][0]
+    assert recovered["status"] == "RECOVERED"
+    assert recovered["replacementConnectionId"]
+    assert downstream.calls == []
+    events = [event for event in store.take_outbox() if event.eventType == "AutoRebookingCompleted"]
+    assert events[-1].payload["additionalCost"] == 0
+    assert events[-1].payload["rebookingSuggestion"]["newSegmentRef"] == "seg-c"
+
+
+def test_guaranteed_missed_without_alternative_offers_remaining_leg_refund() -> None:
+    client, store, _ = setup_client()
+    con = create_plan_and_connection(client)
+    now = datetime.now(UTC).replace(microsecond=0)
+    res = client.post("/api/v1/segment-status-reports", headers={"Idempotency-Key": idem(), "X-Correlation-Id": f"corr-{idem()}"}, json={"segmentRef": "seg-a", "reportType": "DELAY", "reportedBy": {"actorType": "SYSTEM", "actorId": "sys"}, "sourceSystem": "OPERATIONS", "sourceRecordId": "r-refund", "observedAt": rfc3339_utc(now), "estimatedArrivalAt": rfc3339_utc(now + timedelta(hours=2))})
+    assert res.status_code == 202, res.text
+    assert client.get(f"/api/v1/connections/{con['connectionId']}").json()["status"] == "MISSED"
+    failed = [event for event in store.take_outbox() if event.eventType == "RebookingFailed"]
+    assert failed[-1].payload["refundOffered"] is True
+    assert failed[-1].payload["refundScope"] == "REMAINING_LEGS"
+
+
+def test_disruption_train_delayed_event_consumed_as_missed_connection() -> None:
+    from transfer_management.application.service import TransferManagementService
+
+    store = InMemoryStore()
+    downstream = FakeDownstream()
+    service = TransferManagementService(store, downstream)
+    rule = service.create_mct_rule({"fromNodeType": "STATION", "toNodeType": "STATION", "transferCategory": "SAME_STATION", "minimumMinutes": 20, "conditions": {}, "validFrom": "2025-01-01T00:00:00Z"}, "corr-test", "cmd-test")
+    service.publish_mct_rule(rule["mctRuleId"], {"publishedBy": {"actorType": "OPERATIONS", "actorId": "ops"}, "publishReason": "test"}, "corr-test", "cmd-test")
+    plan = service.create_plan({"itineraryRef": "iti-delay", "planningSnapshotVersion": 1, "travelerRefs": ["trav-1"], "journeyOrderId": "jo-delay"}, "corr-test", "cmd-test")
+    now = datetime.now(UTC).replace(microsecond=0)
+    con = service.register_connection({"transferPlanId": plan["transferPlanId"], "itineraryRef": "iti-delay", "journeyOrderId": "jo-delay", "previousSegmentRef": "train-a", "nextSegmentRef": "train-b", "travelerRefs": ["trav-1"], "fromNodeRef": "sta", "toNodeRef": "sta", "fromNodeType": "STATION", "toNodeType": "STATION", "transferCategory": "SAME_STATION", "contractId": "cct-delay", "contractType": "PROTECTED", "window": {"plannedArrivalAt": rfc3339_utc(now), "nextDepartureAt": rfc3339_utc(now + timedelta(minutes=60))}}, "corr-test", "cmd-test")
+    env = EventEnvelope(eventId="evt-" + idem(), eventType="TrainDelayed", producer="disruption-recovery", correlationId="corr-" + idem(), causationId="evt-" + idem(), payload={"segmentRef": "train-a", "estimatedArrivalAt": rfc3339_utc(now + timedelta(hours=2)), "observedAt": rfc3339_utc(now)})
+    assert service.handle_recovery_event(env, "events:disruption-recovery") is True
+    assert service.get_connection(con["connectionId"])["status"] == "MISSED"
+    assert any(event.eventType == "ConnectionMissed" for event in store.take_outbox())

--- a/services/transfer-management/tests/test_domain.py
+++ b/services/transfer-management/tests/test_domain.py
@@ -5,8 +5,9 @@ from uuid import UUID
 
 import pytest
 
+from train_ticket_platform.events import EventEnvelope
 from transfer_management.application.service import InMemoryStore, TransferManagementService, folded_uuid7
-from transfer_management.domain import ConnectionStatus, PreconditionFailed
+from transfer_management.domain import ConnectionStatus, DomainError, PreconditionFailed
 
 
 def test_folded_uuid7_shape_is_stable() -> None:
@@ -48,3 +49,77 @@ def test_published_mct_rule_is_immutable() -> None:
     service.publish_mct_rule(rule["mctRuleId"], {"publishedBy": {"actorType": "OPERATIONS", "actorId": "ops"}, "publishReason": "test"}, "corr-test", "cmd-test")
     with pytest.raises(PreconditionFailed):
         service.update_mct_rule(rule["mctRuleId"], {"minimumMinutes": 25})
+
+
+def test_large_hub_mct_enforced_rejects_ten_minute_gap_and_accepts_thirty() -> None:
+    service = TransferManagementService(InMemoryStore())
+    now = datetime(2026, 1, 1, 10, tzinfo=UTC)
+    plan = service.create_plan({"itineraryRef": "iti-mct", "planningSnapshotVersion": 1, "travelerRefs": ["trav-1"], "journeyOrderId": "jo-mct"}, "corr-test", "cmd-test")
+    base = {"transferPlanId": plan["transferPlanId"], "itineraryRef": "iti-mct", "journeyOrderId": "jo-mct", "previousSegmentRef": "seg-a", "nextSegmentRef": "seg-b", "travelerRefs": ["trav-1"], "fromNodeRef": "北京南", "toNodeRef": "北京南", "fromNodeType": "STATION", "toNodeType": "STATION", "transferCategory": "SAME_STATION", "contractId": "cct-mct", "contractType": "PROTECTED"}
+    with pytest.raises(DomainError) as exc:
+        service.register_connection(base | {"window": {"plannedArrivalAt": now.isoformat().replace("+00:00", "Z"), "nextDepartureAt": (now + timedelta(minutes=10)).isoformat().replace("+00:00", "Z")}}, "corr-test", "cmd-test")
+    assert "INSUFFICIENT_CONNECTION_TIME" in str(exc.value)
+    con = service.register_connection(base | {"nextSegmentRef": "seg-c", "window": {"plannedArrivalAt": now.isoformat().replace("+00:00", "Z"), "nextDepartureAt": (now + timedelta(minutes=30)).isoformat().replace("+00:00", "Z")}}, "corr-test", "cmd-test")
+    assert con["status"] in {"FEASIBLE", "TIGHT"}
+    assert con["window"]["mctMinutes"] == 25
+
+
+def test_cross_mode_train_to_metro_uses_35_minute_mct_and_instructions() -> None:
+    service = TransferManagementService(InMemoryStore())
+    now = datetime(2026, 1, 1, 10, tzinfo=UTC)
+    plan = service.create_plan({"itineraryRef": "iti-metro", "planningSnapshotVersion": 1, "travelerRefs": ["trav-1"]}, "corr-test", "cmd-test")
+    con = service.register_connection({"transferPlanId": plan["transferPlanId"], "itineraryRef": "iti-metro", "previousSegmentRef": "seg-train", "nextSegmentRef": "metro-1", "travelerRefs": ["trav-1"], "fromNodeRef": "北京南", "toNodeRef": "北京南地铁", "fromNodeType": "STATION", "toNodeType": "STATION", "transferCategory": "CROSS_STATION", "contractId": "cct-metro", "contractType": "SELF_TRANSFER", "fromMode": "TRAIN", "toMode": "METRO", "walkingMinutes": 12, "window": {"plannedArrivalAt": now.isoformat().replace("+00:00", "Z"), "nextDepartureAt": (now + timedelta(minutes=40)).isoformat().replace("+00:00", "Z")}}, "corr-test", "cmd-test")
+    assert con["window"]["mctMinutes"] == 35
+    assert con["walkingDistanceMeters"] == 960
+    assert "Transfer from TRAIN" in con["transferInstructions"]
+
+
+def test_cross_mode_train_to_metro_same_station_does_not_use_same_platform_mct() -> None:
+    service = TransferManagementService(InMemoryStore())
+    now = datetime(2026, 1, 1, 10, tzinfo=UTC)
+    plan = service.create_plan({"itineraryRef": "iti-metro-same", "planningSnapshotVersion": 1, "travelerRefs": ["trav-1"]}, "corr-test", "cmd-test")
+    base = {"transferPlanId": plan["transferPlanId"], "itineraryRef": "iti-metro-same", "previousSegmentRef": "seg-train", "nextSegmentRef": "metro-1", "travelerRefs": ["trav-1"], "fromNodeRef": "北京南", "toNodeRef": "北京南", "fromNodeType": "STATION", "toNodeType": "STATION", "transferCategory": "IN_STATION", "contractId": "cct-metro-same", "contractType": "SELF_TRANSFER", "fromMode": "TRAIN", "toMode": "METRO"}
+
+    with pytest.raises(DomainError) as exc:
+        service.register_connection(base | {"window": {"plannedArrivalAt": now.isoformat().replace("+00:00", "Z"), "nextDepartureAt": (now + timedelta(minutes=20)).isoformat().replace("+00:00", "Z")}}, "corr-test", "cmd-test")
+
+    assert "INSUFFICIENT_CONNECTION_TIME" in str(exc.value)
+    con = service.register_connection(base | {"nextSegmentRef": "metro-2", "window": {"plannedArrivalAt": now.isoformat().replace("+00:00", "Z"), "nextDepartureAt": (now + timedelta(minutes=40)).isoformat().replace("+00:00", "Z")}}, "corr-test", "cmd-test")
+    assert con["window"]["mctMinutes"] == 35
+
+
+def test_itinerary_proposed_validates_mct_and_publishes_outbox_events() -> None:
+    store = InMemoryStore()
+    service = TransferManagementService(store)
+    now = datetime(2026, 1, 1, 10, tzinfo=UTC)
+    envelope = EventEnvelope(
+        eventId="evt-itinerary-proposed",
+        eventType="ItineraryProposed",
+        producer="trip-planning",
+        correlationId="corr-test",
+        causationId="cmd-test",
+        payload={
+            "intentRef": "intent-1",
+            "itineraries": [
+                {
+                    "itineraryRef": "iti-proposed",
+                    "legs": [
+                        {"serviceSegmentRef": "seg-train", "originStopRef": "南京南", "destinationStopRef": "北京南", "departureTime": (now - timedelta(hours=1)).isoformat().replace("+00:00", "Z"), "arrivalTime": now.isoformat().replace("+00:00", "Z"), "mode": "TRAIN"},
+                        {"serviceSegmentRef": "metro-1", "originStopRef": "北京南", "destinationStopRef": "西单", "departureTime": (now + timedelta(minutes=20)).isoformat().replace("+00:00", "Z"), "arrivalTime": (now + timedelta(minutes=40)).isoformat().replace("+00:00", "Z"), "mode": "METRO"},
+                    ],
+                    "transfers": [{"transferCategory": "IN_STATION", "samePlatform": True}],
+                }
+            ],
+            "planningSnapshotRefs": ["snapshot-1"],
+        },
+    )
+
+    assert service.handle_trip_planning_event(envelope, "events:trip-planning") is True
+    assert service.handle_trip_planning_event(envelope, "events:trip-planning") is True
+
+    events = store.take_outbox()
+    rejected = [event for event in events if event.eventType == "ConnectionValidationRejected"]
+    assert len(rejected) == 1
+    assert rejected[0].payload["validation"]["reason"] == "INSUFFICIENT_CONNECTION_TIME"
+    assert rejected[0].payload["minimumConnectionTime"]["minutes"] == 35
+    assert [event.eventType for event in events].count("ConnectionValidationRejected") == 1


### PR DESCRIPTION
## Summary
- Enforce station and cross-mode minimum connection times in transfer-management
- Consume ItineraryProposed events to validate proposed itinerary transfers and emit outbox validation/rejection events
- Add tests for TRAIN→METRO same-station MCT precedence and itinerary proposal MCT validation

## Validation
- cd services/transfer-management && uv run python -m compileall src tests
- cd services/transfer-management && uv run python -m pytest -q
- git diff --check origin/refactor/greenfield-ddd...HEAD