### PR TITLE
REQ-313 enrich travel insurance domain

### DIFF
--- a/services/travel-insurance/adapters/messaging/subscriber.go
+++ b/services/travel-insurance/adapters/messaging/subscriber.go
@@ -19,10 +19,12 @@ func NewInboundHandler(service *application.InsuranceService) *InboundHandler {
 
 func (h *InboundHandler) Handle(ctx context.Context, envelope kitmsg.EventEnvelope) error {
 	switch envelope.EventType {
-	case "JourneyOrderConfirmed":
-		return h.handleJourneyOrderConfirmed(ctx, envelope)
-	case "RefundApproved":
-		return h.handleRefundApproved(ctx, envelope)
+	case "JourneyOrderCreated", "JourneyOrderConfirmed":
+		return h.handleJourneyOrder(ctx, envelope)
+	case "PostSalesApplied", "RefundApproved":
+		return h.handleRefundApplied(ctx, envelope)
+	case "TrainDelayed":
+		return h.handleTrainDelayed(ctx, envelope)
 	default:
 		return nil
 	}
@@ -37,20 +39,21 @@ type monetarySummary struct {
 	Total domain.Money `json:"total"`
 }
 
-type journeyOrderConfirmed struct {
-	JourneyOrderID  string           `json:"journeyOrderId"`
-	OrderID         string           `json:"orderId"`
-	AccountID       string           `json:"accountId"`
-	TravelerRef     string           `json:"travelerRef"`
+type journeyOrder struct {
+	JourneyOrderID  string             `json:"journeyOrderId"`
+	OrderID         string             `json:"orderId"`
+	AccountID       string             `json:"accountId"`
+	TravelerRef     string             `json:"travelerRef"`
 	TravelerRefs    []travelerRefEntry `json:"travelerRefs"`
-	SegmentRefs     []string         `json:"segmentRefs"`
-	PaymentIntentID string           `json:"paymentIntentId"`
-	MonetarySummary *monetarySummary `json:"monetarySummary"`
-	ConfirmedAt     time.Time        `json:"confirmedAt"`
+	SegmentRefs     []string           `json:"segmentRefs"`
+	PaymentIntentID string             `json:"paymentIntentId"`
+	MonetarySummary *monetarySummary   `json:"monetarySummary"`
+	CreatedAt       time.Time          `json:"createdAt"`
+	ConfirmedAt     time.Time          `json:"confirmedAt"`
 }
 
-func (h *InboundHandler) handleJourneyOrderConfirmed(ctx context.Context, envelope kitmsg.EventEnvelope) error {
-	var payload journeyOrderConfirmed
+func (h *InboundHandler) handleJourneyOrder(ctx context.Context, envelope kitmsg.EventEnvelope) error {
+	var payload journeyOrder
 	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
 		return nil
 	}
@@ -68,13 +71,16 @@ func (h *InboundHandler) handleJourneyOrderConfirmed(ctx context.Context, envelo
 	}
 	start := payload.ConfirmedAt
 	if start.IsZero() {
+		start = payload.CreatedAt
+	}
+	if start.IsZero() {
 		start = envelope.OccurredAt
 	}
 	_, err := h.service.IssuePolicy(ctx, application.IssuePolicyCommand{ProductCode: string(domain.ProductDelayInsurance), ProductVersion: "v1", JourneyOrderID: orderID, AncillaryOrderItemID: "auto-offer:" + orderID, AccountID: payload.AccountID, TravelerRef: travelerRef, SegmentRefs: payload.SegmentRefs, PaymentIntentID: paymentIntentID, CoverageStartAt: start.UTC(), CoverageEndAt: start.UTC().Add(48 * time.Hour), CorrelationID: envelope.CorrelationID, CausationID: envelope.EventID})
 	return err
 }
 
-func resolveTravelerRef(payload journeyOrderConfirmed) string {
+func resolveTravelerRef(payload journeyOrder) string {
 	if ref := strings.TrimSpace(payload.TravelerRef); ref != "" {
 		return ref
 	}
@@ -86,23 +92,78 @@ func resolveTravelerRef(payload journeyOrderConfirmed) string {
 	return ""
 }
 
-type refundApproved struct {
-	PolicyID       string       `json:"policyId"`
-	JourneyOrderID string       `json:"journeyOrderId"`
-	RefundID       string       `json:"refundId"`
-	Amount         domain.Money `json:"amount"`
-	ApprovedAt     time.Time    `json:"approvedAt"`
+type refundApplied struct {
+	PolicyID        string         `json:"policyId"`
+	JourneyOrderID  string         `json:"journeyOrderId"`
+	OrderID         string         `json:"orderId"`
+	CaseID          string         `json:"caseId"`
+	PostSalesCaseID string         `json:"postSalesCaseId"`
+	RefundID        string         `json:"refundId"`
+	Amount          domain.Money   `json:"amount"`
+	ApprovedAt      time.Time      `json:"approvedAt"`
+	ResultSummary   map[string]any `json:"resultSummary"`
+	RefundDecision  map[string]any `json:"refundDecision"`
 }
 
-func (h *InboundHandler) handleRefundApproved(ctx context.Context, envelope kitmsg.EventEnvelope) error {
-	var payload refundApproved
+func (h *InboundHandler) handleRefundApplied(ctx context.Context, envelope kitmsg.EventEnvelope) error {
+	var payload refundApplied
 	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
 		return nil
 	}
-	if strings.TrimSpace(payload.PolicyID) == "" || payload.Amount.MinorUnits <= 0 {
+	journeyOrderID := firstNonBlank(payload.JourneyOrderID, payload.OrderID)
+	if strings.TrimSpace(payload.PolicyID) == "" && journeyOrderID == "" {
 		return nil
 	}
-	_, err := h.service.FileClaim(ctx, application.FileClaimCommand{PolicyID: payload.PolicyID, ClaimType: string(domain.ClaimServiceFailureManual), TriggerFactKey: firstNonBlank(payload.RefundID, envelope.EventID), SupportCaseID: "refund-approved:" + firstNonBlank(payload.RefundID, envelope.EventID), EvidenceRefs: []string{envelope.EventID}, ClaimedAmount: payload.Amount, CorrelationID: envelope.CorrelationID, CausationID: envelope.EventID})
+	if !refundWasApplied(payload) {
+		return nil
+	}
+	_, err := h.service.CancelPolicyForRefund(ctx, application.RefundAppliedCommand{PolicyID: payload.PolicyID, JourneyOrderID: journeyOrderID, RefundID: firstNonBlank(payload.RefundID, payload.CaseID, payload.PostSalesCaseID, envelope.EventID), CorrelationID: envelope.CorrelationID, CausationID: envelope.EventID})
+	return err
+}
+
+func refundWasApplied(payload refundApplied) bool {
+	if boolField(payload.RefundDecision, "refunded") || boolField(payload.RefundDecision, "eligible") || textContains(payload.RefundDecision, "kind", "REFUND") {
+		return true
+	}
+	if boolField(payload.ResultSummary, "refund") || boolField(payload.ResultSummary, "refunded") {
+		return true
+	}
+	if textContains(payload.ResultSummary, "description", "refund") {
+		return true
+	}
+	return payload.RefundID != "" || payload.Amount.MinorUnits > 0 || payload.CaseID != "" || payload.PostSalesCaseID != ""
+}
+
+func boolField(values map[string]any, key string) bool {
+	v, ok := values[key].(bool)
+	return ok && v
+}
+
+func textContains(values map[string]any, key, needle string) bool {
+	v, ok := values[key].(string)
+	return ok && strings.Contains(strings.ToUpper(v), strings.ToUpper(needle))
+}
+
+type trainDelayed struct {
+	SegmentRef            string    `json:"segmentRef"`
+	ServiceDate           string    `json:"serviceDate"`
+	DelayMinutes          int       `json:"delayMinutes"`
+	OccurredAt            time.Time `json:"occurredAt"`
+	EstimatedNewDeparture time.Time `json:"estimatedNewDeparture"`
+}
+
+func (h *InboundHandler) handleTrainDelayed(ctx context.Context, envelope kitmsg.EventEnvelope) error {
+	var payload trainDelayed
+	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
+		return nil
+	}
+	if payload.OccurredAt.IsZero() {
+		payload.OccurredAt = payload.EstimatedNewDeparture
+	}
+	if payload.OccurredAt.IsZero() {
+		payload.OccurredAt = envelope.OccurredAt
+	}
+	_, err := h.service.ProcessTrainDelayed(ctx, application.TrainDelayedCommand{SegmentRef: payload.SegmentRef, ServiceDate: payload.ServiceDate, DelayMinutes: payload.DelayMinutes, OccurredAt: payload.OccurredAt, SourceEventID: envelope.EventID, CorrelationID: envelope.CorrelationID, CausationID: envelope.EventID})
 	return err
 }
 

--- a/services/travel-insurance/adapters/messaging/subscriber_test.go
+++ b/services/travel-insurance/adapters/messaging/subscriber_test.go
@@ -48,6 +48,91 @@ func makeEnvelope(t *testing.T, eventType string, payload any, occurredAt time.T
 	return env
 }
 
+func TestHandleJourneyOrderCreated_IssuesPolicy(t *testing.T) {
+	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+	pub := &capturePublisher{}
+	svc := newTestService(t, now, pub)
+	handler := NewInboundHandler(svc)
+
+	envelope := makeEnvelope(t, "JourneyOrderCreated", map[string]any{
+		"orderId":      "ord-created",
+		"accountId":    "acc-created",
+		"segmentRefs":  []string{"seg-created"},
+		"travelerRefs": []map[string]any{{"travelerId": "tvl-created", "travelerType": "ADULT"}},
+		"createdAt":    now.Format(time.RFC3339),
+	}, now)
+
+	if err := handler.Handle(context.Background(), envelope); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(pub.events) != 1 || pub.events[0].EventType != "InsurancePolicyIssued" {
+		t.Fatalf("expected policy issued from JourneyOrderCreated, got %#v", pub.events)
+	}
+}
+
+func TestHandleTrainDelayed_TriggersAutoPayout(t *testing.T) {
+	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+	pub := &capturePublisher{}
+	svc := newTestService(t, now, pub)
+	handler := NewInboundHandler(svc)
+	_, err := svc.IssuePolicy(context.Background(), application.IssuePolicyCommand{ProductCode: string(domain.ProductDelayInsurance), ProductVersion: "v1", JourneyOrderID: "ord-delay", AncillaryOrderItemID: "anc-delay", AccountID: "acc-delay", TravelerRef: "tvl-delay", SegmentRefs: []string{"seg-delay"}, PaymentIntentID: "pi-delay", CoverageStartAt: now.Add(-time.Minute), CoverageEndAt: now.Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelope := makeEnvelope(t, "TrainDelayed", map[string]any{
+		"serviceRef":            "svc-delay",
+		"segmentRef":            "seg-delay",
+		"delayMinutes":          90,
+		"estimatedNewDeparture": now.Format(time.RFC3339),
+	}, now)
+	if err := handler.Handle(context.Background(), envelope); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	policy, err := svc.GetPolicy(context.Background(), "pol-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if policy.Status != domain.PolicyPaidOut {
+		t.Fatalf("status = %s, want PAID_OUT", policy.Status)
+	}
+	if got := pub.events[len(pub.events)-1].EventType; got != "InsurancePayoutCompleted" {
+		t.Fatalf("last event = %s, want InsurancePayoutCompleted", got)
+	}
+}
+
+func TestHandlePostSalesApplied_CancelsRefundedPolicy(t *testing.T) {
+	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+	pub := &capturePublisher{}
+	svc := newTestService(t, now, pub)
+	handler := NewInboundHandler(svc)
+	_, err := svc.IssuePolicy(context.Background(), application.IssuePolicyCommand{ProductCode: string(domain.ProductDelayInsurance), ProductVersion: "v1", JourneyOrderID: "ord-refund", AncillaryOrderItemID: "anc-refund", AccountID: "acc-refund", TravelerRef: "tvl-refund", SegmentRefs: []string{"seg-refund"}, PaymentIntentID: "pi-refund", CoverageStartAt: now.Add(-time.Minute), CoverageEndAt: now.Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envelope := makeEnvelope(t, "PostSalesApplied", map[string]any{
+		"caseId":        "psc-refund",
+		"orderId":       "ord-refund",
+		"resultSummary": map[string]any{"description": "refund executed"},
+	}, now)
+	if err := handler.Handle(context.Background(), envelope); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	policy, err := svc.GetPolicy(context.Background(), "pol-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if policy.Status != domain.PolicyCancelled || policy.RefundedPremium.MinorUnits != 300 {
+		t.Fatalf("unexpected policy after PostSalesApplied: %#v", policy)
+	}
+	if got := pub.events[len(pub.events)-1].EventType; got != "InsurancePolicyCancelled" {
+		t.Fatalf("last event = %s, want InsurancePolicyCancelled", got)
+	}
+}
+
 func TestHandleJourneyOrderConfirmed_NewPayloadFormat(t *testing.T) {
 	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
 	pub := &capturePublisher{}
@@ -70,8 +155,8 @@ func TestHandleJourneyOrderConfirmed_NewPayloadFormat(t *testing.T) {
 	if len(pub.events) != 1 {
 		t.Fatalf("expected 1 published event, got %d", len(pub.events))
 	}
-	if pub.events[0].EventType != "PolicyIssued" {
-		t.Fatalf("expected PolicyIssued event, got %s", pub.events[0].EventType)
+	if pub.events[0].EventType != "InsurancePolicyIssued" {
+		t.Fatalf("expected InsurancePolicyIssued event, got %s", pub.events[0].EventType)
 	}
 
 	var payload map[string]any
@@ -96,18 +181,18 @@ func TestHandleJourneyOrderConfirmed_LegacyPayloadFormat(t *testing.T) {
 	handler := NewInboundHandler(svc)
 
 	envelope := makeEnvelope(t, "JourneyOrderConfirmed", map[string]any{
-		"orderId":        "ord-002",
-		"accountId":      "acc-002",
-		"travelerRef":    "trav-002",
-		"segmentRefs":    []string{"seg-002"},
+		"orderId":         "ord-002",
+		"accountId":       "acc-002",
+		"travelerRef":     "trav-002",
+		"segmentRefs":     []string{"seg-002"},
 		"paymentIntentId": "pi-002",
 	}, now)
 
 	if err := handler.Handle(context.Background(), envelope); err != nil {
 		t.Fatalf("Handle: %v", err)
 	}
-	if len(pub.events) != 1 || pub.events[0].EventType != "PolicyIssued" {
-		t.Fatalf("expected 1 PolicyIssued event, got %v", pub.events)
+	if len(pub.events) != 1 || pub.events[0].EventType != "InsurancePolicyIssued" {
+		t.Fatalf("expected 1 InsurancePolicyIssued event, got %v", pub.events)
 	}
 }
 

--- a/services/travel-insurance/adapters/postgres/repository.go
+++ b/services/travel-insurance/adapters/postgres/repository.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/trainticket/greenfield/platform/go-kit/storage"
@@ -46,8 +47,8 @@ func (r *Repository) FindPolicy(ctx context.Context, id string) (domain.Policy, 
 	var policy domain.Policy
 	return policy, json.Unmarshal(snap.Data, &policy)
 }
-func (r *Repository) FindPolicyByUniqueness(ctx context.Context, ancillaryID, travelerRef, segmentScopeHash, productVersion string) (domain.Policy, error) {
-	rows, err := r.db.DBFor(ctx).Query(ctx, `SELECT data FROM policy_snapshots WHERE data->>'ancillaryOrderItemId' = $1 AND data->>'travelerRef' = $2 AND data->>'productVersion' = $3`, strings.TrimSpace(ancillaryID), strings.TrimSpace(travelerRef), strings.TrimSpace(productVersion))
+func (r *Repository) FindPolicyByUniqueness(ctx context.Context, productCode domain.ProductCode, ancillaryID, travelerRef, segmentScopeHash, productVersion string) (domain.Policy, error) {
+	rows, err := r.db.DBFor(ctx).Query(ctx, `SELECT data FROM policy_snapshots WHERE data->>'productCode' = $1 AND data->>'ancillaryOrderItemId' = $2 AND data->>'travelerRef' = $3 AND data->>'productVersion' = $4`, string(productCode), strings.TrimSpace(ancillaryID), strings.TrimSpace(travelerRef), strings.TrimSpace(productVersion))
 	if err != nil {
 		return domain.Policy{}, err
 	}
@@ -61,7 +62,7 @@ func (r *Repository) FindPolicyByUniqueness(ctx context.Context, ancillaryID, tr
 		if err := json.Unmarshal(raw, &policy); err != nil {
 			return domain.Policy{}, err
 		}
-		if policy.SegmentScopeHash() == segmentScopeHash {
+		if policy.ProductCode == productCode && policy.SegmentScopeHash() == segmentScopeHash {
 			return policy, nil
 		}
 	}
@@ -70,6 +71,41 @@ func (r *Repository) FindPolicyByUniqueness(ctx context.Context, ancillaryID, tr
 	}
 	return domain.Policy{}, application.ErrNotFound
 }
+
+func (r *Repository) FindIssuedPoliciesForSegment(ctx context.Context, code domain.ProductCode, segmentRef string, occurredAt time.Time) ([]domain.Policy, error) {
+	rows, err := r.db.DBFor(ctx).Query(ctx, `SELECT data FROM policy_snapshots WHERE data->>'productCode' = $1 AND data->>'status' = $2 AND data->'segmentRefs' ? $3 AND (data->>'coverageStartAt')::timestamptz <= $4 AND (data->>'coverageEndAt')::timestamptz >= $4`, string(code), string(domain.PolicyIssued), strings.TrimSpace(segmentRef), occurredAt.UTC())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	policies := []domain.Policy{}
+	for rows.Next() {
+		var raw json.RawMessage
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		var policy domain.Policy
+		if err := json.Unmarshal(raw, &policy); err != nil {
+			return nil, err
+		}
+		policies = append(policies, policy)
+	}
+	return policies, rows.Err()
+}
+
+func (r *Repository) FindIssuedPolicyByJourneyOrder(ctx context.Context, journeyOrderID string) (domain.Policy, error) {
+	row := r.db.DBFor(ctx).QueryRow(ctx, `SELECT data FROM policy_snapshots WHERE data->>'journeyOrderId' = $1 AND data->>'status' = $2 LIMIT 1`, strings.TrimSpace(journeyOrderID), string(domain.PolicyIssued))
+	var raw json.RawMessage
+	if err := row.Scan(&raw); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.Policy{}, application.ErrNotFound
+		}
+		return domain.Policy{}, err
+	}
+	var policy domain.Policy
+	return policy, json.Unmarshal(raw, &policy)
+}
+
 func (r *Repository) SaveClaim(ctx context.Context, claim domain.Claim) error {
 	return saveJSON(ctx, r.db.DBFor(ctx), "claim_snapshots", claim.ID, claim)
 }

--- a/services/travel-insurance/api/router.go
+++ b/services/travel-insurance/api/router.go
@@ -19,22 +19,25 @@ import (
 type Handler struct{ service *application.InsuranceService }
 
 type issuePolicyRequest struct {
-	ProductCode          string    `json:"productCode"`
-	ProductVersion       string    `json:"productVersion"`
-	JourneyOrderID       string    `json:"journeyOrderId"`
-	AncillaryOrderItemID string    `json:"ancillaryOrderItemId"`
-	AccountID            string    `json:"accountId"`
-	TravelerRef          string    `json:"travelerRef"`
-	SegmentRefs          []string  `json:"segmentRefs"`
-	PaymentIntentID      string    `json:"paymentIntentId"`
-	CoverageStartAt      time.Time `json:"coverageStartAt"`
-	CoverageEndAt        time.Time `json:"coverageEndAt"`
+	ProductCode          string       `json:"productCode"`
+	ProductVersion       string       `json:"productVersion"`
+	JourneyOrderID       string       `json:"journeyOrderId"`
+	AncillaryOrderItemID string       `json:"ancillaryOrderItemId"`
+	AccountID            string       `json:"accountId"`
+	TravelerRef          string       `json:"travelerRef"`
+	SegmentRefs          []string     `json:"segmentRefs"`
+	PaymentIntentID      string       `json:"paymentIntentId"`
+	CoverageStartAt      time.Time    `json:"coverageStartAt"`
+	CoverageEndAt        time.Time    `json:"coverageEndAt"`
+	TicketPrice          domain.Money `json:"ticketPrice"`
+	RouteDistance        int          `json:"routeDistance"`
 }
 
 type fileClaimRequest struct {
 	PolicyID       string            `json:"policyId"`
 	ClaimType      string            `json:"claimType"`
 	TriggerFactKey string            `json:"triggerFactKey"`
+	Description    string            `json:"description"`
 	DelayFact      *domain.DelayFact `json:"delayFact"`
 	SupportCaseID  string            `json:"supportCaseId"`
 	EvidenceRefs   []string          `json:"evidenceRefs"`
@@ -72,6 +75,9 @@ func RegisterRoutes(router gin.IRouter, service *application.InsuranceService, s
 	api.POST("/policies", idempotent, h.issuePolicy)
 	api.GET("/policies/:id", h.getPolicy)
 	api.POST("/claims", idempotent, h.fileClaim)
+	api.GET("/claims/:id", h.getClaim)
+	api.POST("/claims/:id/approve", idempotent, h.approveClaim)
+	api.POST("/claims/:id/reject", idempotent, h.rejectClaim)
 }
 
 func (h Handler) issuePolicy(ctx *gin.Context) {
@@ -83,7 +89,7 @@ func (h Handler) issuePolicy(ctx *gin.Context) {
 	if strings.TrimSpace(req.ProductVersion) == "" {
 		req.ProductVersion = "v1"
 	}
-	policy, err := h.service.IssuePolicy(ctx.Request.Context(), application.IssuePolicyCommand{ProductCode: req.ProductCode, ProductVersion: req.ProductVersion, JourneyOrderID: req.JourneyOrderID, AncillaryOrderItemID: req.AncillaryOrderItemID, AccountID: req.AccountID, TravelerRef: req.TravelerRef, SegmentRefs: req.SegmentRefs, PaymentIntentID: req.PaymentIntentID, CoverageStartAt: req.CoverageStartAt, CoverageEndAt: req.CoverageEndAt, CorrelationID: httpkit.CorrelationID(ctx), CausationID: ctx.GetHeader("X-Causation-Id")})
+	policy, err := h.service.IssuePolicy(ctx.Request.Context(), application.IssuePolicyCommand{ProductCode: req.ProductCode, ProductVersion: req.ProductVersion, JourneyOrderID: req.JourneyOrderID, AncillaryOrderItemID: req.AncillaryOrderItemID, AccountID: req.AccountID, TravelerRef: req.TravelerRef, SegmentRefs: req.SegmentRefs, PaymentIntentID: req.PaymentIntentID, CoverageStartAt: req.CoverageStartAt, CoverageEndAt: req.CoverageEndAt, TicketPrice: req.TicketPrice, RouteDistance: req.RouteDistance, CorrelationID: httpkit.CorrelationID(ctx), CausationID: ctx.GetHeader("X-Causation-Id")})
 	if err != nil {
 		writeMappedError(ctx, err)
 		return
@@ -106,7 +112,7 @@ func (h Handler) fileClaim(ctx *gin.Context) {
 		httpkit.WriteError(ctx, http.StatusBadRequest, httpkit.ValidationFailed, "Request body failed structural validation", nil)
 		return
 	}
-	claim, err := h.service.FileClaim(ctx.Request.Context(), application.FileClaimCommand{PolicyID: req.PolicyID, ClaimType: req.ClaimType, TriggerFactKey: req.TriggerFactKey, DelayFact: req.DelayFact, SupportCaseID: req.SupportCaseID, EvidenceRefs: req.EvidenceRefs, ClaimedAmount: req.ClaimedAmount, CorrelationID: httpkit.CorrelationID(ctx), CausationID: ctx.GetHeader("X-Causation-Id")})
+	claim, err := h.service.FileClaim(ctx.Request.Context(), application.FileClaimCommand{PolicyID: req.PolicyID, ClaimType: req.ClaimType, TriggerFactKey: req.TriggerFactKey, Description: req.Description, DelayFact: req.DelayFact, SupportCaseID: req.SupportCaseID, EvidenceRefs: req.EvidenceRefs, ClaimedAmount: req.ClaimedAmount, CorrelationID: httpkit.CorrelationID(ctx), CausationID: ctx.GetHeader("X-Causation-Id")})
 	if err != nil {
 		writeMappedError(ctx, err)
 		return
@@ -124,9 +130,43 @@ func (h Handler) fileClaim(ctx *gin.Context) {
 		}
 		resp.PayoutAdvice = &advice
 		resp.Claim.PayoutAdviceID = advice.ID
-		resp.Claim.Status = domain.ClaimPayoutRecommended
+		resp.Claim.Status = domain.ClaimPaidOut
 	}
 	ctx.JSON(http.StatusCreated, resp)
+}
+
+func (h Handler) getClaim(ctx *gin.Context) {
+	claim, err := h.service.GetClaim(ctx.Request.Context(), ctx.Param("id"))
+	if err != nil {
+		writeMappedError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, claim)
+}
+
+func (h Handler) approveClaim(ctx *gin.Context) {
+	advice, err := h.service.ApproveClaim(ctx.Request.Context(), application.SettleClaimCommand{ClaimID: ctx.Param("id"), PayoutTarget: string(domain.PayoutPaymentRefund), CorrelationID: httpkit.CorrelationID(ctx), CausationID: ctx.GetHeader("X-Causation-Id")})
+	if err != nil {
+		writeMappedError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, advice)
+}
+
+func (h Handler) rejectClaim(ctx *gin.Context) {
+	var req struct {
+		ReasonCode string `json:"reasonCode"`
+	}
+	if err := bindBody(ctx, &req); err != nil {
+		httpkit.WriteError(ctx, http.StatusBadRequest, httpkit.ValidationFailed, "Request body failed structural validation", nil)
+		return
+	}
+	claim, err := h.service.RejectClaim(ctx.Request.Context(), application.RejectClaimCommand{ClaimID: ctx.Param("id"), ReasonCode: req.ReasonCode, CorrelationID: httpkit.CorrelationID(ctx), CausationID: ctx.GetHeader("X-Causation-Id")})
+	if err != nil {
+		writeMappedError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, claim)
 }
 
 func bindBody(ctx *gin.Context, target any) error {

--- a/services/travel-insurance/api/router_test.go
+++ b/services/travel-insurance/api/router_test.go
@@ -24,7 +24,7 @@ func TestPolicyAndClaimHTTPFlow(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &policy); err != nil {
 		t.Fatal(err)
 	}
-	if policy.PolicyID == "" || policy.Status != "ACTIVE" {
+	if policy.PolicyID == "" || policy.Status != "ISSUED" {
 		t.Fatalf("policy response: %#v", policy)
 	}
 	w = performJSON(router, http.MethodGet, "/api/v1/policies/"+policy.PolicyID, nil)
@@ -47,7 +47,7 @@ func TestPolicyAndClaimHTTPFlow(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &claimResp); err != nil {
 		t.Fatal(err)
 	}
-	if claimResp.Claim.Status != "PAYOUT_RECOMMENDED" || claimResp.PayoutAdvice == nil {
+	if claimResp.Claim.Status != "PAID_OUT" || claimResp.PayoutAdvice == nil {
 		t.Fatalf("claim response: %#v", claimResp)
 	}
 }

--- a/services/travel-insurance/application/ports.go
+++ b/services/travel-insurance/application/ports.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"errors"
+	"time"
 
 	kitmsg "github.com/trainticket/greenfield/platform/go-kit/messaging"
 	"github.com/trainticket/greenfield/services/travel-insurance/domain"
@@ -21,7 +22,9 @@ type Repository interface {
 	FindPublishedProduct(context.Context, domain.ProductCode, string) (domain.InsuranceProduct, error)
 	SavePolicy(context.Context, domain.Policy) error
 	FindPolicy(context.Context, string) (domain.Policy, error)
-	FindPolicyByUniqueness(context.Context, string, string, string, string) (domain.Policy, error)
+	FindPolicyByUniqueness(context.Context, domain.ProductCode, string, string, string, string) (domain.Policy, error)
+	FindIssuedPoliciesForSegment(context.Context, domain.ProductCode, string, time.Time) ([]domain.Policy, error)
+	FindIssuedPolicyByJourneyOrder(context.Context, string) (domain.Policy, error)
 	SaveClaim(context.Context, domain.Claim) error
 	FindClaim(context.Context, string) (domain.Claim, error)
 	FindActiveClaim(context.Context, string, domain.ClaimType, string) (domain.Claim, error)

--- a/services/travel-insurance/application/service.go
+++ b/services/travel-insurance/application/service.go
@@ -61,13 +61,19 @@ func (s *InsuranceService) seedProducts() {
 	now := s.clock.Now()
 	start := now.Add(-24 * time.Hour)
 	end := now.AddDate(2, 0, 0)
-	premiumDelay, _ := domain.NewMoney("CNY", 500)
+	premiumDelay, _ := domain.NewMoney("CNY", 300)
 	limitDelay, _ := domain.NewMoney("CNY", 3000)
-	premiumAccident, _ := domain.NewMoney("CNY", 1200)
-	limitAccident, _ := domain.NewMoney("CNY", 200000)
+	premiumCancellation, _ := domain.NewMoney("CNY", 1)
+	limitCancellation, _ := domain.NewMoney("CNY", 1)
+	premiumAccident, _ := domain.NewMoney("CNY", 500)
+	limitAccident, _ := domain.NewMoney("CNY", 50000000)
+	premiumBaggage, _ := domain.NewMoney("CNY", 200)
+	limitBaggage, _ := domain.NewMoney("CNY", 200000)
 	for _, p := range []domain.InsuranceProduct{
 		mustPublishedProduct("ip-delay-v1", domain.ProductDelayInsurance, "v1", premiumDelay, limitDelay, start, end, now),
+		mustPublishedProduct("ip-cancellation-v1", domain.ProductCancellationInsurance, "v1", premiumCancellation, limitCancellation, start, end, now),
 		mustPublishedProduct("ip-accident-v1", domain.ProductAccidentInsurance, "v1", premiumAccident, limitAccident, start, end, now),
+		mustPublishedProduct("ip-baggage-v1", domain.ProductBaggageInsurance, "v1", premiumBaggage, limitBaggage, start, end, now),
 	} {
 		s.products[productKey(p.ProductCode, p.Version)] = p
 	}
@@ -96,6 +102,8 @@ type IssuePolicyCommand struct {
 	PaymentIntentID      string
 	CoverageStartAt      time.Time
 	CoverageEndAt        time.Time
+	TicketPrice          domain.Money
+	RouteDistance        int
 	CorrelationID        string
 	CausationID          string
 }
@@ -104,6 +112,7 @@ type FileClaimCommand struct {
 	PolicyID       string
 	ClaimType      string
 	TriggerFactKey string
+	Description    string
 	DelayFact      *domain.DelayFact
 	SupportCaseID  string
 	EvidenceRefs   []string
@@ -120,6 +129,31 @@ type SettleClaimCommand struct {
 	CausationID   string
 }
 
+type RejectClaimCommand struct {
+	ClaimID       string
+	ReasonCode    string
+	CorrelationID string
+	CausationID   string
+}
+
+type TrainDelayedCommand struct {
+	SegmentRef    string
+	ServiceDate   string
+	DelayMinutes  int
+	OccurredAt    time.Time
+	SourceEventID string
+	CorrelationID string
+	CausationID   string
+}
+
+type RefundAppliedCommand struct {
+	PolicyID       string
+	JourneyOrderID string
+	RefundID       string
+	CorrelationID  string
+	CausationID    string
+}
+
 func (s *InsuranceService) IssuePolicy(ctx context.Context, cmd IssuePolicyCommand) (domain.Policy, error) {
 	if err := validateIssuePolicy(cmd); err != nil {
 		return domain.Policy{}, err
@@ -127,6 +161,22 @@ func (s *InsuranceService) IssuePolicy(ctx context.Context, cmd IssuePolicyComma
 	product, err := s.findProduct(ctx, domain.ProductCode(strings.TrimSpace(cmd.ProductCode)), strings.TrimSpace(cmd.ProductVersion))
 	if err != nil {
 		return domain.Policy{}, err
+	}
+	premium := product.Premium
+	if product.ProductCode == domain.ProductCancellationInsurance {
+		premium, err = (domain.PremiumCalculator{}).CalculatePremium(product, cmd.TicketPrice, cmd.RouteDistance)
+		if err != nil {
+			return domain.Policy{}, fmt.Errorf("%w: %v", ErrDomainRule, err)
+		}
+	}
+	product.Premium = premium
+	if product.ProductCode == domain.ProductCancellationInsurance {
+		limitMinor := cmd.TicketPrice.MinorUnits * 80 / 100
+		if limitMinor <= 0 {
+			limitMinor = 1
+		}
+		product.CoverageLimit, _ = domain.NewMoney(cmd.TicketPrice.Currency, limitMinor)
+		product.MaxPayout = product.CoverageLimit
 	}
 	policy, err := domain.NewIssuedPolicy(domain.PolicyIssueRequest{PolicyID: s.idGenerator("pol"), Product: product, JourneyOrderID: cmd.JourneyOrderID, AncillaryOrderItemID: cmd.AncillaryOrderItemID, AccountID: cmd.AccountID, TravelerRef: cmd.TravelerRef, SegmentRefs: cmd.SegmentRefs, PaymentIntentID: cmd.PaymentIntentID, CoverageStartAt: cmd.CoverageStartAt, CoverageEndAt: cmd.CoverageEndAt, Now: s.clock.Now()})
 	if err != nil {
@@ -137,7 +187,7 @@ func (s *InsuranceService) IssuePolicy(ctx context.Context, cmd IssuePolicyComma
 	} else if ok {
 		return existing, nil
 	}
-	envelope, err := s.newEnvelope(ctx, "PolicyIssued", cmd.CorrelationID, cmd.CausationID, map[string]any{"policyId": policy.ID, "policyNumber": policy.PolicyNumber, "productCode": policy.ProductCode, "productVersion": policy.ProductVersion, "journeyOrderId": policy.JourneyOrderID, "ancillaryOrderItemId": policy.AncillaryOrderItemID, "accountId": policy.AccountID, "travelerRef": policy.TravelerRef, "segmentRefs": policy.SegmentRefs, "premium": policy.Premium, "coverageLimit": policy.CoverageLimit, "coverageStartAt": policy.CoverageStartAt, "coverageEndAt": policy.CoverageEndAt, "status": policy.Status})
+	envelope, err := s.newEnvelope(ctx, "InsurancePolicyIssued", cmd.CorrelationID, cmd.CausationID, policyIssuedPayload(policy))
 	if err != nil {
 		return domain.Policy{}, err
 	}
@@ -195,72 +245,191 @@ func (s *InsuranceService) FileClaim(ctx context.Context, cmd FileClaimCommand) 
 	if err != nil {
 		return domain.Claim{}, fmt.Errorf("%w: %v", ErrDomainRule, err)
 	}
-	eventType := "ClaimFiled"
-	payload := map[string]any{"claimId": claim.ID, "policyId": claim.PolicyID, "claimType": claim.ClaimType, "triggerFactKey": claim.TriggerFactKey, "status": claim.Status, "claimedAmount": claim.ClaimedAmount, "approvedAmount": claim.ApprovedAmount, "supportCaseId": claim.SupportCaseID, "evidenceRefs": claim.EvidenceRefs}
-	if claim.DelayFact != nil {
-		payload["delayFact"] = claim.DelayFact
+	claim.Description = strings.TrimSpace(cmd.Description)
+	if err := policy.MarkClaimed(s.clock.Now()); err != nil {
+		return domain.Claim{}, fmt.Errorf("%w: %v", ErrDomainRule, err)
 	}
-	envelope, err := s.newEnvelope(ctx, eventType, cmd.CorrelationID, cmd.CausationID, payload)
+	envelopes := []kitmsg.EventEnvelope{}
+	created, err := s.newEnvelope(ctx, "InsuranceClaimCreated", cmd.CorrelationID, cmd.CausationID, claimPayload(claim))
 	if err != nil {
 		return domain.Claim{}, err
 	}
-	if err := s.within(ctx, func(tx context.Context) error {
-		if s.repository != nil {
-			if err := s.repository.SaveClaim(tx, claim); err != nil {
-				return mapRepoErr(err)
-			}
+	envelopes = append(envelopes, created)
+	if claim.Status == domain.ClaimApproved {
+		approved, err := s.newEnvelope(ctx, "InsuranceClaimApproved", cmd.CorrelationID, claim.ID, claimPayload(claim))
+		if err != nil {
+			return domain.Claim{}, err
 		}
-		if err := s.publisher.Publish(tx, envelope); err != nil {
-			return fmt.Errorf("%w: %v", ErrPublish, err)
-		}
-		return nil
-	}); err != nil {
+		envelopes = append(envelopes, approved)
+	}
+	if err := s.savePolicyClaimAndPublish(ctx, policy, claim, domain.PayoutAdvice{}, envelopes); err != nil {
 		return domain.Claim{}, err
 	}
-	s.mu.Lock()
-	s.claims[claim.ID] = claim
-	s.mu.Unlock()
 	return claim, nil
 }
 
-func (s *InsuranceService) SettleClaim(ctx context.Context, cmd SettleClaimCommand) (domain.PayoutAdvice, error) {
-	claimID := strings.TrimSpace(cmd.ClaimID)
-	if claimID == "" {
-		return domain.PayoutAdvice{}, fmt.Errorf("%w: claim id is required", ErrValidation)
+func (s *InsuranceService) GetClaim(ctx context.Context, id string) (domain.Claim, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return domain.Claim{}, fmt.Errorf("%w: claim id is required", ErrValidation)
 	}
-	claim, err := s.findClaim(ctx, claimID)
+	return s.findClaim(ctx, id)
+}
+
+func (s *InsuranceService) ApproveClaim(ctx context.Context, cmd SettleClaimCommand) (domain.PayoutAdvice, error) {
+	claim, policy, err := s.claimAndPolicy(ctx, cmd.ClaimID)
 	if err != nil {
 		return domain.PayoutAdvice{}, err
 	}
-	advice, err := claim.Settle(s.idGenerator("pad"), domain.PayoutTarget(strings.TrimSpace(cmd.PayoutTarget)), strings.TrimSpace(cmd.ReasonCode))
+	if claim.Status == domain.ClaimPending {
+		if err := claim.Approve(claim.ClaimedAmount); err != nil {
+			return domain.PayoutAdvice{}, fmt.Errorf("%w: %v", ErrDomainRule, err)
+		}
+	}
+	advice, err := claim.Settle(s.idGenerator("pad"), payoutTargetOrDefault(cmd.PayoutTarget), strings.TrimSpace(cmd.ReasonCode))
 	if err != nil {
 		return domain.PayoutAdvice{}, fmt.Errorf("%w: %v", ErrDomainRule, err)
 	}
-	envelope, err := s.newEnvelope(ctx, "ClaimSettled", cmd.CorrelationID, cmd.CausationID, map[string]any{"claimId": claim.ID, "policyId": claim.PolicyID, "payoutAdviceId": advice.ID, "payoutTarget": advice.PayoutTarget, "amount": advice.Amount, "reasonCode": advice.ReasonCode, "status": advice.Status})
+	if err := policy.MarkPaidOut(); err != nil {
+		return domain.PayoutAdvice{}, fmt.Errorf("%w: %v", ErrDomainRule, err)
+	}
+	approved, err := s.newEnvelope(ctx, "InsuranceClaimApproved", cmd.CorrelationID, cmd.CausationID, claimPayload(claim))
 	if err != nil {
 		return domain.PayoutAdvice{}, err
 	}
+	paid, err := s.newEnvelope(ctx, "InsurancePayoutCompleted", cmd.CorrelationID, claim.ID, payoutPayload(claim, advice))
+	if err != nil {
+		return domain.PayoutAdvice{}, err
+	}
+	if err := s.savePolicyClaimAndPublish(ctx, policy, claim, advice, []kitmsg.EventEnvelope{approved, paid}); err != nil {
+		return domain.PayoutAdvice{}, err
+	}
+	return advice, nil
+}
+
+func (s *InsuranceService) SettleClaim(ctx context.Context, cmd SettleClaimCommand) (domain.PayoutAdvice, error) {
+	return s.ApproveClaim(ctx, cmd)
+}
+
+func (s *InsuranceService) RejectClaim(ctx context.Context, cmd RejectClaimCommand) (domain.Claim, error) {
+	claim, policy, err := s.claimAndPolicy(ctx, cmd.ClaimID)
+	if err != nil {
+		return domain.Claim{}, err
+	}
+	if err := claim.Reject(cmd.ReasonCode); err != nil {
+		return domain.Claim{}, fmt.Errorf("%w: %v", ErrDomainRule, err)
+	}
+	if err := policy.MarkRejected(); err != nil {
+		return domain.Claim{}, fmt.Errorf("%w: %v", ErrDomainRule, err)
+	}
+	env, err := s.newEnvelope(ctx, "InsuranceClaimRejected", cmd.CorrelationID, cmd.CausationID, claimPayload(claim))
+	if err != nil {
+		return domain.Claim{}, err
+	}
+	if err := s.savePolicyClaimAndPublish(ctx, policy, claim, domain.PayoutAdvice{}, []kitmsg.EventEnvelope{env}); err != nil {
+		return domain.Claim{}, err
+	}
+	return claim, nil
+}
+
+func (s *InsuranceService) ProcessTrainDelayed(ctx context.Context, cmd TrainDelayedCommand) ([]domain.PayoutAdvice, error) {
+	if strings.TrimSpace(cmd.SegmentRef) == "" || cmd.DelayMinutes <= 60 {
+		return nil, nil
+	}
+	policies, err := s.findPoliciesForDelay(ctx, strings.TrimSpace(cmd.SegmentRef), cmd.OccurredAt)
+	if err != nil {
+		return nil, err
+	}
+	advices := []domain.PayoutAdvice{}
+	for _, policy := range policies {
+		amount, _ := domain.NewMoney(policy.CoverageLimit.Currency, 3000)
+		factKey := firstNonBlank(cmd.SourceEventID, fmt.Sprintf("delay:%s:%s:%d", cmd.SegmentRef, cmd.ServiceDate, cmd.DelayMinutes))
+		claim, err := s.FileClaim(ctx, FileClaimCommand{PolicyID: policy.ID, ClaimType: string(domain.ClaimDelayAuto), TriggerFactKey: factKey, DelayFact: &domain.DelayFact{SegmentRef: cmd.SegmentRef, ServiceDate: cmd.ServiceDate, SourceEventType: "TrainDelayed", SourceEventID: factKey, DelayMinutes: cmd.DelayMinutes, OccurredAt: cmd.OccurredAt}, ClaimedAmount: amount, CorrelationID: cmd.CorrelationID, CausationID: firstNonBlank(cmd.CausationID, cmd.SourceEventID)})
+		if err != nil {
+			return advices, err
+		}
+		advice, err := s.ApproveClaim(ctx, SettleClaimCommand{ClaimID: claim.ID, PayoutTarget: string(domain.PayoutPaymentRefund), ReasonCode: "TRAIN_DELAY_GT_60", CorrelationID: cmd.CorrelationID, CausationID: claim.ID})
+		if err != nil {
+			return advices, err
+		}
+		advices = append(advices, advice)
+	}
+	return advices, nil
+}
+
+func (s *InsuranceService) CancelPolicyForRefund(ctx context.Context, cmd RefundAppliedCommand) (domain.Policy, error) {
+	policy, err := s.findPolicyForRefund(ctx, cmd.PolicyID, cmd.JourneyOrderID)
+	if err != nil {
+		return domain.Policy{}, err
+	}
+	refund, err := policy.CancelForRefund()
+	if err != nil {
+		return domain.Policy{}, fmt.Errorf("%w: %v", ErrDomainRule, err)
+	}
+	env, err := s.newEnvelope(ctx, "InsurancePolicyCancelled", cmd.CorrelationID, cmd.CausationID, map[string]any{"policyId": policy.ID, "journeyOrderId": policy.JourneyOrderID, "refundId": cmd.RefundID, "refundedPremium": refund, "status": policy.Status})
+	if err != nil {
+		return domain.Policy{}, err
+	}
 	if err := s.within(ctx, func(tx context.Context) error {
 		if s.repository != nil {
+			if err := s.repository.SavePolicy(tx, policy); err != nil {
+				return mapRepoErr(err)
+			}
+		}
+		return s.publisher.Publish(tx, env)
+	}); err != nil {
+		return domain.Policy{}, err
+	}
+	s.mu.Lock()
+	s.policies[policy.ID] = policy
+	s.mu.Unlock()
+	return policy, nil
+}
+
+func (s *InsuranceService) savePolicyClaimAndPublish(ctx context.Context, policy domain.Policy, claim domain.Claim, advice domain.PayoutAdvice, envelopes []kitmsg.EventEnvelope) error {
+	if err := s.within(ctx, func(tx context.Context) error {
+		if s.repository != nil {
+			if err := s.repository.SavePolicy(tx, policy); err != nil {
+				return mapRepoErr(err)
+			}
 			if err := s.repository.SaveClaim(tx, claim); err != nil {
 				return mapRepoErr(err)
 			}
-			if err := s.repository.SavePayoutAdvice(tx, advice); err != nil {
-				return mapRepoErr(err)
+			if advice.ID != "" {
+				if err := s.repository.SavePayoutAdvice(tx, advice); err != nil {
+					return mapRepoErr(err)
+				}
 			}
 		}
-		if err := s.publisher.Publish(tx, envelope); err != nil {
-			return fmt.Errorf("%w: %v", ErrPublish, err)
+		for _, envelope := range envelopes {
+			if err := s.publisher.Publish(tx, envelope); err != nil {
+				return fmt.Errorf("%w: %v", ErrPublish, err)
+			}
 		}
 		return nil
 	}); err != nil {
-		return domain.PayoutAdvice{}, err
+		return err
 	}
 	s.mu.Lock()
+	s.policies[policy.ID] = policy
 	s.claims[claim.ID] = claim
-	s.advices[advice.ID] = advice
+	if advice.ID != "" {
+		s.advices[advice.ID] = advice
+	}
 	s.mu.Unlock()
-	return advice, nil
+	return nil
+}
+
+func (s *InsuranceService) claimAndPolicy(ctx context.Context, claimID string) (domain.Claim, domain.Policy, error) {
+	claim, err := s.findClaim(ctx, strings.TrimSpace(claimID))
+	if err != nil {
+		return domain.Claim{}, domain.Policy{}, err
+	}
+	policy, err := s.GetPolicy(ctx, claim.PolicyID)
+	if err != nil {
+		return domain.Claim{}, domain.Policy{}, err
+	}
+	return claim, policy, nil
 }
 
 func (s *InsuranceService) findProduct(ctx context.Context, code domain.ProductCode, version string) (domain.InsuranceProduct, error) {
@@ -284,7 +453,7 @@ func (s *InsuranceService) findProduct(ctx context.Context, code domain.ProductC
 
 func (s *InsuranceService) findExistingPolicy(ctx context.Context, policy domain.Policy) (domain.Policy, bool, error) {
 	if s.repository != nil {
-		p, err := s.repository.FindPolicyByUniqueness(ctx, policy.AncillaryOrderItemID, policy.TravelerRef, policy.SegmentScopeHash(), policy.ProductVersion)
+		p, err := s.repository.FindPolicyByUniqueness(ctx, policy.ProductCode, policy.AncillaryOrderItemID, policy.TravelerRef, policy.SegmentScopeHash(), policy.ProductVersion)
 		if err == nil {
 			return p, true, nil
 		}
@@ -295,7 +464,7 @@ func (s *InsuranceService) findExistingPolicy(ctx context.Context, policy domain
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, existing := range s.policies {
-		if existing.AncillaryOrderItemID == policy.AncillaryOrderItemID && existing.TravelerRef == policy.TravelerRef && existing.SegmentScopeHash() == policy.SegmentScopeHash() && existing.ProductVersion == policy.ProductVersion && !terminalPolicy(existing.Status) {
+		if existing.AncillaryOrderItemID == policy.AncillaryOrderItemID && existing.TravelerRef == policy.TravelerRef && existing.SegmentScopeHash() == policy.SegmentScopeHash() && existing.ProductVersion == policy.ProductVersion && existing.ProductCode == policy.ProductCode && !terminalPolicy(existing.Status) {
 			return existing, true, nil
 		}
 	}
@@ -335,6 +504,47 @@ func (s *InsuranceService) findClaim(ctx context.Context, id string) (domain.Cla
 	return claim, nil
 }
 
+func (s *InsuranceService) findPoliciesForDelay(ctx context.Context, segmentRef string, occurredAt time.Time) ([]domain.Policy, error) {
+	if s.repository != nil {
+		return s.repository.FindIssuedPoliciesForSegment(ctx, domain.ProductDelayInsurance, segmentRef, occurredAt)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	policies := []domain.Policy{}
+	for _, policy := range s.policies {
+		if policy.ProductCode != domain.ProductDelayInsurance || !policy.CanClaim(occurredAt) {
+			continue
+		}
+		for _, ref := range policy.SegmentRefs {
+			if ref == segmentRef {
+				policies = append(policies, policy)
+				break
+			}
+		}
+	}
+	return policies, nil
+}
+
+func (s *InsuranceService) findPolicyForRefund(ctx context.Context, policyID, journeyOrderID string) (domain.Policy, error) {
+	if strings.TrimSpace(policyID) != "" {
+		return s.GetPolicy(ctx, policyID)
+	}
+	if strings.TrimSpace(journeyOrderID) == "" {
+		return domain.Policy{}, fmt.Errorf("%w: policyId or journeyOrderId is required", ErrValidation)
+	}
+	if s.repository != nil {
+		return s.repository.FindIssuedPolicyByJourneyOrder(ctx, strings.TrimSpace(journeyOrderID))
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, policy := range s.policies {
+		if policy.JourneyOrderID == strings.TrimSpace(journeyOrderID) && policy.Status == domain.PolicyIssued {
+			return policy, nil
+		}
+	}
+	return domain.Policy{}, ErrNotFound
+}
+
 func (s *InsuranceService) newEnvelope(ctx context.Context, eventType, correlationID, causationID string, payload any) (kitmsg.EventEnvelope, error) {
 	env, err := kitmsg.NewEventEnvelope(eventType, domain.ServiceID, correlationID, payload, kitmsg.EnvelopeOptions{Now: s.clock.Now(), CausationID: causationID, Context: ctx})
 	if err != nil {
@@ -357,14 +567,19 @@ func validateIssuePolicy(cmd IssuePolicyCommand) error {
 			return fmt.Errorf("%w: %s is required", ErrValidation, name)
 		}
 	}
-	if strings.TrimSpace(cmd.ProductVersion) == "" {
-		cmd.ProductVersion = "v1"
+	if !domain.SupportedProductCode(domain.ProductCode(strings.TrimSpace(cmd.ProductCode))) {
+		return fmt.Errorf("%w: unsupported productCode", ErrValidation)
 	}
 	if len(cmd.SegmentRefs) == 0 {
 		return fmt.Errorf("%w: segmentRefs are required", ErrValidation)
 	}
 	if cmd.CoverageStartAt.IsZero() || cmd.CoverageEndAt.IsZero() || !cmd.CoverageEndAt.After(cmd.CoverageStartAt) {
 		return fmt.Errorf("%w: coverage window is invalid", ErrValidation)
+	}
+	if domain.ProductCode(strings.TrimSpace(cmd.ProductCode)) == domain.ProductCancellationInsurance {
+		if err := cmd.TicketPrice.ValidatePositive(); err != nil {
+			return fmt.Errorf("%w: ticketPrice is required for cancellation insurance", ErrValidation)
+		}
 	}
 	return nil
 }
@@ -373,10 +588,36 @@ func validateFileClaim(cmd FileClaimCommand) error {
 	if strings.TrimSpace(cmd.PolicyID) == "" || strings.TrimSpace(cmd.ClaimType) == "" || strings.TrimSpace(cmd.TriggerFactKey) == "" {
 		return fmt.Errorf("%w: policyId, claimType, and triggerFactKey are required", ErrValidation)
 	}
+	if !domain.SupportedClaimType(domain.ClaimType(strings.TrimSpace(cmd.ClaimType))) {
+		return fmt.Errorf("%w: unsupported claimType", ErrValidation)
+	}
 	if err := cmd.ClaimedAmount.ValidatePositive(); err != nil {
 		return fmt.Errorf("%w: invalid claimedAmount: %v", ErrValidation, err)
 	}
 	return nil
+}
+
+func payoutTargetOrDefault(target string) domain.PayoutTarget {
+	if strings.TrimSpace(target) == "" {
+		return domain.PayoutPaymentRefund
+	}
+	return domain.PayoutTarget(strings.TrimSpace(target))
+}
+
+func policyIssuedPayload(policy domain.Policy) map[string]any {
+	return map[string]any{"policyId": policy.ID, "policyNumber": policy.PolicyNumber, "productCode": policy.ProductCode, "productType": policy.ProductCode, "productVersion": policy.ProductVersion, "journeyOrderId": policy.JourneyOrderID, "orderId": policy.JourneyOrderID, "ancillaryOrderItemId": policy.AncillaryOrderItemID, "accountId": policy.AccountID, "travelerRef": policy.TravelerRef, "segmentRefs": policy.SegmentRefs, "premium": policy.Premium, "premiumPaid": policy.Premium, "coverageLimit": policy.CoverageLimit, "coverageStartAt": policy.CoverageStartAt, "coverageEndAt": policy.CoverageEndAt, "status": policy.Status}
+}
+
+func claimPayload(claim domain.Claim) map[string]any {
+	payload := map[string]any{"claimId": claim.ID, "policyId": claim.PolicyID, "claimType": claim.ClaimType, "triggerFactKey": claim.TriggerFactKey, "description": claim.Description, "status": claim.Status, "amount": claim.ClaimedAmount, "claimedAmount": claim.ClaimedAmount, "approvedAmount": claim.ApprovedAmount, "supportCaseId": claim.SupportCaseID, "evidenceRefs": claim.EvidenceRefs}
+	if claim.DelayFact != nil {
+		payload["delayFact"] = claim.DelayFact
+	}
+	return payload
+}
+
+func payoutPayload(claim domain.Claim, advice domain.PayoutAdvice) map[string]any {
+	return map[string]any{"claimId": claim.ID, "policyId": claim.PolicyID, "payoutAdviceId": advice.ID, "payoutTarget": advice.PayoutTarget, "amount": advice.Amount, "reasonCode": advice.ReasonCode, "status": advice.Status, "idempotencyKey": advice.IdempotencyKey}
 }
 
 func productKey(code domain.ProductCode, version string) string {
@@ -386,16 +627,25 @@ func productKey(code domain.ProductCode, version string) string {
 	return string(code) + ":" + strings.TrimSpace(version)
 }
 func terminalPolicy(status domain.PolicyStatus) bool {
-	return status == domain.PolicySurrendered || status == domain.PolicyUnderwritingFailed || status == domain.PolicyExpired || status == domain.PolicyClosed
+	return status == domain.PolicyCancelled || status == domain.PolicySurrendered || status == domain.PolicyUnderwritingFailed || status == domain.PolicyExpired || status == domain.PolicyClosed || status == domain.PolicyPaidOut || status == domain.PolicyRejected
 }
 func terminalClaim(status domain.ClaimStatus) bool {
-	return status == domain.ClaimRejected || status == domain.ClaimFailed || status == domain.ClaimClosed
+	return status == domain.ClaimRejected || status == domain.ClaimFailed || status == domain.ClaimClosed || status == domain.ClaimPaidOut
 }
 func mapRepoErr(err error) error {
 	if err == nil {
 		return nil
 	}
 	return err
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
 }
 
 func EncodeEnvelope(env kitmsg.EventEnvelope) ([]byte, error) { return json.Marshal(env) }

--- a/services/travel-insurance/application/service_test.go
+++ b/services/travel-insurance/application/service_test.go
@@ -31,7 +31,7 @@ func TestIssuePolicyPublishesPolicyIssued(t *testing.T) {
 	if policy.ID != "pol-1" {
 		t.Fatalf("policy id = %s", policy.ID)
 	}
-	if len(pub.events) != 1 || pub.events[0].EventType != "PolicyIssued" {
+	if len(pub.events) != 1 || pub.events[0].EventType != "InsurancePolicyIssued" {
 		t.Fatalf("events = %#v", pub.events)
 	}
 }
@@ -50,6 +50,29 @@ func TestDuplicatePolicyIssueReturnsExistingPolicy(t *testing.T) {
 	}
 	if first.ID != second.ID {
 		t.Fatalf("expected duplicate to return existing policy, got %s and %s", first.ID, second.ID)
+	}
+}
+
+func TestDuplicatePolicyUniquenessIncludesProductCode(t *testing.T) {
+	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+	svc := NewInsuranceService(ServiceConfig{Clock: fixedClock{now}, IDGenerator: sequentialIDs()})
+	base := IssuePolicyCommand{ProductVersion: "v1", JourneyOrderID: "jo-multi", AncillaryOrderItemID: "anc-multi", AccountID: "acct-multi", TravelerRef: "trav-multi", SegmentRefs: []string{"seg-multi"}, PaymentIntentID: "pi-multi", CoverageStartAt: now.Add(-time.Minute), CoverageEndAt: now.Add(time.Hour)}
+
+	base.ProductCode = string(domain.ProductDelayInsurance)
+	delay, err := svc.IssuePolicy(context.Background(), base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base.ProductCode = string(domain.ProductBaggageInsurance)
+	baggage, err := svc.IssuePolicy(context.Background(), base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delay.ID == baggage.ID {
+		t.Fatalf("different products should issue distinct policies, got %s", delay.ID)
+	}
+	if baggage.ProductCode != domain.ProductBaggageInsurance {
+		t.Fatalf("productCode = %s, want BAGGAGE_INSURANCE", baggage.ProductCode)
 	}
 }
 
@@ -73,7 +96,7 @@ func TestFileAndSettleClaimPublishesEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SettleClaim: %v", err)
 	}
-	if len(pub.events) != 3 || pub.events[1].EventType != "ClaimFiled" || pub.events[2].EventType != "ClaimSettled" {
+	if len(pub.events) != 5 || pub.events[1].EventType != "InsuranceClaimCreated" || pub.events[4].EventType != "InsurancePayoutCompleted" {
 		t.Fatalf("events = %#v", pub.events)
 	}
 }
@@ -83,5 +106,68 @@ func sequentialIDs() func(string) string {
 	return func(prefix string) string {
 		counters[prefix]++
 		return prefix + "-" + string(rune('0'+counters[prefix]))
+	}
+}
+
+func TestDelayInsuranceAutoPayoutAndRefundCancellation(t *testing.T) {
+	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+	pub := &capturePublisher{}
+	svc := NewInsuranceService(ServiceConfig{Publisher: pub, Clock: fixedClock{now}, IDGenerator: sequentialIDs()})
+	policy, err := svc.IssuePolicy(context.Background(), IssuePolicyCommand{ProductCode: string(domain.ProductDelayInsurance), ProductVersion: "v1", JourneyOrderID: "jo-delay", AncillaryOrderItemID: "anc-delay", AccountID: "acct-delay", TravelerRef: "trav-delay", SegmentRefs: []string{"seg-delay"}, PaymentIntentID: "pi-delay", CoverageStartAt: now.Add(-time.Minute), CoverageEndAt: now.Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if policy.Premium.MinorUnits != 300 || policy.Status != domain.PolicyIssued {
+		t.Fatalf("unexpected issued policy: %#v", policy)
+	}
+	advices, err := svc.ProcessTrainDelayed(context.Background(), TrainDelayedCommand{SegmentRef: "seg-delay", ServiceDate: "2026-07-10", DelayMinutes: 90, OccurredAt: now, SourceEventID: "evt-019f5414-026a-7000-8888-000000000001"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(advices) != 1 || advices[0].Amount.MinorUnits != 3000 {
+		t.Fatalf("unexpected auto payout: %#v", advices)
+	}
+	paidPolicy, err := svc.GetPolicy(context.Background(), policy.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if paidPolicy.Status != domain.PolicyPaidOut {
+		t.Fatalf("status = %s, want PAID_OUT", paidPolicy.Status)
+	}
+
+	refundable, err := svc.IssuePolicy(context.Background(), IssuePolicyCommand{ProductCode: string(domain.ProductDelayInsurance), ProductVersion: "v1", JourneyOrderID: "jo-refund", AncillaryOrderItemID: "anc-refund", AccountID: "acct-refund", TravelerRef: "trav-refund", SegmentRefs: []string{"seg-refund"}, PaymentIntentID: "pi-refund", CoverageStartAt: now.Add(-time.Minute), CoverageEndAt: now.Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancelled, err := svc.CancelPolicyForRefund(context.Background(), RefundAppliedCommand{PolicyID: refundable.ID, RefundID: "refund-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cancelled.Status != domain.PolicyCancelled || cancelled.RefundedPremium.MinorUnits != 300 {
+		t.Fatalf("unexpected cancelled policy: %#v", cancelled)
+	}
+}
+
+func TestManualClaimPendingThenApproved(t *testing.T) {
+	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+	svc := NewInsuranceService(ServiceConfig{Clock: fixedClock{now}, IDGenerator: sequentialIDs()})
+	policy, err := svc.IssuePolicy(context.Background(), IssuePolicyCommand{ProductCode: string(domain.ProductBaggageInsurance), ProductVersion: "v1", JourneyOrderID: "jo-bag", AncillaryOrderItemID: "anc-bag", AccountID: "acct-bag", TravelerRef: "trav-bag", SegmentRefs: []string{"seg-bag"}, PaymentIntentID: "pi-bag", CoverageStartAt: now.Add(-time.Minute), CoverageEndAt: now.Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	amount, _ := domain.NewMoney("CNY", 50000)
+	claim, err := svc.FileClaim(context.Background(), FileClaimCommand{PolicyID: policy.ID, ClaimType: string(domain.ClaimBaggage), TriggerFactKey: "bag-1", Description: "lost baggage", EvidenceRefs: []string{"doc-1"}, ClaimedAmount: amount})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.Status != domain.ClaimPending {
+		t.Fatalf("status = %s, want PENDING", claim.Status)
+	}
+	advice, err := svc.ApproveClaim(context.Background(), SettleClaimCommand{ClaimID: claim.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if advice.Amount.MinorUnits != amount.MinorUnits {
+		t.Fatalf("advice amount = %#v", advice.Amount)
 	}
 }

--- a/services/travel-insurance/domain/claim.go
+++ b/services/travel-insurance/domain/claim.go
@@ -10,20 +10,25 @@ type ClaimType string
 
 const (
 	ClaimDelayAuto            ClaimType = "DELAY_AUTO"
+	ClaimCancellation         ClaimType = "CANCELLATION"
+	ClaimAccident             ClaimType = "ACCIDENT"
 	ClaimAccidentManual       ClaimType = "ACCIDENT_MANUAL"
+	ClaimBaggage              ClaimType = "BAGGAGE"
 	ClaimServiceFailureManual ClaimType = "SERVICE_FAILURE_MANUAL"
 )
 
 type ClaimStatus string
 
 const (
+	ClaimPending            ClaimStatus = "PENDING"
+	ClaimApproved           ClaimStatus = "APPROVED"
+	ClaimRejected           ClaimStatus = "REJECTED"
+	ClaimPaidOut            ClaimStatus = "PAID_OUT"
 	ClaimOpened             ClaimStatus = "OPENED"
 	ClaimEvidenceCollecting ClaimStatus = "EVIDENCE_COLLECTING"
 	ClaimAutoVerifying      ClaimStatus = "AUTO_VERIFYING"
 	ClaimManualReview       ClaimStatus = "MANUAL_REVIEW"
-	ClaimApproved           ClaimStatus = "APPROVED"
 	ClaimPayoutRecommended  ClaimStatus = "PAYOUT_RECOMMENDED"
-	ClaimRejected           ClaimStatus = "REJECTED"
 	ClaimFailed             ClaimStatus = "FAILED"
 	ClaimClosed             ClaimStatus = "CLOSED"
 )
@@ -51,6 +56,7 @@ type Claim struct {
 	PolicyID         string      `json:"policyId"`
 	ClaimType        ClaimType   `json:"claimType"`
 	TriggerFactKey   string      `json:"triggerFactKey"`
+	Description      string      `json:"description,omitempty"`
 	DelayFact        *DelayFact  `json:"delayFact,omitempty"`
 	SupportCaseID    string      `json:"supportCaseId,omitempty"`
 	EvidenceRefs     []string    `json:"evidenceRefs"`
@@ -80,15 +86,10 @@ func OpenClaim(id string, policy Policy, claimType ClaimType, triggerFactKey str
 		return Claim{}, err
 	}
 	if claimType == ClaimDelayAuto {
-		claim.Status = ClaimAutoVerifying
-		if delayFact != nil && delayFact.DelayMinutes >= 60 {
-			claim.Status = ClaimApproved
-			claim.ApprovedAmount = capAmount(claimedAmount, policy.CoverageLimit)
-		} else {
-			claim.Status = ClaimEvidenceCollecting
-		}
+		claim.Status = ClaimApproved
+		claim.ApprovedAmount = capAmount(claimedAmount, policy.CoverageLimit)
 	} else {
-		claim.Status = ClaimManualReview
+		claim.Status = ClaimPending
 	}
 	return claim, claim.ValidateAgainstPolicy(policy, now)
 }
@@ -100,11 +101,14 @@ func (c Claim) ValidateAgainstPolicy(policy Policy, now time.Time) error {
 	if c.PolicyID != policy.ID {
 		return fmt.Errorf("claim policy does not match policy aggregate")
 	}
-	if !policy.CanClaim(now) {
-		return fmt.Errorf("policy is not active in coverage window")
+	if !policy.CanClaim(now) && policy.Status != PolicyClaimed {
+		return fmt.Errorf("policy is not issued in coverage window")
 	}
-	if c.ClaimType != ClaimDelayAuto && c.ClaimType != ClaimAccidentManual && c.ClaimType != ClaimServiceFailureManual {
+	if !SupportedClaimType(c.ClaimType) {
 		return fmt.Errorf("unsupported claim type: %q", c.ClaimType)
+	}
+	if !claimTypeMatchesProduct(c.ClaimType, policy.ProductCode) {
+		return fmt.Errorf("claim type %s does not match product %s", c.ClaimType, policy.ProductCode)
 	}
 	if strings.TrimSpace(c.TriggerFactKey) == "" {
 		return fmt.Errorf("trigger fact key is required")
@@ -119,14 +123,11 @@ func (c Claim) ValidateAgainstPolicy(policy Policy, now time.Time) error {
 		return fmt.Errorf("claimed amount exceeds policy coverage limit")
 	}
 	if c.ClaimType == ClaimDelayAuto {
-		if policy.ProductCode != ProductDelayInsurance {
-			return fmt.Errorf("auto delay claims require delay insurance")
+		if c.DelayFact == nil || !validDelaySource(c.DelayFact.SourceEventType) || strings.TrimSpace(c.DelayFact.SourceEventID) == "" || c.DelayFact.DelayMinutes <= 60 {
+			return fmt.Errorf("auto delay claim requires verified TrainDelayed fact over 60 minutes")
 		}
-		if c.DelayFact == nil || !validDelaySource(c.DelayFact.SourceEventType) || strings.TrimSpace(c.DelayFact.SourceEventID) == "" {
-			return fmt.Errorf("auto delay claim requires verified Fulfillment or Disruption Recovery fact")
-		}
-	} else if strings.TrimSpace(c.SupportCaseID) == "" || len(c.EvidenceRefs) == 0 {
-		return fmt.Errorf("manual claims require support case and evidence references")
+	} else if len(c.EvidenceRefs) == 0 {
+		return fmt.Errorf("manual claims require evidence references")
 	}
 	if c.ApprovedAmount.MinorUnits > 0 {
 		if err := c.ApprovedAmount.ValidatePositive(); err != nil {
@@ -136,6 +137,35 @@ func (c Claim) ValidateAgainstPolicy(policy Policy, now time.Time) error {
 			return fmt.Errorf("approved amount must be within policy coverage limit")
 		}
 	}
+	return nil
+}
+
+func (c *Claim) Approve(amount Money) error {
+	if c.Status != ClaimPending && c.Status != ClaimApproved {
+		return fmt.Errorf("claim cannot be approved from %s", c.Status)
+	}
+	if err := amount.ValidatePositive(); err != nil {
+		return fmt.Errorf("invalid approved amount: %w", err)
+	}
+	if amount.MinorUnits > c.ClaimedAmount.MinorUnits || !amount.SameCurrency(c.ClaimedAmount) {
+		return fmt.Errorf("approved amount must be within claimed amount")
+	}
+	c.ApprovedAmount = amount
+	c.Status = ClaimApproved
+	c.AggregateVersion++
+	return nil
+}
+
+func (c *Claim) Reject(reason string) error {
+	if c.Status != ClaimPending {
+		return fmt.Errorf("claim cannot be rejected from %s", c.Status)
+	}
+	c.ReasonCode = strings.TrimSpace(reason)
+	if c.ReasonCode == "" {
+		c.ReasonCode = "CLAIM_REJECTED"
+	}
+	c.Status = ClaimRejected
+	c.AggregateVersion++
 	return nil
 }
 
@@ -149,14 +179,38 @@ func (c *Claim) Settle(adviceID string, target PayoutTarget, reasonCode string) 
 	if strings.TrimSpace(reasonCode) == "" {
 		reasonCode = "INSURANCE_CLAIM_APPROVED"
 	}
-	advice := PayoutAdvice{ID: strings.TrimSpace(adviceID), ClaimID: c.ID, PolicyID: c.PolicyID, PayoutTarget: target, Amount: c.ApprovedAmount, ReasonCode: reasonCode, IdempotencyKey: hashText(strings.Join([]string{c.ID, c.PolicyID, c.ApprovedAmount.Currency, fmt.Sprint(c.ApprovedAmount.MinorUnits), string(target), reasonCode, "v1"}, "|")), DecisionVersion: "v1", Status: "RECOMMENDED"}
+	advice := PayoutAdvice{ID: strings.TrimSpace(adviceID), ClaimID: c.ID, PolicyID: c.PolicyID, PayoutTarget: target, Amount: c.ApprovedAmount, ReasonCode: reasonCode, IdempotencyKey: hashText(strings.Join([]string{c.ID, c.PolicyID, c.ApprovedAmount.Currency, fmt.Sprint(c.ApprovedAmount.MinorUnits), string(target), reasonCode, "v1"}, "|")), DecisionVersion: "v1", Status: "COMPLETED"}
 	if strings.TrimSpace(advice.ID) == "" {
 		return PayoutAdvice{}, fmt.Errorf("payout advice id is required")
 	}
 	c.PayoutAdviceID = advice.ID
-	c.Status = ClaimPayoutRecommended
+	c.Status = ClaimPaidOut
 	c.AggregateVersion++
 	return advice, nil
+}
+
+func SupportedClaimType(claimType ClaimType) bool {
+	switch claimType {
+	case ClaimDelayAuto, ClaimCancellation, ClaimAccident, ClaimAccidentManual, ClaimBaggage, ClaimServiceFailureManual:
+		return true
+	default:
+		return false
+	}
+}
+
+func claimTypeMatchesProduct(claimType ClaimType, code ProductCode) bool {
+	switch claimType {
+	case ClaimDelayAuto:
+		return code == ProductDelayInsurance
+	case ClaimCancellation, ClaimServiceFailureManual:
+		return code == ProductCancellationInsurance
+	case ClaimAccident, ClaimAccidentManual:
+		return code == ProductAccidentInsurance
+	case ClaimBaggage:
+		return code == ProductBaggageInsurance
+	default:
+		return false
+	}
 }
 
 func capAmount(amount, limit Money) Money {
@@ -168,7 +222,7 @@ func capAmount(amount, limit Money) Money {
 
 func validDelaySource(eventType string) bool {
 	switch strings.TrimSpace(eventType) {
-	case "SegmentDelayed", "SegmentArrived", "SegmentCancelled", "DisruptionReported", "IncidentOpened", "RecoveryCaseOpened", "RecoveryOptionsGenerated", "RecoveryOptionSelected", "RecoveryCompleted", "RecoveryFailed":
+	case "TrainDelayed", "SegmentDelayed", "SegmentArrived", "SegmentCancelled", "DisruptionReported", "IncidentOpened", "RecoveryCaseOpened", "RecoveryOptionsGenerated", "RecoveryOptionSelected", "RecoveryCompleted", "RecoveryFailed":
 		return true
 	default:
 		return false

--- a/services/travel-insurance/domain/domain_test.go
+++ b/services/travel-insurance/domain/domain_test.go
@@ -7,7 +7,7 @@ import (
 
 func publishedDelayProduct(t *testing.T, now time.Time) InsuranceProduct {
 	t.Helper()
-	premium, err := NewMoney("CNY", 500)
+	premium, err := NewMoney("CNY", 300)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,8 +32,8 @@ func TestIssuePolicyProducesDeterministicPolicyNumberAndActiveStatus(t *testing.
 	if err != nil {
 		t.Fatalf("issue policy: %v", err)
 	}
-	if policy.Status != PolicyActive {
-		t.Fatalf("status = %s, want ACTIVE", policy.Status)
+	if policy.Status != PolicyIssued {
+		t.Fatalf("status = %s, want ISSUED", policy.Status)
 	}
 	if policy.PolicyNumber == "" {
 		t.Fatal("policy number is required")
@@ -50,7 +50,7 @@ func TestClaimRejectsUnverifiedDelayFact(t *testing.T) {
 		t.Fatal(err)
 	}
 	amount, _ := NewMoney("CNY", 1000)
-	_, err = OpenClaim("clm-1", policy, ClaimDelayAuto, "fact-1", &DelayFact{SourceEventType: "TrainDelayed", SourceEventID: "evt-1", DelayMinutes: 90}, "", nil, amount, now)
+	_, err = OpenClaim("clm-1", policy, ClaimDelayAuto, "fact-1", &DelayFact{SourceEventType: "Unverified", SourceEventID: "evt-1", DelayMinutes: 90}, "", nil, amount, now)
 	if err == nil {
 		t.Fatal("expected unsupported delay source error")
 	}
@@ -74,7 +74,7 @@ func TestApprovedClaimCanSettleOnce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if advice.Status != "RECOMMENDED" || claim.Status != ClaimPayoutRecommended {
+	if advice.Status != "COMPLETED" || claim.Status != ClaimPaidOut {
 		t.Fatalf("unexpected settlement: %#v %#v", advice, claim)
 	}
 }

--- a/services/travel-insurance/domain/policy.go
+++ b/services/travel-insurance/domain/policy.go
@@ -12,6 +12,12 @@ import (
 type PolicyStatus string
 
 const (
+	PolicyIssued                PolicyStatus = "ISSUED"
+	PolicyClaimed               PolicyStatus = "CLAIMED"
+	PolicyPaidOut               PolicyStatus = "PAID_OUT"
+	PolicyRejected              PolicyStatus = "REJECTED"
+	PolicyExpired               PolicyStatus = "EXPIRED"
+	PolicyCancelled             PolicyStatus = "CANCELLED"
 	PolicyPurchaseSelected      PolicyStatus = "PURCHASE_SELECTED"
 	PolicyAwaitingPremium       PolicyStatus = "AWAITING_PREMIUM_CAPTURE"
 	PolicyUnderwritingRequested PolicyStatus = "UNDERWRITING_REQUESTED"
@@ -20,7 +26,6 @@ const (
 	PolicySurrenderRequested    PolicyStatus = "SURRENDER_REQUESTED"
 	PolicySurrendered           PolicyStatus = "SURRENDERED"
 	PolicyUnderwritingFailed    PolicyStatus = "UNDERWRITING_FAILED"
-	PolicyExpired               PolicyStatus = "EXPIRED"
 	PolicyClosed                PolicyStatus = "CLOSED"
 )
 
@@ -40,6 +45,7 @@ type Policy struct {
 	CoverageStartAt      time.Time    `json:"coverageStartAt"`
 	CoverageEndAt        time.Time    `json:"coverageEndAt"`
 	Status               PolicyStatus `json:"status"`
+	RefundedPremium      Money        `json:"refundedPremium,omitempty"`
 	UnderwritingSeedRef  string       `json:"underwritingSeedRef"`
 	AggregateVersion     int64        `json:"aggregateVersion"`
 }
@@ -75,10 +81,7 @@ func NewIssuedPolicy(req PolicyIssueRequest) (Policy, error) {
 	policy.Status = PolicyUnderwritingRequested
 	policy.UnderwritingSeedRef = policy.issueFingerprint()
 	policy.PolicyNumber = deterministicPolicyNumber(policy.UnderwritingSeedRef)
-	policy.Status = PolicyUnderwritten
-	if !req.Now.UTC().Before(policy.CoverageStartAt) {
-		policy.Status = PolicyActive
-	}
+	policy.Status = PolicyIssued
 	return policy, policy.Validate()
 }
 
@@ -88,7 +91,7 @@ func (p Policy) Validate() error {
 			return fmt.Errorf("%s is required", name)
 		}
 	}
-	if p.ProductCode != ProductDelayInsurance && p.ProductCode != ProductAccidentInsurance {
+	if !SupportedProductCode(p.ProductCode) {
 		return fmt.Errorf("unsupported product code: %q", p.ProductCode)
 	}
 	if err := p.Premium.ValidatePositive(); err != nil {
@@ -106,7 +109,7 @@ func (p Policy) Validate() error {
 	if p.CoverageStartAt.IsZero() || p.CoverageEndAt.IsZero() || !p.CoverageEndAt.After(p.CoverageStartAt) {
 		return fmt.Errorf("coverage window must be present and end after start")
 	}
-	if p.Status == PolicyUnderwritten || p.Status == PolicyActive || p.Status == PolicyExpired || p.Status == PolicySurrendered {
+	if p.Status == PolicyIssued || p.Status == PolicyClaimed || p.Status == PolicyPaidOut || p.Status == PolicyRejected || p.Status == PolicyExpired || p.Status == PolicyCancelled || p.Status == PolicyUnderwritten || p.Status == PolicyActive || p.Status == PolicySurrendered {
 		if strings.TrimSpace(p.PolicyNumber) == "" {
 			return fmt.Errorf("policy number is required after underwriting succeeds")
 		}
@@ -116,7 +119,66 @@ func (p Policy) Validate() error {
 
 func (p Policy) CanClaim(now time.Time) bool {
 	now = now.UTC()
-	return p.Status == PolicyActive && !now.Before(p.CoverageStartAt) && !now.After(p.CoverageEndAt)
+	return p.Status == PolicyIssued && !now.Before(p.CoverageStartAt) && !now.After(p.CoverageEndAt)
+}
+
+func (p *Policy) MarkClaimed(now time.Time) error {
+	if !p.CanClaim(now) {
+		return fmt.Errorf("policy is not issued in coverage window")
+	}
+	p.Status = PolicyClaimed
+	p.AggregateVersion++
+	return p.Validate()
+}
+
+func (p *Policy) MarkPaidOut() error {
+	if p.Status != PolicyClaimed {
+		return fmt.Errorf("policy must be claimed before payout")
+	}
+	p.Status = PolicyPaidOut
+	p.AggregateVersion++
+	return p.Validate()
+}
+
+func (p *Policy) MarkRejected() error {
+	if p.Status != PolicyClaimed {
+		return fmt.Errorf("policy must be claimed before rejection")
+	}
+	p.Status = PolicyRejected
+	p.AggregateVersion++
+	return p.Validate()
+}
+
+func (p *Policy) CancelForRefund() (Money, error) {
+	if p.Status != PolicyIssued {
+		return Money{}, fmt.Errorf("policy cannot be cancelled from %s", p.Status)
+	}
+	p.Status = PolicyCancelled
+	p.RefundedPremium = p.Premium
+	p.AggregateVersion++
+	return p.RefundedPremium, p.Validate()
+}
+
+func (p *Policy) AdjustCoverage(start, end time.Time) error {
+	if p.Status != PolicyIssued {
+		return fmt.Errorf("policy coverage cannot be adjusted from %s", p.Status)
+	}
+	p.CoverageStartAt = start.UTC()
+	p.CoverageEndAt = end.UTC()
+	p.AggregateVersion++
+	return p.Validate()
+}
+
+func (p *Policy) Expire(now time.Time) error {
+	if p.Status != PolicyIssued {
+		return fmt.Errorf("policy cannot expire from %s", p.Status)
+	}
+	if now.UTC().Before(p.CoverageEndAt) {
+		return fmt.Errorf("policy coverage has not ended")
+	}
+	p.Status = PolicyExpired
+	p.AggregateVersion++
+	return p.Validate()
 }
 
 func (p Policy) SegmentScopeHash() string {

--- a/services/travel-insurance/domain/product.go
+++ b/services/travel-insurance/domain/product.go
@@ -9,8 +9,10 @@ import (
 type ProductCode string
 
 const (
-	ProductDelayInsurance    ProductCode = "DELAY_INSURANCE"
-	ProductAccidentInsurance ProductCode = "ACCIDENT_INSURANCE"
+	ProductDelayInsurance        ProductCode = "DELAY_INSURANCE"
+	ProductCancellationInsurance ProductCode = "CANCELLATION_INSURANCE"
+	ProductAccidentInsurance     ProductCode = "ACCIDENT_INSURANCE"
+	ProductBaggageInsurance      ProductCode = "BAGGAGE_INSURANCE"
 )
 
 type ProductStatus string
@@ -23,22 +25,37 @@ const (
 	ProductRetired    ProductStatus = "RETIRED"
 )
 
+type PremiumCalculation string
+
+const (
+	PremiumFlat3CNY           PremiumCalculation = "FLAT_3_CNY"
+	PremiumTicketPriceFivePct PremiumCalculation = "TICKET_PRICE_5_PERCENT"
+	PremiumFlat5CNY           PremiumCalculation = "FLAT_5_CNY"
+	PremiumFlat2CNY           PremiumCalculation = "FLAT_2_CNY"
+)
+
 type InsuranceProduct struct {
-	ID                   string        `json:"insuranceProductId"`
-	ProductCode          ProductCode   `json:"productCode"`
-	Version              string        `json:"version"`
-	Premium              Money         `json:"premium"`
-	CoverageLimit        Money         `json:"coverageLimit"`
-	CoverageRuleVersion  string        `json:"coverageRuleVersion"`
-	ClaimRuleVersion     string        `json:"claimRuleVersion"`
-	SurrenderRuleVersion string        `json:"surrenderRuleVersion"`
-	SalesStartAt         time.Time     `json:"salesStartAt"`
-	SalesEndAt           time.Time     `json:"salesEndAt"`
-	Status               ProductStatus `json:"status"`
+	ID                   string             `json:"insuranceProductId"`
+	ProductID            string             `json:"productId"`
+	ProductCode          ProductCode        `json:"productCode"`
+	ProductType          ProductCode        `json:"productType"`
+	Version              string             `json:"version"`
+	Premium              Money              `json:"premium"`
+	PremiumCalculation   PremiumCalculation `json:"premiumCalculation"`
+	CoverageDescription  string             `json:"coverageDescription"`
+	CoverageLimit        Money              `json:"coverageLimit"`
+	MaxPayout            Money              `json:"maxPayout"`
+	AutoPayoutEnabled    bool               `json:"autoPayoutEnabled"`
+	CoverageRuleVersion  string             `json:"coverageRuleVersion"`
+	ClaimRuleVersion     string             `json:"claimRuleVersion"`
+	SurrenderRuleVersion string             `json:"surrenderRuleVersion"`
+	SalesStartAt         time.Time          `json:"salesStartAt"`
+	SalesEndAt           time.Time          `json:"salesEndAt"`
+	Status               ProductStatus      `json:"status"`
 }
 
 func NewInsuranceProduct(id string, code ProductCode, version string, premium Money, limit Money, salesStart, salesEnd time.Time) (InsuranceProduct, error) {
-	product := InsuranceProduct{ID: strings.TrimSpace(id), ProductCode: code, Version: strings.TrimSpace(version), Premium: premium, CoverageLimit: limit, CoverageRuleVersion: "coverage-v1", ClaimRuleVersion: "claim-v1", SurrenderRuleVersion: "surrender-v1", SalesStartAt: salesStart.UTC(), SalesEndAt: salesEnd.UTC(), Status: ProductDraft}
+	product := InsuranceProduct{ID: strings.TrimSpace(id), ProductID: strings.TrimSpace(id), ProductCode: code, ProductType: code, Version: strings.TrimSpace(version), Premium: premium, PremiumCalculation: DefaultPremiumCalculation(code), CoverageDescription: DefaultCoverageDescription(code), CoverageLimit: limit, MaxPayout: limit, AutoPayoutEnabled: code == ProductDelayInsurance, CoverageRuleVersion: "coverage-v1", ClaimRuleVersion: "claim-v1", SurrenderRuleVersion: "surrender-v1", SalesStartAt: salesStart.UTC(), SalesEndAt: salesEnd.UTC(), Status: ProductDraft}
 	if err := product.Validate(); err != nil {
 		return InsuranceProduct{}, err
 	}
@@ -49,8 +66,17 @@ func (p InsuranceProduct) Validate() error {
 	if strings.TrimSpace(p.ID) == "" {
 		return fmt.Errorf("insurance product id is required")
 	}
-	if p.ProductCode != ProductDelayInsurance && p.ProductCode != ProductAccidentInsurance {
+	if p.ProductID == "" {
+		p.ProductID = p.ID
+	}
+	if p.ProductType == "" {
+		p.ProductType = p.ProductCode
+	}
+	if !SupportedProductCode(p.ProductCode) {
 		return fmt.Errorf("unsupported insurance product code: %q", p.ProductCode)
+	}
+	if p.ProductType != p.ProductCode {
+		return fmt.Errorf("product type must match product code")
 	}
 	if strings.TrimSpace(p.Version) == "" {
 		return fmt.Errorf("product version is required")
@@ -61,8 +87,29 @@ func (p InsuranceProduct) Validate() error {
 	if err := p.CoverageLimit.ValidatePositive(); err != nil {
 		return fmt.Errorf("invalid coverage limit: %w", err)
 	}
-	if !p.Premium.SameCurrency(p.CoverageLimit) {
+	if p.MaxPayout.MinorUnits == 0 {
+		p.MaxPayout = p.CoverageLimit
+	}
+	if err := p.MaxPayout.ValidatePositive(); err != nil {
+		return fmt.Errorf("invalid max payout: %w", err)
+	}
+	if !p.Premium.SameCurrency(p.CoverageLimit) || !p.Premium.SameCurrency(p.MaxPayout) {
 		return fmt.Errorf("premium and coverage limit currency must match")
+	}
+	if p.PremiumCalculation == "" {
+		p.PremiumCalculation = DefaultPremiumCalculation(p.ProductCode)
+	}
+	if p.PremiumCalculation != DefaultPremiumCalculation(p.ProductCode) {
+		return fmt.Errorf("premium calculation does not match product code")
+	}
+	if strings.TrimSpace(p.CoverageDescription) == "" {
+		return fmt.Errorf("coverage description is required")
+	}
+	if !p.AutoPayoutEnabled && p.ProductCode == ProductDelayInsurance {
+		return fmt.Errorf("delay insurance must have auto payout enabled")
+	}
+	if p.AutoPayoutEnabled && p.ProductCode != ProductDelayInsurance {
+		return fmt.Errorf("only delay insurance can enable auto payout")
 	}
 	if p.SalesStartAt.IsZero() || p.SalesEndAt.IsZero() || p.SalesEndAt.Before(p.SalesStartAt) {
 		return fmt.Errorf("sales window must be present and not inverted")
@@ -84,4 +131,65 @@ func (p InsuranceProduct) Publish(now time.Time) (InsuranceProduct, error) {
 func (p InsuranceProduct) AvailableAt(now time.Time) bool {
 	now = now.UTC()
 	return p.Status == ProductPublished && !now.Before(p.SalesStartAt) && !now.After(p.SalesEndAt)
+}
+
+func SupportedProductCode(code ProductCode) bool {
+	switch code {
+	case ProductDelayInsurance, ProductCancellationInsurance, ProductAccidentInsurance, ProductBaggageInsurance:
+		return true
+	default:
+		return false
+	}
+}
+
+type PremiumCalculator struct{}
+
+func (PremiumCalculator) CalculatePremium(product InsuranceProduct, ticketPrice Money, _ int) (Money, error) {
+	if err := product.Validate(); err != nil {
+		return Money{}, err
+	}
+	if product.ProductCode != ProductCancellationInsurance {
+		return product.Premium, nil
+	}
+	if err := ticketPrice.ValidatePositive(); err != nil {
+		return Money{}, fmt.Errorf("ticket price is required for cancellation premium: %w", err)
+	}
+	if !ticketPrice.SameCurrency(product.Premium) {
+		return Money{}, fmt.Errorf("ticket price currency must match product premium")
+	}
+	premium := ticketPrice.MinorUnits * 5 / 100
+	if premium <= 0 {
+		premium = 1
+	}
+	return NewMoney(ticketPrice.Currency, premium)
+}
+
+func DefaultPremiumCalculation(code ProductCode) PremiumCalculation {
+	switch code {
+	case ProductDelayInsurance:
+		return PremiumFlat3CNY
+	case ProductCancellationInsurance:
+		return PremiumTicketPriceFivePct
+	case ProductAccidentInsurance:
+		return PremiumFlat5CNY
+	case ProductBaggageInsurance:
+		return PremiumFlat2CNY
+	default:
+		return ""
+	}
+}
+
+func DefaultCoverageDescription(code ProductCode) string {
+	switch code {
+	case ProductDelayInsurance:
+		return "Train delay greater than 60 minutes"
+	case ProductCancellationInsurance:
+		return "Voluntary cancellation within 24 hours of departure"
+	case ProductAccidentInsurance:
+		return "Personal injury during travel"
+	case ProductBaggageInsurance:
+		return "Lost or damaged baggage"
+	default:
+		return ""
+	}
 }

--- a/services/travel-insurance/migrations/001_travel_insurance.sql
+++ b/services/travel-insurance/migrations/001_travel_insurance.sql
@@ -12,6 +12,8 @@ CREATE TABLE IF NOT EXISTS policy_snapshots (
   updated_at timestamptz NOT NULL DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS idx_policy_uniqueness ON policy_snapshots ((data->>'ancillaryOrderItemId'), (data->>'travelerRef'), (data->>'productVersion'));
+CREATE INDEX IF NOT EXISTS idx_policy_delay_segment ON policy_snapshots ((data->>'productCode'), (data->>'status'));
+CREATE INDEX IF NOT EXISTS idx_policy_journey_status ON policy_snapshots ((data->>'journeyOrderId'), (data->>'status'));
 
 CREATE TABLE IF NOT EXISTS claim_snapshots (
   id text PRIMARY KEY,


### PR DESCRIPTION
## Summary
- Adds multi-product insurance catalog with premium calculation and ISSUED/CLAIMED/PAID_OUT/CANCELLED lifecycle
- Adds delay auto-claim/payout flow, manual claims APIs, and refund cancellation
- Extends messaging consumers and repository queries while publishing insurance events through existing outbox publisher

## Validation
- go test ./services/travel-insurance/...