### PR TITLE
REQ-314 corporate travel approval workflow and budget control

### DIFF
--- a/services/corporate-travel/migrations/001_corporate_travel.sql
+++ b/services/corporate-travel/migrations/001_corporate_travel.sql
@@ -68,3 +68,74 @@ CREATE TABLE IF NOT EXISTS outbox_events (
     payload JSONB NOT NULL,
     published_at TIMESTAMPTZ
 );
+
+CREATE TABLE IF NOT EXISTS travel_policies (
+    agreement_id TEXT PRIMARY KEY REFERENCES corporate_agreements (agreement_id),
+    document JSONB NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS approval_requests (
+    request_id TEXT PRIMARY KEY,
+    booking_ref TEXT NOT NULL,
+    employee_ref TEXT NOT NULL,
+    current_level INTEGER NOT NULL CHECK (current_level BETWEEN 1 AND 3),
+    status TEXT NOT NULL,
+    document JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_approval_requests_booking
+    ON approval_requests (booking_ref, status);
+
+CREATE TABLE IF NOT EXISTS budget_pools (
+    pool_id TEXT PRIMARY KEY,
+    dimension TEXT NOT NULL,
+    period_start TIMESTAMPTZ NOT NULL,
+    period_end TIMESTAMPTZ NOT NULL,
+    limit_minor BIGINT NOT NULL CHECK (limit_minor >= 0),
+    reserved_minor BIGINT NOT NULL CHECK (reserved_minor >= 0),
+    committed_minor BIGINT NOT NULL CHECK (committed_minor >= 0),
+    document JSONB NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT budget_period_window CHECK (period_end > period_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_budget_pools_dimension_period
+    ON budget_pools (dimension, period_start, period_end);
+
+CREATE TABLE IF NOT EXISTS budget_reservations (
+    reservation_id TEXT PRIMARY KEY,
+    pool_id TEXT NOT NULL REFERENCES budget_pools (pool_id),
+    booking_ref TEXT NOT NULL,
+    amount_minor BIGINT NOT NULL CHECK (amount_minor >= 0),
+    status TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_budget_reservations_booking
+    ON budget_reservations (booking_ref, status);
+
+CREATE TABLE IF NOT EXISTS monthly_invoices (
+    invoice_id TEXT PRIMARY KEY,
+    agreement_id TEXT NOT NULL REFERENCES corporate_agreements (agreement_id),
+    billing_period TEXT NOT NULL,
+    total_minor BIGINT NOT NULL CHECK (total_minor >= 0),
+    discount_minor BIGINT NOT NULL CHECK (discount_minor >= 0),
+    document JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS outbox (
+    seq BIGSERIAL PRIMARY KEY,
+    event_id TEXT NOT NULL UNIQUE,
+    stream TEXT NOT NULL,
+    envelope JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    published_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq
+    ON outbox (seq) WHERE published_at IS NULL;

--- a/services/corporate-travel/migrations/001_corporate_travel.sql
+++ b/services/corporate-travel/migrations/001_corporate_travel.sql
@@ -128,6 +128,13 @@ CREATE TABLE IF NOT EXISTS monthly_invoices (
     created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+
+CREATE TABLE IF NOT EXISTS processed_events (
+    event_id TEXT PRIMARY KEY,
+    stream TEXT,
+    processed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
 CREATE TABLE IF NOT EXISTS outbox (
     seq BIGSERIAL PRIMARY KEY,
     event_id TEXT NOT NULL UNIQUE,

--- a/services/corporate-travel/src/corporate_travel/api.py
+++ b/services/corporate-travel/src/corporate_travel/api.py
@@ -81,6 +81,44 @@ class AuthorizeTravelerRequest(BaseModel):
     validUntil: str | None = None
 
 
+
+
+class PolicyCheckRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    employeeRef: str = Field(min_length=1)
+    departmentRef: str = Field(min_length=1)
+    origin: str = Field(min_length=1)
+    destination: str = Field(min_length=1)
+    seatClass: str = "SECOND_CLASS"
+    amount: MoneyModel
+    requestedAt: str = Field(min_length=1)
+    departureAt: str = Field(min_length=1)
+    tripDurationMinutes: int = Field(ge=0)
+    employeeLevel: str = "STAFF"
+    managerRef: str | None = None
+    emergency: bool = False
+    bookingRef: str | None = None
+
+
+class InvoiceLineItemModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bookingRef: str = Field(min_length=1)
+    employeeName: str = Field(min_length=1)
+    route: str = Field(min_length=1)
+    travelDate: str = Field(min_length=1)
+    amountMinor: int = Field(ge=0)
+
+
+class GenerateInvoiceRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    period: str = Field(min_length=1)
+    lineItems: list[InvoiceLineItemModel]
+    discountRateBps: int = Field(default=0, ge=0, le=10000)
+
+
 class ErrorBody(BaseModel):
     code: str
     message: str
@@ -203,6 +241,52 @@ def configure_corporate_travel_endpoints(app: FastAPI, service: CorporateTravelS
         except CorporateTravelError as exc:
             return error_response(request, 400, "CORPORATE_TRAVEL_INVARIANT_VIOLATION", str(exc))
         return JSONResponse(status_code=201, content=traveler.to_dict())
+
+    @app.post("/agreements/{agreementId}/policy-checks", status_code=201, response_model=None)
+    @app.post("/api/v1/agreements/{agreementId}/policy-checks", status_code=201, response_model=None)
+    def check_policy(request: Request, agreementId: str, payload: PolicyCheckRequest) -> JSONResponse:
+        try:
+            result = service.check_policy_and_reserve(
+                agreement_id=agreementId,
+                employee_ref=payload.employeeRef,
+                department_ref=payload.departmentRef,
+                origin=payload.origin,
+                destination=payload.destination,
+                seat_class=payload.seatClass,
+                amount=payload.amount.model_dump(),
+                requested_at=payload.requestedAt,
+                departure_at=payload.departureAt,
+                trip_duration_minutes=payload.tripDurationMinutes,
+                employee_level=payload.employeeLevel,
+                manager_ref=payload.managerRef,
+                emergency=payload.emergency,
+                booking_ref=payload.bookingRef,
+                correlation_id=request.state.correlation_id,
+                causation_id=request.headers.get("Idempotency-Key") or request.state.request_id,
+            )
+        except AgreementNotFoundError:
+            return error_response(request, 404, "NOT_FOUND", "Corporate agreement was not found")
+        except (CorporateTravelError, ValueError) as exc:
+            return error_response(request, 400, "CORPORATE_TRAVEL_INVARIANT_VIOLATION", str(exc))
+        return JSONResponse(status_code=201, content=result.to_dict())
+
+    @app.post("/agreements/{agreementId}/monthly-invoices", status_code=201, response_model=None)
+    @app.post("/api/v1/agreements/{agreementId}/monthly-invoices", status_code=201, response_model=None)
+    def generate_invoice(request: Request, agreementId: str, payload: GenerateInvoiceRequest) -> JSONResponse:
+        try:
+            result = service.generate_monthly_invoice(
+                agreement_id=agreementId,
+                period=payload.period,
+                line_items=[item.model_dump() for item in payload.lineItems],
+                discount_rate_bps=payload.discountRateBps,
+                correlation_id=request.state.correlation_id,
+                causation_id=request.headers.get("Idempotency-Key") or request.state.request_id,
+            )
+        except AgreementNotFoundError:
+            return error_response(request, 404, "NOT_FOUND", "Corporate agreement was not found")
+        except CorporateTravelError as exc:
+            return error_response(request, 400, "CORPORATE_TRAVEL_INVARIANT_VIOLATION", str(exc))
+        return JSONResponse(status_code=201, content=result.to_dict())
 
 
 def create_app(service: CorporateTravelService | None = None) -> FastAPI:

--- a/services/corporate-travel/src/corporate_travel/api.py
+++ b/services/corporate-travel/src/corporate_travel/api.py
@@ -12,15 +12,30 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from train_ticket_platform.messaging import InMemoryEventPublisher
 from train_ticket_platform.observability import init_opentelemetry
+from train_ticket_platform.storage import DatabaseConfig, DatabasePool, OutboxRelay, run_migrations
 
 from train_ticket_platform.ids import is_uuid7
 
-from .application import AgreementNotFoundError, CorporateTravelService, InMemoryCorporateTravelRepository, uuid7
+from .application import AgreementNotFoundError, CorporateTravelService, InMemoryCorporateTravelRepository, PostgresCorporateTravelRepository, uuid7
 from .domain import CorporateTravelError
 from .runtime import health, profile
 
 REQUEST_ID_HEADER = "X-Request-ID"
 CORRELATION_ID_HEADER = "X-Correlation-ID"
+
+_default_service: CorporateTravelService | None = None
+
+
+def get_default_service() -> CorporateTravelService:
+    global _default_service
+    if _default_service is None:
+        _default_service = CorporateTravelService(publisher=InMemoryEventPublisher(), repository=InMemoryCorporateTravelRepository())
+    return _default_service
+
+
+def set_default_service(service: CorporateTravelService) -> None:
+    global _default_service
+    _default_service = service
 
 
 class MoneyModel(BaseModel):
@@ -296,33 +311,48 @@ def create_app(service: CorporateTravelService | None = None) -> FastAPI:
         CORPORATE_TRAVEL_SUBSCRIPTIONS,
         RedisEventSubscriber,
         corporate_travel_consumer_name,
-        handle_event,
+        build_event_handler,
     )
 
     subscriber: RedisEventSubscriber | None = None
+    relay: OutboxRelay | None = None
+    pool: DatabasePool | None = None
     redis_url = os.environ.get("REDIS_URL", "")
+    database_config = DatabaseConfig.from_env()
+    app_service = service or CorporateTravelService(publisher=InMemoryEventPublisher(), repository=InMemoryCorporateTravelRepository())
+    if database_config is not None and service is None:
+        pool = DatabasePool(database_config)
+        migrations_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "migrations")
+        run_migrations(pool, migrations_dir)
+        repository = PostgresCorporateTravelRepository(pool)
+        app_service = CorporateTravelService(repository=repository, unit_of_work=repository.transaction)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-        nonlocal subscriber
+        nonlocal subscriber, relay, pool
+        if redis_url and pool is not None:
+            relay = OutboxRelay(pool, redis_url=redis_url)
+            relay.start()
         if redis_url:
             subscriber = RedisEventSubscriber()
             subscriber.start_in_background(
                 CORPORATE_TRAVEL_SUBSCRIPTIONS,
                 CORPORATE_TRAVEL_CONSUMER_GROUP,
-                handle_event,
+                build_event_handler(app.state.corporate_travel_service),
                 consumer_name=corporate_travel_consumer_name(),
             )
         yield
         if subscriber is not None:
             subscriber.stop()
+        if relay is not None:
+            relay.stop()
+        if pool is not None:
+            pool.close()
 
     app = FastAPI(title="Corporate Travel", version="0.1.0", lifespan=lifespan)
     init_opentelemetry(profile()["service_id"], app=app)
-    app.state.corporate_travel_service = service or CorporateTravelService(
-        publisher=InMemoryEventPublisher(),
-        repository=InMemoryCorporateTravelRepository(),
-    )
+    app.state.corporate_travel_service = app_service
+    set_default_service(app_service)
     configure_error_handlers(app)
     configure_runtime_endpoints(app)
     configure_corporate_travel_endpoints(app, app.state.corporate_travel_service)

--- a/services/corporate-travel/src/corporate_travel/application.py
+++ b/services/corporate-travel/src/corporate_travel/application.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any, Mapping
+from typing import Any, Callable, Iterator, Mapping
 from uuid import NAMESPACE_URL, uuid5
 
 from train_ticket_platform.events import EventEnvelope, envelope_factory
@@ -12,13 +15,18 @@ from train_ticket_platform.storage import OutboxAppender
 
 from .domain import (
     AgreementPriceRef,
+    AgreementStatus,
     ApprovalLevel,
     ApprovalRequest,
+    AuthorizationStatus,
     AuthorizedTraveler,
     BillingCalendar,
     BillingPeriod,
+    BillingPeriodStatus,
     BookingRequest,
     BudgetDimension,
+    BudgetReservation,
+    BudgetReservationStatus,
     BudgetPool,
     CorporateAgreement,
     CorporateTravelError,
@@ -31,7 +39,11 @@ from .domain import (
     PolicyChecker,
     PolicyDecision,
     PolicyResult,
+    RouteRestriction,
     SeatClass,
+    SeatClassLimit,
+    AdvanceBookingRule,
+    BudgetLimit,
     StatementLine,
     StatementLineSource,
     TravelPolicy,
@@ -39,6 +51,11 @@ from .domain import (
 
 PRODUCER = "corporate-travel"
 SCHEMA_VERSION = 1
+
+
+@contextmanager
+def null_unit_of_work() -> Iterator[None]:
+    yield
 
 
 class AgreementNotFoundError(KeyError):
@@ -147,17 +164,301 @@ class InMemoryCorporateTravelRepository:
         statement_id = self.open_period_by_agreement.get((agreement_id, billing_period))
         return self.billing_periods.get(statement_id) if statement_id else None
 
-    def try_mark_processed(self, event_id: str) -> bool:
+    def try_mark_processed(self, event_id: str, stream: str | None = None) -> bool:
+        del stream
         if event_id in self.processed_event_ids:
             return False
         self.processed_event_ids.add(event_id)
         return True
+
+    def pending_outbox(self) -> tuple[OutboxEventRecord, ...]:
+        return tuple(record for record in self.outbox if record.published_at is None)
+
+
+class _TxState:
+    def __init__(self, connection: Any) -> None:
+        self.connection = connection
+
+
+_CORPORATE_TRAVEL_TX: ContextVar[_TxState | None] = ContextVar("corporate_travel_postgres_tx", default=None)
+
+
+def _jsonb_payload(value: Mapping[str, Any]) -> Any:
+    try:
+        from psycopg.types.json import Jsonb
+
+        return Jsonb(dict(value))
+    except ImportError:  # pragma: no cover - psycopg optional in unit tests
+        return json.dumps(dict(value), separators=(",", ":"))
+
+
+def _event_stream(envelope: EventEnvelope) -> str:
+    return f"events:{envelope.producer}"
+
+
+class PostgresCorporateTravelRepository:
+    def __init__(self, pool: Any, outbox: OutboxAppender | None = None) -> None:
+        self._pool = pool
+        self._outbox = outbox or OutboxAppender()
+
+    @contextmanager
+    def transaction(self) -> Iterator[None]:
+        state = _CORPORATE_TRAVEL_TX.get()
+        if state is not None:
+            yield
+            return
+        with self._pool.connection() as conn:
+            with conn.transaction():
+                token = _CORPORATE_TRAVEL_TX.set(_TxState(conn))
+                try:
+                    yield
+                finally:
+                    _CORPORATE_TRAVEL_TX.reset(token)
+
+    def with_connection(self, fn: Callable[[Any], Any]) -> Any:
+        state = _CORPORATE_TRAVEL_TX.get()
+        if state is not None:
+            return fn(state.connection)
+        with self.transaction():
+            state = _CORPORATE_TRAVEL_TX.get()
+            if state is None:  # pragma: no cover - defensive
+                raise RuntimeError("corporate travel transaction was not established")
+            return fn(state.connection)
+
+    def enqueue_outbox(self, envelope: EventEnvelope) -> None:
+        self.with_connection(lambda conn: self._outbox.append(conn, envelope, stream=_event_stream(envelope)))
+
+    def pending_outbox(self) -> tuple[OutboxEventRecord, ...]:
+        def read(conn: Any) -> tuple[OutboxEventRecord, ...]:
+            rows = conn.execute("SELECT event_id, stream, envelope, published_at FROM outbox WHERE published_at IS NULL ORDER BY seq").fetchall()
+            return tuple(OutboxEventRecord(str(row[0]), str(row[1]), EventEnvelope.from_json_dict(dict(row[2])), row[3]) for row in rows)
+
+        return self.with_connection(read)
+
+    def save_policy(self, policy: TravelPolicy) -> None:
+        self.with_connection(
+            lambda conn: conn.execute(
+                "INSERT INTO travel_policies(agreement_id, document) VALUES (%s, %s) "
+                "ON CONFLICT (agreement_id) DO UPDATE SET document = EXCLUDED.document, updated_at = now()",
+                (policy.agreement_id, _jsonb_payload(policy.to_dict())),
+            )
+        )
+
+    def get_policy(self, agreement_id: str) -> TravelPolicy:
+        row = self.with_connection(lambda conn: conn.execute("SELECT document FROM travel_policies WHERE agreement_id = %s", (agreement_id,)).fetchone())
+        return _policy_from_dict(dict(row[0])) if row else TravelPolicy.default(agreement_id)
+
+    def save_approval_request(self, request: ApprovalRequest) -> None:
+        self.with_connection(
+            lambda conn: conn.execute(
+                "INSERT INTO approval_requests(request_id, booking_ref, employee_ref, current_level, status, document) "
+                "VALUES (%s, %s, %s, %s, %s, %s) ON CONFLICT (request_id) DO UPDATE SET "
+                "booking_ref = EXCLUDED.booking_ref, employee_ref = EXCLUDED.employee_ref, current_level = EXCLUDED.current_level, "
+                "status = EXCLUDED.status, document = EXCLUDED.document, updated_at = now()",
+                (request.request_id, request.booking_ref, request.employee_ref, request.current_level.value, request.status.value, _jsonb_payload(request.to_dict())),
+            )
+        )
+
+    def save_budget_pool(self, pool: BudgetPool) -> None:
+        def write(conn: Any) -> None:
+            conn.execute(
+                "INSERT INTO budget_pools(pool_id, dimension, period_start, period_end, limit_minor, reserved_minor, committed_minor, document) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (pool_id) DO UPDATE SET "
+                "dimension = EXCLUDED.dimension, period_start = EXCLUDED.period_start, period_end = EXCLUDED.period_end, "
+                "limit_minor = EXCLUDED.limit_minor, reserved_minor = EXCLUDED.reserved_minor, committed_minor = EXCLUDED.committed_minor, "
+                "document = EXCLUDED.document, updated_at = now()",
+                (pool.pool_id, pool.dimension.value, pool.period_start, pool.period_end, pool.limit_minor, pool.reserved_minor, pool.committed_minor, _jsonb_payload(pool.to_dict())),
+            )
+            for reservation in pool.reservations:
+                conn.execute(
+                    "INSERT INTO budget_reservations(reservation_id, pool_id, booking_ref, amount_minor, status) VALUES (%s, %s, %s, %s, %s) "
+                    "ON CONFLICT (reservation_id) DO UPDATE SET status = EXCLUDED.status, updated_at = now()",
+                    (reservation.reservation_id, reservation.pool_id, reservation.booking_ref, reservation.amount_minor, reservation.status.value),
+                )
+
+        self.with_connection(write)
+
+    @property
+    def budget_pools(self) -> dict[str, BudgetPool]:
+        rows = self.with_connection(lambda conn: conn.execute("SELECT pool_id, document FROM budget_pools").fetchall())
+        return {str(row[0]): _budget_pool_from_dict(dict(row[1])) for row in rows}
+
+    def save_agreement(self, agreement: CorporateAgreement) -> None:
+        self.with_connection(
+            lambda conn: conn.execute(
+                "INSERT INTO corporate_agreements(agreement_id, corporate_id, agreement_code, legal_name, agreement_version, status, "
+                "effective_starts_at, effective_ends_at, monthly_credit_currency, monthly_credit_minor_units, agreement_price_ref_digest, document, activated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (agreement_id) DO UPDATE SET "
+                "corporate_id = EXCLUDED.corporate_id, agreement_code = EXCLUDED.agreement_code, legal_name = EXCLUDED.legal_name, "
+                "agreement_version = EXCLUDED.agreement_version, status = EXCLUDED.status, effective_starts_at = EXCLUDED.effective_starts_at, "
+                "effective_ends_at = EXCLUDED.effective_ends_at, monthly_credit_currency = EXCLUDED.monthly_credit_currency, "
+                "monthly_credit_minor_units = EXCLUDED.monthly_credit_minor_units, agreement_price_ref_digest = EXCLUDED.agreement_price_ref_digest, "
+                "document = EXCLUDED.document, activated_at = EXCLUDED.activated_at",
+                (
+                    agreement.agreement_id,
+                    agreement.corporate_id,
+                    agreement.agreement_code,
+                    agreement.legal_name,
+                    agreement.version,
+                    agreement.status.value,
+                    agreement.effective_window.starts_at,
+                    agreement.effective_window.ends_at,
+                    agreement.monthly_credit_limit.currency,
+                    agreement.monthly_credit_limit.minor_units,
+                    agreement.price_ref.digest,
+                    _jsonb_payload(agreement.to_dict()),
+                    agreement.activated_at,
+                ),
+            )
+        )
+
+    def get_agreement(self, agreement_id: str) -> CorporateAgreement:
+        row = self.with_connection(lambda conn: conn.execute("SELECT document FROM corporate_agreements WHERE agreement_id = %s", (agreement_id,)).fetchone())
+        if row is None:
+            raise AgreementNotFoundError(agreement_id)
+        return _agreement_from_dict(dict(row[0]))
+
+    def save_billing_period(self, period: BillingPeriod) -> None:
+        self.with_connection(
+            lambda conn: conn.execute(
+                "INSERT INTO corporate_billing_periods(statement_id, corporate_id, agreement_id, billing_period, currency, status, statement_hash, cutoff_at, due_at, closed_at, document) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (corporate_id, agreement_id, billing_period) DO UPDATE SET "
+                "status = EXCLUDED.status, statement_hash = EXCLUDED.statement_hash, closed_at = EXCLUDED.closed_at, document = EXCLUDED.document",
+                (period.statement_id, period.corporate_id, period.agreement_id, period.billing_period, period.currency, period.status.value, period.statement_hash, period.cutoff_at, period.due_at, period.closed_at, _jsonb_payload(period.to_dict())),
+            )
+        )
+
+    def get_billing_period(self, statement_id: str) -> BillingPeriod:
+        row = self.with_connection(lambda conn: conn.execute("SELECT document FROM corporate_billing_periods WHERE statement_id = %s", (statement_id,)).fetchone())
+        if row is None:
+            raise BillingPeriodNotFoundError(statement_id)
+        return _billing_period_from_dict(dict(row[0]))
+
+    def find_open_period(self, agreement_id: str, billing_period: str) -> BillingPeriod | None:
+        row = self.with_connection(
+            lambda conn: conn.execute(
+                "SELECT document FROM corporate_billing_periods WHERE agreement_id = %s AND billing_period = %s AND status = 'OPEN'",
+                (agreement_id, billing_period),
+            ).fetchone()
+        )
+        return _billing_period_from_dict(dict(row[0])) if row else None
+
+    def try_mark_processed(self, event_id: str, stream: str | None = None) -> bool:
+        return bool(
+            self.with_connection(
+                lambda conn: conn.execute(
+                    "INSERT INTO processed_events(event_id, stream) VALUES (%s, %s) ON CONFLICT DO NOTHING RETURNING event_id",
+                    (event_id, stream),
+                ).fetchone()
+            )
+        )
+
+
+def _agreement_from_dict(data: Mapping[str, Any]) -> CorporateAgreement:
+    return CorporateAgreement(
+        agreement_id=str(data["agreementId"]),
+        corporate_id=str(data["corporateId"]),
+        agreement_code=str(data["agreementCode"]),
+        legal_name=str(data["legalName"]),
+        version=int(data["agreementVersion"]),
+        effective_window=EffectiveWindow(parse_rfc3339(str(data["effectiveWindow"]["startsAt"])), parse_rfc3339(str(data["effectiveWindow"]["endsAt"]))),
+        price_ref=AgreementPriceRef(tuple(str(ref) for ref in data["priceRef"].get("fareRuleRefs", ())), _optional_text(data["priceRef"].get("ruleSetId")), _optional_text(data["priceRef"].get("ruleSetVersion"))),
+        monthly_credit_limit=money_from_mapping(data["monthlyCreditLimit"]),
+        billing_calendar=BillingCalendar(str(data["billingCalendar"]["billingPeriod"]), parse_rfc3339(str(data["billingCalendar"]["cutoffAt"])), parse_rfc3339(str(data["billingCalendar"]["dueAt"])), str(data["billingCalendar"].get("timezonePolicy", "UTC"))),
+        contact=dict(data.get("contact") or {}),
+        status=AgreementStatus(str(data["status"])),
+        authorized_travelers=tuple(_traveler_from_dict(item) for item in data.get("authorizedTravelers", ())),
+        created_at=parse_rfc3339(str(data["createdAt"])),
+        activated_at=parse_rfc3339(str(data["activatedAt"])) if data.get("activatedAt") else None,
+    )
+
+
+def _traveler_from_dict(data: Mapping[str, Any]) -> AuthorizedTraveler:
+    return AuthorizedTraveler(
+        authorization_id=str(data["authorizationId"]),
+        account_id=str(data["accountId"]),
+        corporate_id=str(data["corporateId"]),
+        agreement_id=str(data["agreementId"]),
+        cost_center=str(data["costCenter"]),
+        project_code=_optional_text(data.get("projectCode")),
+        scope=dict(data.get("scope") or {}),
+        max_trip_amount=money_from_mapping(data["maxTripAmount"]) if data.get("maxTripAmount") else None,
+        can_delegate_booking=bool(data.get("canDelegateBooking", False)),
+        valid_from=parse_rfc3339(str(data["validFrom"])),
+        valid_until=parse_rfc3339(str(data["validUntil"])),
+        status=AuthorizationStatus(str(data["status"])),
+        version=int(data.get("version", 1)),
+    )
+
+
+def _billing_period_from_dict(data: Mapping[str, Any]) -> BillingPeriod:
+    return BillingPeriod(
+        statement_id=str(data["statementId"]),
+        corporate_id=str(data["corporateId"]),
+        agreement_id=str(data["agreementId"]),
+        billing_period=str(data["billingPeriod"]),
+        currency=str(data["currency"]),
+        cutoff_at=parse_rfc3339(str(data["cutoffAt"])),
+        due_at=parse_rfc3339(str(data["dueAt"])),
+        status=BillingPeriodStatus(str(data["status"])),
+        lines=tuple(_statement_line_from_dict(item) for item in data.get("lines", ())),
+        statement_hash=_optional_text(data.get("statementHash")),
+        closed_at=parse_rfc3339(str(data["closedAt"])) if data.get("closedAt") else None,
+    )
+
+
+def _statement_line_from_dict(data: Mapping[str, Any]) -> StatementLine:
+    return StatementLine(
+        line_id=str(data["lineId"]),
+        source_type=StatementLineSource(str(data["sourceType"])),
+        source_business_ref=str(data["sourceBusinessRef"]),
+        order_id=_optional_text(data.get("orderId")),
+        payment_intent_id=_optional_text(data.get("paymentIntentId")),
+        amount=money_from_mapping(data["amount"]),
+        authorization_snapshot_ref=_optional_text(data.get("authorizationSnapshotRef")),
+        source_event_id=str(data["sourceEventId"]),
+        occurred_at=parse_rfc3339(str(data["occurredAt"])),
+    )
+
+
+def _budget_pool_from_dict(data: Mapping[str, Any]) -> BudgetPool:
+    return BudgetPool(
+        pool_id=str(data["poolId"]),
+        dimension=BudgetDimension(str(data["dimension"])),
+        period_start=parse_rfc3339(str(data["periodStart"])),
+        period_end=parse_rfc3339(str(data["periodEnd"])),
+        limit_minor=int(data["limitMinor"]),
+        reserved_minor=int(data["reservedMinor"]),
+        committed_minor=int(data["committedMinor"]),
+        reservations=tuple(_budget_reservation_from_dict(item) for item in data.get("reservations", ())),
+    )
+
+
+def _budget_reservation_from_dict(data: Mapping[str, Any]) -> BudgetReservation:
+    return BudgetReservation(str(data["reservationId"]), str(data["poolId"]), str(data["bookingRef"]), int(data["amountMinor"]), BudgetReservationStatus(str(data["status"])))
+
+
+def _policy_from_dict(data: Mapping[str, Any]) -> TravelPolicy:
+    rules = []
+    for rule in data.get("rules", ()):
+        rule_type = rule.get("type")
+        if rule_type == "SEAT_CLASS_LIMIT":
+            rules.append(SeatClassLimit(SeatClass(str(rule.get("default", "SECOND_CLASS"))), bool(rule.get("vpException", True)), int(rule.get("longTripMinutes", 360))))
+        elif rule_type == "ADVANCE_BOOKING":
+            rules.append(AdvanceBookingRule(int(rule.get("minimumDays", 3)), bool(rule.get("emergencyRequiresApproval", True))))
+        elif rule_type == "ROUTE_RESTRICTION":
+            routes = tuple((str(item[0]), str(item[1])) for item in rule.get("allowedRoutes", ()))
+            rules.append(RouteRestriction(routes, bool(rule.get("requireApprovalForUnlisted", True))))
+        elif rule_type == "BUDGET_LIMIT":
+            rules.append(BudgetLimit(int(rule.get("perTripMinor", 200000)), int(rule.get("perEmployeeMonthlyMinor", 800000)), int(rule.get("perDepartmentMonthlyMinor", 10000000))))
+    return TravelPolicy(str(data["agreementId"]), tuple(rules) or TravelPolicy.default(str(data["agreementId"])).rules)
 
 
 @dataclass(slots=True)
 class CorporateTravelService:
     publisher: EventPublisher = field(default_factory=InMemoryEventPublisher)
     repository: InMemoryCorporateTravelRepository = field(default_factory=InMemoryCorporateTravelRepository)
+    unit_of_work: Callable[[], Iterator[None]] = null_unit_of_work
 
     def create_agreement(
         self,
@@ -174,42 +475,43 @@ class CorporateTravelService:
         correlation_id: str | None = None,
         causation_id: str | None = None,
     ) -> CorporateAgreementResult:
-        agreement_id = prefixed_id("agr")
-        agreement = CorporateAgreement(
-            agreement_id=agreement_id,
-            corporate_id=corporate_id,
-            agreement_code=agreement_code,
-            legal_name=legal_name,
-            version=1,
-            effective_window=EffectiveWindow(
-                starts_at=parse_rfc3339(str(effective_window["startsAt"])),
-                ends_at=parse_rfc3339(str(effective_window["endsAt"])),
-            ),
-            price_ref=AgreementPriceRef(
-                fare_rule_refs=tuple(str(ref) for ref in price_ref.get("fareRuleRefs", ())),
-                rule_set_id=_optional_text(price_ref.get("ruleSetId")),
-                rule_set_version=_optional_text(price_ref.get("ruleSetVersion")),
-            ),
-            monthly_credit_limit=money_from_mapping(monthly_credit_limit),
-            billing_calendar=BillingCalendar(
-                period=str(billing_calendar["billingPeriod"]),
-                cutoff_at=parse_rfc3339(str(billing_calendar["cutoffAt"])),
-                due_at=parse_rfc3339(str(billing_calendar["dueAt"])),
-                timezone_policy=str(billing_calendar.get("timezonePolicy", "UTC")),
-            ),
-            contact=dict(contact or {}),
-        )
-        created_event = _agreement_event("CorporateAgreementCreated", agreement, correlation_id, causation_id)
-        if activate:
-            agreement = agreement.activate()
-            activated_event = _agreement_event("CorporateAgreementActivated", agreement, correlation_id, created_event.eventId)
+        with self.unit_of_work():
+            agreement_id = prefixed_id("agr")
+            agreement = CorporateAgreement(
+                agreement_id=agreement_id,
+                corporate_id=corporate_id,
+                agreement_code=agreement_code,
+                legal_name=legal_name,
+                version=1,
+                effective_window=EffectiveWindow(
+                    starts_at=parse_rfc3339(str(effective_window["startsAt"])),
+                    ends_at=parse_rfc3339(str(effective_window["endsAt"])),
+                ),
+                price_ref=AgreementPriceRef(
+                    fare_rule_refs=tuple(str(ref) for ref in price_ref.get("fareRuleRefs", ())),
+                    rule_set_id=_optional_text(price_ref.get("ruleSetId")),
+                    rule_set_version=_optional_text(price_ref.get("ruleSetVersion")),
+                ),
+                monthly_credit_limit=money_from_mapping(monthly_credit_limit),
+                billing_calendar=BillingCalendar(
+                    period=str(billing_calendar["billingPeriod"]),
+                    cutoff_at=parse_rfc3339(str(billing_calendar["cutoffAt"])),
+                    due_at=parse_rfc3339(str(billing_calendar["dueAt"])),
+                    timezone_policy=str(billing_calendar.get("timezonePolicy", "UTC")),
+                ),
+                contact=dict(contact or {}),
+            )
+            created_event = _agreement_event("CorporateAgreementCreated", agreement, correlation_id, causation_id)
+            if activate:
+                agreement = agreement.activate()
+                activated_event = _agreement_event("CorporateAgreementActivated", agreement, correlation_id, created_event.eventId)
+                self.repository.save_agreement(agreement)
+                self._publish(created_event)
+                self._publish(activated_event)
+                return CorporateAgreementResult(agreement)
             self.repository.save_agreement(agreement)
             self._publish(created_event)
-            self._publish(activated_event)
             return CorporateAgreementResult(agreement)
-        self.repository.save_agreement(agreement)
-        self._publish(created_event)
-        return CorporateAgreementResult(agreement)
 
     def get_agreement(self, agreement_id: str) -> CorporateAgreementResult:
         return CorporateAgreementResult(self.repository.get_agreement(agreement_id))
@@ -229,52 +531,54 @@ class CorporateTravelService:
         correlation_id: str | None = None,
         causation_id: str | None = None,
     ) -> AuthorizedTraveler:
-        agreement = self.repository.get_agreement(agreement_id)
-        traveler = AuthorizedTraveler(
-            authorization_id=prefixed_id("auth"),
-            account_id=account_id,
-            corporate_id=agreement.corporate_id,
-            agreement_id=agreement.agreement_id,
-            cost_center=cost_center,
-            project_code=project_code,
-            scope=dict(scope or {}),
-            max_trip_amount=money_from_mapping(max_trip_amount) if max_trip_amount else None,
-            can_delegate_booking=can_delegate_booking,
-            valid_from=parse_rfc3339(valid_from) if valid_from else agreement.effective_window.starts_at,
-            valid_until=parse_rfc3339(valid_until) if valid_until else agreement.effective_window.ends_at,
-        )
-        updated = agreement.authorize_traveler(traveler)
-        self.repository.save_agreement(updated)
-        self._publish(_authorization_event(traveler, correlation_id, causation_id))
-        return traveler
-
-    def handle_event(self, envelope: EventEnvelope) -> None:
-        if envelope.eventType not in {"JourneyOrderConfirmed", "PaymentCaptured", "PostSalesRefundCompleted", "TripCancelled"}:
-            return
-        if not self.repository.try_mark_processed(envelope.eventId):
-            return
-        if envelope.eventType in {"PostSalesRefundCompleted", "TripCancelled"}:
-            booking_ref = str(envelope.payload.get("bookingRef") or envelope.payload.get("orderId") or "")
-            self.release_budget_reservations(booking_ref=booking_ref, correlation_id=envelope.correlationId, causation_id=envelope.eventId)
-            return
-        line = line_from_event(envelope)
-        agreement = self.repository.get_agreement(str(envelope.payload["agreementId"]))
-        booking_ref = str(envelope.payload.get("bookingRef") or envelope.payload.get("orderId") or "")
-        if envelope.eventType == "PaymentCaptured" and booking_ref:
-            self.commit_budget_reservations(booking_ref=booking_ref, correlation_id=envelope.correlationId, causation_id=envelope.eventId)
-        billing_period = str(envelope.payload.get("billingPeriod") or agreement.billing_calendar.period)
-        period = self.repository.find_open_period(agreement.agreement_id, billing_period)
-        if period is None:
-            period = BillingPeriod(
-                statement_id=deterministic_prefixed_id("stmt", agreement.agreement_id, billing_period),
+        with self.unit_of_work():
+            agreement = self.repository.get_agreement(agreement_id)
+            traveler = AuthorizedTraveler(
+                authorization_id=prefixed_id("auth"),
+                account_id=account_id,
                 corporate_id=agreement.corporate_id,
                 agreement_id=agreement.agreement_id,
-                billing_period=billing_period,
-                currency=agreement.monthly_credit_limit.currency,
-                cutoff_at=agreement.billing_calendar.cutoff_at,
-                due_at=agreement.billing_calendar.due_at,
+                cost_center=cost_center,
+                project_code=project_code,
+                scope=dict(scope or {}),
+                max_trip_amount=money_from_mapping(max_trip_amount) if max_trip_amount else None,
+                can_delegate_booking=can_delegate_booking,
+                valid_from=parse_rfc3339(valid_from) if valid_from else agreement.effective_window.starts_at,
+                valid_until=parse_rfc3339(valid_until) if valid_until else agreement.effective_window.ends_at,
             )
-        self.repository.save_billing_period(period.attach_line(line))
+            updated = agreement.authorize_traveler(traveler)
+            self.repository.save_agreement(updated)
+            self._publish(_authorization_event(traveler, correlation_id, causation_id))
+            return traveler
+
+    def handle_event(self, envelope: EventEnvelope) -> None:
+        with self.unit_of_work():
+            if envelope.eventType not in {"JourneyOrderConfirmed", "PaymentCaptured", "PostSalesRefundCompleted", "TripCancelled"}:
+                return
+            if not self.repository.try_mark_processed(envelope.eventId, f"events:{envelope.producer}"):
+                return
+            if envelope.eventType in {"PostSalesRefundCompleted", "TripCancelled"}:
+                booking_ref = str(envelope.payload.get("bookingRef") or envelope.payload.get("orderId") or "")
+                self.release_budget_reservations(booking_ref=booking_ref, correlation_id=envelope.correlationId, causation_id=envelope.eventId)
+                return
+            line = line_from_event(envelope)
+            agreement = self.repository.get_agreement(str(envelope.payload["agreementId"]))
+            booking_ref = str(envelope.payload.get("bookingRef") or envelope.payload.get("orderId") or "")
+            if envelope.eventType == "PaymentCaptured" and booking_ref:
+                self.commit_budget_reservations(booking_ref=booking_ref, correlation_id=envelope.correlationId, causation_id=envelope.eventId)
+            billing_period = str(envelope.payload.get("billingPeriod") or agreement.billing_calendar.period)
+            period = self.repository.find_open_period(agreement.agreement_id, billing_period)
+            if period is None:
+                period = BillingPeriod(
+                    statement_id=deterministic_prefixed_id("stmt", agreement.agreement_id, billing_period),
+                    corporate_id=agreement.corporate_id,
+                    agreement_id=agreement.agreement_id,
+                    billing_period=billing_period,
+                    currency=agreement.monthly_credit_limit.currency,
+                    cutoff_at=agreement.billing_calendar.cutoff_at,
+                    due_at=agreement.billing_calendar.due_at,
+                )
+            self.repository.save_billing_period(period.attach_line(line))
 
     def check_policy_and_reserve(
         self,
@@ -296,81 +600,84 @@ class CorporateTravelService:
         correlation_id: str | None = None,
         causation_id: str | None = None,
     ) -> PolicyCheckResult:
-        agreement = self.repository.get_agreement(agreement_id)
-        money = money_from_mapping(amount)
-        if money.currency != agreement.monthly_credit_limit.currency:
-            raise CorporateTravelError("booking amount currency must match agreement currency")
-        booking = BookingRequest(
-            booking_ref=booking_ref or prefixed_id("book"),
-            agreement_id=agreement_id,
-            employee_ref=employee_ref,
-            department_ref=department_ref,
-            origin=origin,
-            destination=destination,
-            seat_class=SeatClass(seat_class),
-            amount=money,
-            requested_at=parse_rfc3339(requested_at),
-            departure_at=parse_rfc3339(departure_at),
-            trip_duration_minutes=trip_duration_minutes,
-            emergency=emergency,
-        )
-        employee = EmployeeProfile(employee_ref=employee_ref, department_ref=department_ref, level=EmployeeLevel(employee_level), manager_ref=manager_ref)
-        month_start = datetime(booking.departure_at.year, booking.departure_at.month, 1, tzinfo=UTC)
-        month_end = _next_month(month_start)
-        employee_pool = self._budget_pool(BudgetDimension.EMPLOYEE, agreement_id, employee_ref, month_start, month_end, 800_000)
-        department_pool = self._budget_pool(BudgetDimension.DEPARTMENT, agreement_id, department_ref, month_start, month_end, 10_000_000)
-        quarter_start = _quarter_start(booking.departure_at)
-        agreement_pool = self._budget_pool(
-            BudgetDimension.AGREEMENT,
-            agreement_id,
-            agreement_id,
-            quarter_start,
-            _add_months(quarter_start, 3),
-            agreement.monthly_credit_limit.minor_units * 3,
-        )
-        context = {
-            "employeeMonthlyUsedMinor": employee_pool.utilized_minor,
-            "departmentMonthlyUsedMinor": department_pool.utilized_minor,
-        }
-        result = PolicyChecker().check(booking, employee, self.repository.get_policy(agreement_id), context)
-        self._publish(_policy_checked_event(booking, result, correlation_id, causation_id))
-        approval_request: ApprovalRequest | None = None
-        if result.decision is PolicyDecision.COMPLIANT:
-            approval_request = ApprovalRequest.for_policy_result(prefixed_id("appr"), booking.booking_ref, employee_ref, result)
-            self.repository.save_approval_request(approval_request)
-            self._publish(_approval_event("ApprovalGranted", approval_request, correlation_id, causation_id))
-            pools = self._reserve_budget(booking, (employee_pool, department_pool, agreement_pool), allow_over_limit=False, correlation_id=correlation_id, causation_id=causation_id)
-        elif result.requires_level is ApprovalLevel.FINANCE:
-            approval_request = ApprovalRequest.for_policy_result(prefixed_id("appr"), booking.booking_ref, employee_ref, result)
-            self.repository.save_approval_request(approval_request)
-            self._publish(_approval_event("ApprovalRequested", approval_request, correlation_id, causation_id))
-            pools = (employee_pool, department_pool, agreement_pool)
-        else:
-            approval_request = ApprovalRequest.for_policy_result(prefixed_id("appr"), booking.booking_ref, employee_ref, result)
-            self.repository.save_approval_request(approval_request)
-            self._publish(_approval_event("ApprovalRequested", approval_request, correlation_id, causation_id))
-            pools = self._reserve_budget(booking, (employee_pool, department_pool, agreement_pool), allow_over_limit=True, correlation_id=correlation_id, causation_id=causation_id)
-        return PolicyCheckResult(result, approval_request, pools)
+        with self.unit_of_work():
+            agreement = self.repository.get_agreement(agreement_id)
+            money = money_from_mapping(amount)
+            if money.currency != agreement.monthly_credit_limit.currency:
+                raise CorporateTravelError("booking amount currency must match agreement currency")
+            booking = BookingRequest(
+                booking_ref=booking_ref or prefixed_id("book"),
+                agreement_id=agreement_id,
+                employee_ref=employee_ref,
+                department_ref=department_ref,
+                origin=origin,
+                destination=destination,
+                seat_class=SeatClass(seat_class),
+                amount=money,
+                requested_at=parse_rfc3339(requested_at),
+                departure_at=parse_rfc3339(departure_at),
+                trip_duration_minutes=trip_duration_minutes,
+                emergency=emergency,
+            )
+            employee = EmployeeProfile(employee_ref=employee_ref, department_ref=department_ref, level=EmployeeLevel(employee_level), manager_ref=manager_ref)
+            month_start = datetime(booking.departure_at.year, booking.departure_at.month, 1, tzinfo=UTC)
+            month_end = _next_month(month_start)
+            employee_pool = self._budget_pool(BudgetDimension.EMPLOYEE, agreement_id, employee_ref, month_start, month_end, 800_000)
+            department_pool = self._budget_pool(BudgetDimension.DEPARTMENT, agreement_id, department_ref, month_start, month_end, 10_000_000)
+            quarter_start = _quarter_start(booking.departure_at)
+            agreement_pool = self._budget_pool(
+                BudgetDimension.AGREEMENT,
+                agreement_id,
+                agreement_id,
+                quarter_start,
+                _add_months(quarter_start, 3),
+                agreement.monthly_credit_limit.minor_units * 3,
+            )
+            context = {
+                "employeeMonthlyUsedMinor": employee_pool.utilized_minor,
+                "departmentMonthlyUsedMinor": department_pool.utilized_minor,
+            }
+            result = PolicyChecker().check(booking, employee, self.repository.get_policy(agreement_id), context)
+            self._publish(_policy_checked_event(booking, result, correlation_id, causation_id))
+            approval_request: ApprovalRequest | None = None
+            if result.decision is PolicyDecision.COMPLIANT:
+                approval_request = ApprovalRequest.for_policy_result(prefixed_id("appr"), booking.booking_ref, employee_ref, result)
+                self.repository.save_approval_request(approval_request)
+                self._publish(_approval_event("ApprovalGranted", approval_request, correlation_id, causation_id))
+                pools = self._reserve_budget(booking, (employee_pool, department_pool, agreement_pool), allow_over_limit=False, correlation_id=correlation_id, causation_id=causation_id)
+            elif result.requires_level is ApprovalLevel.FINANCE:
+                approval_request = ApprovalRequest.for_policy_result(prefixed_id("appr"), booking.booking_ref, employee_ref, result)
+                self.repository.save_approval_request(approval_request)
+                self._publish(_approval_event("ApprovalRequested", approval_request, correlation_id, causation_id))
+                pools = (employee_pool, department_pool, agreement_pool)
+            else:
+                approval_request = ApprovalRequest.for_policy_result(prefixed_id("appr"), booking.booking_ref, employee_ref, result)
+                self.repository.save_approval_request(approval_request)
+                self._publish(_approval_event("ApprovalRequested", approval_request, correlation_id, causation_id))
+                pools = self._reserve_budget(booking, (employee_pool, department_pool, agreement_pool), allow_over_limit=True, correlation_id=correlation_id, causation_id=causation_id)
+            return PolicyCheckResult(result, approval_request, pools)
 
     def commit_budget_reservations(self, *, booking_ref: str, correlation_id: str | None = None, causation_id: str | None = None) -> tuple[BudgetPool, ...]:
-        updated = []
-        for pool in tuple(self.repository.budget_pools.values()):
-            committed = pool.commit(booking_ref)
-            if committed is not pool:
-                self.repository.save_budget_pool(committed)
-                updated.append(committed)
-        return tuple(updated)
+        with self.unit_of_work():
+            updated = []
+            for pool in tuple(self.repository.budget_pools.values()):
+                committed = pool.commit(booking_ref)
+                if committed is not pool:
+                    self.repository.save_budget_pool(committed)
+                    updated.append(committed)
+            return tuple(updated)
 
     def release_budget_reservations(self, *, booking_ref: str, correlation_id: str | None = None, causation_id: str | None = None) -> tuple[BudgetPool, ...]:
-        updated = []
-        for pool in tuple(self.repository.budget_pools.values()):
-            released = pool.release(booking_ref)
-            if released is not pool:
-                self.repository.save_budget_pool(released)
-                updated.append(released)
-        if updated:
-            self._publish(_budget_released_event(booking_ref, updated, correlation_id, causation_id))
-        return tuple(updated)
+        with self.unit_of_work():
+            updated = []
+            for pool in tuple(self.repository.budget_pools.values()):
+                released = pool.release(booking_ref)
+                if released is not pool:
+                    self.repository.save_budget_pool(released)
+                    updated.append(released)
+            if updated:
+                self._publish(_budget_released_event(booking_ref, updated, correlation_id, causation_id))
+            return tuple(updated)
 
     def generate_monthly_invoice(
         self,
@@ -382,20 +689,21 @@ class CorporateTravelService:
         correlation_id: str | None = None,
         causation_id: str | None = None,
     ) -> InvoiceResult:
-        self.repository.get_agreement(agreement_id)
-        items = tuple(
-            InvoiceLineItem(
-                booking_ref=str(item["bookingRef"]),
-                employee_name=str(item["employeeName"]),
-                route=str(item["route"]),
-                travel_date=parse_rfc3339(item["travelDate"]),
-                amount_minor=int(item["amountMinor"]),
+        with self.unit_of_work():
+            self.repository.get_agreement(agreement_id)
+            items = tuple(
+                InvoiceLineItem(
+                    booking_ref=str(item["bookingRef"]),
+                    employee_name=str(item["employeeName"]),
+                    route=str(item["route"]),
+                    travel_date=parse_rfc3339(item["travelDate"]),
+                    amount_minor=int(item["amountMinor"]),
+                )
+                for item in line_items
             )
-            for item in line_items
-        )
-        invoice = MonthlyInvoice.generate(prefixed_id("inv"), agreement_id, period, items, discount_rate_bps)
-        self._publish(_invoice_event(invoice, correlation_id, causation_id))
-        return InvoiceResult(invoice)
+            invoice = MonthlyInvoice.generate(prefixed_id("inv"), agreement_id, period, items, discount_rate_bps)
+            self._publish(_invoice_event(invoice, correlation_id, causation_id))
+            return InvoiceResult(invoice)
 
     def _budget_pool(self, dimension: BudgetDimension, agreement_id: str, subject_ref: str, period_start: datetime, period_end: datetime, limit_minor: int) -> BudgetPool:
         pool_id = deterministic_prefixed_id("budget", agreement_id, dimension.value, subject_ref, period_start.strftime("%Y-%m"))
@@ -419,7 +727,17 @@ class CorporateTravelService:
 
     def _publish(self, envelope: EventEnvelope) -> None:
         self.repository.enqueue_outbox(envelope)
-        self.publisher.publish(envelope)
+
+    def flush_outbox(self) -> None:
+        """Relay unpublished in-memory outbox rows for local tests/dev only.
+
+        Production deployments use the platform OutboxRelay against the durable
+        outbox table. The application service only enqueues events as part of
+        the state-changing unit of work.
+        """
+        for record in self.repository.pending_outbox():
+            self.publisher.publish(record.envelope)
+            record.published_at = datetime.now(UTC)
 
     def append_outbox(self, conn: Any, envelope: EventEnvelope) -> None:
         OutboxAppender().append(conn, envelope)
@@ -432,22 +750,23 @@ class CorporateTravelService:
         correlation_id: str | None = None,
         causation_id: str | None = None,
     ) -> BillingPeriodResult:
-        agreement = self.repository.get_agreement(agreement_id)
-        period = self.repository.find_open_period(agreement_id, billing_period)
-        if period is None:
-            period = BillingPeriod(
-                statement_id=deterministic_prefixed_id("stmt", agreement_id, billing_period),
-                corporate_id=agreement.corporate_id,
-                agreement_id=agreement_id,
-                billing_period=billing_period,
-                currency=agreement.monthly_credit_limit.currency,
-                cutoff_at=agreement.billing_calendar.cutoff_at,
-                due_at=agreement.billing_calendar.due_at,
-            )
-        closed = period.freeze().close()
-        self.repository.save_billing_period(closed)
-        self._publish(_billing_event(closed, correlation_id, causation_id))
-        return BillingPeriodResult(closed)
+        with self.unit_of_work():
+            agreement = self.repository.get_agreement(agreement_id)
+            period = self.repository.find_open_period(agreement_id, billing_period)
+            if period is None:
+                period = BillingPeriod(
+                    statement_id=deterministic_prefixed_id("stmt", agreement_id, billing_period),
+                    corporate_id=agreement.corporate_id,
+                    agreement_id=agreement_id,
+                    billing_period=billing_period,
+                    currency=agreement.monthly_credit_limit.currency,
+                    cutoff_at=agreement.billing_calendar.cutoff_at,
+                    due_at=agreement.billing_calendar.due_at,
+                )
+            closed = period.freeze().close()
+            self.repository.save_billing_period(closed)
+            self._publish(_billing_event(closed, correlation_id, causation_id))
+            return BillingPeriodResult(closed)
 
 
 def line_from_event(envelope: EventEnvelope) -> StatementLine:

--- a/services/corporate-travel/src/corporate_travel/application.py
+++ b/services/corporate-travel/src/corporate_travel/application.py
@@ -8,17 +8,33 @@ from uuid import NAMESPACE_URL, uuid5
 from train_ticket_platform.events import EventEnvelope, envelope_factory
 from train_ticket_platform.ids import new_prefixed_uuid7, new_uuid7
 from train_ticket_platform.messaging import EventPublisher, InMemoryEventPublisher
+from train_ticket_platform.storage import OutboxAppender
 
 from .domain import (
     AgreementPriceRef,
+    ApprovalLevel,
+    ApprovalRequest,
     AuthorizedTraveler,
     BillingCalendar,
     BillingPeriod,
+    BookingRequest,
+    BudgetDimension,
+    BudgetPool,
     CorporateAgreement,
+    CorporateTravelError,
     EffectiveWindow,
+    EmployeeLevel,
+    EmployeeProfile,
+    InvoiceLineItem,
     Money,
+    MonthlyInvoice,
+    PolicyChecker,
+    PolicyDecision,
+    PolicyResult,
+    SeatClass,
     StatementLine,
     StatementLineSource,
+    TravelPolicy,
 )
 
 PRODUCER = "corporate-travel"
@@ -31,6 +47,36 @@ class AgreementNotFoundError(KeyError):
 
 class BillingPeriodNotFoundError(KeyError):
     pass
+
+
+@dataclass(slots=True)
+class OutboxEventRecord:
+    event_id: str
+    stream: str
+    envelope: EventEnvelope
+    published_at: datetime | None = None
+
+
+@dataclass(slots=True)
+class PolicyCheckResult:
+    policy_result: PolicyResult
+    approval_request: ApprovalRequest | None
+    budget_pools: tuple[BudgetPool, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **self.policy_result.to_dict(),
+            "approvalRequest": self.approval_request.to_dict() if self.approval_request else None,
+            "budgetPools": [pool.to_dict() for pool in self.budget_pools],
+        }
+
+
+@dataclass(slots=True)
+class InvoiceResult:
+    invoice: MonthlyInvoice
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.invoice.to_dict()
 
 
 @dataclass(slots=True)
@@ -55,6 +101,28 @@ class InMemoryCorporateTravelRepository:
     billing_periods: dict[str, BillingPeriod] = field(default_factory=dict)
     processed_event_ids: set[str] = field(default_factory=set)
     open_period_by_agreement: dict[tuple[str, str], str] = field(default_factory=dict)
+    policies: dict[str, TravelPolicy] = field(default_factory=dict)
+    approval_requests: dict[str, ApprovalRequest] = field(default_factory=dict)
+    budget_pools: dict[str, BudgetPool] = field(default_factory=dict)
+    outbox: list[OutboxEventRecord] = field(default_factory=list)
+    invoice_lines: dict[tuple[str, str], list[InvoiceLineItem]] = field(default_factory=dict)
+
+    def enqueue_outbox(self, envelope: EventEnvelope) -> None:
+        if any(record.event_id == envelope.eventId for record in self.outbox):
+            return
+        self.outbox.append(OutboxEventRecord(envelope.eventId, f"events:{envelope.producer}", envelope))
+
+    def save_policy(self, policy: TravelPolicy) -> None:
+        self.policies[policy.agreement_id] = policy
+
+    def get_policy(self, agreement_id: str) -> TravelPolicy:
+        return self.policies.get(agreement_id) or TravelPolicy.default(agreement_id)
+
+    def save_approval_request(self, request: ApprovalRequest) -> None:
+        self.approval_requests[request.request_id] = request
+
+    def save_budget_pool(self, pool: BudgetPool) -> None:
+        self.budget_pools[pool.pool_id] = pool
 
     def save_agreement(self, agreement: CorporateAgreement) -> None:
         self.agreements[agreement.agreement_id] = agreement
@@ -136,11 +204,11 @@ class CorporateTravelService:
             agreement = agreement.activate()
             activated_event = _agreement_event("CorporateAgreementActivated", agreement, correlation_id, created_event.eventId)
             self.repository.save_agreement(agreement)
-            self.publisher.publish(created_event)
-            self.publisher.publish(activated_event)
+            self._publish(created_event)
+            self._publish(activated_event)
             return CorporateAgreementResult(agreement)
         self.repository.save_agreement(agreement)
-        self.publisher.publish(created_event)
+        self._publish(created_event)
         return CorporateAgreementResult(agreement)
 
     def get_agreement(self, agreement_id: str) -> CorporateAgreementResult:
@@ -177,16 +245,23 @@ class CorporateTravelService:
         )
         updated = agreement.authorize_traveler(traveler)
         self.repository.save_agreement(updated)
-        self.publisher.publish(_authorization_event(traveler, correlation_id, causation_id))
+        self._publish(_authorization_event(traveler, correlation_id, causation_id))
         return traveler
 
     def handle_event(self, envelope: EventEnvelope) -> None:
-        if envelope.eventType not in {"JourneyOrderConfirmed", "PaymentCaptured"}:
+        if envelope.eventType not in {"JourneyOrderConfirmed", "PaymentCaptured", "PostSalesRefundCompleted", "TripCancelled"}:
             return
         if not self.repository.try_mark_processed(envelope.eventId):
             return
+        if envelope.eventType in {"PostSalesRefundCompleted", "TripCancelled"}:
+            booking_ref = str(envelope.payload.get("bookingRef") or envelope.payload.get("orderId") or "")
+            self.release_budget_reservations(booking_ref=booking_ref, correlation_id=envelope.correlationId, causation_id=envelope.eventId)
+            return
         line = line_from_event(envelope)
         agreement = self.repository.get_agreement(str(envelope.payload["agreementId"]))
+        booking_ref = str(envelope.payload.get("bookingRef") or envelope.payload.get("orderId") or "")
+        if envelope.eventType == "PaymentCaptured" and booking_ref:
+            self.commit_budget_reservations(booking_ref=booking_ref, correlation_id=envelope.correlationId, causation_id=envelope.eventId)
         billing_period = str(envelope.payload.get("billingPeriod") or agreement.billing_calendar.period)
         period = self.repository.find_open_period(agreement.agreement_id, billing_period)
         if period is None:
@@ -200,6 +275,154 @@ class CorporateTravelService:
                 due_at=agreement.billing_calendar.due_at,
             )
         self.repository.save_billing_period(period.attach_line(line))
+
+    def check_policy_and_reserve(
+        self,
+        *,
+        agreement_id: str,
+        employee_ref: str,
+        department_ref: str,
+        origin: str,
+        destination: str,
+        seat_class: str,
+        amount: Mapping[str, Any],
+        requested_at: str,
+        departure_at: str,
+        trip_duration_minutes: int,
+        employee_level: str = "STAFF",
+        manager_ref: str | None = None,
+        emergency: bool = False,
+        booking_ref: str | None = None,
+        correlation_id: str | None = None,
+        causation_id: str | None = None,
+    ) -> PolicyCheckResult:
+        agreement = self.repository.get_agreement(agreement_id)
+        money = money_from_mapping(amount)
+        if money.currency != agreement.monthly_credit_limit.currency:
+            raise CorporateTravelError("booking amount currency must match agreement currency")
+        booking = BookingRequest(
+            booking_ref=booking_ref or prefixed_id("book"),
+            agreement_id=agreement_id,
+            employee_ref=employee_ref,
+            department_ref=department_ref,
+            origin=origin,
+            destination=destination,
+            seat_class=SeatClass(seat_class),
+            amount=money,
+            requested_at=parse_rfc3339(requested_at),
+            departure_at=parse_rfc3339(departure_at),
+            trip_duration_minutes=trip_duration_minutes,
+            emergency=emergency,
+        )
+        employee = EmployeeProfile(employee_ref=employee_ref, department_ref=department_ref, level=EmployeeLevel(employee_level), manager_ref=manager_ref)
+        month_start = datetime(booking.departure_at.year, booking.departure_at.month, 1, tzinfo=UTC)
+        month_end = _next_month(month_start)
+        employee_pool = self._budget_pool(BudgetDimension.EMPLOYEE, agreement_id, employee_ref, month_start, month_end, 800_000)
+        department_pool = self._budget_pool(BudgetDimension.DEPARTMENT, agreement_id, department_ref, month_start, month_end, 10_000_000)
+        quarter_start = _quarter_start(booking.departure_at)
+        agreement_pool = self._budget_pool(
+            BudgetDimension.AGREEMENT,
+            agreement_id,
+            agreement_id,
+            quarter_start,
+            _add_months(quarter_start, 3),
+            agreement.monthly_credit_limit.minor_units * 3,
+        )
+        context = {
+            "employeeMonthlyUsedMinor": employee_pool.utilized_minor,
+            "departmentMonthlyUsedMinor": department_pool.utilized_minor,
+        }
+        result = PolicyChecker().check(booking, employee, self.repository.get_policy(agreement_id), context)
+        self._publish(_policy_checked_event(booking, result, correlation_id, causation_id))
+        approval_request: ApprovalRequest | None = None
+        if result.decision is PolicyDecision.COMPLIANT:
+            approval_request = ApprovalRequest.for_policy_result(prefixed_id("appr"), booking.booking_ref, employee_ref, result)
+            self.repository.save_approval_request(approval_request)
+            self._publish(_approval_event("ApprovalGranted", approval_request, correlation_id, causation_id))
+            pools = self._reserve_budget(booking, (employee_pool, department_pool, agreement_pool), allow_over_limit=False, correlation_id=correlation_id, causation_id=causation_id)
+        elif result.requires_level is ApprovalLevel.FINANCE:
+            approval_request = ApprovalRequest.for_policy_result(prefixed_id("appr"), booking.booking_ref, employee_ref, result)
+            self.repository.save_approval_request(approval_request)
+            self._publish(_approval_event("ApprovalRequested", approval_request, correlation_id, causation_id))
+            pools = (employee_pool, department_pool, agreement_pool)
+        else:
+            approval_request = ApprovalRequest.for_policy_result(prefixed_id("appr"), booking.booking_ref, employee_ref, result)
+            self.repository.save_approval_request(approval_request)
+            self._publish(_approval_event("ApprovalRequested", approval_request, correlation_id, causation_id))
+            pools = self._reserve_budget(booking, (employee_pool, department_pool, agreement_pool), allow_over_limit=True, correlation_id=correlation_id, causation_id=causation_id)
+        return PolicyCheckResult(result, approval_request, pools)
+
+    def commit_budget_reservations(self, *, booking_ref: str, correlation_id: str | None = None, causation_id: str | None = None) -> tuple[BudgetPool, ...]:
+        updated = []
+        for pool in tuple(self.repository.budget_pools.values()):
+            committed = pool.commit(booking_ref)
+            if committed is not pool:
+                self.repository.save_budget_pool(committed)
+                updated.append(committed)
+        return tuple(updated)
+
+    def release_budget_reservations(self, *, booking_ref: str, correlation_id: str | None = None, causation_id: str | None = None) -> tuple[BudgetPool, ...]:
+        updated = []
+        for pool in tuple(self.repository.budget_pools.values()):
+            released = pool.release(booking_ref)
+            if released is not pool:
+                self.repository.save_budget_pool(released)
+                updated.append(released)
+        if updated:
+            self._publish(_budget_released_event(booking_ref, updated, correlation_id, causation_id))
+        return tuple(updated)
+
+    def generate_monthly_invoice(
+        self,
+        *,
+        agreement_id: str,
+        period: str,
+        line_items: list[Mapping[str, Any]],
+        discount_rate_bps: int = 0,
+        correlation_id: str | None = None,
+        causation_id: str | None = None,
+    ) -> InvoiceResult:
+        self.repository.get_agreement(agreement_id)
+        items = tuple(
+            InvoiceLineItem(
+                booking_ref=str(item["bookingRef"]),
+                employee_name=str(item["employeeName"]),
+                route=str(item["route"]),
+                travel_date=parse_rfc3339(item["travelDate"]),
+                amount_minor=int(item["amountMinor"]),
+            )
+            for item in line_items
+        )
+        invoice = MonthlyInvoice.generate(prefixed_id("inv"), agreement_id, period, items, discount_rate_bps)
+        self._publish(_invoice_event(invoice, correlation_id, causation_id))
+        return InvoiceResult(invoice)
+
+    def _budget_pool(self, dimension: BudgetDimension, agreement_id: str, subject_ref: str, period_start: datetime, period_end: datetime, limit_minor: int) -> BudgetPool:
+        pool_id = deterministic_prefixed_id("budget", agreement_id, dimension.value, subject_ref, period_start.strftime("%Y-%m"))
+        pool = self.repository.budget_pools.get(pool_id)
+        if pool:
+            return pool
+        pool = BudgetPool(pool_id, dimension, period_start, period_end, limit_minor)
+        self.repository.save_budget_pool(pool)
+        return pool
+
+    def _reserve_budget(self, booking: BookingRequest, pools: tuple[BudgetPool, ...], *, allow_over_limit: bool, correlation_id: str | None, causation_id: str | None) -> tuple[BudgetPool, ...]:
+        updated = []
+        for pool in pools:
+            reserved = pool.reserve(deterministic_prefixed_id("resv", pool.pool_id, booking.booking_ref), booking.booking_ref, booking.amount.minor_units, allow_over_limit=allow_over_limit)
+            self.repository.save_budget_pool(reserved)
+            updated.append(reserved)
+            threshold = reserved.alert_threshold()
+            if threshold is not None:
+                self._publish(_budget_alert_event(reserved, threshold, correlation_id, causation_id))
+        return tuple(updated)
+
+    def _publish(self, envelope: EventEnvelope) -> None:
+        self.repository.enqueue_outbox(envelope)
+        self.publisher.publish(envelope)
+
+    def append_outbox(self, conn: Any, envelope: EventEnvelope) -> None:
+        OutboxAppender().append(conn, envelope)
 
     def close_billing_period(
         self,
@@ -223,7 +446,7 @@ class CorporateTravelService:
             )
         closed = period.freeze().close()
         self.repository.save_billing_period(closed)
-        self.publisher.publish(_billing_event(closed, correlation_id, causation_id))
+        self._publish(_billing_event(closed, correlation_id, causation_id))
         return BillingPeriodResult(closed)
 
 
@@ -305,6 +528,77 @@ def _billing_event(period: BillingPeriod, correlation_id: str | None, causation_
         occurred_at=period.closed_at,
         schema_version=SCHEMA_VERSION,
     )
+
+
+def _policy_checked_event(booking: BookingRequest, result: PolicyResult, correlation_id: str | None, causation_id: str | None) -> EventEnvelope:
+    return envelope_factory(
+        event_type="TravelPolicyChecked",
+        producer=PRODUCER,
+        payload={"booking": booking.to_dict(), **result.to_dict()},
+        correlation_id=correlation_id,
+        causation_id=causation_id,
+        schema_version=SCHEMA_VERSION,
+    )
+
+
+def _approval_event(event_type: str, request: ApprovalRequest, correlation_id: str | None, causation_id: str | None) -> EventEnvelope:
+    return envelope_factory(
+        event_type=event_type,
+        producer=PRODUCER,
+        payload=request.to_dict(),
+        correlation_id=correlation_id,
+        causation_id=causation_id,
+        schema_version=SCHEMA_VERSION,
+    )
+
+
+def _budget_alert_event(pool: BudgetPool, threshold: int, correlation_id: str | None, causation_id: str | None) -> EventEnvelope:
+    return envelope_factory(
+        event_type="BudgetAlertTriggered",
+        producer=PRODUCER,
+        payload={"thresholdPercent": threshold, "pool": pool.to_dict()},
+        correlation_id=correlation_id,
+        causation_id=causation_id,
+        schema_version=SCHEMA_VERSION,
+    )
+
+
+def _budget_released_event(booking_ref: str, pools: tuple[BudgetPool, ...], correlation_id: str | None, causation_id: str | None) -> EventEnvelope:
+    return envelope_factory(
+        event_type="BudgetReservationReleased",
+        producer=PRODUCER,
+        payload={"bookingRef": booking_ref, "budgetPools": [pool.to_dict() for pool in pools]},
+        correlation_id=correlation_id,
+        causation_id=causation_id,
+        schema_version=SCHEMA_VERSION,
+    )
+
+
+def _invoice_event(invoice: MonthlyInvoice, correlation_id: str | None, causation_id: str | None) -> EventEnvelope:
+    return envelope_factory(
+        event_type="ConsolidatedInvoiceGenerated",
+        producer=PRODUCER,
+        payload=invoice.to_dict(),
+        correlation_id=correlation_id,
+        causation_id=causation_id,
+        schema_version=SCHEMA_VERSION,
+    )
+
+
+def _next_month(value: datetime) -> datetime:
+    return _add_months(value, 1)
+
+
+def _quarter_start(value: datetime) -> datetime:
+    month = ((value.month - 1) // 3) * 3 + 1
+    return datetime(value.year, month, 1, tzinfo=UTC)
+
+
+def _add_months(value: datetime, months: int) -> datetime:
+    month_index = value.month - 1 + months
+    year = value.year + month_index // 12
+    month = month_index % 12 + 1
+    return datetime(year, month, 1, tzinfo=UTC)
 
 
 def _optional_text(value: object) -> str | None:

--- a/services/corporate-travel/src/corporate_travel/domain.py
+++ b/services/corporate-travel/src/corporate_travel/domain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field, replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from hashlib import sha256
 from typing import Any, Mapping, Self
@@ -400,6 +400,521 @@ class BillingPeriod:
             "statementHash": self.statement_hash,
             "closedAt": rfc3339_utc(self.closed_at) if self.closed_at else None,
         }
+
+
+class SeatClass(str, Enum):
+    SECOND_CLASS = "SECOND_CLASS"
+    FIRST_CLASS = "FIRST_CLASS"
+
+
+class EmployeeLevel(str, Enum):
+    STAFF = "STAFF"
+    MANAGER = "MANAGER"
+    DIRECTOR = "DIRECTOR"
+    VP = "VP"
+    C_LEVEL = "C_LEVEL"
+
+
+class PolicyDecision(str, Enum):
+    COMPLIANT = "COMPLIANT"
+    NEEDS_APPROVAL = "NEEDS_APPROVAL"
+    REJECTED = "REJECTED"
+
+
+class ApprovalLevel(int, Enum):
+    DIRECT_MANAGER = 1
+    DEPARTMENT_HEAD = 2
+    FINANCE = 3
+
+
+class ApprovalStatus(str, Enum):
+    PENDING = "PENDING"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+    ESCALATED = "ESCALATED"
+
+
+class ApprovalDecisionValue(str, Enum):
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+    ESCALATED = "ESCALATED"
+
+
+class BudgetDimension(str, Enum):
+    EMPLOYEE = "EMPLOYEE"
+    DEPARTMENT = "DEPARTMENT"
+    AGREEMENT = "AGREEMENT"
+
+
+class BudgetReservationStatus(str, Enum):
+    RESERVED = "RESERVED"
+    COMMITTED = "COMMITTED"
+    RELEASED = "RELEASED"
+
+
+@dataclass(frozen=True, slots=True)
+class EmployeeProfile:
+    employee_ref: str
+    department_ref: str
+    level: EmployeeLevel = EmployeeLevel.STAFF
+    manager_ref: str | None = None
+    display_name: str | None = None
+
+    def __post_init__(self) -> None:
+        _require_text(self.employee_ref, "employee_ref")
+        _require_text(self.department_ref, "department_ref")
+
+    @property
+    def is_vp_or_above(self) -> bool:
+        return self.level in {EmployeeLevel.VP, EmployeeLevel.C_LEVEL}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "employeeRef": self.employee_ref,
+            "departmentRef": self.department_ref,
+            "level": self.level.value,
+            "managerRef": self.manager_ref,
+            "displayName": self.display_name,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BookingRequest:
+    booking_ref: str
+    agreement_id: str
+    employee_ref: str
+    department_ref: str
+    origin: str
+    destination: str
+    seat_class: SeatClass
+    amount: Money
+    requested_at: datetime
+    departure_at: datetime
+    trip_duration_minutes: int
+    emergency: bool = False
+
+    def __post_init__(self) -> None:
+        _require_text(self.booking_ref, "booking_ref")
+        _require_text(self.agreement_id, "agreement_id")
+        _require_text(self.employee_ref, "employee_ref")
+        _require_text(self.department_ref, "department_ref")
+        _require_text(self.origin, "origin")
+        _require_text(self.destination, "destination")
+        if self.trip_duration_minutes < 0:
+            raise CorporateTravelError("trip_duration_minutes must be non-negative")
+        object.__setattr__(self, "requested_at", _coerce_utc(self.requested_at))
+        object.__setattr__(self, "departure_at", _coerce_utc(self.departure_at))
+
+    @property
+    def route_pair(self) -> tuple[str, str]:
+        return (self.origin.strip().upper(), self.destination.strip().upper())
+
+    @property
+    def duration_exceeds_six_hours(self) -> bool:
+        return self.trip_duration_minutes > 6 * 60
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "bookingRef": self.booking_ref,
+            "agreementId": self.agreement_id,
+            "employeeRef": self.employee_ref,
+            "departmentRef": self.department_ref,
+            "origin": self.origin,
+            "destination": self.destination,
+            "seatClass": self.seat_class.value,
+            "amount": self.amount.to_dict(),
+            "requestedAt": rfc3339_utc(self.requested_at),
+            "departureAt": rfc3339_utc(self.departure_at),
+            "tripDurationMinutes": self.trip_duration_minutes,
+            "emergency": self.emergency,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyViolation:
+    rule_type: str
+    decision: PolicyDecision
+    message: str
+    approval_level: ApprovalLevel | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ruleType": self.rule_type,
+            "decision": self.decision.value,
+            "message": self.message,
+            "approvalLevel": self.approval_level.value if self.approval_level else None,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyResult:
+    decision: PolicyDecision
+    violations: tuple[PolicyViolation, ...] = field(default_factory=tuple)
+
+    @property
+    def requires_level(self) -> ApprovalLevel | None:
+        levels = [violation.approval_level for violation in self.violations if violation.approval_level is not None]
+        return max(levels, key=lambda level: level.value) if levels else None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"result": self.decision.value, "violations": [violation.to_dict() for violation in self.violations]}
+
+
+class PolicyRule:
+    rule_type: str
+
+    def check(self, booking: BookingRequest, employee: EmployeeProfile, budget_context: Mapping[str, int]) -> PolicyViolation | None:
+        raise NotImplementedError
+
+    def to_dict(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True, slots=True)
+class SeatClassLimit(PolicyRule):
+    default_class: SeatClass = SeatClass.SECOND_CLASS
+    vp_exception: bool = True
+    long_trip_minutes: int = 6 * 60
+    rule_type: str = "SEAT_CLASS_LIMIT"
+
+    def check(self, booking: BookingRequest, employee: EmployeeProfile, budget_context: Mapping[str, int]) -> PolicyViolation | None:
+        del budget_context
+        if booking.seat_class is not SeatClass.FIRST_CLASS:
+            return None
+        if self.vp_exception and employee.is_vp_or_above:
+            return None
+        if booking.trip_duration_minutes > self.long_trip_minutes:
+            return None
+        return PolicyViolation(self.rule_type, PolicyDecision.NEEDS_APPROVAL, "FIRST_CLASS requires VP+ level or trip longer than 6 hours", ApprovalLevel.DEPARTMENT_HEAD)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"type": self.rule_type, "default": self.default_class.value, "vpException": self.vp_exception, "longTripMinutes": self.long_trip_minutes}
+
+
+@dataclass(frozen=True, slots=True)
+class AdvanceBookingRule(PolicyRule):
+    minimum_days: int = 3
+    emergency_requires_approval: bool = True
+    rule_type: str = "ADVANCE_BOOKING"
+
+    def __post_init__(self) -> None:
+        if self.minimum_days < 0:
+            raise CorporateTravelError("minimum_days must be non-negative")
+
+    def check(self, booking: BookingRequest, employee: EmployeeProfile, budget_context: Mapping[str, int]) -> PolicyViolation | None:
+        del employee, budget_context
+        if booking.departure_at - booking.requested_at >= timedelta(days=self.minimum_days):
+            return None
+        if booking.emergency and self.emergency_requires_approval:
+            return PolicyViolation(self.rule_type, PolicyDecision.NEEDS_APPROVAL, "emergency travel inside advance-booking window requires manager approval", ApprovalLevel.DIRECT_MANAGER)
+        return PolicyViolation(self.rule_type, PolicyDecision.NEEDS_APPROVAL, "booking must be made at least 3 days before departure", ApprovalLevel.DIRECT_MANAGER)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"type": self.rule_type, "minimumDays": self.minimum_days, "emergencyRequiresApproval": self.emergency_requires_approval}
+
+
+@dataclass(frozen=True, slots=True)
+class RouteRestriction(PolicyRule):
+    allowed_routes: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+    require_approval_for_unlisted: bool = True
+    rule_type: str = "ROUTE_RESTRICTION"
+
+    def __post_init__(self) -> None:
+        routes = tuple((origin.strip().upper(), destination.strip().upper()) for origin, destination in self.allowed_routes)
+        object.__setattr__(self, "allowed_routes", routes)
+
+    def check(self, booking: BookingRequest, employee: EmployeeProfile, budget_context: Mapping[str, int]) -> PolicyViolation | None:
+        del employee, budget_context
+        if not self.allowed_routes or booking.route_pair in self.allowed_routes:
+            return None
+        decision = PolicyDecision.NEEDS_APPROVAL if self.require_approval_for_unlisted else PolicyDecision.REJECTED
+        level = ApprovalLevel.DEPARTMENT_HEAD if self.require_approval_for_unlisted else None
+        return PolicyViolation(self.rule_type, decision, "route is not approved for this corporate agreement", level)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"type": self.rule_type, "allowedRoutes": [[o, d] for o, d in self.allowed_routes], "requireApprovalForUnlisted": self.require_approval_for_unlisted}
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetLimit(PolicyRule):
+    per_trip_minor: int = 200_000
+    per_employee_monthly_minor: int = 800_000
+    per_department_monthly_minor: int = 10_000_000
+    rule_type: str = "BUDGET_LIMIT"
+
+    def __post_init__(self) -> None:
+        if min(self.per_trip_minor, self.per_employee_monthly_minor, self.per_department_monthly_minor) < 0:
+            raise CorporateTravelError("budget limits must be non-negative")
+
+    def check(self, booking: BookingRequest, employee: EmployeeProfile, budget_context: Mapping[str, int]) -> PolicyViolation | None:
+        del employee
+        department_used = int(budget_context.get("departmentMonthlyUsedMinor", 0)) + booking.amount.minor_units
+        if department_used > self.per_department_monthly_minor:
+            return PolicyViolation(self.rule_type, PolicyDecision.REJECTED, "department monthly budget exceeded; Level 3 approval required", ApprovalLevel.FINANCE)
+        if booking.amount.minor_units > self.per_trip_minor:
+            return PolicyViolation(self.rule_type, PolicyDecision.NEEDS_APPROVAL, "trip exceeds per-trip budget limit", ApprovalLevel.DEPARTMENT_HEAD)
+        employee_used = int(budget_context.get("employeeMonthlyUsedMinor", 0)) + booking.amount.minor_units
+        if employee_used > self.per_employee_monthly_minor:
+            return PolicyViolation(self.rule_type, PolicyDecision.NEEDS_APPROVAL, "employee monthly budget exceeded", ApprovalLevel.DEPARTMENT_HEAD)
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"type": self.rule_type, "perTripMinor": self.per_trip_minor, "perEmployeeMonthlyMinor": self.per_employee_monthly_minor, "perDepartmentMonthlyMinor": self.per_department_monthly_minor}
+
+
+@dataclass(frozen=True, slots=True)
+class TravelPolicy:
+    agreement_id: str
+    rules: tuple[PolicyRule, ...]
+
+    def __post_init__(self) -> None:
+        _require_text(self.agreement_id, "agreement_id")
+        if not self.rules:
+            raise CorporateTravelError("travel policy requires at least one rule")
+
+    @classmethod
+    def default(cls, agreement_id: str, *, allowed_routes: tuple[tuple[str, str], ...] = ()) -> Self:
+        return cls(agreement_id=agreement_id, rules=(SeatClassLimit(), AdvanceBookingRule(), RouteRestriction(allowed_routes), BudgetLimit()))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"agreementId": self.agreement_id, "rules": [rule.to_dict() for rule in self.rules]}
+
+
+class PolicyChecker:
+    def check(self, booking: BookingRequest, employee: EmployeeProfile, policy: TravelPolicy, budget_context: Mapping[str, int] | None = None) -> PolicyResult:
+        if booking.agreement_id != policy.agreement_id:
+            raise CorporateTravelError("booking agreement must match policy")
+        if booking.employee_ref != employee.employee_ref or booking.department_ref != employee.department_ref:
+            raise CorporateTravelError("booking employee and department must match employee profile")
+        violations = tuple(filter(None, (rule.check(booking, employee, budget_context or {}) for rule in policy.rules)))
+        if any(violation.decision is PolicyDecision.REJECTED for violation in violations):
+            return PolicyResult(PolicyDecision.REJECTED, violations)
+        if violations:
+            return PolicyResult(PolicyDecision.NEEDS_APPROVAL, violations)
+        return PolicyResult(PolicyDecision.COMPLIANT, ())
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalDecision:
+    level: ApprovalLevel
+    approver_ref: str
+    decision: ApprovalDecisionValue
+    reason: str
+    decided_at: datetime
+
+    def __post_init__(self) -> None:
+        _require_text(self.approver_ref, "approver_ref")
+        object.__setattr__(self, "decided_at", _coerce_utc(self.decided_at))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"level": self.level.value, "approverRef": self.approver_ref, "decision": self.decision.value, "reason": self.reason, "decidedAt": rfc3339_utc(self.decided_at)}
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalRequest:
+    request_id: str
+    booking_ref: str
+    employee_ref: str
+    current_level: ApprovalLevel
+    status: ApprovalStatus = ApprovalStatus.PENDING
+    history: tuple[ApprovalDecision, ...] = field(default_factory=tuple)
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def __post_init__(self) -> None:
+        _require_text(self.request_id, "request_id")
+        _require_text(self.booking_ref, "booking_ref")
+        _require_text(self.employee_ref, "employee_ref")
+        object.__setattr__(self, "created_at", _coerce_utc(self.created_at))
+
+    @classmethod
+    def for_policy_result(cls, request_id: str, booking_ref: str, employee_ref: str, result: PolicyResult) -> Self:
+        level = result.requires_level or ApprovalLevel.DIRECT_MANAGER
+        status = ApprovalStatus.APPROVED if result.decision is PolicyDecision.COMPLIANT else ApprovalStatus.PENDING
+        return cls(request_id=request_id, booking_ref=booking_ref, employee_ref=employee_ref, current_level=level, status=status)
+
+    def decide(self, decision: ApprovalDecision) -> Self:
+        if self.status not in {ApprovalStatus.PENDING, ApprovalStatus.ESCALATED}:
+            raise CorporateTravelError("terminal approval request cannot be decided")
+        if decision.level != self.current_level:
+            raise CorporateTravelError("approval decision level must match current level")
+        history = self.history + (decision,)
+        if decision.decision is ApprovalDecisionValue.REJECTED:
+            return replace(self, status=ApprovalStatus.REJECTED, history=history)
+        if decision.decision is ApprovalDecisionValue.ESCALATED:
+            if self.current_level is ApprovalLevel.FINANCE:
+                raise CorporateTravelError("finance approval cannot be escalated")
+            return replace(self, current_level=ApprovalLevel(self.current_level.value + 1), status=ApprovalStatus.ESCALATED, history=history)
+        return replace(self, status=ApprovalStatus.APPROVED, history=history)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"requestId": self.request_id, "bookingRef": self.booking_ref, "employeeRef": self.employee_ref, "currentLevel": self.current_level.value, "status": self.status.value, "history": [item.to_dict() for item in self.history], "createdAt": rfc3339_utc(self.created_at)}
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetReservation:
+    reservation_id: str
+    pool_id: str
+    booking_ref: str
+    amount_minor: int
+    status: BudgetReservationStatus = BudgetReservationStatus.RESERVED
+
+    def __post_init__(self) -> None:
+        _require_text(self.reservation_id, "reservation_id")
+        _require_text(self.pool_id, "pool_id")
+        _require_text(self.booking_ref, "booking_ref")
+        if self.amount_minor < 0:
+            raise CorporateTravelError("reservation amount_minor must be non-negative")
+
+    def commit(self) -> Self:
+        if self.status is not BudgetReservationStatus.RESERVED:
+            raise CorporateTravelError("only RESERVED budget reservations can be committed")
+        return replace(self, status=BudgetReservationStatus.COMMITTED)
+
+    def release(self) -> Self:
+        if self.status is BudgetReservationStatus.RELEASED:
+            return self
+        return replace(self, status=BudgetReservationStatus.RELEASED)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"reservationId": self.reservation_id, "poolId": self.pool_id, "bookingRef": self.booking_ref, "amountMinor": self.amount_minor, "status": self.status.value}
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetPool:
+    pool_id: str
+    dimension: BudgetDimension
+    period_start: datetime
+    period_end: datetime
+    limit_minor: int
+    reserved_minor: int = 0
+    committed_minor: int = 0
+    reservations: tuple[BudgetReservation, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        _require_text(self.pool_id, "pool_id")
+        start = _coerce_utc(self.period_start)
+        end = _coerce_utc(self.period_end)
+        if end <= start:
+            raise CorporateTravelError("budget period_end must be after period_start")
+        if min(self.limit_minor, self.reserved_minor, self.committed_minor) < 0:
+            raise CorporateTravelError("budget amounts must be non-negative")
+        object.__setattr__(self, "period_start", start)
+        object.__setattr__(self, "period_end", end)
+
+    @property
+    def utilized_minor(self) -> int:
+        return self.reserved_minor + self.committed_minor
+
+    @property
+    def utilization_ratio(self) -> float:
+        return 1.0 if self.limit_minor == 0 and self.utilized_minor > 0 else (self.utilized_minor / self.limit_minor if self.limit_minor else 0.0)
+
+    def reserve(self, reservation_id: str, booking_ref: str, amount_minor: int, *, allow_over_limit: bool = False) -> Self:
+        if amount_minor < 0:
+            raise CorporateTravelError("reservation amount_minor must be non-negative")
+        if not allow_over_limit and self.utilized_minor + amount_minor > self.limit_minor:
+            raise CorporateTravelError("budget limit exceeded")
+        if any(item.booking_ref == booking_ref and item.status is BudgetReservationStatus.RESERVED for item in self.reservations):
+            return self
+        reservation = BudgetReservation(reservation_id, self.pool_id, booking_ref, amount_minor)
+        return replace(self, reserved_minor=self.reserved_minor + amount_minor, reservations=self.reservations + (reservation,))
+
+    def commit(self, booking_ref: str) -> Self:
+        reservations: list[BudgetReservation] = []
+        committed = 0
+        reserved = self.reserved_minor
+        found = False
+        for reservation in self.reservations:
+            if reservation.booking_ref == booking_ref and reservation.status is BudgetReservationStatus.RESERVED:
+                found = True
+                reservations.append(reservation.commit())
+                reserved -= reservation.amount_minor
+                committed += reservation.amount_minor
+            else:
+                reservations.append(reservation)
+        if not found:
+            return self
+        return replace(self, reserved_minor=reserved, committed_minor=self.committed_minor + committed, reservations=tuple(reservations))
+
+    def release(self, booking_ref: str) -> Self:
+        reservations: list[BudgetReservation] = []
+        reserved = self.reserved_minor
+        committed = self.committed_minor
+        found = False
+        for reservation in self.reservations:
+            if reservation.booking_ref == booking_ref and reservation.status is not BudgetReservationStatus.RELEASED:
+                found = True
+                if reservation.status is BudgetReservationStatus.RESERVED:
+                    reserved -= reservation.amount_minor
+                if reservation.status is BudgetReservationStatus.COMMITTED:
+                    committed -= reservation.amount_minor
+                reservations.append(reservation.release())
+            else:
+                reservations.append(reservation)
+        if not found:
+            return self
+        return replace(self, reserved_minor=reserved, committed_minor=committed, reservations=tuple(reservations))
+
+    def alert_threshold(self) -> int | None:
+        if self.utilization_ratio >= 1:
+            return 100
+        if self.utilization_ratio >= 0.8:
+            return 80
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"poolId": self.pool_id, "dimension": self.dimension.value, "periodStart": rfc3339_utc(self.period_start), "periodEnd": rfc3339_utc(self.period_end), "limitMinor": self.limit_minor, "reservedMinor": self.reserved_minor, "committedMinor": self.committed_minor, "reservations": [item.to_dict() for item in self.reservations]}
+
+
+@dataclass(frozen=True, slots=True)
+class InvoiceLineItem:
+    booking_ref: str
+    employee_name: str
+    route: str
+    travel_date: datetime
+    amount_minor: int
+
+    def __post_init__(self) -> None:
+        _require_text(self.booking_ref, "booking_ref")
+        _require_text(self.employee_name, "employee_name")
+        _require_text(self.route, "route")
+        if self.amount_minor < 0:
+            raise CorporateTravelError("invoice amount_minor must be non-negative")
+        object.__setattr__(self, "travel_date", _coerce_utc(self.travel_date))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"bookingRef": self.booking_ref, "employeeName": self.employee_name, "route": self.route, "travelDate": rfc3339_utc(self.travel_date), "amountMinor": self.amount_minor}
+
+
+@dataclass(frozen=True, slots=True)
+class MonthlyInvoice:
+    invoice_id: str
+    agreement_id: str
+    period: str
+    line_items: tuple[InvoiceLineItem, ...]
+    total_minor: int
+    discount_minor: int = 0
+
+    def __post_init__(self) -> None:
+        _require_text(self.invoice_id, "invoice_id")
+        _require_text(self.agreement_id, "agreement_id")
+        _require_text(self.period, "period")
+        if min(self.total_minor, self.discount_minor) < 0:
+            raise CorporateTravelError("invoice totals must be non-negative")
+        expected_total = max(sum(item.amount_minor for item in self.line_items) - self.discount_minor, 0)
+        if self.total_minor != expected_total:
+            raise CorporateTravelError("invoice total must equal line item sum minus discount")
+
+    @classmethod
+    def generate(cls, invoice_id: str, agreement_id: str, period: str, line_items: tuple[InvoiceLineItem, ...], discount_rate_bps: int = 0) -> Self:
+        if discount_rate_bps < 0 or discount_rate_bps > 10_000:
+            raise CorporateTravelError("discount_rate_bps must be between 0 and 10000")
+        gross = sum(item.amount_minor for item in line_items)
+        discount = gross * discount_rate_bps // 10_000
+        return cls(invoice_id, agreement_id, period, line_items, gross - discount, discount)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"invoiceId": self.invoice_id, "agreementId": self.agreement_id, "period": self.period, "lineItems": [item.to_dict() for item in self.line_items], "totalMinor": self.total_minor, "discountMinor": self.discount_minor}
 
 
 def rfc3339_utc(value: datetime) -> str:

--- a/services/corporate-travel/src/corporate_travel/messaging.py
+++ b/services/corporate-travel/src/corporate_travel/messaging.py
@@ -5,7 +5,7 @@ import logging
 from train_ticket_platform.events import EventEnvelope
 from train_ticket_platform.messaging import RedisEventPublisher, RedisEventSubscriber, default_consumer_name
 
-CORPORATE_TRAVEL_SUBSCRIPTIONS: tuple[str, ...] = ("events:payment",)
+CORPORATE_TRAVEL_SUBSCRIPTIONS: tuple[str, ...] = ("events:journey-order", "events:payment", "events:post-sales")
 CORPORATE_TRAVEL_CONSUMER_GROUP = "corporate-travel"
 
 logger = logging.getLogger("corporate-travel.events")
@@ -16,15 +16,8 @@ def corporate_travel_consumer_name() -> str:
 
 
 def handle_event(envelope: EventEnvelope) -> None:
-    if envelope.eventType == "PaymentCaptured":
-        payload = envelope.payload or {}
-        business_ref = payload.get("businessRef", "")
-        amount = payload.get("capturedAmount", {})
-        logger.info(
-            "PaymentCaptured: businessRef=%s amount=%s",
-            business_ref,
-            amount,
-        )
+    if envelope.eventType in {"JourneyOrderConfirmed", "PaymentCaptured", "PostSalesRefundCompleted", "TripCancelled"}:
+        logger.info("corporate travel consumed eventType=%s eventId=%s", envelope.eventType, envelope.eventId)
 
 
 __all__ = [

--- a/services/corporate-travel/src/corporate_travel/messaging.py
+++ b/services/corporate-travel/src/corporate_travel/messaging.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import logging
+from typing import Callable
 
 from train_ticket_platform.events import EventEnvelope
 from train_ticket_platform.messaging import RedisEventPublisher, RedisEventSubscriber, default_consumer_name
 
+from .application import CorporateTravelService
+
 CORPORATE_TRAVEL_SUBSCRIPTIONS: tuple[str, ...] = ("events:journey-order", "events:payment", "events:post-sales")
 CORPORATE_TRAVEL_CONSUMER_GROUP = "corporate-travel"
+CONSUMED_EVENT_TYPES = {"JourneyOrderConfirmed", "PaymentCaptured", "PostSalesRefundCompleted", "TripCancelled"}
 
 logger = logging.getLogger("corporate-travel.events")
 
@@ -15,9 +19,21 @@ def corporate_travel_consumer_name() -> str:
     return default_consumer_name(CORPORATE_TRAVEL_CONSUMER_GROUP)
 
 
-def handle_event(envelope: EventEnvelope) -> None:
-    if envelope.eventType in {"JourneyOrderConfirmed", "PaymentCaptured", "PostSalesRefundCompleted", "TripCancelled"}:
+def build_event_handler(service: CorporateTravelService) -> Callable[[EventEnvelope], None]:
+    def handle(envelope: EventEnvelope) -> None:
+        if envelope.eventType not in CONSUMED_EVENT_TYPES:
+            return
+        service.handle_event(envelope)
         logger.info("corporate travel consumed eventType=%s eventId=%s", envelope.eventType, envelope.eventId)
+
+    return handle
+
+
+def handle_event(envelope: EventEnvelope) -> None:
+    """Compatibility hook for tests; create_app wires a service-bound handler."""
+    from .api import get_default_service
+
+    build_event_handler(get_default_service())(envelope)
 
 
 __all__ = [
@@ -25,6 +41,7 @@ __all__ = [
     "CORPORATE_TRAVEL_SUBSCRIPTIONS",
     "RedisEventPublisher",
     "RedisEventSubscriber",
+    "build_event_handler",
     "corporate_travel_consumer_name",
     "handle_event",
 ]

--- a/services/corporate-travel/tests/test_api.py
+++ b/services/corporate-travel/tests/test_api.py
@@ -48,3 +48,28 @@ def test_unknown_agreement_returns_canonical_error() -> None:
 
     assert response.status_code == 404
     assert response.json()["code"] == "NOT_FOUND"
+
+
+def test_policy_check_endpoint_is_backward_compatible_addition() -> None:
+    client = TestClient(create_app())
+    agreement_id = client.post("/agreements", json=create_payload()).json()["agreementId"]
+
+    response = client.post(
+        f"/agreements/{agreement_id}/policy-checks",
+        json={
+            "employeeRef": "emp-1",
+            "departmentRef": "dep-1",
+            "origin": "BJS",
+            "destination": "SHA",
+            "seatClass": "SECOND_CLASS",
+            "amount": {"currency": "USD", "minorUnits": 1200},
+            "requestedAt": "2026-01-01T00:00:00Z",
+            "departureAt": "2026-01-05T00:00:00Z",
+            "tripDurationMinutes": 300,
+            "bookingRef": "book-api-1",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json()["result"] == "COMPLIANT"
+    assert response.json()["approvalRequest"]["status"] == "APPROVED"

--- a/services/corporate-travel/tests/test_application.py
+++ b/services/corporate-travel/tests/test_application.py
@@ -26,6 +26,8 @@ def test_service_creates_active_agreement_and_publishes_activation() -> None:
     result = service.create_agreement(**agreement_payload())
 
     assert result.agreement.status.value == "ACTIVE"
+    service.flush_outbox()
+
     assert [event.eventType for event in publisher.envelopes] == ["CorporateAgreementCreated", "CorporateAgreementActivated"]
     assert publisher.envelopes[1].payload["monthlyCreditLimit"] == {"currency": "USD", "minorUnits": 100000}
 
@@ -78,6 +80,8 @@ def test_service_authorizes_and_closes_billing_period_from_events() -> None:
 
     assert closed.status.value == "CLOSED"
     assert closed.total_amount.minor_units == 5000
+    service.flush_outbox()
+
     assert publisher.envelopes[-1].eventType == "CorporateBillingPeriodClosed"
     assert publisher.envelopes[-1].payload["statementHash"] == closed.statement_hash
 
@@ -105,6 +109,8 @@ def test_policy_check_reserves_budget_and_publishes_outbox_events() -> None:
     assert result.approval_request is not None
     assert result.approval_request.status.value == "APPROVED"
     assert any(pool.reserved_minor == 1200 for pool in result.budget_pools)
+    service.flush_outbox()
+
     assert "TravelPolicyChecked" in [event.eventType for event in publisher.envelopes]
     assert "ApprovalGranted" in [event.eventType for event in publisher.envelopes]
     assert service.repository.outbox[-1].stream == "events:corporate-travel"
@@ -133,6 +139,7 @@ def test_department_budget_exceeded_is_blocked_without_finance_approval() -> Non
     assert result.approval_request is not None
     assert result.approval_request.current_level.value == 3
     assert all(pool.reserved_minor == 0 for pool in result.budget_pools)
+    service.flush_outbox()
     assert publisher.envelopes[-1].eventType == "ApprovalRequested"
 
 
@@ -161,3 +168,57 @@ def test_payment_commits_and_cancellation_releases_budget_reservation() -> None:
     assert any(pool.committed_minor == 1200 for pool in committed)
     assert released
     assert all(pool.committed_minor == 0 for pool in released)
+
+
+def test_messaging_handler_invokes_service_budget_side_effects() -> None:
+    from corporate_travel.messaging import build_event_handler
+
+    service = CorporateTravelService(publisher=InMemoryEventPublisher())
+    agreement = service.create_agreement(**agreement_payload()).agreement
+    service.check_policy_and_reserve(
+        agreement_id=agreement.agreement_id,
+        booking_ref="book-subscriber-1",
+        employee_ref="emp-1",
+        department_ref="dep-1",
+        origin="BJS",
+        destination="SHA",
+        seat_class="SECOND_CLASS",
+        amount={"currency": "USD", "minorUnits": 1200},
+        requested_at="2026-01-01T00:00:00Z",
+        departure_at="2026-01-05T00:00:00Z",
+        trip_duration_minutes=300,
+    )
+
+    build_event_handler(service)(
+        EventEnvelope(
+            eventId="evt-pay-subscriber-1",
+            eventType="PaymentCaptured",
+            occurredAt="2026-01-10T00:05:00Z",
+            correlationId="corr-test",
+            causationId="cmd-test",
+            producer="payment",
+            schemaVersion=1,
+            payload={
+                "agreementId": agreement.agreement_id,
+                "billingPeriod": "2026-01",
+                "bookingRef": "book-subscriber-1",
+                "paymentIntentId": "pay-subscriber-1",
+                "capturedAmount": {"currency": "USD", "minorUnits": 1200},
+            },
+        )
+    )
+
+    assert all(pool.reserved_minor == 0 for pool in service.repository.budget_pools.values())
+    assert any(pool.committed_minor == 1200 for pool in service.repository.budget_pools.values())
+
+
+def test_publish_enqueues_outbox_without_direct_publish() -> None:
+    publisher = InMemoryEventPublisher()
+    service = CorporateTravelService(publisher=publisher)
+
+    service.create_agreement(**agreement_payload())
+
+    assert publisher.envelopes == []
+    assert [record.envelope.eventType for record in service.repository.outbox] == ["CorporateAgreementCreated", "CorporateAgreementActivated"]
+    service.flush_outbox()
+    assert [event.eventType for event in publisher.envelopes] == ["CorporateAgreementCreated", "CorporateAgreementActivated"]

--- a/services/corporate-travel/tests/test_application.py
+++ b/services/corporate-travel/tests/test_application.py
@@ -80,3 +80,84 @@ def test_service_authorizes_and_closes_billing_period_from_events() -> None:
     assert closed.total_amount.minor_units == 5000
     assert publisher.envelopes[-1].eventType == "CorporateBillingPeriodClosed"
     assert publisher.envelopes[-1].payload["statementHash"] == closed.statement_hash
+
+
+def test_policy_check_reserves_budget_and_publishes_outbox_events() -> None:
+    publisher = InMemoryEventPublisher()
+    service = CorporateTravelService(publisher=publisher)
+    agreement = service.create_agreement(**agreement_payload()).agreement
+
+    result = service.check_policy_and_reserve(
+        agreement_id=agreement.agreement_id,
+        booking_ref="book-policy-1",
+        employee_ref="emp-1",
+        department_ref="dep-1",
+        origin="BJS",
+        destination="SHA",
+        seat_class="SECOND_CLASS",
+        amount={"currency": "USD", "minorUnits": 1200},
+        requested_at="2026-01-01T00:00:00Z",
+        departure_at="2026-01-05T00:00:00Z",
+        trip_duration_minutes=300,
+    )
+
+    assert result.policy_result.decision.value == "COMPLIANT"
+    assert result.approval_request is not None
+    assert result.approval_request.status.value == "APPROVED"
+    assert any(pool.reserved_minor == 1200 for pool in result.budget_pools)
+    assert "TravelPolicyChecked" in [event.eventType for event in publisher.envelopes]
+    assert "ApprovalGranted" in [event.eventType for event in publisher.envelopes]
+    assert service.repository.outbox[-1].stream == "events:corporate-travel"
+
+
+def test_department_budget_exceeded_is_blocked_without_finance_approval() -> None:
+    publisher = InMemoryEventPublisher()
+    service = CorporateTravelService(publisher=publisher)
+    agreement = service.create_agreement(**agreement_payload()).agreement
+
+    result = service.check_policy_and_reserve(
+        agreement_id=agreement.agreement_id,
+        booking_ref="book-policy-2",
+        employee_ref="emp-1",
+        department_ref="dep-1",
+        origin="BJS",
+        destination="SHA",
+        seat_class="SECOND_CLASS",
+        amount={"currency": "USD", "minorUnits": 10000100},
+        requested_at="2026-01-01T00:00:00Z",
+        departure_at="2026-01-05T00:00:00Z",
+        trip_duration_minutes=300,
+    )
+
+    assert result.policy_result.decision.value == "REJECTED"
+    assert result.approval_request is not None
+    assert result.approval_request.current_level.value == 3
+    assert all(pool.reserved_minor == 0 for pool in result.budget_pools)
+    assert publisher.envelopes[-1].eventType == "ApprovalRequested"
+
+
+def test_payment_commits_and_cancellation_releases_budget_reservation() -> None:
+    service = CorporateTravelService(publisher=InMemoryEventPublisher())
+    agreement = service.create_agreement(**agreement_payload()).agreement
+    service.check_policy_and_reserve(
+        agreement_id=agreement.agreement_id,
+        booking_ref="book-policy-3",
+        employee_ref="emp-1",
+        department_ref="dep-1",
+        origin="BJS",
+        destination="SHA",
+        seat_class="SECOND_CLASS",
+        amount={"currency": "USD", "minorUnits": 1200},
+        requested_at="2026-01-01T00:00:00Z",
+        departure_at="2026-01-05T00:00:00Z",
+        trip_duration_minutes=300,
+    )
+
+    committed = service.commit_budget_reservations(booking_ref="book-policy-3")
+    released = service.release_budget_reservations(booking_ref="book-policy-3")
+
+    assert committed
+    assert all(pool.reserved_minor == 0 for pool in committed)
+    assert any(pool.committed_minor == 1200 for pool in committed)
+    assert released
+    assert all(pool.committed_minor == 0 for pool in released)

--- a/services/corporate-travel/tests/test_domain.py
+++ b/services/corporate-travel/tests/test_domain.py
@@ -98,3 +98,72 @@ def test_billing_period_freezes_hash_and_closes() -> None:
     assert closed.total_amount.minor_units == 1234
     with pytest.raises(CorporateTravelError):
         closed.attach_line(line)
+
+
+def test_policy_compliant_second_class_auto_approved() -> None:
+    from corporate_travel.domain import BookingRequest, EmployeeLevel, EmployeeProfile, PolicyChecker, PolicyDecision, SeatClass, TravelPolicy
+
+    booking = BookingRequest(
+        booking_ref="book-1",
+        agreement_id="agr-1",
+        employee_ref="emp-1",
+        department_ref="dep-1",
+        origin="BJS",
+        destination="SHA",
+        seat_class=SeatClass.SECOND_CLASS,
+        amount=Money("USD", 1200),
+        requested_at=datetime(2026, 1, 1, tzinfo=UTC),
+        departure_at=datetime(2026, 1, 5, tzinfo=UTC),
+        trip_duration_minutes=300,
+    )
+    employee = EmployeeProfile("emp-1", "dep-1", EmployeeLevel.STAFF)
+
+    result = PolicyChecker().check(booking, employee, TravelPolicy.default("agr-1", allowed_routes=(("BJS", "SHA"),)))
+
+    assert result.decision is PolicyDecision.COMPLIANT
+    assert result.violations == ()
+
+
+def test_first_class_non_vp_needs_department_head_approval() -> None:
+    from corporate_travel.domain import ApprovalLevel, BookingRequest, EmployeeLevel, EmployeeProfile, PolicyChecker, PolicyDecision, SeatClass, TravelPolicy
+
+    booking = BookingRequest(
+        booking_ref="book-2",
+        agreement_id="agr-1",
+        employee_ref="emp-1",
+        department_ref="dep-1",
+        origin="BJS",
+        destination="SHA",
+        seat_class=SeatClass.FIRST_CLASS,
+        amount=Money("USD", 1200),
+        requested_at=datetime(2026, 1, 1, tzinfo=UTC),
+        departure_at=datetime(2026, 1, 5, tzinfo=UTC),
+        trip_duration_minutes=300,
+    )
+    employee = EmployeeProfile("emp-1", "dep-1", EmployeeLevel.STAFF)
+
+    result = PolicyChecker().check(booking, employee, TravelPolicy.default("agr-1", allowed_routes=(("BJS", "SHA"),)))
+
+    assert result.decision is PolicyDecision.NEEDS_APPROVAL
+    assert result.requires_level is ApprovalLevel.DEPARTMENT_HEAD
+
+
+def test_budget_pool_alerts_and_release_reservation() -> None:
+    from corporate_travel.domain import BudgetDimension, BudgetPool
+
+    pool = BudgetPool(
+        pool_id="pool-1",
+        dimension=BudgetDimension.DEPARTMENT,
+        period_start=datetime(2026, 1, 1, tzinfo=UTC),
+        period_end=datetime(2026, 2, 1, tzinfo=UTC),
+        limit_minor=1000,
+        committed_minor=750,
+    )
+
+    warned = pool.reserve("res-1", "book-1", 150)
+    released = warned.release("book-1")
+
+    assert warned.alert_threshold() == 80
+    assert warned.utilized_minor == 900
+    assert released.reserved_minor == 0
+    assert released.committed_minor == 750


### PR DESCRIPTION
## Summary
- Adds corporate travel policy checking, approval request workflow, budget pools/reservations, invoice generation, and domain events.
- Adds backward-compatible policy-check and monthly-invoice endpoints.
- Extends migrations with policy, approval, budget, invoice, and canonical outbox tables.

## Validation
- cd services/corporate-travel && uv run python -m compileall -q src
- cd services/corporate-travel && uv run pytest -q