### PR TITLE
REQ-312 service-plan seasonal schedules and delay propagation

### DIFF
--- a/docs/08-contracts/events/service-plan.md
+++ b/docs/08-contracts/events/service-plan.md
@@ -50,6 +50,86 @@ timestamps. All timestamps are RFC3339 UTC.
 | `departureTime` | RFC3339 UTC | yes | Segment departure time. |
 | `arrivalTime` | RFC3339 UTC | yes | Segment arrival time. |
 
+
+### TemporaryServiceAdded
+
+| Field | Description |
+|---|---|
+| **Producer** | service-plan |
+| **Consumers** | trip-planning, notification |
+| **Trigger** | A rush-period temporary service (`L*` train number) is added. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `tempServiceRef` | string | yes | Temporary scheduled service ID. |
+| `baseServiceRef` | string | yes | Base scheduled service ID. |
+| `period` | string | yes | Schedule period (`SPRING_RUSH`, `SUMMER_RUSH`, `NATIONAL_DAY`, `LABOR_DAY`). |
+
+### TrainDelayed
+
+| Field | Description |
+|---|---|
+| **Producer** | service-plan |
+| **Consumers** | trip-planning, disruption-recovery, notification |
+| **Trigger** | A delay is recorded for a service segment and propagated downstream. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `serviceRef` | string | yes | Scheduled service ID. |
+| `segmentRef` | string | yes | Affected segment ID. |
+| `delayMinutes` | integer | yes | Propagated delay minutes after dampening. |
+| `estimatedNewDeparture` | RFC3339 UTC | yes | Estimated departure time after delay propagation. |
+
+### TrainCancelled
+
+| Field | Description |
+|---|---|
+| **Producer** | service-plan |
+| **Consumers** | trip-planning, disruption-recovery, notification |
+| **Trigger** | A service is cancelled for a specific service date. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `serviceRef` | string | yes | Scheduled service ID. |
+| `date` | RFC3339 UTC | yes | Cancelled service date. |
+| `reason` | string | yes | Operational cancellation reason code or text. |
+
+### TrainRestored
+
+| Field | Description |
+|---|---|
+| **Producer** | service-plan |
+| **Consumers** | trip-planning, disruption-recovery, notification |
+| **Trigger** | A previously cancelled service date is restored. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `serviceRef` | string | yes | Scheduled service ID. |
+| `date` | RFC3339 UTC | yes | Restored service date. |
+
+### TemporaryServiceExpired
+
+| Field | Description |
+|---|---|
+| **Producer** | service-plan |
+| **Consumers** | trip-planning |
+| **Trigger** | Rush-period cleanup expires temporary services after period end. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `serviceRef` | string | yes | Temporary scheduled service ID. |
+| `periodEndDate` | RFC3339 UTC | yes | End date of the rush period. |
+
 ## Consumer Notes
 
 - Trip Planning treats these events as the authoritative plan feed: itinerary

--- a/services/service-plan/README.md
+++ b/services/service-plan/README.md
@@ -16,12 +16,13 @@ Status: tested domain foundation (REQ-005)
 - Timetable planned stop times, timezone, and explicit cross-day offsets.
 - ScheduledService materialized from published plan versions.
 - ServiceSegment references derived from ordered stop sequences.
+- Seasonal schedule variants, rush-period temporary trains, dated service cancellations, and delay propagation facts.
 
 ## Does Not Own
 
 - Place, TransportNode, topology, or timezone master data; this context stores
   only Place & Network identifiers and node snapshot versions.
-- Capacity, seats, quotas, holds, or sellability decisions.
+- Capacity, seats, quotas, holds, or sellability decisions beyond publishing schedule-period capacity multipliers for downstream contexts.
 - Fare, tax, rule, order, entitlement, payment, post-sales, or realtime
   disruption state.
 
@@ -55,3 +56,17 @@ Go keeps schedule query services small, fast, and easy to operate.
 ```bash
 go test ./...
 ```
+
+
+## Seasonal schedules and real-time operations
+
+REQ-312 enriches the service-plan domain with production timetable operations:
+
+- Built-in schedule periods: `REGULAR`, `SPRING_RUSH`, `SUMMER_RUSH`, `NATIONAL_DAY`, and `LABOR_DAY` with the required capacity multipliers.
+- Temporary rush-period trains (`L*` train numbers), including stops subsets and available travel classes, exposed via `POST /api/v1/scheduled-services/{serviceRef}/temporary-services`.
+- Delay recording via `POST /api/v1/scheduled-services/{serviceRef}/delays`; downstream stops receive dampened delay events at two minutes recovery per subsequent stop.
+- Dated cancellation/restoration via `/cancellations` and `/restorations`; responses expose whether the service-date remains bookable.
+- Rush-period cleanup through the application service emits `TemporaryServiceExpired` after a configured period end.
+
+Events continue to use the outbox publisher when the service is wired with Postgres:
+`TemporaryServiceAdded`, `TrainDelayed`, `TrainCancelled`, `TrainRestored`, and `TemporaryServiceExpired` are appended in the same unit of work as persisted snapshot changes.

--- a/services/service-plan/internal/adapters/postgres/service.go
+++ b/services/service-plan/internal/adapters/postgres/service.go
@@ -87,6 +87,18 @@ func (r *Repository) SaveServiceSegment(ctx context.Context, segment application
 	return insertOrUpdate(ctx, r.db.DBFor(ctx), "service_segment_snapshots", segment.SegmentRef, data)
 }
 
+func (r *Repository) FindServiceSegment(ctx context.Context, ref string) (application.ServiceSegment, error) {
+	snap, ok, err := storage.NewSnapshotRepository(r.db.DBFor(ctx), "service_segment_snapshots").Get(ctx, strings.TrimSpace(ref))
+	if err != nil {
+		return application.ServiceSegment{}, err
+	}
+	if !ok {
+		return application.ServiceSegment{}, application.ErrNotFound
+	}
+	var segment application.ServiceSegment
+	return segment, json.Unmarshal(snap.Data, &segment)
+}
+
 func insertOrUpdate(ctx context.Context, db storage.DBTX, table, id string, data []byte) error {
 	repo := storage.NewSnapshotRepository(db, table)
 	snap, ok, err := repo.Get(ctx, id)

--- a/services/service-plan/internal/application/events_test.go
+++ b/services/service-plan/internal/application/events_test.go
@@ -59,6 +59,13 @@ func (r *memoryRepository) SaveServiceSegment(_ context.Context, segment Service
 	r.segments[segment.SegmentRef] = segment
 	return nil
 }
+func (r *memoryRepository) FindServiceSegment(_ context.Context, ref string) (ServiceSegment, error) {
+	segment, ok := r.segments[ref]
+	if !ok {
+		return ServiceSegment{}, ErrNotFound
+	}
+	return segment, nil
+}
 
 type failingRepository struct{ err error }
 
@@ -72,6 +79,9 @@ func (r failingRepository) ListScheduledServices(context.Context, ListScheduledS
 	return PaginatedScheduledServices{}, r.err
 }
 func (r failingRepository) SaveServiceSegment(context.Context, ServiceSegment) error { return r.err }
+func (r failingRepository) FindServiceSegment(context.Context, string) (ServiceSegment, error) {
+	return ServiceSegment{}, r.err
+}
 
 func TestPublisherReceivesCorrectServicePlanEnvelope(t *testing.T) {
 	publisher := &recordingPublisher{}
@@ -306,4 +316,108 @@ func mustSpanContext(t *testing.T) trace.SpanContext {
 		t.Fatal("invalid span context")
 	}
 	return spanContext
+}
+
+func TestRecordDelayPublishesDampenedTrainDelayedEvents(t *testing.T) {
+	publisher := &recordingPublisher{}
+	service := NewService(publisher)
+	_, err := service.CreateScheduledService(context.Background(), CreateScheduledServiceCommand{
+		ServiceRef:        "ss-0194f2e0-7b3e-7610-0284-5c26e8b0c221",
+		CarrierID:         "car-0194f2e0-7b3e-7610-0284-5c26e8b0c001",
+		ServiceNumber:     "G1234",
+		DepartureTime:     time.Date(2026, 7, 5, 10, 30, 0, 0, time.UTC),
+		ArrivalTime:       time.Date(2026, 7, 5, 12, 30, 0, 0, time.UTC),
+		OriginNodeID:      "node-a",
+		DestinationNodeID: "node-b",
+	})
+	if err != nil {
+		t.Fatalf("create scheduled service: %v", err)
+	}
+	result, err := service.RecordDelay(context.Background(), RecordDelayCommand{
+		ScheduledServiceRef: "ss-0194f2e0-7b3e-7610-0284-5c26e8b0c221",
+		SegmentRef:          "node-a:node-b",
+		DelayMinutes:        30,
+	})
+	if err != nil {
+		t.Fatalf("record delay: %v", err)
+	}
+	if len(result.Events) != 1 || result.Events[0].DelayMinutes != 30 {
+		t.Fatalf("unexpected delay result: %#v", result)
+	}
+	last := publisher.envelopes[len(publisher.envelopes)-1]
+	if last.EventType != "TrainDelayed" {
+		t.Fatalf("expected TrainDelayed event, got %#v", last.EventType)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(last.Payload, &payload); err != nil {
+		t.Fatalf("payload json: %v", err)
+	}
+	if payload["serviceRef"] != "ss-0194f2e0-7b3e-7610-0284-5c26e8b0c221" || payload["delayMinutes"].(float64) != 30 {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+}
+
+func TestCancelAndRestorePublishEventsAndBookability(t *testing.T) {
+	publisher := &recordingPublisher{}
+	service := NewService(publisher)
+	_, err := service.CreateScheduledService(context.Background(), CreateScheduledServiceCommand{
+		ServiceRef:        "ss-0194f2e0-7b3e-7610-0284-5c26e8b0c222",
+		CarrierID:         "car-0194f2e0-7b3e-7610-0284-5c26e8b0c001",
+		ServiceNumber:     "G1234",
+		DepartureTime:     time.Date(2026, 7, 5, 10, 30, 0, 0, time.UTC),
+		ArrivalTime:       time.Date(2026, 7, 5, 12, 30, 0, 0, time.UTC),
+		OriginNodeID:      "node-a",
+		DestinationNodeID: "node-b",
+	})
+	if err != nil {
+		t.Fatalf("create scheduled service: %v", err)
+	}
+	cancelled, err := service.CancelForDate(context.Background(), CancelServiceCommand{ScheduledServiceRef: "ss-0194f2e0-7b3e-7610-0284-5c26e8b0c222", Date: time.Date(2026, 7, 5, 0, 0, 0, 0, time.UTC), Reason: "WEATHER"})
+	if err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	if cancelled.Bookable {
+		t.Fatalf("expected not bookable after cancellation")
+	}
+	if publisher.envelopes[len(publisher.envelopes)-1].EventType != "TrainCancelled" {
+		t.Fatalf("expected TrainCancelled event")
+	}
+	restored, err := service.RestoreForDate(context.Background(), RestoreServiceCommand{ScheduledServiceRef: "ss-0194f2e0-7b3e-7610-0284-5c26e8b0c222", Date: time.Date(2026, 7, 5, 0, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if !restored.Bookable || publisher.envelopes[len(publisher.envelopes)-1].EventType != "TrainRestored" {
+		t.Fatalf("unexpected restore result/event: %#v", restored)
+	}
+}
+
+func TestTemporaryServiceAddedAndExpiredEvents(t *testing.T) {
+	publisher := &recordingPublisher{}
+	service := NewService(publisher)
+	_, err := service.CreateScheduledService(context.Background(), CreateScheduledServiceCommand{
+		ServiceRef:        "ss-0194f2e0-7b3e-7610-0284-5c26e8b0c223",
+		CarrierID:         "car-0194f2e0-7b3e-7610-0284-5c26e8b0c001",
+		ServiceNumber:     "G1234",
+		DepartureTime:     time.Date(2026, 2, 5, 10, 30, 0, 0, time.UTC),
+		ArrivalTime:       time.Date(2026, 2, 5, 12, 30, 0, 0, time.UTC),
+		OriginNodeID:      "node-a",
+		DestinationNodeID: "node-b",
+	})
+	if err != nil {
+		t.Fatalf("create scheduled service: %v", err)
+	}
+	_, err = service.AddTemporaryService(context.Background(), AddTemporaryServiceCommand{BaseServiceRef: "ss-0194f2e0-7b3e-7610-0284-5c26e8b0c223", TempServiceRef: "ss-0194f2e0-7b3e-7610-0284-5c26e8b0c224", TempTrainNumber: "L1234", Period: "SPRING_RUSH", StopsSubset: []string{"node-a", "node-b"}, AvailableClasses: []string{"SECOND_CLASS"}})
+	if err != nil {
+		t.Fatalf("add temporary service: %v", err)
+	}
+	if publisher.envelopes[len(publisher.envelopes)-1].EventType != "TemporaryServiceAdded" {
+		t.Fatalf("expected TemporaryServiceAdded event")
+	}
+	expired, err := service.ExpireTemporaryServices(context.Background(), "ss-0194f2e0-7b3e-7610-0284-5c26e8b0c223", time.Date(2026, 3, 11, 0, 0, 0, 0, time.UTC), "", "")
+	if err != nil {
+		t.Fatalf("expire temporary services: %v", err)
+	}
+	if expired != 1 || publisher.envelopes[len(publisher.envelopes)-1].EventType != "TemporaryServiceExpired" {
+		t.Fatalf("expected expiration event, expired=%d", expired)
+	}
 }

--- a/services/service-plan/internal/application/events_test.go
+++ b/services/service-plan/internal/application/events_test.go
@@ -421,3 +421,60 @@ func TestTemporaryServiceAddedAndExpiredEvents(t *testing.T) {
 		t.Fatalf("expected expiration event, expired=%d", expired)
 	}
 }
+
+func TestRepositoryBackedSeasonalStateSurvivesReloads(t *testing.T) {
+	publisher := &recordingPublisher{}
+	repository := newMemoryRepository()
+	service := NewService(publisher).WithRepository(repository)
+	ctx := context.Background()
+	serviceRef := "ss-0194f2e0-7b3e-7610-0284-5c26e8b0c225"
+
+	_, err := service.CreateScheduledService(ctx, CreateScheduledServiceCommand{
+		ServiceRef:        serviceRef,
+		CarrierID:         "car-0194f2e0-7b3e-7610-0284-5c26e8b0c001",
+		ServiceNumber:     "G1234",
+		DepartureTime:     time.Date(2026, 2, 5, 10, 30, 0, 0, time.UTC),
+		ArrivalTime:       time.Date(2026, 2, 5, 12, 30, 0, 0, time.UTC),
+		OriginNodeID:      "node-a",
+		DestinationNodeID: "node-b",
+	})
+	if err != nil {
+		t.Fatalf("create scheduled service: %v", err)
+	}
+
+	_, err = service.CancelForDate(ctx, CancelServiceCommand{ScheduledServiceRef: serviceRef, Date: time.Date(2026, 2, 5, 0, 0, 0, 0, time.UTC), Reason: "WEATHER"})
+	if err != nil {
+		t.Fatalf("cancel with repository: %v", err)
+	}
+	_, err = service.RestoreForDate(ctx, RestoreServiceCommand{ScheduledServiceRef: serviceRef, Date: time.Date(2026, 2, 5, 0, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatalf("restore after repository-backed cancel should succeed: %v", err)
+	}
+
+	_, err = service.AddTemporaryService(ctx, AddTemporaryServiceCommand{BaseServiceRef: serviceRef, TempServiceRef: "ss-0194f2e0-7b3e-7610-0284-5c26e8b0c226", TempTrainNumber: "L1234", Period: "SPRING_RUSH", StopsSubset: []string{"node-a", "node-b"}, AvailableClasses: []string{"SECOND_CLASS"}})
+	if err != nil {
+		t.Fatalf("add temporary service with repository: %v", err)
+	}
+	expired, err := service.ExpireTemporaryServices(ctx, serviceRef, time.Date(2026, 3, 11, 0, 0, 0, 0, time.UTC), "", "")
+	if err != nil {
+		t.Fatalf("expire repository-backed temporary service: %v", err)
+	}
+	if expired != 1 {
+		t.Fatalf("expected one expired temporary service, got %d", expired)
+	}
+
+	_, err = service.RecordDelay(ctx, RecordDelayCommand{ScheduledServiceRef: serviceRef, SegmentRef: "node-a:node-b", DelayMinutes: 12})
+	if err != nil {
+		t.Fatalf("record delay with repository: %v", err)
+	}
+	stored := repository.services[serviceRef]
+	if len(stored.Cancellations) != 1 || stored.Cancellations[0].RestoredAt == nil {
+		t.Fatalf("expected restored cancellation snapshot, got %#v", stored.Cancellations)
+	}
+	if len(stored.TemporaryServices) != 1 || stored.TemporaryServices[0].ExpiredAt == nil {
+		t.Fatalf("expected expired temporary service snapshot, got %#v", stored.TemporaryServices)
+	}
+	if len(stored.DelayRecords) == 0 {
+		t.Fatalf("expected persisted delay records")
+	}
+}

--- a/services/service-plan/internal/application/service.go
+++ b/services/service-plan/internal/application/service.go
@@ -39,15 +39,19 @@ type ScheduledService struct {
 	ArrivalTime         time.Time `json:"arrivalTime"`
 	OriginNodeID        string    `json:"originNodeId"`
 	DestinationNodeID   string    `json:"destinationNodeId"`
+	SchedulePeriod      string    `json:"schedulePeriod,omitempty"`
+	CapacityMultiplier  float64   `json:"capacityMultiplier,omitempty"`
+	Bookable            bool      `json:"bookable"`
 }
 
 type ServiceSegment struct {
-	SegmentRef          string    `json:"segmentRef"`
-	ScheduledServiceRef string    `json:"scheduledServiceRef"`
-	OriginStopRef       string    `json:"originStopRef"`
-	DestinationStopRef  string    `json:"destinationStopRef"`
-	DepartureTime       time.Time `json:"departureTime"`
-	ArrivalTime         time.Time `json:"arrivalTime"`
+	SegmentRef          string     `json:"segmentRef"`
+	ScheduledServiceRef string     `json:"scheduledServiceRef"`
+	OriginStopRef       string     `json:"originStopRef"`
+	DestinationStopRef  string     `json:"destinationStopRef"`
+	DepartureTime       time.Time  `json:"departureTime"`
+	ArrivalTime         time.Time  `json:"arrivalTime"`
+	ActualDepartureTime *time.Time `json:"actualDepartureTime,omitempty"`
 }
 
 type CreateScheduledServiceCommand struct {
@@ -84,6 +88,64 @@ type CreateServiceSegmentResult struct {
 	ScheduledServiceRef string `json:"scheduledServiceRef"`
 }
 
+type AddTemporaryServiceCommand struct {
+	BaseServiceRef   string
+	TempServiceRef   string
+	TempTrainNumber  string
+	Period           string
+	StopsSubset      []string
+	AvailableClasses []string
+	CorrelationID    string
+	CausationID      string
+}
+
+type AddTemporaryServiceResult struct {
+	TempServiceRef  string `json:"tempServiceRef"`
+	BaseServiceRef  string `json:"baseServiceRef"`
+	TempTrainNumber string `json:"tempTrainNumber"`
+	Period          string `json:"period"`
+}
+
+type RecordDelayCommand struct {
+	ScheduledServiceRef string
+	SegmentRef          string
+	DelayMinutes        int
+	CorrelationID       string
+	CausationID         string
+}
+
+type TrainDelayed struct {
+	ServiceRef            string    `json:"serviceRef"`
+	SegmentRef            string    `json:"segmentRef"`
+	DelayMinutes          int       `json:"delayMinutes"`
+	EstimatedNewDeparture time.Time `json:"estimatedNewDeparture"`
+}
+
+type RecordDelayResult struct {
+	Events []TrainDelayed `json:"events"`
+}
+
+type CancelServiceCommand struct {
+	ScheduledServiceRef string
+	Date                time.Time
+	Reason              string
+	CorrelationID       string
+	CausationID         string
+}
+
+type RestoreServiceCommand struct {
+	ScheduledServiceRef string
+	Date                time.Time
+	CorrelationID       string
+	CausationID         string
+}
+
+type ServiceDateStatusResult struct {
+	ScheduledServiceRef string `json:"scheduledServiceRef"`
+	Date                string `json:"date"`
+	Bookable            bool   `json:"bookable"`
+}
+
 type ListScheduledServicesQuery struct {
 	Limit     int
 	Offset    int
@@ -98,6 +160,7 @@ type PaginatedScheduledServices struct {
 }
 
 type scheduledServiceState struct {
+	plan      domain.ServicePlan
 	aggregate domain.ScheduledService
 	view      ScheduledService
 }
@@ -107,6 +170,7 @@ type Repository interface {
 	FindScheduledService(context.Context, string) (ScheduledService, error)
 	ListScheduledServices(context.Context, ListScheduledServicesQuery) (PaginatedScheduledServices, error)
 	SaveServiceSegment(context.Context, ServiceSegment) error
+	FindServiceSegment(context.Context, string) (ServiceSegment, error)
 }
 
 type UnitOfWork func(context.Context, func(context.Context) error) error
@@ -287,15 +351,22 @@ func (s *Service) buildScheduledService(command CreateScheduledServiceCommand) (
 		ArrivalTime:         arrival,
 		OriginNodeID:        origin,
 		DestinationNodeID:   destination,
+		SchedulePeriod:      string(plan.ActiveVariant(departure).PeriodType()),
+		CapacityMultiplier:  plan.ActiveVariant(departure).CapacityMultiplier(),
+		Bookable:            status != StatusCancelled,
 	}
 	result := CreateScheduledServiceResult{ScheduledServiceRef: view.ScheduledServiceRef, ServiceNumber: view.ServiceNumber, Status: view.Status}
-	return scheduledServiceState{aggregate: aggregate, view: view}, result, nil
+	return scheduledServiceState{plan: plan, aggregate: aggregate, view: view}, result, nil
 }
 
 func (s *Service) GetScheduledService(ctx context.Context, serviceRef string) (ScheduledService, error) {
 	serviceRef = strings.TrimSpace(serviceRef)
 	if s.repository != nil {
-		return s.repository.FindScheduledService(ctx, serviceRef)
+		service, err := s.repository.FindScheduledService(ctx, serviceRef)
+		if err != nil {
+			return ScheduledService{}, err
+		}
+		return normalizeScheduledServiceView(service), nil
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -308,7 +379,14 @@ func (s *Service) GetScheduledService(ctx context.Context, serviceRef string) (S
 
 func (s *Service) ListScheduledServices(ctx context.Context, query ListScheduledServicesQuery) (PaginatedScheduledServices, error) {
 	if s.repository != nil {
-		return s.repository.ListScheduledServices(ctx, query)
+		page, err := s.repository.ListScheduledServices(ctx, query)
+		if err != nil {
+			return PaginatedScheduledServices{}, err
+		}
+		for i := range page.Items {
+			page.Items[i] = normalizeScheduledServiceView(page.Items[i])
+		}
+		return page, nil
 	}
 	return s.listScheduledServicesFromMemory(query), nil
 }
@@ -398,6 +476,209 @@ func (s *Service) CreateServiceSegment(ctx context.Context, command CreateServic
 	return result, nil
 }
 
+func (s *Service) AddTemporaryService(ctx context.Context, command AddTemporaryServiceCommand) (AddTemporaryServiceResult, error) {
+	if err := validateAddTemporaryService(command); err != nil {
+		return AddTemporaryServiceResult{}, err
+	}
+	state, err := s.loadScheduledServiceState(ctx, strings.TrimSpace(command.BaseServiceRef))
+	if err != nil {
+		return AddTemporaryServiceResult{}, err
+	}
+	period := domain.SchedulePeriodType(strings.ToUpper(strings.TrimSpace(command.Period)))
+	tempRef := strings.TrimSpace(command.TempServiceRef)
+	if tempRef == "" {
+		tempRef = s.idGenerator("ss")
+	}
+	tempService, err := domain.NewTemporaryService(domain.TemporaryServiceID(tempRef), domain.ScheduledServiceID(command.BaseServiceRef), command.TempTrainNumber, period, toNodeIDs(command.StopsSubset), command.AvailableClasses)
+	if err != nil {
+		return AddTemporaryServiceResult{}, domainRule(err)
+	}
+	plan, event, err := state.plan.AddTemporaryService(tempService)
+	if err != nil {
+		return AddTemporaryServiceResult{}, domainRule(err)
+	}
+	payload, err := json.Marshal(map[string]any{"tempServiceRef": event.TempServiceRef, "baseServiceRef": event.BaseServiceRef, "period": event.Period})
+	if err != nil {
+		return AddTemporaryServiceResult{}, err
+	}
+	envelope := s.newEnvelope(ctx, "TemporaryServiceAdded", command.CorrelationID, command.CausationID, payload)
+	if err := s.within(ctx, func(txCtx context.Context) error {
+		if err := s.publisher.Publish(txCtx, envelope); err != nil {
+			return fmt.Errorf("%w: %v", ErrPublish, err)
+		}
+		return nil
+	}); err != nil {
+		return AddTemporaryServiceResult{}, err
+	}
+	state.plan = plan
+	s.mu.Lock()
+	s.scheduledServices[state.view.ScheduledServiceRef] = state
+	s.mu.Unlock()
+	return AddTemporaryServiceResult{TempServiceRef: string(tempService.TempServiceRef), BaseServiceRef: string(tempService.BaseServiceRef), TempTrainNumber: tempService.TempTrainNumber, Period: string(tempService.PeriodRef)}, nil
+}
+
+func (s *Service) RecordDelay(ctx context.Context, command RecordDelayCommand) (RecordDelayResult, error) {
+	if err := validateRecordDelay(command); err != nil {
+		return RecordDelayResult{}, err
+	}
+	state, err := s.loadScheduledServiceState(ctx, strings.TrimSpace(command.ScheduledServiceRef))
+	if err != nil {
+		return RecordDelayResult{}, err
+	}
+	if s.repository != nil {
+		if segment, err := s.repository.FindServiceSegment(ctx, strings.TrimSpace(command.SegmentRef)); err == nil {
+			s.mu.Lock()
+			s.segments[segment.SegmentRef] = segment
+			s.mu.Unlock()
+		}
+	}
+	scheduledDepartures := make(map[domain.ServiceSegmentID]time.Time, len(state.aggregate.Segments()))
+	for _, segment := range state.aggregate.Segments() {
+		scheduledDepartures[segment.ID] = departureForSequence(state.view.DepartureTime, state.view.ArrivalTime, segment.FromSequence, len(state.aggregate.Segments()))
+	}
+	domainSegmentRef := s.resolveDomainSegmentRef(command.SegmentRef, state)
+	aggregate, domainEvents, err := state.aggregate.RecordDelay(domainSegmentRef, command.DelayMinutes, scheduledDepartures)
+	if err != nil {
+		return RecordDelayResult{}, domainRule(err)
+	}
+	envelopes := make([]EventEnvelope, 0, len(domainEvents))
+	result := RecordDelayResult{Events: make([]TrainDelayed, 0, len(domainEvents))}
+	for _, event := range domainEvents {
+		viewEvent := TrainDelayed{ServiceRef: string(event.ServiceRef), SegmentRef: string(event.SegmentRef), DelayMinutes: event.DelayMinutes, EstimatedNewDeparture: event.EstimatedNewDeparture}
+		result.Events = append(result.Events, viewEvent)
+		payload, err := json.Marshal(map[string]any{"serviceRef": viewEvent.ServiceRef, "segmentRef": viewEvent.SegmentRef, "delayMinutes": viewEvent.DelayMinutes, "estimatedNewDeparture": viewEvent.EstimatedNewDeparture})
+		if err != nil {
+			return RecordDelayResult{}, err
+		}
+		envelopes = append(envelopes, s.newEnvelope(ctx, "TrainDelayed", command.CorrelationID, command.CausationID, payload))
+	}
+	if err := s.within(ctx, func(txCtx context.Context) error {
+		for _, envelope := range envelopes {
+			if err := s.publisher.Publish(txCtx, envelope); err != nil {
+				return fmt.Errorf("%w: %v", ErrPublish, err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return RecordDelayResult{}, err
+	}
+	state.aggregate = aggregate
+	s.mu.Lock()
+	s.scheduledServices[state.view.ScheduledServiceRef] = state
+	s.mu.Unlock()
+	return result, nil
+}
+
+func (s *Service) CancelForDate(ctx context.Context, command CancelServiceCommand) (ServiceDateStatusResult, error) {
+	if err := validateCancelService(command); err != nil {
+		return ServiceDateStatusResult{}, err
+	}
+	state, err := s.loadScheduledServiceState(ctx, strings.TrimSpace(command.ScheduledServiceRef))
+	if err != nil {
+		return ServiceDateStatusResult{}, err
+	}
+	plan, event, err := state.plan.CancelForDate(domain.ScheduledServiceID(command.ScheduledServiceRef), command.Date, command.Reason, s.now().UTC())
+	if err != nil {
+		return ServiceDateStatusResult{}, domainRule(err)
+	}
+	payload, err := json.Marshal(map[string]any{"serviceRef": event.ServiceRef, "date": event.Date, "reason": event.Reason})
+	if err != nil {
+		return ServiceDateStatusResult{}, err
+	}
+	envelope := s.newEnvelope(ctx, "TrainCancelled", command.CorrelationID, command.CausationID, payload)
+	state.plan = plan
+	if serviceDate(command.Date).Equal(serviceDate(state.view.DepartureTime)) {
+		state.view.Status = StatusCancelled
+		state.view.Bookable = false
+	}
+	if err := s.persistStateAndPublish(ctx, state, envelope); err != nil {
+		return ServiceDateStatusResult{}, err
+	}
+	return ServiceDateStatusResult{ScheduledServiceRef: state.view.ScheduledServiceRef, Date: dateString(command.Date), Bookable: false}, nil
+}
+
+func (s *Service) RestoreForDate(ctx context.Context, command RestoreServiceCommand) (ServiceDateStatusResult, error) {
+	if err := validateRestoreService(command); err != nil {
+		return ServiceDateStatusResult{}, err
+	}
+	state, err := s.loadScheduledServiceState(ctx, strings.TrimSpace(command.ScheduledServiceRef))
+	if err != nil {
+		return ServiceDateStatusResult{}, err
+	}
+	plan, event, err := state.plan.RestoreForDate(domain.ScheduledServiceID(command.ScheduledServiceRef), command.Date, s.now().UTC())
+	if err != nil {
+		return ServiceDateStatusResult{}, domainRule(err)
+	}
+	payload, err := json.Marshal(map[string]any{"serviceRef": event.ServiceRef, "date": event.Date})
+	if err != nil {
+		return ServiceDateStatusResult{}, err
+	}
+	envelope := s.newEnvelope(ctx, "TrainRestored", command.CorrelationID, command.CausationID, payload)
+	state.plan = plan
+	if serviceDate(command.Date).Equal(serviceDate(state.view.DepartureTime)) {
+		state.view.Status = StatusActive
+		state.view.Bookable = true
+	}
+	if err := s.persistStateAndPublish(ctx, state, envelope); err != nil {
+		return ServiceDateStatusResult{}, err
+	}
+	return ServiceDateStatusResult{ScheduledServiceRef: state.view.ScheduledServiceRef, Date: dateString(command.Date), Bookable: true}, nil
+}
+
+func (s *Service) ExpireTemporaryServices(ctx context.Context, serviceRef string, asOf time.Time, correlationID, causationID string) (int, error) {
+	state, err := s.loadScheduledServiceState(ctx, strings.TrimSpace(serviceRef))
+	if err != nil {
+		return 0, err
+	}
+	plan, events, err := state.plan.ExpireTemporaryServices(asOf)
+	if err != nil {
+		return 0, domainRule(err)
+	}
+	envelopes := make([]EventEnvelope, 0, len(events))
+	for _, event := range events {
+		payload, err := json.Marshal(map[string]any{"serviceRef": event.ServiceRef, "periodEndDate": event.PeriodEndDate})
+		if err != nil {
+			return 0, err
+		}
+		envelopes = append(envelopes, s.newEnvelope(ctx, "TemporaryServiceExpired", correlationID, causationID, payload))
+	}
+	state.plan = plan
+	if err := s.within(ctx, func(txCtx context.Context) error {
+		for _, envelope := range envelopes {
+			if err := s.publisher.Publish(txCtx, envelope); err != nil {
+				return fmt.Errorf("%w: %v", ErrPublish, err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return 0, err
+	}
+	s.mu.Lock()
+	s.scheduledServices[state.view.ScheduledServiceRef] = state
+	s.mu.Unlock()
+	return len(events), nil
+}
+
+func (s *Service) persistStateAndPublish(ctx context.Context, state scheduledServiceState, envelope EventEnvelope) error {
+	if err := s.within(ctx, func(txCtx context.Context) error {
+		if s.repository != nil {
+			if err := s.repository.SaveScheduledService(txCtx, state.view); err != nil {
+				return err
+			}
+		}
+		if err := s.publisher.Publish(txCtx, envelope); err != nil {
+			return fmt.Errorf("%w: %v", ErrPublish, err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.scheduledServices[state.view.ScheduledServiceRef] = state
+	s.mu.Unlock()
+	return nil
+}
+
 func (s *Service) loadScheduledServiceState(ctx context.Context, serviceRef string) (scheduledServiceState, error) {
 	if s.repository != nil {
 		service, err := s.repository.FindScheduledService(ctx, serviceRef)
@@ -437,12 +718,55 @@ func (s *Service) stateFromScheduledService(service ScheduledService) (scheduled
 	if err != nil {
 		return scheduledServiceState{}, err
 	}
-	state.view = service
+	state.view = normalizeScheduledServiceView(service)
 	return state, nil
+}
+
+func (s *Service) resolveDomainSegmentRef(segmentRef string, state scheduledServiceState) domain.ServiceSegmentID {
+	segmentRef = strings.TrimSpace(segmentRef)
+	for _, segment := range state.aggregate.Segments() {
+		if string(segment.ID) == segmentRef {
+			return segment.ID
+		}
+	}
+	s.mu.Lock()
+	apiSegment, exists := s.segments[segmentRef]
+	s.mu.Unlock()
+	if exists && apiSegment.ScheduledServiceRef == state.view.ScheduledServiceRef {
+		for _, segment := range state.aggregate.Segments() {
+			if string(segment.FromNodeID) == apiSegment.OriginStopRef && string(segment.ToNodeID) == apiSegment.DestinationStopRef {
+				return segment.ID
+			}
+		}
+	}
+	if parts := strings.Split(segmentRef, ":"); len(parts) == 2 {
+		for _, segment := range state.aggregate.Segments() {
+			if string(segment.FromNodeID) == strings.TrimSpace(parts[0]) && string(segment.ToNodeID) == strings.TrimSpace(parts[1]) {
+				return segment.ID
+			}
+		}
+	}
+	return domain.ServiceSegmentID(segmentRef)
 }
 
 func serviceViewHasSegment(service ScheduledService, originStopRef, destinationStopRef string) bool {
 	return strings.TrimSpace(service.OriginNodeID) == strings.TrimSpace(originStopRef) && strings.TrimSpace(service.DestinationNodeID) == strings.TrimSpace(destinationStopRef)
+}
+
+func normalizeScheduledServiceView(service ScheduledService) ScheduledService {
+	if service.Status == "" {
+		service.Status = StatusActive
+	}
+	if service.SchedulePeriod == "" {
+		service.SchedulePeriod = string(domain.SchedulePeriodRegular)
+	}
+	if service.CapacityMultiplier == 0 {
+		service.CapacityMultiplier = 1
+	}
+	if service.Status != StatusCancelled {
+		service.Bookable = true
+	}
+	return service
 }
 
 func (s *Service) removePendingEvent(eventID string) {
@@ -537,6 +861,79 @@ func validateCreateServiceSegment(command CreateServiceSegmentCommand) error {
 	}
 	return nil
 }
+
+func validateAddTemporaryService(command AddTemporaryServiceCommand) error {
+	if strings.TrimSpace(command.BaseServiceRef) == "" || strings.TrimSpace(command.TempTrainNumber) == "" || strings.TrimSpace(command.Period) == "" {
+		return fmt.Errorf("%w: required field missing", ErrValidation)
+	}
+	if !ids.ValidPrefixedUUIDv7(strings.TrimSpace(command.BaseServiceRef), "ss") {
+		return fmt.Errorf("%w: baseServiceRef must be ss-prefixed UUID v7", ErrValidation)
+	}
+	if strings.TrimSpace(command.TempServiceRef) != "" && !ids.ValidPrefixedUUIDv7(strings.TrimSpace(command.TempServiceRef), "ss") {
+		return fmt.Errorf("%w: tempServiceRef must be ss-prefixed UUID v7", ErrValidation)
+	}
+	if len(command.StopsSubset) < 2 || len(command.AvailableClasses) == 0 {
+		return fmt.Errorf("%w: stopsSubset and availableClasses are required", ErrValidation)
+	}
+	return nil
+}
+
+func validateRecordDelay(command RecordDelayCommand) error {
+	if strings.TrimSpace(command.ScheduledServiceRef) == "" || strings.TrimSpace(command.SegmentRef) == "" {
+		return fmt.Errorf("%w: required field missing", ErrValidation)
+	}
+	if !ids.ValidPrefixedUUIDv7(strings.TrimSpace(command.ScheduledServiceRef), "ss") {
+		return fmt.Errorf("%w: scheduledServiceRef must be ss-prefixed UUID v7", ErrValidation)
+	}
+	if command.DelayMinutes < 0 {
+		return fmt.Errorf("%w: delayMinutes cannot be negative", ErrValidation)
+	}
+	return nil
+}
+
+func validateCancelService(command CancelServiceCommand) error {
+	if strings.TrimSpace(command.ScheduledServiceRef) == "" || strings.TrimSpace(command.Reason) == "" || command.Date.IsZero() {
+		return fmt.Errorf("%w: required field missing", ErrValidation)
+	}
+	if !ids.ValidPrefixedUUIDv7(strings.TrimSpace(command.ScheduledServiceRef), "ss") {
+		return fmt.Errorf("%w: scheduledServiceRef must be ss-prefixed UUID v7", ErrValidation)
+	}
+	return nil
+}
+
+func validateRestoreService(command RestoreServiceCommand) error {
+	if strings.TrimSpace(command.ScheduledServiceRef) == "" || command.Date.IsZero() {
+		return fmt.Errorf("%w: required field missing", ErrValidation)
+	}
+	if !ids.ValidPrefixedUUIDv7(strings.TrimSpace(command.ScheduledServiceRef), "ss") {
+		return fmt.Errorf("%w: scheduledServiceRef must be ss-prefixed UUID v7", ErrValidation)
+	}
+	return nil
+}
+
+func toNodeIDs(values []string) []domain.TransportNodeID {
+	nodes := make([]domain.TransportNodeID, len(values))
+	for i, value := range values {
+		nodes[i] = domain.TransportNodeID(strings.TrimSpace(value))
+	}
+	return nodes
+}
+
+func departureForSequence(start, end time.Time, sequence, segmentCount int) time.Time {
+	if sequence <= 1 || segmentCount <= 1 {
+		return start.UTC()
+	}
+	// Derived domain segments include every origin-destination pair; use a stable
+	// interpolation only as an API estimate when no detailed stop times are stored.
+	span := end.Sub(start)
+	if span <= 0 {
+		return start.UTC()
+	}
+	step := span / time.Duration(segmentCount)
+	return start.Add(time.Duration(sequence-1) * step).UTC()
+}
+
+func dateString(value time.Time) string { return serviceDate(value).Format("2006-01-02") }
 
 func normalizedStatus(status string) string {
 	status = strings.TrimSpace(status)

--- a/services/service-plan/internal/application/service.go
+++ b/services/service-plan/internal/application/service.go
@@ -31,17 +31,46 @@ var (
 )
 
 type ScheduledService struct {
-	ScheduledServiceRef string    `json:"scheduledServiceRef"`
-	ServiceNumber       string    `json:"serviceNumber"`
-	Status              string    `json:"status"`
-	CarrierID           string    `json:"carrierId"`
-	DepartureTime       time.Time `json:"departureTime"`
-	ArrivalTime         time.Time `json:"arrivalTime"`
-	OriginNodeID        string    `json:"originNodeId"`
-	DestinationNodeID   string    `json:"destinationNodeId"`
-	SchedulePeriod      string    `json:"schedulePeriod,omitempty"`
-	CapacityMultiplier  float64   `json:"capacityMultiplier,omitempty"`
-	Bookable            bool      `json:"bookable"`
+	ScheduledServiceRef string                        `json:"scheduledServiceRef"`
+	ServiceNumber       string                        `json:"serviceNumber"`
+	Status              string                        `json:"status"`
+	CarrierID           string                        `json:"carrierId"`
+	DepartureTime       time.Time                     `json:"departureTime"`
+	ArrivalTime         time.Time                     `json:"arrivalTime"`
+	OriginNodeID        string                        `json:"originNodeId"`
+	DestinationNodeID   string                        `json:"destinationNodeId"`
+	SchedulePeriod      string                        `json:"schedulePeriod,omitempty"`
+	CapacityMultiplier  float64                       `json:"capacityMultiplier,omitempty"`
+	Bookable            bool                          `json:"bookable"`
+	TemporaryServices   []TemporaryServiceSnapshot    `json:"temporaryServices,omitempty"`
+	Cancellations       []ServiceCancellationSnapshot `json:"cancellations,omitempty"`
+	DelayRecords        []DelayRecordSnapshot         `json:"delayRecords,omitempty"`
+}
+
+type TemporaryServiceSnapshot struct {
+	TempServiceRef   string     `json:"tempServiceRef"`
+	BaseServiceRef   string     `json:"baseServiceRef"`
+	TempTrainNumber  string     `json:"tempTrainNumber"`
+	PeriodRef        string     `json:"periodRef"`
+	StopsSubset      []string   `json:"stopsSubset"`
+	AvailableClasses []string   `json:"availableClasses"`
+	ExpiredAt        *time.Time `json:"expiredAt,omitempty"`
+}
+
+type ServiceCancellationSnapshot struct {
+	ServiceRef  string     `json:"serviceRef"`
+	Date        time.Time  `json:"date"`
+	Reason      string     `json:"reason"`
+	CancelledAt time.Time  `json:"cancelledAt"`
+	RestoredAt  *time.Time `json:"restoredAt,omitempty"`
+}
+
+type DelayRecordSnapshot struct {
+	SegmentRef    string    `json:"segmentRef"`
+	ScheduledTime time.Time `json:"scheduledTime"`
+	EstimatedTime time.Time `json:"estimatedTime"`
+	DelayMinutes  int       `json:"delayMinutes"`
+	Source        string    `json:"source"`
 }
 
 type ServiceSegment struct {
@@ -502,18 +531,10 @@ func (s *Service) AddTemporaryService(ctx context.Context, command AddTemporaryS
 		return AddTemporaryServiceResult{}, err
 	}
 	envelope := s.newEnvelope(ctx, "TemporaryServiceAdded", command.CorrelationID, command.CausationID, payload)
-	if err := s.within(ctx, func(txCtx context.Context) error {
-		if err := s.publisher.Publish(txCtx, envelope); err != nil {
-			return fmt.Errorf("%w: %v", ErrPublish, err)
-		}
-		return nil
-	}); err != nil {
+	state.plan = plan
+	if err := s.persistStateAndPublish(ctx, state, envelope); err != nil {
 		return AddTemporaryServiceResult{}, err
 	}
-	state.plan = plan
-	s.mu.Lock()
-	s.scheduledServices[state.view.ScheduledServiceRef] = state
-	s.mu.Unlock()
 	return AddTemporaryServiceResult{TempServiceRef: string(tempService.TempServiceRef), BaseServiceRef: string(tempService.BaseServiceRef), TempTrainNumber: tempService.TempTrainNumber, Period: string(tempService.PeriodRef)}, nil
 }
 
@@ -552,20 +573,10 @@ func (s *Service) RecordDelay(ctx context.Context, command RecordDelayCommand) (
 		}
 		envelopes = append(envelopes, s.newEnvelope(ctx, "TrainDelayed", command.CorrelationID, command.CausationID, payload))
 	}
-	if err := s.within(ctx, func(txCtx context.Context) error {
-		for _, envelope := range envelopes {
-			if err := s.publisher.Publish(txCtx, envelope); err != nil {
-				return fmt.Errorf("%w: %v", ErrPublish, err)
-			}
-		}
-		return nil
-	}); err != nil {
+	state.aggregate = aggregate
+	if err := s.persistStateAndPublish(ctx, state, envelopes...); err != nil {
 		return RecordDelayResult{}, err
 	}
-	state.aggregate = aggregate
-	s.mu.Lock()
-	s.scheduledServices[state.view.ScheduledServiceRef] = state
-	s.mu.Unlock()
 	return result, nil
 }
 
@@ -643,31 +654,24 @@ func (s *Service) ExpireTemporaryServices(ctx context.Context, serviceRef string
 		envelopes = append(envelopes, s.newEnvelope(ctx, "TemporaryServiceExpired", correlationID, causationID, payload))
 	}
 	state.plan = plan
-	if err := s.within(ctx, func(txCtx context.Context) error {
-		for _, envelope := range envelopes {
-			if err := s.publisher.Publish(txCtx, envelope); err != nil {
-				return fmt.Errorf("%w: %v", ErrPublish, err)
-			}
-		}
-		return nil
-	}); err != nil {
+	if err := s.persistStateAndPublish(ctx, state, envelopes...); err != nil {
 		return 0, err
 	}
-	s.mu.Lock()
-	s.scheduledServices[state.view.ScheduledServiceRef] = state
-	s.mu.Unlock()
 	return len(events), nil
 }
 
-func (s *Service) persistStateAndPublish(ctx context.Context, state scheduledServiceState, envelope EventEnvelope) error {
+func (s *Service) persistStateAndPublish(ctx context.Context, state scheduledServiceState, envelopes ...EventEnvelope) error {
+	state.view = viewWithOperationalState(state)
 	if err := s.within(ctx, func(txCtx context.Context) error {
 		if s.repository != nil {
 			if err := s.repository.SaveScheduledService(txCtx, state.view); err != nil {
 				return err
 			}
 		}
-		if err := s.publisher.Publish(txCtx, envelope); err != nil {
-			return fmt.Errorf("%w: %v", ErrPublish, err)
+		for _, envelope := range envelopes {
+			if err := s.publisher.Publish(txCtx, envelope); err != nil {
+				return fmt.Errorf("%w: %v", ErrPublish, err)
+			}
 		}
 		return nil
 	}); err != nil {
@@ -719,7 +723,138 @@ func (s *Service) stateFromScheduledService(service ScheduledService) (scheduled
 		return scheduledServiceState{}, err
 	}
 	state.view = normalizeScheduledServiceView(service)
+	plan, err := state.plan.WithOperationalState(toDomainTemporaryServices(state.view.TemporaryServices), toDomainCancellations(state.view.Cancellations))
+	if err != nil {
+		return scheduledServiceState{}, domainRule(err)
+	}
+	aggregate, err := state.aggregate.WithDelayRecords(toDomainDelayRecords(state.view.DelayRecords))
+	if err != nil {
+		return scheduledServiceState{}, domainRule(err)
+	}
+	state.plan = plan
+	state.aggregate = aggregate
 	return state, nil
+}
+
+func viewWithOperationalState(state scheduledServiceState) ScheduledService {
+	view := state.view
+	view.TemporaryServices = temporaryServiceSnapshots(state.plan.TemporaryServices())
+	view.Cancellations = serviceCancellationSnapshots(state.plan.Cancellations())
+	view.DelayRecords = delayRecordSnapshots(state.aggregate.DelayRecords())
+	return view
+}
+
+func temporaryServiceSnapshots(services []domain.TemporaryService) []TemporaryServiceSnapshot {
+	if len(services) == 0 {
+		return nil
+	}
+	snapshots := make([]TemporaryServiceSnapshot, 0, len(services))
+	for _, service := range services {
+		stops := make([]string, 0, len(service.StopsSubset))
+		for _, stop := range service.StopsSubset {
+			stops = append(stops, string(stop))
+		}
+		snapshots = append(snapshots, TemporaryServiceSnapshot{
+			TempServiceRef:   string(service.TempServiceRef),
+			BaseServiceRef:   string(service.BaseServiceRef),
+			TempTrainNumber:  service.TempTrainNumber,
+			PeriodRef:        string(service.PeriodRef),
+			StopsSubset:      stops,
+			AvailableClasses: append([]string{}, service.AvailableClasses...),
+			ExpiredAt:        copyTimePtr(service.ExpiredAt),
+		})
+	}
+	return snapshots
+}
+
+func serviceCancellationSnapshots(cancellations []domain.ServiceCancellation) []ServiceCancellationSnapshot {
+	if len(cancellations) == 0 {
+		return nil
+	}
+	snapshots := make([]ServiceCancellationSnapshot, 0, len(cancellations))
+	for _, cancellation := range cancellations {
+		snapshots = append(snapshots, ServiceCancellationSnapshot{
+			ServiceRef:  string(cancellation.ServiceRef),
+			Date:        cancellation.Date,
+			Reason:      cancellation.Reason,
+			CancelledAt: cancellation.CancelledAt,
+			RestoredAt:  copyTimePtr(cancellation.RestoredAt),
+		})
+	}
+	return snapshots
+}
+
+func delayRecordSnapshots(records []domain.DelayRecord) []DelayRecordSnapshot {
+	if len(records) == 0 {
+		return nil
+	}
+	snapshots := make([]DelayRecordSnapshot, 0, len(records))
+	for _, record := range records {
+		snapshots = append(snapshots, DelayRecordSnapshot{
+			SegmentRef:    string(record.SegmentRef),
+			ScheduledTime: record.ScheduledTime,
+			EstimatedTime: record.EstimatedTime,
+			DelayMinutes:  record.DelayMinutes,
+			Source:        string(record.Source),
+		})
+	}
+	return snapshots
+}
+
+func toDomainTemporaryServices(snapshots []TemporaryServiceSnapshot) []domain.TemporaryService {
+	services := make([]domain.TemporaryService, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		stops := make([]domain.TransportNodeID, 0, len(snapshot.StopsSubset))
+		for _, stop := range snapshot.StopsSubset {
+			stops = append(stops, domain.TransportNodeID(stop))
+		}
+		services = append(services, domain.TemporaryService{
+			TempServiceRef:   domain.TemporaryServiceID(snapshot.TempServiceRef),
+			BaseServiceRef:   domain.ScheduledServiceID(snapshot.BaseServiceRef),
+			TempTrainNumber:  snapshot.TempTrainNumber,
+			PeriodRef:        domain.SchedulePeriodType(snapshot.PeriodRef),
+			StopsSubset:      stops,
+			AvailableClasses: append([]string{}, snapshot.AvailableClasses...),
+			ExpiredAt:        copyTimePtr(snapshot.ExpiredAt),
+		})
+	}
+	return services
+}
+
+func toDomainCancellations(snapshots []ServiceCancellationSnapshot) []domain.ServiceCancellation {
+	cancellations := make([]domain.ServiceCancellation, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		cancellations = append(cancellations, domain.ServiceCancellation{
+			ServiceRef:  domain.ScheduledServiceID(snapshot.ServiceRef),
+			Date:        serviceDate(snapshot.Date),
+			Reason:      snapshot.Reason,
+			CancelledAt: snapshot.CancelledAt.UTC(),
+			RestoredAt:  copyTimePtr(snapshot.RestoredAt),
+		})
+	}
+	return cancellations
+}
+
+func toDomainDelayRecords(snapshots []DelayRecordSnapshot) []domain.DelayRecord {
+	records := make([]domain.DelayRecord, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		records = append(records, domain.DelayRecord{
+			SegmentRef:    domain.ServiceSegmentID(snapshot.SegmentRef),
+			ScheduledTime: snapshot.ScheduledTime,
+			EstimatedTime: snapshot.EstimatedTime,
+			DelayMinutes:  snapshot.DelayMinutes,
+			Source:        domain.DelaySource(snapshot.Source),
+		})
+	}
+	return records
+}
+
+func copyTimePtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copied := value.UTC()
+	return &copied
 }
 
 func (s *Service) resolveDomainSegmentRef(segmentRef string, state scheduledServiceState) domain.ServiceSegmentID {

--- a/services/service-plan/internal/domain/service_plan.go
+++ b/services/service-plan/internal/domain/service_plan.go
@@ -22,6 +22,7 @@ type (
 	TransportNodeID     string
 	NodeSnapshotVersion string
 	CarrierID           string
+	TemporaryServiceID  string
 )
 
 type ServiceMode string
@@ -588,17 +589,207 @@ func (v PlanVersion) overlaps(other PlanVersion) bool {
 	return !v.effectiveTo.Before(other.effectiveFrom) && !other.effectiveTo.Before(v.effectiveFrom)
 }
 
+type SchedulePeriodType string
+
+const (
+	SchedulePeriodRegular     SchedulePeriodType = "REGULAR"
+	SchedulePeriodSpringRush  SchedulePeriodType = "SPRING_RUSH"
+	SchedulePeriodSummerRush  SchedulePeriodType = "SUMMER_RUSH"
+	SchedulePeriodNationalDay SchedulePeriodType = "NATIONAL_DAY"
+	SchedulePeriodLaborDay    SchedulePeriodType = "LABOR_DAY"
+)
+
+type SchedulePeriod struct {
+	PeriodType         SchedulePeriodType
+	StartDate          time.Time
+	EndDate            time.Time
+	CapacityMultiplier float64
+}
+
+func NewSchedulePeriod(periodType SchedulePeriodType, startDate, endDate time.Time, capacityMultiplier float64) (SchedulePeriod, error) {
+	period := SchedulePeriod{PeriodType: periodType, StartDate: normalizeDate(startDate), EndDate: normalizeDate(endDate), CapacityMultiplier: capacityMultiplier}
+	if err := period.Validate(); err != nil {
+		return SchedulePeriod{}, err
+	}
+	return period, nil
+}
+
+func (p SchedulePeriod) Validate() error {
+	if !validSchedulePeriodType(p.PeriodType) {
+		return fmt.Errorf("unsupported schedule period type: %q", p.PeriodType)
+	}
+	if p.StartDate.IsZero() || p.EndDate.IsZero() {
+		return fmt.Errorf("schedule period date window is required")
+	}
+	if p.EndDate.Before(p.StartDate) {
+		return fmt.Errorf("schedule period end date must be on or after start date")
+	}
+	if p.CapacityMultiplier <= 0 {
+		return fmt.Errorf("schedule period capacity multiplier must be positive")
+	}
+	return nil
+}
+
+func (p SchedulePeriod) Contains(date time.Time) bool {
+	date = normalizeDate(date)
+	return !date.Before(p.StartDate) && !date.After(p.EndDate)
+}
+
+type TemporaryService struct {
+	TempServiceRef   TemporaryServiceID
+	BaseServiceRef   ScheduledServiceID
+	TempTrainNumber  string
+	PeriodRef        SchedulePeriodType
+	StopsSubset      []TransportNodeID
+	AvailableClasses []string
+	ExpiredAt        *time.Time
+}
+
+func NewTemporaryService(tempServiceRef TemporaryServiceID, baseServiceRef ScheduledServiceID, tempTrainNumber string, periodRef SchedulePeriodType, stopsSubset []TransportNodeID, availableClasses []string) (TemporaryService, error) {
+	service := TemporaryService{
+		TempServiceRef:   TemporaryServiceID(strings.TrimSpace(string(tempServiceRef))),
+		BaseServiceRef:   ScheduledServiceID(strings.TrimSpace(string(baseServiceRef))),
+		TempTrainNumber:  strings.TrimSpace(tempTrainNumber),
+		PeriodRef:        periodRef,
+		StopsSubset:      copyTransportNodeIDs(stopsSubset),
+		AvailableClasses: copyStrings(availableClasses),
+	}
+	if err := service.Validate(); err != nil {
+		return TemporaryService{}, err
+	}
+	return service, nil
+}
+
+func (s TemporaryService) Validate() error {
+	if strings.TrimSpace(string(s.TempServiceRef)) == "" {
+		return fmt.Errorf("temporary service ref is required")
+	}
+	if strings.TrimSpace(string(s.BaseServiceRef)) == "" {
+		return fmt.Errorf("temporary service base service ref is required")
+	}
+	if !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(s.TempTrainNumber)), "L") {
+		return fmt.Errorf("temporary train number must use L prefix")
+	}
+	if s.PeriodRef == SchedulePeriodRegular || !validSchedulePeriodType(s.PeriodRef) {
+		return fmt.Errorf("temporary service requires a rush schedule period")
+	}
+	if len(s.StopsSubset) < 2 {
+		return fmt.Errorf("temporary service requires at least two stops")
+	}
+	for _, stop := range s.StopsSubset {
+		if strings.TrimSpace(string(stop)) == "" {
+			return fmt.Errorf("temporary service stops cannot be blank")
+		}
+	}
+	if len(s.AvailableClasses) == 0 {
+		return fmt.Errorf("temporary service available classes are required")
+	}
+	for _, class := range s.AvailableClasses {
+		if strings.TrimSpace(class) == "" {
+			return fmt.Errorf("temporary service available classes cannot be blank")
+		}
+	}
+	return nil
+}
+
+func (s TemporaryService) IsExpired() bool { return s.ExpiredAt != nil }
+
+type ScheduleVariant struct {
+	Period            SchedulePeriod
+	TemporaryServices []TemporaryService
+}
+
+func (v ScheduleVariant) PeriodType() SchedulePeriodType { return v.Period.PeriodType }
+func (v ScheduleVariant) CapacityMultiplier() float64    { return v.Period.CapacityMultiplier }
+
+type ServiceCancellation struct {
+	ServiceRef  ScheduledServiceID
+	Date        time.Time
+	Reason      string
+	CancelledAt time.Time
+	RestoredAt  *time.Time
+}
+
+func NewServiceCancellation(serviceRef ScheduledServiceID, date time.Time, reason string, cancelledAt time.Time) (ServiceCancellation, error) {
+	cancellation := ServiceCancellation{ServiceRef: ScheduledServiceID(strings.TrimSpace(string(serviceRef))), Date: normalizeDate(date), Reason: strings.TrimSpace(reason), CancelledAt: cancelledAt.UTC()}
+	if err := cancellation.Validate(); err != nil {
+		return ServiceCancellation{}, err
+	}
+	return cancellation, nil
+}
+
+func (c ServiceCancellation) Validate() error {
+	if strings.TrimSpace(string(c.ServiceRef)) == "" {
+		return fmt.Errorf("service cancellation service ref is required")
+	}
+	if c.Date.IsZero() {
+		return fmt.Errorf("service cancellation date is required")
+	}
+	if strings.TrimSpace(c.Reason) == "" {
+		return fmt.Errorf("service cancellation reason is required")
+	}
+	if c.CancelledAt.IsZero() {
+		return fmt.Errorf("service cancellation cancelled-at is required")
+	}
+	return nil
+}
+
+func (c ServiceCancellation) IsActive() bool { return c.RestoredAt == nil }
+
+type DelaySource string
+
+const DelaySourceOperations DelaySource = "OPERATIONS"
+
+type DelayRecord struct {
+	SegmentRef    ServiceSegmentID
+	ScheduledTime time.Time
+	EstimatedTime time.Time
+	DelayMinutes  int
+	Source        DelaySource
+}
+
+type TrainDelayedEvent struct {
+	ServiceRef            ScheduledServiceID
+	SegmentRef            ServiceSegmentID
+	DelayMinutes          int
+	EstimatedNewDeparture time.Time
+}
+
+type DelayPropagator struct {
+	DampeningPerStopMinutes int
+}
+
+func NewDelayPropagator() DelayPropagator { return DelayPropagator{DampeningPerStopMinutes: 2} }
+
+func (p DelayPropagator) Propagate(delayMinutes, downstreamIndex int) int {
+	if delayMinutes < 0 {
+		delayMinutes = 0
+	}
+	if p.DampeningPerStopMinutes < 0 {
+		p.DampeningPerStopMinutes = 0
+	}
+	propagated := delayMinutes - downstreamIndex*p.DampeningPerStopMinutes
+	if propagated < 0 {
+		return 0
+	}
+	return propagated
+}
+
 type ServicePlan struct {
-	id          ServicePlanID
-	businessKey ServicePlanKey
-	versions    []PlanVersion
+	id                ServicePlanID
+	businessKey       ServicePlanKey
+	versions          []PlanVersion
+	schedulePeriods   []SchedulePeriod
+	temporaryServices []TemporaryService
+	cancellations     []ServiceCancellation
 }
 
 func NewServicePlan(id ServicePlanID, businessKey ServicePlanKey, initialVersion PlanVersion) (ServicePlan, ServicePlanCreatedEvent, error) {
 	plan := ServicePlan{
-		id:          ServicePlanID(strings.TrimSpace(string(id))),
-		businessKey: ServicePlanKey(strings.TrimSpace(string(businessKey))),
-		versions:    []PlanVersion{initialVersion},
+		id:              ServicePlanID(strings.TrimSpace(string(id))),
+		businessKey:     ServicePlanKey(strings.TrimSpace(string(businessKey))),
+		versions:        []PlanVersion{initialVersion},
+		schedulePeriods: defaultSchedulePeriodsFor(initialVersion.EffectiveFrom().Year()),
 	}
 	if err := plan.Validate(); err != nil {
 		return ServicePlan{}, ServicePlanCreatedEvent{}, err
@@ -609,6 +800,15 @@ func NewServicePlan(id ServicePlanID, businessKey ServicePlanKey, initialVersion
 func (p ServicePlan) ID() ServicePlanID           { return p.id }
 func (p ServicePlan) BusinessKey() ServicePlanKey { return p.businessKey }
 func (p ServicePlan) Versions() []PlanVersion     { return copyPlanVersions(p.versions) }
+func (p ServicePlan) SchedulePeriods() []SchedulePeriod {
+	return copySchedulePeriods(p.schedulePeriods)
+}
+func (p ServicePlan) TemporaryServices() []TemporaryService {
+	return copyTemporaryServices(p.temporaryServices)
+}
+func (p ServicePlan) Cancellations() []ServiceCancellation {
+	return copyServiceCancellations(p.cancellations)
+}
 
 func (p ServicePlan) Validate() error {
 	if strings.TrimSpace(string(p.id)) == "" {
@@ -629,6 +829,31 @@ func (p ServicePlan) Validate() error {
 			return fmt.Errorf("duplicate plan version id: %s", version.ID())
 		}
 		seen[version.ID()] = struct{}{}
+	}
+	periods := map[SchedulePeriodType]SchedulePeriod{}
+	for _, period := range p.schedulePeriods {
+		if err := period.Validate(); err != nil {
+			return err
+		}
+		if _, exists := periods[period.PeriodType]; exists {
+			return fmt.Errorf("duplicate schedule period: %s", period.PeriodType)
+		}
+		periods[period.PeriodType] = period
+	}
+	for _, service := range p.temporaryServices {
+		if err := service.Validate(); err != nil {
+			return err
+		}
+		if service.PeriodRef != SchedulePeriodRegular {
+			if _, exists := periods[service.PeriodRef]; !exists {
+				return fmt.Errorf("temporary service period is not configured: %s", service.PeriodRef)
+			}
+		}
+	}
+	for _, cancellation := range p.cancellations {
+		if err := cancellation.Validate(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -681,6 +906,158 @@ func (p ServicePlan) PublishVersion(versionID PlanVersionID, publishedAt time.Ti
 	return next, PlanVersionPublishedEvent{ServicePlanID: p.id, PlanVersionID: candidate.ID(), EffectiveFrom: candidate.EffectiveFrom(), EffectiveTo: candidate.EffectiveTo()}, nil
 }
 
+func (p ServicePlan) WithSchedulePeriod(period SchedulePeriod) (ServicePlan, error) {
+	if err := period.Validate(); err != nil {
+		return ServicePlan{}, err
+	}
+	next := p
+	next.versions = copyPlanVersions(p.versions)
+	next.schedulePeriods = copySchedulePeriods(p.schedulePeriods)
+	next.temporaryServices = copyTemporaryServices(p.temporaryServices)
+	next.cancellations = copyServiceCancellations(p.cancellations)
+	for i, existing := range next.schedulePeriods {
+		if existing.PeriodType == period.PeriodType {
+			next.schedulePeriods[i] = period
+			return next, next.Validate()
+		}
+	}
+	next.schedulePeriods = append(next.schedulePeriods, period)
+	return next, next.Validate()
+}
+
+func (p ServicePlan) ActiveVariant(date time.Time) ScheduleVariant {
+	active := regularSchedulePeriod(normalizeDate(date).Year())
+	for _, period := range p.schedulePeriods {
+		if period.PeriodType != SchedulePeriodRegular && period.Contains(date) {
+			active = period
+			break
+		}
+		if period.PeriodType == SchedulePeriodRegular {
+			active = period
+		}
+	}
+	services := []TemporaryService{}
+	if active.PeriodType != SchedulePeriodRegular {
+		for _, service := range p.temporaryServices {
+			if service.PeriodRef == active.PeriodType && !service.IsExpired() {
+				services = append(services, service)
+			}
+		}
+	}
+	return ScheduleVariant{Period: active, TemporaryServices: services}
+}
+
+func (p ServicePlan) AddTemporaryService(service TemporaryService) (ServicePlan, TemporaryServiceAddedEvent, error) {
+	if err := service.Validate(); err != nil {
+		return ServicePlan{}, TemporaryServiceAddedEvent{}, err
+	}
+	next := p
+	next.versions = copyPlanVersions(p.versions)
+	next.schedulePeriods = copySchedulePeriods(p.schedulePeriods)
+	next.temporaryServices = copyTemporaryServices(p.temporaryServices)
+	next.cancellations = copyServiceCancellations(p.cancellations)
+	for _, existing := range next.temporaryServices {
+		if existing.TempServiceRef == service.TempServiceRef {
+			return ServicePlan{}, TemporaryServiceAddedEvent{}, fmt.Errorf("temporary service already exists: %s", service.TempServiceRef)
+		}
+	}
+	next.temporaryServices = append(next.temporaryServices, service)
+	if err := next.Validate(); err != nil {
+		return ServicePlan{}, TemporaryServiceAddedEvent{}, err
+	}
+	return next, TemporaryServiceAddedEvent{TempServiceRef: service.TempServiceRef, BaseServiceRef: service.BaseServiceRef, Period: service.PeriodRef}, nil
+}
+
+func (p ServicePlan) RemoveTemporaryService(tempServiceRef TemporaryServiceID) (ServicePlan, TemporaryServiceRemovedEvent, error) {
+	next := p
+	next.versions = copyPlanVersions(p.versions)
+	next.schedulePeriods = copySchedulePeriods(p.schedulePeriods)
+	next.temporaryServices = copyTemporaryServices(p.temporaryServices)
+	next.cancellations = copyServiceCancellations(p.cancellations)
+	for i, service := range next.temporaryServices {
+		if service.TempServiceRef == tempServiceRef {
+			next.temporaryServices = append(next.temporaryServices[:i], next.temporaryServices[i+1:]...)
+			return next, TemporaryServiceRemovedEvent{TempServiceRef: tempServiceRef, BaseServiceRef: service.BaseServiceRef, Period: service.PeriodRef}, next.Validate()
+		}
+	}
+	return ServicePlan{}, TemporaryServiceRemovedEvent{}, fmt.Errorf("temporary service not found: %s", tempServiceRef)
+}
+
+func (p ServicePlan) ActivateSchedulePeriod(date time.Time) SchedulePeriodActivatedEvent {
+	variant := p.ActiveVariant(date)
+	return SchedulePeriodActivatedEvent{ServicePlanID: p.id, Period: variant.Period.PeriodType, StartDate: variant.Period.StartDate, EndDate: variant.Period.EndDate, CapacityMultiplier: variant.Period.CapacityMultiplier}
+}
+
+func (p ServicePlan) ExpireTemporaryServices(asOf time.Time) (ServicePlan, []TemporaryServiceExpiredEvent, error) {
+	next := p
+	next.versions = copyPlanVersions(p.versions)
+	next.schedulePeriods = copySchedulePeriods(p.schedulePeriods)
+	next.temporaryServices = copyTemporaryServices(p.temporaryServices)
+	next.cancellations = copyServiceCancellations(p.cancellations)
+	events := []TemporaryServiceExpiredEvent{}
+	when := normalizeDate(asOf)
+	for i, service := range next.temporaryServices {
+		if service.IsExpired() {
+			continue
+		}
+		for _, period := range next.schedulePeriods {
+			if period.PeriodType == service.PeriodRef && when.After(period.EndDate) {
+				expiredAt := asOf.UTC()
+				next.temporaryServices[i].ExpiredAt = &expiredAt
+				events = append(events, TemporaryServiceExpiredEvent{ServiceRef: ScheduledServiceID(service.TempServiceRef), PeriodEndDate: period.EndDate})
+			}
+		}
+	}
+	if err := next.Validate(); err != nil {
+		return ServicePlan{}, nil, err
+	}
+	return next, events, nil
+}
+
+func (p ServicePlan) CancelForDate(serviceRef ScheduledServiceID, date time.Time, reason string, cancelledAt time.Time) (ServicePlan, TrainCancelledEvent, error) {
+	cancellation, err := NewServiceCancellation(serviceRef, date, reason, cancelledAt)
+	if err != nil {
+		return ServicePlan{}, TrainCancelledEvent{}, err
+	}
+	next := p
+	next.versions = copyPlanVersions(p.versions)
+	next.schedulePeriods = copySchedulePeriods(p.schedulePeriods)
+	next.temporaryServices = copyTemporaryServices(p.temporaryServices)
+	next.cancellations = copyServiceCancellations(p.cancellations)
+	key := cancellation.ServiceRef + ScheduledServiceID(":"+dateKey(cancellation.Date))
+	for i, existing := range next.cancellations {
+		if existing.ServiceRef+ScheduledServiceID(":"+dateKey(existing.Date)) == key {
+			if existing.IsActive() {
+				return ServicePlan{}, TrainCancelledEvent{}, fmt.Errorf("service already cancelled for %s", dateKey(cancellation.Date))
+			}
+			next.cancellations[i] = cancellation
+			return next, TrainCancelledEvent{ServiceRef: cancellation.ServiceRef, Date: cancellation.Date, Reason: cancellation.Reason}, next.Validate()
+		}
+	}
+	next.cancellations = append(next.cancellations, cancellation)
+	return next, TrainCancelledEvent{ServiceRef: cancellation.ServiceRef, Date: cancellation.Date, Reason: cancellation.Reason}, next.Validate()
+}
+
+func (p ServicePlan) RestoreForDate(serviceRef ScheduledServiceID, date time.Time, restoredAt time.Time) (ServicePlan, TrainRestoredEvent, error) {
+	next := p
+	next.versions = copyPlanVersions(p.versions)
+	next.schedulePeriods = copySchedulePeriods(p.schedulePeriods)
+	next.temporaryServices = copyTemporaryServices(p.temporaryServices)
+	next.cancellations = copyServiceCancellations(p.cancellations)
+	date = normalizeDate(date)
+	for i, existing := range next.cancellations {
+		if existing.ServiceRef == serviceRef && existing.Date.Equal(date) {
+			if !existing.IsActive() {
+				return ServicePlan{}, TrainRestoredEvent{}, fmt.Errorf("service cancellation already restored for %s", dateKey(date))
+			}
+			restored := restoredAt.UTC()
+			next.cancellations[i].RestoredAt = &restored
+			return next, TrainRestoredEvent{ServiceRef: serviceRef, Date: date}, next.Validate()
+		}
+	}
+	return ServicePlan{}, TrainRestoredEvent{}, fmt.Errorf("active cancellation not found for %s", dateKey(date))
+}
+
 // ScheduledService is a planned service instance materialized from a published
 // PlanVersion and a service date. It is suitable for Trip Planning and Capacity
 // seeding, but does not own seats, fares, orders, or real-time disruption state.
@@ -691,6 +1068,7 @@ type ScheduledService struct {
 	serviceDate   time.Time
 	status        ScheduledServiceStatus
 	segments      []ServiceSegment
+	delayRecords  []DelayRecord
 }
 
 func NewScheduledService(id ScheduledServiceID, key ScheduledServiceKey, version PlanVersion, serviceDate time.Time) (ScheduledService, ScheduledServiceMaterializedEvent, error) {
@@ -725,6 +1103,85 @@ func (s ScheduledService) PlanVersionID() PlanVersionID   { return s.planVersion
 func (s ScheduledService) ServiceDate() time.Time         { return s.serviceDate }
 func (s ScheduledService) Status() ScheduledServiceStatus { return s.status }
 func (s ScheduledService) Segments() []ServiceSegment     { return copySegments(s.segments) }
+func (s ScheduledService) DelayRecords() []DelayRecord    { return copyDelayRecords(s.delayRecords) }
+
+func (s ScheduledService) RecordDelay(segmentRef ServiceSegmentID, delayMinutes int, scheduledDepartures map[ServiceSegmentID]time.Time) (ScheduledService, []TrainDelayedEvent, error) {
+	if delayMinutes < 0 {
+		return ScheduledService{}, nil, fmt.Errorf("delay minutes cannot be negative")
+	}
+	segmentRef = ServiceSegmentID(strings.TrimSpace(string(segmentRef)))
+	sourceIndex := -1
+	for i, segment := range s.segments {
+		if segment.ID == segmentRef {
+			sourceIndex = i
+			break
+		}
+	}
+	if sourceIndex == -1 {
+		return ScheduledService{}, nil, fmt.Errorf("service segment not found: %s", segmentRef)
+	}
+	propagator := NewDelayPropagator()
+	next := s
+	next.segments = copySegments(s.segments)
+	next.delayRecords = copyDelayRecords(s.delayRecords)
+	events := []TrainDelayedEvent{}
+	sourceFrom := s.segments[sourceIndex].FromSequence
+	maxSequence := sourceFrom
+	for _, segment := range s.segments {
+		if segment.ToSequence > maxSequence {
+			maxSequence = segment.ToSequence
+		}
+	}
+	lastSequence := maxSequence
+	if maxSequence == sourceFrom+1 {
+		lastSequence = sourceFrom
+	}
+	for sequence, downstreamIndex := sourceFrom, 0; sequence <= lastSequence; sequence, downstreamIndex = sequence+1, downstreamIndex+1 {
+		segment, ok := s.segmentForDelaySequence(sequence, maxSequence)
+		if !ok {
+			continue
+		}
+		propagated := propagator.Propagate(delayMinutes, downstreamIndex)
+		scheduled := scheduledDepartures[segment.ID]
+		estimated := scheduled
+		if !scheduled.IsZero() {
+			estimated = scheduled.Add(time.Duration(propagated) * time.Minute)
+		}
+		next.delayRecords = append(next.delayRecords, DelayRecord{SegmentRef: segment.ID, ScheduledTime: scheduled, EstimatedTime: estimated, DelayMinutes: propagated, Source: DelaySourceOperations})
+		events = append(events, TrainDelayedEvent{ServiceRef: s.id, SegmentRef: segment.ID, DelayMinutes: propagated, EstimatedNewDeparture: estimated})
+	}
+	if err := next.Validate(); err != nil {
+		return ScheduledService{}, nil, err
+	}
+	return next, events, nil
+}
+
+func (s ScheduledService) segmentForDelaySequence(sequence, maxSequence int) (ServiceSegment, bool) {
+	var selected ServiceSegment
+	found := false
+	if sequence < maxSequence {
+		for _, segment := range s.segments {
+			if segment.FromSequence != sequence {
+				continue
+			}
+			if !found || segment.ToSequence < selected.ToSequence {
+				selected = segment
+				found = true
+			}
+		}
+		return selected, found
+	}
+	for _, segment := range s.segments {
+		if segment.ToSequence != maxSequence {
+			continue
+		}
+		if !found || segment.FromSequence > selected.FromSequence {
+			selected = segment
+			found = true
+		}
+	}
+	return selected, found
+}
 
 func (s ScheduledService) Validate() error {
 	if strings.TrimSpace(string(s.id)) == "" {
@@ -770,6 +1227,42 @@ type ScheduledServiceMaterializedEvent struct {
 	ServiceDate        time.Time
 }
 
+type TemporaryServiceAddedEvent struct {
+	TempServiceRef TemporaryServiceID
+	BaseServiceRef ScheduledServiceID
+	Period         SchedulePeriodType
+}
+
+type TemporaryServiceRemovedEvent struct {
+	TempServiceRef TemporaryServiceID
+	BaseServiceRef ScheduledServiceID
+	Period         SchedulePeriodType
+}
+
+type SchedulePeriodActivatedEvent struct {
+	ServicePlanID      ServicePlanID
+	Period             SchedulePeriodType
+	StartDate          time.Time
+	EndDate            time.Time
+	CapacityMultiplier float64
+}
+
+type TrainCancelledEvent struct {
+	ServiceRef ScheduledServiceID
+	Date       time.Time
+	Reason     string
+}
+
+type TrainRestoredEvent struct {
+	ServiceRef ScheduledServiceID
+	Date       time.Time
+}
+
+type TemporaryServiceExpiredEvent struct {
+	ServiceRef    ScheduledServiceID
+	PeriodEndDate time.Time
+}
+
 func validServiceMode(value ServiceMode) bool {
 	switch value {
 	case ServiceModeTrain, ServiceModeBus, ServiceModeAir, ServiceModeFerry, ServiceModeShuttle:
@@ -808,6 +1301,29 @@ func validateCalendarException(exception CalendarException) error {
 		return fmt.Errorf("calendar exception reason code is required")
 	}
 	return nil
+}
+
+func validSchedulePeriodType(value SchedulePeriodType) bool {
+	switch value {
+	case SchedulePeriodRegular, SchedulePeriodSpringRush, SchedulePeriodSummerRush, SchedulePeriodNationalDay, SchedulePeriodLaborDay:
+		return true
+	default:
+		return false
+	}
+}
+
+func defaultSchedulePeriodsFor(year int) []SchedulePeriod {
+	return []SchedulePeriod{
+		regularSchedulePeriod(year),
+		{PeriodType: SchedulePeriodSpringRush, StartDate: time.Date(year, time.January, 10, 0, 0, 0, 0, time.UTC), EndDate: time.Date(year, time.March, 10, 0, 0, 0, 0, time.UTC), CapacityMultiplier: 1.30},
+		{PeriodType: SchedulePeriodSummerRush, StartDate: time.Date(year, time.July, 1, 0, 0, 0, 0, time.UTC), EndDate: time.Date(year, time.August, 31, 0, 0, 0, 0, time.UTC), CapacityMultiplier: 1.20},
+		{PeriodType: SchedulePeriodNationalDay, StartDate: time.Date(year, time.September, 28, 0, 0, 0, 0, time.UTC), EndDate: time.Date(year, time.October, 8, 0, 0, 0, 0, time.UTC), CapacityMultiplier: 1.25},
+		{PeriodType: SchedulePeriodLaborDay, StartDate: time.Date(year, time.April, 29, 0, 0, 0, 0, time.UTC), EndDate: time.Date(year, time.May, 5, 0, 0, 0, 0, time.UTC), CapacityMultiplier: 1.15},
+	}
+}
+
+func regularSchedulePeriod(year int) SchedulePeriod {
+	return SchedulePeriod{PeriodType: SchedulePeriodRegular, StartDate: time.Date(year, time.January, 1, 0, 0, 0, 0, time.UTC), EndDate: time.Date(year, time.December, 31, 0, 0, 0, 0, time.UTC), CapacityMultiplier: 1.0}
 }
 
 func normalizeDate(value time.Time) time.Time {
@@ -854,6 +1370,52 @@ func copyPlannedTimePtr(value *PlannedTime) *PlannedTime {
 	}
 	copied := *value
 	return &copied
+}
+
+func copySchedulePeriods(periods []SchedulePeriod) []SchedulePeriod {
+	copied := make([]SchedulePeriod, len(periods))
+	copy(copied, periods)
+	return copied
+}
+
+func copyTemporaryServices(services []TemporaryService) []TemporaryService {
+	copied := make([]TemporaryService, len(services))
+	for i, service := range services {
+		copied[i] = service
+		copied[i].StopsSubset = copyTransportNodeIDs(service.StopsSubset)
+		copied[i].AvailableClasses = copyStrings(service.AvailableClasses)
+		copied[i].ExpiredAt = copyTimePtr(service.ExpiredAt)
+	}
+	return copied
+}
+
+func copyServiceCancellations(cancellations []ServiceCancellation) []ServiceCancellation {
+	copied := make([]ServiceCancellation, len(cancellations))
+	for i, cancellation := range cancellations {
+		copied[i] = cancellation
+		copied[i].RestoredAt = copyTimePtr(cancellation.RestoredAt)
+	}
+	return copied
+}
+
+func copyTransportNodeIDs(values []TransportNodeID) []TransportNodeID {
+	copied := make([]TransportNodeID, len(values))
+	copy(copied, values)
+	return copied
+}
+
+func copyStrings(values []string) []string {
+	copied := make([]string, len(values))
+	for i, value := range values {
+		copied[i] = strings.TrimSpace(value)
+	}
+	return copied
+}
+
+func copyDelayRecords(records []DelayRecord) []DelayRecord {
+	copied := make([]DelayRecord, len(records))
+	copy(copied, records)
+	return copied
 }
 
 func copyTimePtr(value *time.Time) *time.Time {

--- a/services/service-plan/internal/domain/service_plan.go
+++ b/services/service-plan/internal/domain/service_plan.go
@@ -810,6 +810,18 @@ func (p ServicePlan) Cancellations() []ServiceCancellation {
 	return copyServiceCancellations(p.cancellations)
 }
 
+func (p ServicePlan) WithOperationalState(temporaryServices []TemporaryService, cancellations []ServiceCancellation) (ServicePlan, error) {
+	next := p
+	next.versions = copyPlanVersions(p.versions)
+	next.schedulePeriods = copySchedulePeriods(p.schedulePeriods)
+	next.temporaryServices = copyTemporaryServices(temporaryServices)
+	next.cancellations = copyServiceCancellations(cancellations)
+	if err := next.Validate(); err != nil {
+		return ServicePlan{}, err
+	}
+	return next, nil
+}
+
 func (p ServicePlan) Validate() error {
 	if strings.TrimSpace(string(p.id)) == "" {
 		return fmt.Errorf("service plan id is required")
@@ -1104,6 +1116,16 @@ func (s ScheduledService) ServiceDate() time.Time         { return s.serviceDate
 func (s ScheduledService) Status() ScheduledServiceStatus { return s.status }
 func (s ScheduledService) Segments() []ServiceSegment     { return copySegments(s.segments) }
 func (s ScheduledService) DelayRecords() []DelayRecord    { return copyDelayRecords(s.delayRecords) }
+
+func (s ScheduledService) WithDelayRecords(records []DelayRecord) (ScheduledService, error) {
+	next := s
+	next.segments = copySegments(s.segments)
+	next.delayRecords = copyDelayRecords(records)
+	if err := next.Validate(); err != nil {
+		return ScheduledService{}, err
+	}
+	return next, nil
+}
 
 func (s ScheduledService) RecordDelay(segmentRef ServiceSegmentID, delayMinutes int, scheduledDepartures map[ServiceSegmentID]time.Time) (ScheduledService, []TrainDelayedEvent, error) {
 	if delayMinutes < 0 {

--- a/services/service-plan/internal/domain/service_plan_test.go
+++ b/services/service-plan/internal/domain/service_plan_test.go
@@ -226,3 +226,105 @@ func plannedPtr(t *testing.T, dayOffset int, minuteOfDay time.Duration) *Planned
 func date(year int, month time.Month, day int) time.Time {
 	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 }
+
+func TestSeasonalVariantShowsTemporaryServicesAndExpiresAfterPeriod(t *testing.T) {
+	plan := mustPublishedPlan(t, 2026)
+	temp, err := NewTemporaryService("tmp-1", "svc-1", "L1234", SchedulePeriodSpringRush, []TransportNodeID{"node-a", "node-c"}, []string{"SECOND_CLASS"})
+	if err != nil {
+		t.Fatalf("temporary service: %v", err)
+	}
+	plan, added, err := plan.AddTemporaryService(temp)
+	if err != nil {
+		t.Fatalf("add temporary service: %v", err)
+	}
+	if added.Period != SchedulePeriodSpringRush || added.BaseServiceRef != "svc-1" {
+		t.Fatalf("unexpected temporary event: %#v", added)
+	}
+	variant := plan.ActiveVariant(date(2026, time.February, 1))
+	if variant.PeriodType() != SchedulePeriodSpringRush || variant.CapacityMultiplier() != 1.30 || len(variant.TemporaryServices) != 1 {
+		t.Fatalf("unexpected spring variant: %#v", variant)
+	}
+	regular := plan.ActiveVariant(date(2026, time.June, 1))
+	if regular.PeriodType() != SchedulePeriodRegular || len(regular.TemporaryServices) != 0 {
+		t.Fatalf("unexpected regular variant: %#v", regular)
+	}
+
+	expiredPlan, events, err := plan.ExpireTemporaryServices(date(2026, time.March, 11))
+	if err != nil {
+		t.Fatalf("expire temporary services: %v", err)
+	}
+	if len(events) != 1 || events[0].ServiceRef != "tmp-1" || !events[0].PeriodEndDate.Equal(date(2026, time.March, 10)) {
+		t.Fatalf("unexpected expiration events: %#v", events)
+	}
+	if got := expiredPlan.ActiveVariant(date(2026, time.February, 1)); len(got.TemporaryServices) != 0 {
+		t.Fatalf("expected expired temporary service hidden, got %#v", got.TemporaryServices)
+	}
+}
+
+func TestDelayPropagationDampensDownstreamStops(t *testing.T) {
+	service := mustScheduledService(t)
+	segments := service.Segments()
+	scheduled := map[ServiceSegmentID]time.Time{
+		segments[0].ID: time.Date(2026, time.January, 5, 8, 0, 0, 0, time.UTC),
+		segments[1].ID: time.Date(2026, time.January, 5, 9, 0, 0, 0, time.UTC),
+		segments[2].ID: time.Date(2026, time.January, 5, 10, 0, 0, 0, time.UTC),
+	}
+	updated, events, err := service.RecordDelay(segments[0].ID, 30, scheduled)
+	if err != nil {
+		t.Fatalf("record delay: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected delay event for each downstream stop, got %#v", events)
+	}
+	want := []int{30, 28, 26}
+	for i, event := range events {
+		if event.DelayMinutes != want[i] {
+			t.Fatalf("event %d delay=%d want %d", i, event.DelayMinutes, want[i])
+		}
+	}
+	if len(updated.DelayRecords()) != 3 || updated.DelayRecords()[1].DelayMinutes != 28 {
+		t.Fatalf("expected delay records retained: %#v", updated.DelayRecords())
+	}
+}
+
+func TestCancelAndRestoreSpecificDate(t *testing.T) {
+	plan := mustPublishedPlan(t, 2026)
+	cancelled, cancelEvent, err := plan.CancelForDate("svc-1", date(2026, time.January, 5), "WEATHER", time.Date(2026, time.January, 4, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	if cancelEvent.ServiceRef != "svc-1" || cancelEvent.Reason != "WEATHER" || !cancelled.Cancellations()[0].IsActive() {
+		t.Fatalf("unexpected cancellation: %#v %#v", cancelEvent, cancelled.Cancellations())
+	}
+	restored, restoreEvent, err := cancelled.RestoreForDate("svc-1", date(2026, time.January, 5), time.Date(2026, time.January, 4, 13, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if restoreEvent.ServiceRef != "svc-1" || restored.Cancellations()[0].IsActive() {
+		t.Fatalf("unexpected restoration: %#v %#v", restoreEvent, restored.Cancellations())
+	}
+}
+
+func mustPublishedPlan(t *testing.T, year int) ServicePlan {
+	t.Helper()
+	validated := mustValidatedVersion(t, "v-seasonal", date(year, time.January, 1), date(year, time.December, 31))
+	plan, _, err := NewServicePlan("plan-seasonal", "G1", validated)
+	if err != nil {
+		t.Fatalf("service plan: %v", err)
+	}
+	plan, _, err = plan.PublishVersion(validated.ID(), time.Date(year-1, time.December, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("publish plan: %v", err)
+	}
+	return plan
+}
+
+func mustScheduledService(t *testing.T) ScheduledService {
+	t.Helper()
+	plan := mustPublishedPlan(t, 2026)
+	service, _, err := NewScheduledService("svc-1", "G1-20260105", plan.Versions()[0], date(2026, time.January, 5))
+	if err != nil {
+		t.Fatalf("scheduled service: %v", err)
+	}
+	return service
+}

--- a/services/service-plan/internal/http/router.go
+++ b/services/service-plan/internal/http/router.go
@@ -42,6 +42,28 @@ type createServiceSegmentRequest struct {
 	ArrivalTime         time.Time `json:"arrivalTime"`
 }
 
+type addTemporaryServiceRequest struct {
+	TempServiceRef   string   `json:"tempServiceRef"`
+	TempTrainNumber  string   `json:"tempTrainNumber"`
+	Period           string   `json:"period"`
+	StopsSubset      []string `json:"stopsSubset"`
+	AvailableClasses []string `json:"availableClasses"`
+}
+
+type recordDelayRequest struct {
+	SegmentRef   string `json:"segmentRef"`
+	DelayMinutes int    `json:"delayMinutes"`
+}
+
+type cancelServiceRequest struct {
+	Date   time.Time `json:"date"`
+	Reason string    `json:"reason"`
+}
+
+type restoreServiceRequest struct {
+	Date time.Time `json:"date"`
+}
+
 func Router() *gin.Engine {
 	return RouterWithService(application.NewService(application.NoopPublisher{}))
 }
@@ -73,6 +95,10 @@ func RegisterRoutes(router gin.IRouter, service *application.Service, store idem
 	api.GET("/scheduled-services/:serviceRef", handler.getScheduledService)
 	api.GET("/scheduled-services", handler.listScheduledServices)
 	api.POST("/service-segments", idempotent, handler.createServiceSegment)
+	api.POST("/scheduled-services/:serviceRef/temporary-services", idempotent, handler.addTemporaryService)
+	api.POST("/scheduled-services/:serviceRef/delays", idempotent, handler.recordDelay)
+	api.POST("/scheduled-services/:serviceRef/cancellations", idempotent, handler.cancelServiceForDate)
+	api.POST("/scheduled-services/:serviceRef/restorations", idempotent, handler.restoreServiceForDate)
 }
 
 func (h Handler) createScheduledService(ctx *gin.Context) {
@@ -148,6 +174,88 @@ func (h Handler) createServiceSegment(ctx *gin.Context) {
 		return
 	}
 	ctx.JSON(http.StatusCreated, result)
+}
+
+func (h Handler) addTemporaryService(ctx *gin.Context) {
+	var request addTemporaryServiceRequest
+	if err := bindBody(ctx, &request); err != nil {
+		httpkit.WriteError(ctx, http.StatusBadRequest, httpkit.ValidationFailed, "Request body failed structural validation", nil)
+		return
+	}
+	result, err := h.service.AddTemporaryService(ctx.Request.Context(), application.AddTemporaryServiceCommand{
+		BaseServiceRef:   ctx.Param("serviceRef"),
+		TempServiceRef:   request.TempServiceRef,
+		TempTrainNumber:  request.TempTrainNumber,
+		Period:           request.Period,
+		StopsSubset:      request.StopsSubset,
+		AvailableClasses: request.AvailableClasses,
+		CorrelationID:    httpkit.CorrelationID(ctx),
+		CausationID:      ctx.GetHeader("X-Causation-Id"),
+	})
+	if err != nil {
+		writeMappedError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusCreated, result)
+}
+
+func (h Handler) recordDelay(ctx *gin.Context) {
+	var request recordDelayRequest
+	if err := bindBody(ctx, &request); err != nil {
+		httpkit.WriteError(ctx, http.StatusBadRequest, httpkit.ValidationFailed, "Request body failed structural validation", nil)
+		return
+	}
+	result, err := h.service.RecordDelay(ctx.Request.Context(), application.RecordDelayCommand{
+		ScheduledServiceRef: ctx.Param("serviceRef"),
+		SegmentRef:          request.SegmentRef,
+		DelayMinutes:        request.DelayMinutes,
+		CorrelationID:       httpkit.CorrelationID(ctx),
+		CausationID:         ctx.GetHeader("X-Causation-Id"),
+	})
+	if err != nil {
+		writeMappedError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, result)
+}
+
+func (h Handler) cancelServiceForDate(ctx *gin.Context) {
+	var request cancelServiceRequest
+	if err := bindBody(ctx, &request); err != nil {
+		httpkit.WriteError(ctx, http.StatusBadRequest, httpkit.ValidationFailed, "Request body failed structural validation", nil)
+		return
+	}
+	result, err := h.service.CancelForDate(ctx.Request.Context(), application.CancelServiceCommand{
+		ScheduledServiceRef: ctx.Param("serviceRef"),
+		Date:                request.Date,
+		Reason:              request.Reason,
+		CorrelationID:       httpkit.CorrelationID(ctx),
+		CausationID:         ctx.GetHeader("X-Causation-Id"),
+	})
+	if err != nil {
+		writeMappedError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, result)
+}
+
+func (h Handler) restoreServiceForDate(ctx *gin.Context) {
+	var request restoreServiceRequest
+	if err := bindBody(ctx, &request); err != nil {
+		httpkit.WriteError(ctx, http.StatusBadRequest, httpkit.ValidationFailed, "Request body failed structural validation", nil)
+		return
+	}
+	result, err := h.service.RestoreForDate(ctx.Request.Context(), application.RestoreServiceCommand{
+		ScheduledServiceRef: ctx.Param("serviceRef"),
+		Date:                request.Date,
+		CorrelationID:       httpkit.CorrelationID(ctx),
+		CausationID:         ctx.GetHeader("X-Causation-Id"),
+	})
+	if err != nil {
+		writeMappedError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, result)
 }
 
 func bindBody(ctx *gin.Context, target any) error {

--- a/services/service-plan/internal/http/router_test.go
+++ b/services/service-plan/internal/http/router_test.go
@@ -236,3 +236,62 @@ func assertCanonicalError(t *testing.T, recorder *httptest.ResponseRecorder, sta
 		t.Fatalf("unexpected error body: %#v", response)
 	}
 }
+
+func TestRecordDelayEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := Router()
+	serviceBody := `{"serviceRef":"ss-0194f2e0-7b3e-7610-0284-5c26e8b0c301","carrierId":"car-0194f2e0-7b3e-7610-0284-5c26e8b0c001","serviceNumber":"G1234","departureTime":"2026-07-05T10:30:00Z","arrivalTime":"2026-07-05T12:30:00Z","originNodeId":"node-a","destinationNodeId":"node-b"}`
+	performJSON(router, http.MethodPost, "/api/v1/scheduled-services", serviceBody, "0194f2e0-7b3e-7610-0284-5c26e8b0c301")
+	recorder := performJSON(router, http.MethodPost, "/api/v1/scheduled-services/ss-0194f2e0-7b3e-7610-0284-5c26e8b0c301/delays", `{"segmentRef":"node-a:node-b","delayMinutes":30}`, "0194f2e0-7b3e-7610-0284-5c26e8b0c302")
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response struct {
+		Events []struct {
+			ServiceRef   string `json:"serviceRef"`
+			DelayMinutes int    `json:"delayMinutes"`
+		} `json:"events"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("response json: %v", err)
+	}
+	if len(response.Events) == 0 || response.Events[0].DelayMinutes != 30 {
+		t.Fatalf("unexpected delay response: %#v", response)
+	}
+}
+
+func TestCancelAndRestoreEndpointsUpdateBookability(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := Router()
+	serviceBody := `{"serviceRef":"ss-0194f2e0-7b3e-7610-0284-5c26e8b0c303","carrierId":"car-0194f2e0-7b3e-7610-0284-5c26e8b0c001","serviceNumber":"G1234","departureTime":"2026-07-05T10:30:00Z","arrivalTime":"2026-07-05T12:30:00Z","originNodeId":"node-a","destinationNodeId":"node-b"}`
+	performJSON(router, http.MethodPost, "/api/v1/scheduled-services", serviceBody, "0194f2e0-7b3e-7610-0284-5c26e8b0c303")
+	cancel := performJSON(router, http.MethodPost, "/api/v1/scheduled-services/ss-0194f2e0-7b3e-7610-0284-5c26e8b0c303/cancellations", `{"date":"2026-07-05T00:00:00Z","reason":"WEATHER"}`, "0194f2e0-7b3e-7610-0284-5c26e8b0c304")
+	if cancel.Code != http.StatusOK {
+		t.Fatalf("unexpected cancel status: %d body=%s", cancel.Code, cancel.Body.String())
+	}
+	var cancelResponse map[string]any
+	_ = json.Unmarshal(cancel.Body.Bytes(), &cancelResponse)
+	if cancelResponse["bookable"] != false {
+		t.Fatalf("expected not bookable: %#v", cancelResponse)
+	}
+	restore := performJSON(router, http.MethodPost, "/api/v1/scheduled-services/ss-0194f2e0-7b3e-7610-0284-5c26e8b0c303/restorations", `{"date":"2026-07-05T00:00:00Z"}`, "0194f2e0-7b3e-7610-0284-5c26e8b0c305")
+	if restore.Code != http.StatusOK {
+		t.Fatalf("unexpected restore status: %d body=%s", restore.Code, restore.Body.String())
+	}
+	var restoreResponse map[string]any
+	_ = json.Unmarshal(restore.Body.Bytes(), &restoreResponse)
+	if restoreResponse["bookable"] != true {
+		t.Fatalf("expected bookable after restore: %#v", restoreResponse)
+	}
+}
+
+func TestAddTemporaryServiceEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := Router()
+	serviceBody := `{"serviceRef":"ss-0194f2e0-7b3e-7610-0284-5c26e8b0c306","carrierId":"car-0194f2e0-7b3e-7610-0284-5c26e8b0c001","serviceNumber":"G1234","departureTime":"2026-02-05T10:30:00Z","arrivalTime":"2026-02-05T12:30:00Z","originNodeId":"node-a","destinationNodeId":"node-b"}`
+	performJSON(router, http.MethodPost, "/api/v1/scheduled-services", serviceBody, "0194f2e0-7b3e-7610-0284-5c26e8b0c306")
+	recorder := performJSON(router, http.MethodPost, "/api/v1/scheduled-services/ss-0194f2e0-7b3e-7610-0284-5c26e8b0c306/temporary-services", `{"tempServiceRef":"ss-0194f2e0-7b3e-7610-0284-5c26e8b0c307","tempTrainNumber":"L1234","period":"SPRING_RUSH","stopsSubset":["node-a","node-b"],"availableClasses":["SECOND_CLASS"]}`, "0194f2e0-7b3e-7610-0284-5c26e8b0c307")
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("unexpected status: %d body=%s", recorder.Code, recorder.Body.String())
+	}
+}

--- a/services/service-plan/migrations/001_service_plan_storage.sql
+++ b/services/service-plan/migrations/001_service_plan_storage.sql
@@ -37,3 +37,5 @@ CREATE TABLE IF NOT EXISTS idempotency_records (
   response_body jsonb,
   created_at   timestamptz NOT NULL DEFAULT now()
 );
+CREATE INDEX IF NOT EXISTS idx_scheduled_service_period ON scheduled_service_snapshots ((data->>'schedulePeriod'));
+CREATE INDEX IF NOT EXISTS idx_scheduled_service_bookable ON scheduled_service_snapshots ((data->>'bookable'));


### PR DESCRIPTION
## Summary
- Add service-plan domain models for schedule periods, temporary rush services, delay records/propagation, and dated cancellations/restorations.
- Expose HTTP/application APIs for temporary services, delays, cancellations, and restorations with outbox-published events.
- Extend tests, migration indexes, README, and event contract docs for new service-plan events.

## Validation
- go test ./services/service-plan/...
