### PR TITLE
REQ-311 notification multi-channel enrichment

### DIFF
--- a/services/notification/migrations/001_notification_storage.sql
+++ b/services/notification/migrations/001_notification_storage.sql
@@ -57,3 +57,27 @@ CREATE TABLE IF NOT EXISTS notification_templates (
   data          jsonb NOT NULL,
   updated_at    timestamptz NOT NULL DEFAULT now()
 );
+
+
+CREATE TABLE IF NOT EXISTS recipient_contacts (
+  recipient_ref     text PRIMARY KEY,
+  device_token      text,
+  phone_number      text,
+  email_address     text,
+  preferred_channel text,
+  updated_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS notification_rate_limits (
+  id            bigserial PRIMARY KEY,
+  recipient_ref text NOT NULL,
+  channel       text NOT NULL,
+  occurred_at   timestamptz NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS notification_rate_limits_user_channel_time_idx
+  ON notification_rate_limits (recipient_ref, channel, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS notification_rate_limits_sms_time_idx
+  ON notification_rate_limits (occurred_at DESC)
+  WHERE channel = 'SMS';

--- a/services/notification/src/adapters/messaging/runtime.ts
+++ b/services/notification/src/adapters/messaging/runtime.ts
@@ -1,5 +1,6 @@
 import { DeduplicatingEventHandler, fatalHandling, successfulHandling } from "../../application/messaging.js";
 import { DirectSuccessGateway, type NotificationChannelGateway, NonConformantNotificationTrigger, NotificationApplicationService } from "../../application/notification-service.js";
+import { NotificationAggregator, RateLimitExceeded } from "../../domain.js";
 import { startNotificationStorage, type NotificationStorageRuntime } from "../storage/runtime.js";
 import { RedisStreamEventPublisher } from "./publisher.js";
 import { RedisStreamEventSubscriber } from "./subscriber.js";
@@ -23,7 +24,7 @@ export async function startNotificationMessaging(
   const storage = existingStorage ?? await optionalStorageRuntime(channelGateway);
   const publisher = storage ? undefined : new RedisStreamEventPublisher();
   const subscriber = new RedisStreamEventSubscriber();
-  const application = publisher ? new NotificationApplicationService(publisher, undefined, channelGateway) : undefined;
+  const application = publisher ? new NotificationApplicationService(publisher, undefined, channelGateway, undefined, undefined, undefined, new NotificationAggregator()) : undefined;
   const handler = new DeduplicatingEventHandler(async (envelope) => {
     try {
       if (storage) {
@@ -38,6 +39,9 @@ export async function startNotificationMessaging(
     } catch (error) {
       if (error instanceof NonConformantNotificationTrigger) {
         return fatalHandling(error);
+      }
+      if (error instanceof RateLimitExceeded) {
+        throw error;
       }
       throw error;
     }

--- a/services/notification/src/adapters/messaging/stream-config.ts
+++ b/services/notification/src/adapters/messaging/stream-config.ts
@@ -8,6 +8,8 @@ export const NOTIFICATION_SUBSCRIBED_STREAMS = Object.freeze([
   "events:payment",
   "events:entitlement-ticketing",
   "events:post-sales",
+  "events:disruption-recovery",
+  "events:waitlist",
   "events:wallet-promotion",
 ]);
 

--- a/services/notification/src/adapters/storage/notification-repository.ts
+++ b/services/notification/src/adapters/storage/notification-repository.ts
@@ -2,8 +2,8 @@ import { type PoolClient, type QueryResult } from "pg";
 
 import { SnapshotRepository, type SnapshotRecord } from "@trainticket/ts-kit";
 
-import { type NotificationTaskSnapshot } from "../../domain.js";
-import { type UserPreferenceRepository } from "../../application/notification-service.js";
+import { type NotificationChannel, type NotificationTaskSnapshot } from "../../domain.js";
+import { type ContactProfile, type RateLimitStore, type RecipientContactRepository, type UserPreferenceRepository } from "../../application/notification-service.js";
 
 export type PersistedNotificationTask = SnapshotRecord<NotificationTaskSnapshot>;
 
@@ -39,4 +39,73 @@ export class PostgresUserPreferenceRepository implements UserPreferenceRepositor
 
 function serializeSnapshot(snapshot: NotificationTaskSnapshot): NotificationTaskSnapshot {
   return JSON.parse(JSON.stringify(snapshot)) as NotificationTaskSnapshot;
+}
+
+
+export class PostgresRecipientContactRepository implements RecipientContactRepository {
+  constructor(private readonly client: PoolClient) {}
+
+  async getContactProfile(recipientRef: string): Promise<ContactProfile> {
+    const result = await this.client.query(
+      `SELECT device_token, phone_number, email_address, preferred_channel
+       FROM recipient_contacts
+       WHERE recipient_ref = $1`,
+      [recipientRef],
+    ) as QueryResult<{ device_token: string | null; phone_number: string | null; email_address: string | null; preferred_channel: NotificationChannel | null }>;
+    const row = result.rows[0];
+    return {
+      ...(row?.device_token ? { deviceToken: row.device_token } : {}),
+      ...(row?.phone_number ? { phoneNumber: row.phone_number } : {}),
+      emailAddress: row?.email_address ?? `${recipientRef}@passengers.train-ticket.local`,
+      ...(row?.preferred_channel ? { preferredChannel: row.preferred_channel } : {}),
+    };
+  }
+}
+
+export class PostgresRateLimitRepository implements RateLimitStore {
+  constructor(private readonly client: PoolClient) {}
+
+  async checkAndRecord(recipientRef: string, channel: NotificationChannel, at: Date): Promise<{ allowed: true } | { allowed: false; retryAfter: Date }> {
+    const limit = channelLimit(channel);
+    const userResult = await this.client.query(
+      `SELECT occurred_at
+       FROM notification_rate_limits
+       WHERE recipient_ref = $1 AND channel = $2 AND occurred_at > $3
+       ORDER BY occurred_at ASC`,
+      [recipientRef, channel, new Date(at.getTime() - limit.windowMs).toISOString()],
+    ) as QueryResult<{ occurred_at: Date }>;
+    if (userResult.rows.length >= limit.max) {
+      return { allowed: false, retryAfter: new Date(userResult.rows[0].occurred_at.getTime() + limit.windowMs) };
+    }
+
+    if (channel === "SMS") {
+      const globalResult = await this.client.query(
+        `SELECT occurred_at
+         FROM notification_rate_limits
+         WHERE channel = 'SMS' AND occurred_at > $1
+         ORDER BY occurred_at ASC`,
+        [new Date(at.getTime() - 60_000).toISOString()],
+      ) as QueryResult<{ occurred_at: Date }>;
+      if (globalResult.rows.length >= 1000) {
+        return { allowed: false, retryAfter: new Date(globalResult.rows[0].occurred_at.getTime() + 60_000) };
+      }
+    }
+
+    await this.client.query(
+      `INSERT INTO notification_rate_limits (recipient_ref, channel, occurred_at) VALUES ($1, $2, $3)`,
+      [recipientRef, channel, at.toISOString()],
+    );
+    return { allowed: true };
+  }
+}
+
+function channelLimit(channel: NotificationChannel): Readonly<{ max: number; windowMs: number }> {
+  switch (channel) {
+    case "PUSH":
+      return { max: 10, windowMs: 60 * 60 * 1000 };
+    case "SMS":
+      return { max: 5, windowMs: 24 * 60 * 60 * 1000 };
+    case "EMAIL":
+      return { max: 20, windowMs: 24 * 60 * 60 * 1000 };
+  }
 }

--- a/services/notification/src/adapters/storage/runtime.ts
+++ b/services/notification/src/adapters/storage/runtime.ts
@@ -17,13 +17,14 @@ import {
 } from "@trainticket/ts-kit";
 
 import { DirectSuccessGateway, type NotificationChannelGateway, NonConformantNotificationTrigger, NotificationApplicationService } from "../../application/notification-service.js";
-import { type NotificationTask } from "../../domain.js";
+import { NotificationAggregator, RateLimitExceeded, type NotificationTask } from "../../domain.js";
 import { redisUrl } from "../messaging/stream-config.js";
-import { PostgresNotificationTaskRepository, PostgresUserPreferenceRepository } from "./notification-repository.js";
+import { PostgresNotificationTaskRepository, PostgresRateLimitRepository, PostgresRecipientContactRepository, PostgresUserPreferenceRepository } from "./notification-repository.js";
 
 export type NotificationStorageRuntime = Readonly<{
   ready: () => Promise<boolean>;
   failure: () => unknown;
+  getNotificationTrail: (notificationId: string) => Promise<Readonly<{ notificationId: string; status: string; attempts: readonly Readonly<{ channelUsed: string; attemptedAt: string; status: string; reason?: string }>[] }> | undefined>;
   handleExternalTrigger: (envelope: EventEnvelope, stream?: string) => Promise<"ack" | "retry" | "dlq">;
   stop: () => Promise<void>;
 }>;
@@ -45,9 +46,28 @@ export async function startNotificationStorage(channelGateway: NotificationChann
   });
   relay.start();
 
+  const aggregator = new NotificationAggregator();
+
   return {
     ready: () => migrations.isReady ? checkPostgresReadiness(pool) : Promise.resolve(false),
     failure: () => migrations.failure,
+    getNotificationTrail: async (notificationId) => withTransaction(pool, async (client) => {
+      const record = await new PostgresNotificationTaskRepository(client).get(notificationId);
+      if (!record) {
+        return undefined;
+      }
+      const snapshot = record.data;
+      return {
+        notificationId,
+        status: snapshot.status,
+        attempts: snapshot.receipts.map((receipt) => ({
+          channelUsed: receipt.channel,
+          attemptedAt: new Date(receipt.recordedAt).toISOString(),
+          status: receipt.outcome === "Delivered" ? "DELIVERED" : receipt.outcome === "Bounced" ? "BOUNCED" : "FAILED",
+          ...(receipt.providerCode ? { reason: receipt.providerCode } : {}),
+        })),
+      };
+    }),
     handleExternalTrigger: async (envelope, stream) => withTransaction(pool, async (client) => {
       const guard = new ProcessedEventsGuard(client);
       if (!await guard.tryStart(envelope.eventId, stream)) {
@@ -61,6 +81,9 @@ export async function startNotificationStorage(channelGateway: NotificationChann
         new PostgresUserPreferenceRepository(client),
         channelGateway,
         new TransactionalNotificationTaskStore(new PostgresNotificationTaskRepository(client)),
+        new PostgresRecipientContactRepository(client),
+        new PostgresRateLimitRepository(client),
+        aggregator,
       );
 
       try {
@@ -69,6 +92,9 @@ export async function startNotificationStorage(channelGateway: NotificationChann
       } catch (error) {
         if (error instanceof NonConformantNotificationTrigger) {
           return "dlq";
+        }
+        if (error instanceof RateLimitExceeded) {
+          throw error;
         }
         if (error instanceof OptimisticConcurrencyConflict && await sameBusinessTaskExists(client, envelope)) {
           return "ack";
@@ -140,7 +166,7 @@ function templateCodeFor(eventType: string): string | undefined {
     case "JourneyOrderPaymentRecorded":
       return "order_payment_recorded";
     case "JourneyOrderConfirmed":
-      return "order_confirmed";
+      return "ORDER_CONFIRMED";
     case "JourneyOrderCancelled":
       return "order_cancelled";
     case "JourneyOrderPostSalesAdjusted":
@@ -153,11 +179,17 @@ function templateCodeFor(eventType: string): string | undefined {
       return "payment_failed";
     case "PaymentIntentExpired":
     case "PaymentExpired":
-      return "payment_expired";
+      return "PAYMENT_REMINDER";
     case "RefundSettled":
-      return "refund_settled";
+      return "REFUND_COMPLETED";
     case "EntitlementIssued":
-      return "ticket_issued";
+      return "TICKET_ISSUED";
+    case "WaitlistFulfilled":
+      return "WAITLIST_PROMOTED";
+    case "ServiceAlertPublished":
+      return "DELAY_ALERT";
+    case "RecoveryCompleted":
+      return "DISRUPTION_REBOOK";
     case "PostSalesEligibilityEvaluated":
       return "post_sales_eligibility";
     case "PostSalesDecisionQuoted":
@@ -182,7 +214,15 @@ function templateCodeFor(eventType: string): string | undefined {
 }
 
 function recipientRefFor(payload: Record<string, unknown>): string | undefined {
-  return stringValue(payload.recipientRef) ?? stringValue(payload.travelerId) ?? stringValue(payload.accountId) ?? stringValue(payload.actorRef) ?? stringValue(payload.travelerRef) ?? recipientFromTravelerRefs(payload.travelerRefs);
+  return stringValue(payload.recipientRef)
+    ?? stringValue(payload.travelerId)
+    ?? stringValue(payload.accountId)
+    ?? stringValue(payload.actorRef)
+    ?? stringValue(payload.travelerRef)
+    ?? firstString(payload.affectedOrderIds)
+    ?? stringValue(payload.journeyOrderId)
+    ?? stringValue(payload.serviceAlertId)
+    ?? recipientFromTravelerRefs(payload.travelerRefs);
 }
 
 function recipientFromTravelerRefs(value: unknown): string | undefined {
@@ -214,9 +254,20 @@ function triggerBusinessRefFor(envelope: EventEnvelope): string | undefined {
     ?? stringValue(payload.benefitId)
     ?? stringValue(payload.segmentBookingId)
     ?? stringValue(payload.caseId)
+    ?? stringValue(payload.serviceAlertId)
+    ?? stringValue(payload.incidentId)
+    ?? stringValue(payload.waitlistRequestId)
+    ?? stringValue(payload.journeyOrderRef)
     ?? stringValue(payload.postSalesCaseId)
     ?? stringValue(payload.businessRef);
   return direct ? `${envelope.eventType}:${direct}` : undefined;
+}
+
+function firstString(value: unknown): string | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.find((candidate): candidate is string => typeof candidate === "string" && candidate.trim().length > 0);
 }
 
 function stringValue(value: unknown): string | undefined {

--- a/services/notification/src/app.ts
+++ b/services/notification/src/app.ts
@@ -109,6 +109,18 @@ export function metadata(): ServiceMetadata {
 
 export type AppStorage = Readonly<{
   ready: () => boolean | Promise<boolean>;
+  getNotificationTrail?: (notificationId: string) => Promise<NotificationTrailResponse | undefined> | NotificationTrailResponse | undefined;
+}>;
+
+export type NotificationTrailResponse = Readonly<{
+  notificationId: string;
+  status: string;
+  attempts: readonly Readonly<{
+    channelUsed: string;
+    attemptedAt: string;
+    status: string;
+    reason?: string;
+  }>[];
 }>;
 
 export function createApp(instrumentation: InstrumentationHooks = {}, storage?: AppStorage): FastifyInstance {
@@ -142,6 +154,15 @@ export function createApp(instrumentation: InstrumentationHooks = {}, storage?: 
   app.get("/ready", async (_request, reply) => readyBody(reply, storage));
   app.get("/readyz", async (_request, reply) => readyBody(reply, storage));
 
+  app.get("/api/v1/notifications/:id/trail", async (request, reply) => {
+    const id = (request.params as { id: string }).id;
+    const trail = await storage?.getNotificationTrail?.(id);
+    if (trail === undefined) {
+      sendError(reply, 404, "NOT_FOUND", `Notification ${id} was not found`, requestContext(request));
+      return;
+    }
+    return trail;
+  });
 
   app.setNotFoundHandler((request, reply) => {
     sendError(reply, 404, "NOT_FOUND", `Route ${request.method} ${request.url} was not found`, requestContext(request));

--- a/services/notification/src/application/messaging.ts
+++ b/services/notification/src/application/messaging.ts
@@ -53,6 +53,7 @@ function domainEventPayload(event: NotificationDomainEvent): Record<string, unkn
         recipientRef: event.recipientRef,
         channel: event.channel,
         intent: event.intent,
+        ...(isReq311Template(event.templateCode) ? { templateType: event.templateCode } : {}),
         transactionRequired: event.transactionRequired,
         scheduledAt: event.scheduledAt.toISOString(),
       };
@@ -93,4 +94,16 @@ function domainEventPayload(event: NotificationDomainEvent): Record<string, unkn
         cancelledAt: event.cancelledAt.toISOString(),
       };
   }
+}
+
+function isReq311Template(templateCode: string): boolean {
+  return [
+    "ORDER_CONFIRMED",
+    "PAYMENT_REMINDER",
+    "TICKET_ISSUED",
+    "DELAY_ALERT",
+    "REFUND_COMPLETED",
+    "WAITLIST_PROMOTED",
+    "DISRUPTION_REBOOK",
+  ].includes(templateCode);
 }

--- a/services/notification/src/application/notification-service.ts
+++ b/services/notification/src/application/notification-service.ts
@@ -1,7 +1,14 @@
 import {
+  ChannelFallbackChain,
   type ChannelType,
+  type NotificationChannel,
+  NotificationAggregator,
   type NotificationTask,
   NotificationTask as NotificationTaskAggregate,
+  type NotificationTemplateType,
+  RateLimitExceeded,
+  RateLimiter,
+  TemplateRenderer,
   newNotificationTaskId,
   newReceiptId,
   type ScheduleNotification,
@@ -16,7 +23,7 @@ export type ExternalNotificationTrigger = Readonly<{
   payload: Record<string, unknown>;
 }>;
 
-export type ExternalTriggerResult = "delivered" | "cancelled" | "failed" | "ignored";
+export type ExternalTriggerResult = "delivered" | "cancelled" | "failed" | "ignored" | "deferred";
 
 export type UserPreference = Readonly<{
   recipientRef: string;
@@ -29,9 +36,24 @@ export interface UserPreferenceRepository {
   isEnabled(recipientRef: string, intent: string, channel: ChannelType): Promise<boolean> | boolean;
 }
 
+export type ContactProfile = Readonly<{
+  deviceToken?: string;
+  phoneNumber?: string;
+  emailAddress?: string;
+  preferredChannel?: NotificationChannel;
+}>;
+
+export interface RecipientContactRepository {
+  getContactProfile(recipientRef: string): Promise<ContactProfile> | ContactProfile;
+}
+
 export interface NotificationTaskStore {
   saveNew(task: NotificationTask): Promise<{ version: bigint }> | { version: bigint };
   save(task: NotificationTask, expectedVersion: bigint): Promise<{ version: bigint }> | { version: bigint };
+}
+
+export interface RateLimitStore {
+  checkAndRecord(recipientRef: string, channel: NotificationChannel, at: Date): Promise<{ allowed: true } | { allowed: false; retryAfter: Date }> | { allowed: true } | { allowed: false; retryAfter: Date };
 }
 
 export type DeliveryResult =
@@ -64,8 +86,23 @@ class AllowAllPreferences implements UserPreferenceRepository {
   }
 }
 
+class DefaultContactRepository implements RecipientContactRepository {
+  getContactProfile(): ContactProfile {
+    return { deviceToken: "push-default", phoneNumber: "+860000000000", emailAddress: "default@train-ticket.local" };
+  }
+}
+
+class InMemoryRateLimitStore implements RateLimitStore {
+  private readonly limiter = new RateLimiter();
+
+  checkAndRecord(recipientRef: string, channel: NotificationChannel, at: Date): { allowed: true } | { allowed: false; retryAfter: Date } {
+    return this.limiter.checkAndRecord(recipientRef, channel, at);
+  }
+}
+
 type TriggerMapping = Readonly<{
   templateCode: string;
+  templateType?: NotificationTemplateType;
   intent: string;
   channel: ChannelType;
   recipient: (payload: Record<string, unknown>) => string | undefined;
@@ -73,15 +110,20 @@ type TriggerMapping = Readonly<{
 }>;
 
 export class NotificationApplicationService {
+  private readonly renderer = new TemplateRenderer();
+
   constructor(
     private readonly publisher: EventPublisher,
     private readonly preferences: UserPreferenceRepository = new AllowAllPreferences(),
     private readonly channelGateway: NotificationChannelGateway = new DirectSuccessGateway(),
     private readonly taskStore?: NotificationTaskStore,
+    private readonly contacts: RecipientContactRepository = new DefaultContactRepository(),
+    private readonly rateLimits: RateLimitStore = new InMemoryRateLimitStore(),
+    private readonly aggregator: NotificationAggregator = new NotificationAggregator(),
   ) {}
 
   async handleExternalTrigger(envelope: EventEnvelope): Promise<ExternalTriggerResult> {
-    const command = scheduleCommandFromEnvelope(envelope);
+    const command = scheduleCommandFromEnvelope(envelope, this.aggregator);
     if (command === undefined) {
       if (mappingFor(envelope.eventType) === undefined) {
         console.info(`Ignoring unsupported notification trigger ${envelope.eventType} (${envelope.eventId})`);
@@ -89,64 +131,107 @@ export class NotificationApplicationService {
       return "ignored";
     }
 
-    const { task, event: scheduled } = NotificationTaskAggregate.schedule(command);
+    const templateType = mappingFor(envelope.eventType)?.templateType;
+    if (templateType) {
+      (command.variables as Record<string, string>).renderedPreview = this.renderer.render(templateType, "PUSH", command.variables).body;
+    }
+
+    return this.deliverWithFallback(command, templateType);
+  }
+
+  private async deliverWithFallback(command: ScheduleNotification, templateType: NotificationTemplateType | undefined): Promise<ExternalTriggerResult> {
+    const profile = await this.contacts.getContactProfile(command.recipientRef);
+    const available = availableChannels(profile);
+    const primary = command.channel === "PUSH" || command.channel === "SMS" || command.channel === "EMAIL"
+      ? command.channel
+      : (profile.preferredChannel ?? "PUSH");
+    const channels = new ChannelFallbackChain(primary, available).toArray();
+    if (!command.transactionRequired && !await this.preferences.isEnabled(command.recipientRef, command.intent, channels[0])) {
+      return this.publishCancellation({ ...command, notificationTaskId: newNotificationTaskId(), channel: channels[0], templateCode: templateType ?? command.templateCode }, "SUPPRESSED_BY_PREFERENCES");
+    }
+
+    const scheduledCommand: ScheduleNotification = {
+      ...command,
+      notificationTaskId: newNotificationTaskId(),
+      channel: channels[0],
+      templateCode: templateType ?? command.templateCode,
+      variables: renderedVariables(command.variables, templateType, channels[0], this.renderer),
+    };
+    const { task, event: scheduled } = NotificationTaskAggregate.schedule(scheduledCommand);
     let version = (await this.taskStore?.saveNew(task))?.version;
     await this.publisher.publish(toEventEnvelope(scheduled));
 
-    if (!command.transactionRequired && !await this.preferences.isEnabled(command.recipientRef, command.intent, command.channel)) {
-      const { task: cancelled, event } = task.cancel({
-        notificationTaskId: task.id,
-        reason: "SUPPRESSED_BY_PREFERENCES",
-        cancelledAt: new Date(),
-      });
-      if (version !== undefined) {
-        version = (await this.taskStore?.save(cancelled, version))?.version ?? version;
-      }
-      await this.publisher.publish(toEventEnvelope(event));
-      return "cancelled";
-    }
-
     const dispatchedAt = new Date();
-    const { task: delivering, event: dispatched } = task.dispatch({ notificationTaskId: task.id, dispatchedAt });
+    let { task: currentTask, event: dispatched } = task.dispatch({ notificationTaskId: task.id, dispatchedAt });
     if (version !== undefined) {
-      version = (await this.taskStore?.save(delivering, version))?.version ?? version;
+      version = (await this.taskStore?.save(currentTask, version))?.version ?? version;
     }
     await this.publisher.publish(toEventEnvelope(dispatched));
 
-    const delivery = await this.channelGateway.send(delivering.toSnapshot());
-    if (delivery.ok) {
-      const { task: delivered, event: deliveredEvent } = delivering.recordReceipt({
+    for (const channel of channels) {
+      const rateDecision = await this.rateLimits.checkAndRecord(command.recipientRef, channel, new Date());
+      if (!rateDecision.allowed) {
+        throw new RateLimitExceeded(command.recipientRef, channel, rateDecision.retryAfter);
+      }
+
+      const delivery = await this.channelGateway.send({
+        ...currentTask.toSnapshot(),
+        channel,
+        variables: renderedVariables(command.variables, templateType, channel, this.renderer),
+      });
+      const finalFailure = channels[channels.length - 1] === channel;
+      const { task: updatedTask, event } = currentTask.recordReceipt({
         receiptId: newReceiptId(),
-        notificationTaskId: delivering.id,
-        channel: command.channel,
-        outcome: "Delivered",
+        notificationTaskId: currentTask.id,
+        channel,
+        outcome: delivery.ok ? "Delivered" : delivery.outcome,
+        ...(delivery.ok ? {} : { providerCode: delivery.providerCode, providerMessage: delivery.providerMessage, finalFailure }),
         recordedAt: new Date(),
       });
+      currentTask = updatedTask;
       if (version !== undefined) {
-        version = (await this.taskStore?.save(delivered, version))?.version ?? version;
+        version = (await this.taskStore?.save(currentTask, version))?.version ?? version;
       }
-      await this.publisher.publish(toEventEnvelope(deliveredEvent));
-      return "delivered";
+      await this.publisher.publish(toEventEnvelope(event));
+      if (delivery.ok) {
+        return "delivered";
+      }
     }
 
-    const { task: failed, event: failedEvent } = delivering.recordReceipt({
-      receiptId: newReceiptId(),
-      notificationTaskId: delivering.id,
-      channel: command.channel,
-      outcome: delivery.outcome,
-      providerCode: delivery.providerCode,
-      providerMessage: delivery.providerMessage,
-      recordedAt: new Date(),
-    });
-    if (version !== undefined) {
-      await this.taskStore?.save(failed, version);
-    }
-    await this.publisher.publish(toEventEnvelope(failedEvent));
     return "failed";
+  }
+
+  private async publishCancellation(command: ScheduleNotification, reason: string): Promise<ExternalTriggerResult> {
+    const { task, event: scheduled } = NotificationTaskAggregate.schedule(command);
+    let version = (await this.taskStore?.saveNew(task))?.version;
+    await this.publisher.publish(toEventEnvelope(scheduled));
+    const { task: cancelled, event } = task.cancel({ notificationTaskId: task.id, reason, cancelledAt: new Date() });
+    if (version !== undefined) {
+      version = (await this.taskStore?.save(cancelled, version))?.version ?? version;
+    }
+    await this.publisher.publish(toEventEnvelope(event));
+    return "cancelled";
   }
 }
 
-function scheduleCommandFromEnvelope(envelope: EventEnvelope): ScheduleNotification | undefined {
+function renderedVariables(
+  variables: Readonly<Record<string, string>>,
+  templateType: NotificationTemplateType | undefined,
+  channel: NotificationChannel,
+  renderer: TemplateRenderer,
+): Record<string, string> {
+  if (!templateType) {
+    return { ...variables };
+  }
+  const rendered = renderer.render(templateType, channel, variables);
+  return {
+    ...variables,
+    subject: rendered.subject ?? rendered.title ?? templateType,
+    body: rendered.body,
+  };
+}
+
+function scheduleCommandFromEnvelope(envelope: EventEnvelope, aggregator?: NotificationAggregator): ScheduleNotification | undefined {
   const mapping = mappingFor(envelope.eventType);
   if (mapping === undefined) {
     return undefined;
@@ -161,6 +246,17 @@ function scheduleCommandFromEnvelope(envelope: EventEnvelope): ScheduleNotificat
     return undefined;
   }
 
+  const businessRef = triggerBusinessRef(envelope);
+  const aggregationRef = aggregationBusinessRef(envelope);
+  if (aggregator && mapping.templateType && aggregationRef && aggregator.shouldSuppress({
+    recipientRef,
+    orderRef: aggregationRef,
+    templateType: mapping.templateType,
+    occurredAt: dateValue(envelope.occurredAt) ?? new Date(),
+  })) {
+    return undefined;
+  }
+
   return {
     notificationTaskId: newNotificationTaskId(),
     triggerEventId: envelope.eventId,
@@ -168,14 +264,32 @@ function scheduleCommandFromEnvelope(envelope: EventEnvelope): ScheduleNotificat
     correlationId: envelope.correlationId,
     causationId: envelope.eventId,
     recipientRef,
-    templateCode: mapping.templateCode,
+    templateCode: mapping.templateType ?? mapping.templateCode,
     channel: mapping.channel,
     intent: mapping.intent,
     transactionRequired: booleanValue(payload.transactionRequired) ?? true,
     variables: mapping.variables(payload),
     scheduledAt: new Date(),
-    triggerBusinessRef: triggerBusinessRef(envelope),
+    triggerBusinessRef: businessRef,
   };
+}
+
+
+function aggregationBusinessRef(envelope: EventEnvelope): string | undefined {
+  const payload = envelope.payload;
+  return stringValue(payload.orderId)
+    ?? stringValue(payload.journeyOrderId)
+    ?? stringValue(payload.businessRef)
+    ?? stringValue(payload.paymentIntentId)
+    ?? stringValue(payload.refundId)
+    ?? stringValue(payload.entitlementId)
+    ?? stringValue(payload.segmentBookingId)
+    ?? stringValue(payload.caseId)
+    ?? stringValue(payload.serviceAlertId)
+    ?? stringValue(payload.incidentId)
+    ?? stringValue(payload.waitlistRequestId)
+    ?? stringValue(payload.journeyOrderRef)
+    ?? stringValue(payload.postSalesCaseId);
 }
 
 function triggerBusinessRef(envelope: EventEnvelope): string | undefined {
@@ -188,6 +302,10 @@ function triggerBusinessRef(envelope: EventEnvelope): string | undefined {
     ?? stringValue(payload.benefitId)
     ?? stringValue(payload.segmentBookingId)
     ?? stringValue(payload.caseId)
+    ?? stringValue(payload.serviceAlertId)
+    ?? stringValue(payload.incidentId)
+    ?? stringValue(payload.waitlistRequestId)
+    ?? stringValue(payload.journeyOrderRef)
     ?? stringValue(payload.postSalesCaseId)
     ?? stringValue(payload.businessRef);
   return businessRef ? `${envelope.eventType}:${businessRef}` : undefined;
@@ -261,12 +379,8 @@ const CONTRACT_FIELDS_BY_EVENT: Readonly<Record<string, readonly RequiredField[]
     { name: "reasonCode", type: "string" },
     { name: "retryable", type: "boolean" },
   ],
-  PaymentIntentExpired: [
-    { name: "paymentIntentId", type: "string" },
-  ],
-  PaymentExpired: [
-    { name: "paymentIntentId", type: "string" },
-  ],
+  PaymentIntentExpired: [{ name: "paymentIntentId", type: "string" }],
+  PaymentExpired: [{ name: "paymentIntentId", type: "string" }],
   RefundSettled: [
     { name: "refundId", type: "string" },
     { name: "paymentIntentId", type: "string" },
@@ -334,6 +448,34 @@ const CONTRACT_FIELDS_BY_EVENT: Readonly<Record<string, readonly RequiredField[]
     { name: "accountId", type: "string" },
     { name: "revokedAmount", type: "money" },
     { name: "revokedAt", type: "string" },
+  ],
+  WaitlistFulfilled: [
+    { name: "waitlistRequestId", type: "string" },
+    { name: "accountId", type: "string" },
+    { name: "travelerRef", type: "string" },
+    { name: "segmentRef", type: "string" },
+    { name: "journeyOrderRef", type: "string" },
+    { name: "fulfilledAt", type: "string" },
+    { name: "status", type: "string" },
+  ],
+  ServiceAlertPublished: [
+    { name: "serviceAlertId", type: "string" },
+    { name: "incidentId", type: "string" },
+    { name: "disruptionType", type: "string" },
+    { name: "serviceDate", type: "string" },
+    { name: "audience", type: "string" },
+    { name: "messageSummary", type: "string" },
+    { name: "publishedAt", type: "string" },
+  ],
+  RecoveryCompleted: [
+    { name: "caseId", type: "string" },
+    { name: "incidentId", type: "string" },
+    { name: "journeyOrderId", type: "string" },
+    { name: "optionId", type: "string" },
+    { name: "optionType", type: "string" },
+    { name: "executionId", type: "string" },
+    { name: "completedAt", type: "string" },
+    { name: "status", type: "string" },
   ],
 });
 
@@ -415,11 +557,13 @@ function mappingFor(eventType: string): TriggerMapping | undefined {
     case "JourneyOrderCreated":
       return orderMapping("order_created", "ORDER_CREATED");
     case "JourneyOrderPendingPayment":
-      return orderMapping("order_pending_payment", "ORDER_PENDING_PAYMENT");
+    case "PaymentIntentExpired":
+    case "PaymentExpired":
+      return paymentReminderMapping();
     case "JourneyOrderPaymentRecorded":
       return orderMapping("order_payment_recorded", "ORDER_PAYMENT_RECORDED");
     case "JourneyOrderConfirmed":
-      return orderMapping("order_confirmed", "ORDER_CONFIRMED");
+      return orderMapping("ORDER_CONFIRMED", "ORDER_CONFIRMED", "ORDER_CONFIRMED");
     case "JourneyOrderCancelled":
       return orderMapping("order_cancelled", "ORDER_CANCELLED");
     case "JourneyOrderPostSalesAdjusted":
@@ -430,9 +574,6 @@ function mappingFor(eventType: string): TriggerMapping | undefined {
     case "PaymentFailed":
     case "PaymentIntentFailed":
       return paymentMapping("payment_failed", "PAYMENT_RESULT");
-    case "PaymentIntentExpired":
-    case "PaymentExpired":
-      return paymentMapping("payment_expired", "PAYMENT_RESULT");
     case "RefundSettled":
       return refundMapping();
     case "EntitlementIssued":
@@ -455,18 +596,45 @@ function mappingFor(eventType: string): TriggerMapping | undefined {
       return walletBenefitMapping("wallet_benefit_expired", "WALLET_BENEFIT_EXPIRED");
     case "BenefitRevoked":
       return walletBenefitMapping("wallet_benefit_revoked", "WALLET_BENEFIT_REVOKED");
+    case "WaitlistFulfilled":
+      return waitlistFulfilledMapping();
+    case "ServiceAlertPublished":
+      return serviceAlertPublishedMapping();
+    case "RecoveryCompleted":
+      return recoveryCompletedMapping();
     default:
       return undefined;
   }
 }
 
-function orderMapping(templateCode: string, intent: string): TriggerMapping {
+function orderMapping(templateCode: string, intent: string, templateType?: NotificationTemplateType): TriggerMapping {
   return {
     templateCode,
+    templateType,
     intent,
-    channel: "IN_APP",
+    channel: "PUSH",
     recipient: recipientFromOrderEvent,
-    variables: (payload) => pickStringVariables(payload, ["orderId", "journeyOrderId", "offerId", "paymentIntentId", "postSalesCaseId", "reason"]),
+    variables: (payload) => ({
+      ...pickStringVariables(payload, ["orderId", "journeyOrderId", "offerId", "paymentIntentId", "postSalesCaseId", "reason", "origin", "destination", "departureTime"]),
+      origin: stringValue(payload.origin) ?? stringValue(recordValue(payload.trip)?.origin) ?? "--",
+      destination: stringValue(payload.destination) ?? stringValue(recordValue(payload.trip)?.destination) ?? "--",
+      departureTime: stringValue(payload.departureTime) ?? stringValue(recordValue(payload.trip)?.departureTime) ?? stringValue(payload.confirmedAt) ?? "--",
+    }),
+  };
+}
+
+function paymentReminderMapping(): TriggerMapping {
+  return {
+    templateCode: "PAYMENT_REMINDER",
+    templateType: "PAYMENT_REMINDER",
+    intent: "PAYMENT_REMINDER",
+    channel: "PUSH",
+    recipient: recipientFromDirectFields,
+    variables: (payload) => ({
+      ...pickStringVariables(payload, ["paymentIntentId", "orderId", "businessRef", "expiresAt"]),
+      orderId: stringValue(payload.orderId) ?? stringValue(payload.businessRef) ?? stringValue(payload.paymentIntentId) ?? "--",
+      expiresAt: stringValue(payload.expiresAt) ?? stringValue(payload.expiredAt) ?? "--",
+    }),
   };
 }
 
@@ -474,7 +642,7 @@ function paymentMapping(templateCode: string, intent: string): TriggerMapping {
   return {
     templateCode,
     intent,
-    channel: "IN_APP",
+    channel: "PUSH",
     recipient: recipientFromDirectFields,
     variables: (payload) => pickStringVariables(payload, ["paymentIntentId", "orderId", "businessRef", "channel", "channelTransactionId", "reason", "reasonCode"]),
   };
@@ -482,23 +650,85 @@ function paymentMapping(templateCode: string, intent: string): TriggerMapping {
 
 function refundMapping(): TriggerMapping {
   return {
-    templateCode: "refund_settled",
-    intent: "REFUND_SETTLED",
-    channel: "IN_APP",
+    templateCode: "REFUND_COMPLETED",
+    templateType: "REFUND_COMPLETED",
+    intent: "REFUND_COMPLETED",
+    channel: "PUSH",
     recipient: recipientFromDirectFields,
-    variables: (payload) => pickStringVariables(payload, ["refundId", "paymentIntentId", "orderId", "reason"]),
+    variables: (payload) => ({
+      ...pickStringVariables(payload, ["refundId", "paymentIntentId", "orderId", "reason", "arrivalDays"]),
+      amount: moneyString(payload.amount) ?? "0",
+      arrivalDays: stringValue(payload.arrivalDays) ?? "3",
+    }),
   };
 }
 
 function ticketIssuedMapping(): TriggerMapping {
   return {
-    templateCode: "ticket_issued",
+    templateCode: "TICKET_ISSUED",
+    templateType: "TICKET_ISSUED",
     intent: "TICKET_ISSUED",
-    // The one real EMAIL intent: ticket issuance is the canonical
-    // customer email; every other intent stays IN_APP.
-    channel: "EMAIL",
+    channel: "PUSH",
     recipient: (payload) => recipientFromDirectFields(payload) ?? stringValue(payload.travelerRef),
-    variables: (payload) => pickStringVariables(payload, ["entitlementId", "journeyOrderId", "orderId", "orderItemId", "segmentBookingId", "segmentRef", "credentialNo", "credentialType"]),
+    variables: (payload) => ({
+      ...pickStringVariables(payload, ["entitlementId", "journeyOrderId", "orderId", "orderItemId", "segmentBookingId", "segmentRef", "credentialNo", "credentialType", "trainNumber", "seatInfo"]),
+      trainNumber: stringValue(payload.trainNumber) ?? stringValue(payload.segmentRef) ?? "--",
+      seatInfo: stringValue(payload.seatInfo) ?? stringValue(payload.credentialType) ?? "--",
+    }),
+  };
+}
+
+function waitlistFulfilledMapping(): TriggerMapping {
+  return {
+    templateCode: "WAITLIST_PROMOTED",
+    templateType: "WAITLIST_PROMOTED",
+    intent: "WAITLIST_PROMOTED",
+    channel: "PUSH",
+    recipient: recipientFromDirectFields,
+    variables: (payload) => ({
+      ...pickStringVariables(payload, ["waitlistRequestId", "journeyOrderRef", "segmentRef", "travelClass", "fulfilledAt"]),
+      orderId: stringValue(payload.journeyOrderRef) ?? stringValue(payload.waitlistRequestId) ?? "--",
+      origin: stringValue(payload.origin) ?? stringValue(payload.segmentRef) ?? "--",
+      destination: stringValue(payload.destination) ?? stringValue(payload.travelClass) ?? "--",
+      departureDate: stringValue(payload.departureDate) ?? stringValue(payload.fulfilledAt) ?? "--",
+    }),
+  };
+}
+
+function serviceAlertPublishedMapping(): TriggerMapping {
+  return {
+    templateCode: "DELAY_ALERT",
+    templateType: "DELAY_ALERT",
+    intent: "DELAY_ALERT",
+    channel: "PUSH",
+    recipient: recipientFromDisruptionAlert,
+    variables: (payload) => ({
+      ...pickStringVariables(payload, ["serviceAlertId", "incidentId", "disruptionType", "scheduledServiceRef", "segmentRef", "serviceDate", "messageSummary"]),
+      trainNumber: stringValue(payload.trainNumber)
+        ?? stringValue(payload.scheduledServiceRef)
+        ?? stringValue(payload.segmentRef)
+        ?? stringValue(payload.incidentId)
+        ?? "--",
+      delayMinutes: stringValue(payload.delayMinutes) ?? numberString(payload.delayMinutes) ?? "0",
+    }),
+  };
+}
+
+function recoveryCompletedMapping(): TriggerMapping {
+  return {
+    templateCode: "DISRUPTION_REBOOK",
+    templateType: "DISRUPTION_REBOOK",
+    intent: "DISRUPTION_REBOOK",
+    channel: "PUSH",
+    recipient: recipientFromRecoveryEvent,
+    variables: (payload) => ({
+      ...pickStringVariables(payload, ["caseId", "incidentId", "journeyOrderId", "optionId", "optionType", "executionId", "externalRef", "completedAt"]),
+      newTrainNumber: stringValue(payload.newTrainNumber)
+        ?? stringValue(payload.externalRef)
+        ?? stringValue(payload.journeyOrderId)
+        ?? "--",
+      newDepartureTime: stringValue(payload.newDepartureTime) ?? stringValue(payload.completedAt) ?? "--",
+    }),
   };
 }
 
@@ -506,7 +736,7 @@ function walletBenefitMapping(templateCode: string, intent: string): TriggerMapp
   return {
     templateCode,
     intent,
-    channel: "IN_APP",
+    channel: "PUSH",
     recipient: (payload) => stringValue(payload.accountId),
     variables: (payload) => pickStringVariables(payload, ["benefitId", "accountId", "issuanceSource", "caseId", "status"]),
   };
@@ -516,10 +746,24 @@ function postSalesMapping(templateCode: string, intent: string): TriggerMapping 
   return {
     templateCode,
     intent,
-    channel: "IN_APP",
+    channel: "PUSH",
     recipient: (payload) => recipientFromDirectFields(payload) ?? stringValue(payload.actorRef),
     variables: (payload) => pickStringVariables(payload, ["caseId", "orderId", "journeyOrderId", "reasonCode", "decisionKind", "approvalRef", "reason"]),
   };
+}
+
+function availableChannels(profile: ContactProfile): readonly NotificationChannel[] {
+  const channels: NotificationChannel[] = [];
+  if (profile.deviceToken) {
+    channels.push("PUSH");
+  }
+  if (profile.phoneNumber) {
+    channels.push("SMS");
+  }
+  if (profile.emailAddress !== undefined) {
+    channels.push("EMAIL");
+  }
+  return channels.length > 0 ? channels : ["EMAIL"];
 }
 
 function recipientFromOrderEvent(payload: Record<string, unknown>): string | undefined {
@@ -528,6 +772,21 @@ function recipientFromOrderEvent(payload: Record<string, unknown>): string | und
 
 function recipientFromDirectFields(payload: Record<string, unknown>): string | undefined {
   return stringValue(payload.recipientRef) ?? stringValue(payload.travelerId) ?? stringValue(payload.accountId) ?? stringValue(payload.actorRef);
+}
+
+function recipientFromDisruptionAlert(payload: Record<string, unknown>): string | undefined {
+  return recipientFromDirectFields(payload) ?? firstString(payload.affectedOrderIds) ?? stringValue(payload.serviceAlertId);
+}
+
+function recipientFromRecoveryEvent(payload: Record<string, unknown>): string | undefined {
+  return recipientFromDirectFields(payload) ?? stringValue(payload.journeyOrderId);
+}
+
+function firstString(value: unknown): string | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.find((candidate): candidate is string => typeof candidate === "string" && candidate.trim().length > 0);
 }
 
 function recipientFromTravelerRefs(value: unknown): string | undefined {
@@ -571,6 +830,26 @@ function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
 
+function numberString(value: unknown): string | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? String(value) : undefined;
+}
+
+function moneyString(value: unknown): string | undefined {
+  const money = recordValue(value);
+  if (!money || typeof money.minorUnits !== "number") {
+    return undefined;
+  }
+  return (money.minorUnits / 100).toFixed(2).replace(/\.00$/, "");
+}
+
 function booleanValue(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
+}
+
+function dateValue(value: unknown): Date | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date : undefined;
 }

--- a/services/notification/src/domain.test.ts
+++ b/services/notification/src/domain.test.ts
@@ -14,6 +14,10 @@ import {
   type DispatchNotification,
   type RecordDeliveryReceipt,
   type CancelNotification,
+  ChannelFallbackChain,
+  NotificationAggregator,
+  RateLimiter,
+  TemplateRenderer,
 } from "./domain.js";
 
 const scheduledAt = new Date("2026-07-03T10:00:00.000Z");
@@ -505,5 +509,38 @@ describe("Notification domain foundation", () => {
       const differentTemplate = idempotencyKey("evt-payment-001", "tvl-user-001", "payment_failed");
       assert.notEqual(key, differentTemplate);
     });
+  });
+});
+
+describe("REQ-311 notification enrichment domain", () => {
+  it("orders PUSH, SMS, EMAIL fallback by primary preference and availability", () => {
+    const chain = new ChannelFallbackChain("PUSH", ["SMS", "EMAIL"]);
+    assert.deepEqual(chain.toArray(), ["SMS", "EMAIL"]);
+  });
+
+  it("renders built-in template variables without unresolved placeholders", () => {
+    const rendered = new TemplateRenderer().render("ORDER_CONFIRMED", "PUSH", {
+      orderId: "ord-1",
+      origin: "北京",
+      destination: "上海",
+      departureTime: "10:00",
+    });
+    assert.equal(rendered.body, "您的订单 ord-1 已确认，北京→上海，10:00 出发");
+  });
+
+  it("rate limits the eleventh push notification in an hour", () => {
+    const limiter = new RateLimiter();
+    const at = new Date("2026-07-05T10:00:00Z");
+    for (let index = 0; index < 10; index += 1) {
+      assert.deepEqual(limiter.checkAndRecord("usr-1", "PUSH", new Date(at.getTime() + index)), { allowed: true });
+    }
+    assert.equal(limiter.checkAndRecord("usr-1", "PUSH", new Date(at.getTime() + 10)).allowed, false);
+  });
+
+  it("suppresses lower-priority events for the same order within five minutes", () => {
+    const aggregator = new NotificationAggregator();
+    const at = new Date("2026-07-05T10:00:00Z");
+    assert.equal(aggregator.shouldSuppress({ recipientRef: "usr-1", orderRef: "ord-1", templateType: "ORDER_CONFIRMED", occurredAt: at }), false);
+    assert.equal(aggregator.shouldSuppress({ recipientRef: "usr-1", orderRef: "ord-1", templateType: "PAYMENT_REMINDER", occurredAt: new Date(at.getTime() + 60_000) }), true);
   });
 });

--- a/services/notification/src/domain.ts
+++ b/services/notification/src/domain.ts
@@ -34,6 +34,7 @@ export type TemplateId = string;         // "tpl-<uuid>"
 export type TemplateCode = string;       // human-readable key, e.g. "order_confirmed"
 export type RecipientRef = string;       // "tvl-<uuid>" or "usr-<uuid>"
 export type ChannelType = "EMAIL" | "SMS" | "PUSH" | "IN_APP";
+export type NotificationChannel = Exclude<ChannelType, "IN_APP">;
 export type IntentType = string;         // e.g. "PAYMENT_RESULT", "TICKET_ISSUED", "REFUND_SETTLED"
 export type EventId = string;            // "evt-<uuid>"
 export type ReceiptId = string;          // "rct-<uuid>"
@@ -62,6 +63,19 @@ export type DeliveryReceiptOutcome =
   | "Rejected"
   | "Timeout"
   | "Expired";
+
+export type DeliveryAttemptStatus = "SENT" | "DELIVERED" | "FAILED" | "BOUNCED";
+
+export type NotificationStatus = "QUEUED" | "SENDING" | "SENT" | "DELIVERED" | "FAILED";
+
+export type NotificationTemplateType =
+  | "ORDER_CONFIRMED"
+  | "PAYMENT_REMINDER"
+  | "TICKET_ISSUED"
+  | "DELAY_ALERT"
+  | "REFUND_COMPLETED"
+  | "WAITLIST_PROMOTED"
+  | "DISRUPTION_REBOOK";
 
 // ─── Value Objects ─────────────────────────────────────────────────────────────
 
@@ -113,6 +127,7 @@ export type RecordDeliveryReceipt = Readonly<{
   providerCode?: string;
   providerMessage?: string;
   recordedAt: Date;
+  finalFailure?: boolean;
 }>;
 
 export type CancelNotification = Readonly<{
@@ -338,7 +353,11 @@ export class NotificationTask {
     const receipts = [...this.snapshot.receipts, receipt.toSnapshot()];
 
     const isDelivered = command.outcome === "Delivered";
-    const newStatus: NotificationTaskStatus = isDelivered ? "Delivered" : "Failed";
+    const newStatus: NotificationTaskStatus = isDelivered
+      ? "Delivered"
+      : command.finalFailure === false
+        ? "Delivering"
+        : "Failed";
 
     const newSnapshot: NotificationTaskSnapshot = deepFreeze({
       ...this.snapshot,
@@ -693,6 +712,188 @@ export class DeliveryReceipt {
 
   toSnapshot(): DeliveryReceiptSnapshot {
     return deepFreeze(cloneForSnapshot(this.snapshot));
+  }
+}
+
+// ─── REQ-311 Multi-channel delivery, templates, rate limits ─────────────────────
+
+export type DeliveryAttempt = Readonly<{
+  channelUsed: NotificationChannel;
+  attemptedAt: Date;
+  status: DeliveryAttemptStatus;
+  reason?: string;
+}>;
+
+export class ChannelFallbackChain {
+  private static readonly priority: readonly NotificationChannel[] = Object.freeze(["PUSH", "SMS", "EMAIL"]);
+  private readonly channels: readonly NotificationChannel[];
+
+  constructor(primary: NotificationChannel = "PUSH", availableChannels: readonly NotificationChannel[] = ChannelFallbackChain.priority) {
+    const unique = new Set<NotificationChannel>();
+    unique.add(primary);
+    for (const channel of ChannelFallbackChain.priority) {
+      unique.add(channel);
+    }
+    this.channels = Object.freeze([...unique].filter((channel) => availableChannels.includes(channel)));
+    if (this.channels.length === 0) {
+      throw new DomainError("NO_AVAILABLE_CHANNELS", "At least one notification channel must be available");
+    }
+    Object.freeze(this);
+  }
+
+  toArray(): readonly NotificationChannel[] {
+    return this.channels;
+  }
+}
+
+export type NotificationTemplate = Readonly<{
+  templateId: string;
+  templateType: NotificationTemplateType;
+  channel: NotificationChannel;
+  subjectTemplate?: string;
+  bodyTemplate: string;
+  pushTitleTemplate?: string;
+}>;
+
+export type RenderedNotification = Readonly<{
+  subject?: string;
+  title?: string;
+  body: string;
+}>;
+
+export class TemplateRenderer {
+  constructor(private readonly templates: readonly NotificationTemplate[] = builtInNotificationTemplates()) {}
+
+  render(templateType: NotificationTemplateType, channel: NotificationChannel, variables: Readonly<Record<string, string>>): RenderedNotification {
+    const template = this.templates.find((candidate) => candidate.templateType === templateType && candidate.channel === channel);
+    if (!template) {
+      throw new DomainError("TEMPLATE_NOT_FOUND", `Template ${templateType} for ${channel} is not registered`);
+    }
+    return deepFreeze({
+      ...(template.subjectTemplate ? { subject: renderTemplate(template.subjectTemplate, variables) } : {}),
+      ...(template.pushTitleTemplate ? { title: renderTemplate(template.pushTitleTemplate, variables) } : {}),
+      body: renderTemplate(template.bodyTemplate, variables),
+    });
+  }
+}
+
+export class RateLimitExceeded extends Error {
+  constructor(
+    public readonly recipientRef: string,
+    public readonly channel: NotificationChannel,
+    public readonly retryAfter: Date,
+    message = `Rate limit exceeded for ${recipientRef} on ${channel}`,
+  ) {
+    super(message);
+    this.name = "RateLimitExceeded";
+  }
+}
+
+export type RateLimitDecision = Readonly<{ allowed: true } | { allowed: false; retryAfter: Date }>;
+
+export class RateLimiter {
+  private readonly events: Array<Readonly<{ recipientRef: string; channel: NotificationChannel; at: Date }>> = [];
+
+  checkAndRecord(recipientRef: string, channel: NotificationChannel, at: Date = new Date()): RateLimitDecision {
+    this.prune(at);
+    const perUser = this.limitFor(channel);
+    const windowStart = new Date(at.getTime() - perUser.windowMs);
+    const userEvents = this.events.filter((event) => event.recipientRef === recipientRef && event.channel === channel && event.at > windowStart);
+    if (userEvents.length >= perUser.max) {
+      return { allowed: false, retryAfter: new Date(Math.min(...userEvents.map((event) => event.at.getTime())) + perUser.windowMs) };
+    }
+    if (channel === "SMS") {
+      const globalWindowStart = new Date(at.getTime() - 60_000);
+      const smsEvents = this.events.filter((event) => event.channel === "SMS" && event.at > globalWindowStart);
+      if (smsEvents.length >= 1000) {
+        return { allowed: false, retryAfter: new Date(Math.min(...smsEvents.map((event) => event.at.getTime())) + 60_000) };
+      }
+    }
+    this.events.push(Object.freeze({ recipientRef, channel, at: new Date(at) }));
+    return { allowed: true };
+  }
+
+  private limitFor(channel: NotificationChannel): Readonly<{ max: number; windowMs: number }> {
+    switch (channel) {
+      case "PUSH":
+        return { max: 10, windowMs: 60 * 60 * 1000 };
+      case "SMS":
+        return { max: 5, windowMs: 24 * 60 * 60 * 1000 };
+      case "EMAIL":
+        return { max: 20, windowMs: 24 * 60 * 60 * 1000 };
+    }
+  }
+
+  private prune(at: Date): void {
+    const cutoff = at.getTime() - 24 * 60 * 60 * 1000;
+    for (let index = this.events.length - 1; index >= 0; index -= 1) {
+      if (this.events[index].at.getTime() < cutoff) {
+        this.events.splice(index, 1);
+      }
+    }
+  }
+}
+
+export type AggregatableNotification = Readonly<{
+  recipientRef: string;
+  orderRef: string;
+  templateType: NotificationTemplateType;
+  occurredAt: Date;
+}>;
+
+export class NotificationAggregator {
+  private readonly seen = new Map<string, AggregatableNotification>();
+
+  shouldSuppress(candidate: AggregatableNotification): boolean {
+    const key = `${candidate.recipientRef}:${candidate.orderRef}`;
+    const previous = this.seen.get(key);
+    this.seen.set(key, candidate);
+    if (!previous) {
+      return false;
+    }
+    const withinWindow = Math.abs(candidate.occurredAt.getTime() - previous.occurredAt.getTime()) <= 5 * 60 * 1000;
+    return withinWindow && aggregationPriority(previous.templateType) <= aggregationPriority(candidate.templateType);
+  }
+}
+
+export function builtInNotificationTemplates(): readonly NotificationTemplate[] {
+  return Object.freeze([
+    templateSet("ORDER_CONFIRMED", "订单已确认", "您的订单 {orderId} 已确认，{origin}→{destination}，{departureTime} 出发", "订单{orderId}已确认 {origin}→{destination}", "订单已确认"),
+    templateSet("PAYMENT_REMINDER", "待支付提醒", "订单 {orderId} 待支付，请在 {expiresAt} 前完成付款", "订单{orderId}待支付，请尽快付款", "待支付提醒"),
+    templateSet("TICKET_ISSUED", "电子客票已出票", "电子客票已出票：{trainNumber} {seatInfo}，请凭身份证进站", "{trainNumber}{seatInfo}已出票", "电子客票"),
+    templateSet("DELAY_ALERT", "列车晚点提醒", "您乘坐的 {trainNumber} 次列车预计晚点 {delayMinutes} 分钟", "{trainNumber}晚点{delayMinutes}分钟", "列车晚点"),
+    templateSet("REFUND_COMPLETED", "退款到账提醒", "退款 {amount} 元已原路返回，预计 {arrivalDays} 个工作日到账", "退款{amount}元已返回", "退款完成"),
+    templateSet("WAITLIST_PROMOTED", "候补购票成功", "候补购票成功！{origin}→{destination} {departureDate}，请在 15 分钟内确认", "候补成功，请15分钟内确认", "候补成功"),
+    templateSet("DISRUPTION_REBOOK", "列车取消改签", "由于列车取消，已为您改签至 {newTrainNumber} {newDepartureTime}", "已改签至{newTrainNumber}", "已为您改签"),
+  ].flat());
+}
+
+function templateSet(type: NotificationTemplateType, subject: string, body: string, smsBody: string, pushTitle: string): NotificationTemplate[] {
+  return [
+    { templateId: `${type}:EMAIL`, templateType: type, channel: "EMAIL", subjectTemplate: subject, bodyTemplate: body },
+    { templateId: `${type}:SMS`, templateType: type, channel: "SMS", bodyTemplate: smsBody },
+    { templateId: `${type}:PUSH`, templateType: type, channel: "PUSH", pushTitleTemplate: pushTitle, bodyTemplate: body },
+  ];
+}
+
+function renderTemplate(template: string, variables: Readonly<Record<string, string>>): string {
+  return template.replace(/\{([A-Za-z0-9_]+)\}/g, (_placeholder, key: string) => variables[key] ?? "");
+}
+
+function aggregationPriority(type: NotificationTemplateType): number {
+  switch (type) {
+    case "ORDER_CONFIRMED":
+      return 1;
+    case "TICKET_ISSUED":
+      return 2;
+    case "DISRUPTION_REBOOK":
+      return 3;
+    case "DELAY_ALERT":
+    case "REFUND_COMPLETED":
+    case "WAITLIST_PROMOTED":
+      return 4;
+    case "PAYMENT_REMINDER":
+      return 5;
   }
 }
 

--- a/services/notification/src/index.ts
+++ b/services/notification/src/index.ts
@@ -31,6 +31,19 @@ export {
   type TemplateCode,
   type RecipientRef,
   type ChannelType,
+  type NotificationChannel,
+  ChannelFallbackChain,
+  NotificationAggregator,
+  RateLimiter,
+  RateLimitExceeded,
+  TemplateRenderer,
+  builtInNotificationTemplates,
+  type DeliveryAttempt,
+  type DeliveryAttemptStatus,
+  type NotificationStatus,
+  type NotificationTemplate,
+  type NotificationTemplateType,
+  type RenderedNotification,
   type IntentType,
   type EventId,
   type ReceiptId,
@@ -77,7 +90,7 @@ export {
   type EventPublisher,
   type EventSubscriber,
 } from "./application/messaging.js";
-export { NonConformantNotificationTrigger, NotificationApplicationService, type DeliveryResult, type ExternalTriggerResult, type NotificationChannelGateway, type NotificationTaskStore, type UserPreference, type UserPreferenceRepository } from "./application/notification-service.js";
+export { NonConformantNotificationTrigger, NotificationApplicationService, type ContactProfile, type DeliveryResult, type ExternalTriggerResult, type NotificationChannelGateway, type NotificationTaskStore, type RateLimitStore, type RecipientContactRepository, type UserPreference, type UserPreferenceRepository } from "./application/notification-service.js";
 export {
   NOTIFICATION_CONSUMER_GROUP,
   NOTIFICATION_PRODUCER,
@@ -88,5 +101,5 @@ export {
 export { RedisStreamEventPublisher } from "./adapters/messaging/publisher.js";
 export { RedisStreamEventSubscriber } from "./adapters/messaging/subscriber.js";
 export { startNotificationMessaging, type NotificationMessagingRuntime } from "./adapters/messaging/runtime.js";
-export { PostgresNotificationTaskRepository, PostgresUserPreferenceRepository } from "./adapters/storage/notification-repository.js";
+export { PostgresNotificationTaskRepository, PostgresRateLimitRepository, PostgresRecipientContactRepository, PostgresUserPreferenceRepository } from "./adapters/storage/notification-repository.js";
 export { startNotificationStorage, type NotificationStorageRuntime } from "./adapters/storage/runtime.js";

--- a/services/notification/src/messaging.test.ts
+++ b/services/notification/src/messaging.test.ts
@@ -341,4 +341,136 @@ describe("notification messaging integration surface", () => {
     assert.equal(publisher.envelopes.length, 0);
   });
 
+
+  it("falls back from unavailable PUSH to SMS", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const sentChannels: string[] = [];
+    const service = new NotificationApplicationService(
+      publisher,
+      undefined,
+      { send: (task) => { sentChannels.push(task.channel); return { ok: true }; } },
+      undefined,
+      { getContactProfile: () => ({ phoneNumber: "+8613800000000", emailAddress: "u@example.test" }) },
+    );
+
+    assert.equal(await service.handleExternalTrigger({
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c229",
+      eventType: "JourneyOrderConfirmed",
+      schemaVersion: 1,
+      producer: "journey-order",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      occurredAt: "2026-07-05T10:00:00.000Z",
+      payload: {
+        orderId: "ord-test-001",
+        accountId: "acc-test-001",
+        monetarySummary: {},
+        confirmedAt: "2026-07-05T10:00:00.000Z",
+        origin: "北京",
+        destination: "上海",
+        departureTime: "12:00",
+      },
+    }), "delivered");
+    assert.deepEqual(sentChannels, ["SMS"]);
+  });
+
+  it("falls back from failed SMS to EMAIL", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const sentChannels: string[] = [];
+    const service = new NotificationApplicationService(
+      publisher,
+      undefined,
+      { send: (task) => {
+        sentChannels.push(task.channel);
+        return task.channel === "SMS" ? { ok: false, outcome: "Rejected" } : { ok: true };
+      } },
+      undefined,
+      { getContactProfile: () => ({ phoneNumber: "+8613800000000", emailAddress: "u@example.test", preferredChannel: "SMS" }) },
+    );
+
+    assert.equal(await service.handleExternalTrigger({
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c230",
+      eventType: "RefundSettled",
+      schemaVersion: 1,
+      producer: "post-sales",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      occurredAt: "2026-07-05T10:00:00.000Z",
+      payload: { recipientRef: "usr-test-001", refundId: "ref-1", paymentIntentId: "pi-1", amount: { currency: "CNY", minorUnits: 1200 } },
+    }), "delivered");
+    assert.deepEqual(sentChannels, ["SMS", "EMAIL"]);
+    assert.deepEqual(publisher.envelopes.map((envelope) => envelope.eventType), ["NotificationScheduled", "NotificationDispatched", "NotificationFailed", "NotificationDelivered"]);
+  });
+
+  it("maps documented waitlist and disruption recovery events", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const service = new NotificationApplicationService(publisher);
+
+    await service.handleExternalTrigger({
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c231",
+      eventType: "WaitlistFulfilled",
+      schemaVersion: 1,
+      producer: "waitlist",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      occurredAt: "2026-07-05T10:00:00.000Z",
+      payload: {
+        waitlistRequestId: "wlr-1",
+        accountId: "acc-1",
+        travelerRef: "tvl-1",
+        segmentRef: "seg-1",
+        journeyOrderRef: "ord-1",
+        fulfilledAt: "2026-07-05T10:00:00.000Z",
+        status: "FULFILLED",
+      },
+    });
+    await service.handleExternalTrigger({
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c232",
+      eventType: "ServiceAlertPublished",
+      schemaVersion: 1,
+      producer: "disruption-recovery",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      occurredAt: "2026-07-05T10:01:00.000Z",
+      payload: {
+        serviceAlertId: "sal-1",
+        incidentId: "inc-1",
+        disruptionType: "DELAY",
+        scheduledServiceRef: "G123",
+        serviceDate: "2026-07-05",
+        audience: "AFFECTED_ORDERS",
+        affectedOrderIds: ["ord-2"],
+        messageSummary: "列车晚点",
+        publishedAt: "2026-07-05T10:01:00.000Z",
+      },
+    });
+    await service.handleExternalTrigger({
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c233",
+      eventType: "RecoveryCompleted",
+      schemaVersion: 1,
+      producer: "disruption-recovery",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      occurredAt: "2026-07-05T10:02:00.000Z",
+      payload: {
+        caseId: "rcv-1",
+        incidentId: "inc-1",
+        journeyOrderId: "ord-3",
+        optionId: "rop-1",
+        optionType: "REACCOMMODATION",
+        executionId: "rex-1",
+        externalRef: "conn-2",
+        completedAt: "2026-07-05T10:02:00.000Z",
+        status: "RECOVERED",
+      },
+    });
+
+    assert.deepEqual(
+      publisher.envelopes
+        .filter((envelope) => envelope.eventType === "NotificationScheduled")
+        .map((envelope) => envelope.payload.templateType),
+      ["WAITLIST_PROMOTED", "DELAY_ALERT", "DISRUPTION_REBOOK"],
+    );
+  });
+
 });


### PR DESCRIPTION
## Summary
- Adds notification domain objects for PUSH/SMS/EMAIL fallback chains, delivery attempts/trails, templates, aggregation, and rate limit decisions.
- Wires application delivery to render REQ-311 templates, select available channels from recipient contacts, apply persistent rate limits, aggregate same-order events, and fallback on channel failure.
- Extends storage migrations/repositories for contacts and rate counters, subscribes to waitlist/disruption streams, and exposes `/api/v1/notifications/{id}/trail`.

## Validation
- `npm --prefix services/notification run build`
- `npm --prefix services/notification test`
- `git diff --check`