### PR TITLE
REQ-317 finance settlement reconciliation enrichment

### DIFF
--- a/services/finance-settlement/migrations/004_reconciliation_supplier_settlements.sql
+++ b/services/finance-settlement/migrations/004_reconciliation_supplier_settlements.sql
@@ -24,3 +24,25 @@ CREATE TABLE IF NOT EXISTS fee_accrual_snapshots (
 );
 CREATE INDEX IF NOT EXISTS idx_fee_accrual_snapshots_order_id
   ON fee_accrual_snapshots ((data->>'orderId'));
+
+ALTER TABLE captures_by_order_id
+  ADD COLUMN IF NOT EXISTS occurred_at timestamptz NOT NULL DEFAULT now();
+CREATE INDEX IF NOT EXISTS idx_captures_by_order_id_occurred_at
+  ON captures_by_order_id (occurred_at);
+
+CREATE TABLE IF NOT EXISTS channel_statement_lines (
+  statement_line_id   text PRIMARY KEY,
+  channel_statement_id text NOT NULL,
+  statement_date      text NOT NULL,
+  order_id            text NOT NULL DEFAULT '',
+  payment_intent_id   text NOT NULL DEFAULT '',
+  channel_order_id    text NOT NULL DEFAULT '',
+  currency            text NOT NULL,
+  amount              numeric(19, 4) NOT NULL,
+  source_event_id     text NOT NULL,
+  updated_at          timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_channel_statement_lines_statement_date
+  ON channel_statement_lines (statement_date);
+CREATE INDEX IF NOT EXISTS idx_channel_statement_lines_order_payment
+  ON channel_statement_lines (order_id, payment_intent_id);

--- a/services/finance-settlement/migrations/004_reconciliation_supplier_settlements.sql
+++ b/services/finance-settlement/migrations/004_reconciliation_supplier_settlements.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS reconciliation_batch_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_reconciliation_batch_snapshots_settlement_date
+  ON reconciliation_batch_snapshots ((data->>'settlementDate'));
+
+CREATE TABLE IF NOT EXISTS supplier_settlement_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_supplier_settlement_snapshots_supplier_period
+  ON supplier_settlement_snapshots ((data->>'supplierId'), (data->>'startDate'), (data->>'endDate'));
+
+CREATE TABLE IF NOT EXISTS fee_accrual_snapshots (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_fee_accrual_snapshots_order_id
+  ON fee_accrual_snapshots ((data->>'orderId'));

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/adapters/http/FinanceSettlementController.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/adapters/http/FinanceSettlementController.java
@@ -6,9 +6,13 @@ import com.trainticket.financesettlement.application.DomainEventEnvelopeMapper;
 import com.trainticket.financesettlement.application.FinanceSettlementApplicationService;
 import com.trainticket.financesettlement.application.FinanceSettlementApplicationService.Page;
 import com.trainticket.financesettlement.domain.Invoice;
+import com.trainticket.financesettlement.domain.ReconciliationBatch;
+import com.trainticket.financesettlement.domain.ReconciliationEntry;
+import com.trainticket.financesettlement.domain.SupplierSettlement;
 import com.trainticket.financesettlement.domain.ReconciliationCase;
 import com.trainticket.financesettlement.domain.RevenueRecognition;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import jakarta.servlet.http.HttpServletRequest;
@@ -64,6 +68,25 @@ public class FinanceSettlementController {
     @GetMapping("/api/v1/channel-statements/{channelStatementId}")
     public ChannelStatementResponse getChannelStatement(@PathVariable String channelStatementId) {
         return ChannelStatementResponse.from(service.getChannelStatement(channelStatementId));
+    }
+
+    @GetMapping("/api/v1/settlements/daily/{date}")
+    public DailySettlementResponse getDailySettlement(@PathVariable String date) {
+        return DailySettlementResponse.from(service.getDailySettlement(LocalDate.parse(date)));
+    }
+
+    @GetMapping("/api/v1/settlements/suppliers/{supplierId}/period")
+    public SupplierSettlementResponse getSupplierSettlement(
+        @PathVariable String supplierId,
+        @RequestParam String startDate,
+        @RequestParam String endDate
+    ) {
+        return SupplierSettlementResponse.from(service.getSupplierSettlement(supplierId, LocalDate.parse(startDate), LocalDate.parse(endDate)));
+    }
+
+    @GetMapping("/api/v1/settlements/reconciliation/{batchId}")
+    public ReconciliationBatchResponse getReconciliationBatch(@PathVariable String batchId) {
+        return ReconciliationBatchResponse.from(service.getReconciliationBatch(batchId));
     }
 
     @GetMapping("/api/v1/benefit-costs")
@@ -170,6 +193,98 @@ public class FinanceSettlementController {
                 reconciliationCase.status().name(),
                 reconciliationCase.resolution(),
                 reconciliationCase.resolutionNote()
+            );
+        }
+    }
+
+    public record DailySettlementResponse(
+        String batchId,
+        String settlementDate,
+        int totalEntries,
+        int matchedEntries,
+        Object matchRate,
+        Map<String, Object> totalVariance,
+        int exceptionCount,
+        Map<String, Long> statusCounts
+    ) {
+        static DailySettlementResponse from(ReconciliationBatch batch) {
+            return new DailySettlementResponse(
+                batch.batchId(),
+                batch.settlementDate().toString(),
+                batch.report().totalEntries(),
+                batch.report().matchedEntries(),
+                batch.report().matchRate(),
+                DomainEventEnvelopeMapper.moneyPayload(batch.report().totalVariance()),
+                batch.report().exceptions().size(),
+                batch.statusCounts()
+            );
+        }
+    }
+
+    public record ReconciliationBatchResponse(
+        String batchId,
+        String settlementDate,
+        Instant cutoffAt,
+        List<ReconciliationEntryResponse> entries,
+        DailySettlementResponse report
+    ) {
+        static ReconciliationBatchResponse from(ReconciliationBatch batch) {
+            return new ReconciliationBatchResponse(
+                batch.batchId(),
+                batch.settlementDate().toString(),
+                batch.cutoffAt(),
+                batch.entries().stream().map(ReconciliationEntryResponse::from).toList(),
+                DailySettlementResponse.from(batch)
+            );
+        }
+    }
+
+    public record ReconciliationEntryResponse(
+        String entryId,
+        String orderId,
+        String paymentIntentId,
+        Map<String, Object> platformAmount,
+        Map<String, Object> channelAmount,
+        String status,
+        Map<String, Object> variance,
+        List<String> sourceEventIds
+    ) {
+        static ReconciliationEntryResponse from(ReconciliationEntry entry) {
+            return new ReconciliationEntryResponse(
+                entry.entryId(), entry.orderId(), entry.paymentIntentId(),
+                DomainEventEnvelopeMapper.moneyPayload(entry.platformAmount()),
+                DomainEventEnvelopeMapper.moneyPayload(entry.channelAmount()),
+                entry.status().name(),
+                DomainEventEnvelopeMapper.moneyPayload(entry.variance()),
+                entry.sourceEventIds()
+            );
+        }
+    }
+
+    public record SupplierSettlementResponse(
+        String supplierSettlementId,
+        String supplierId,
+        String periodStartDate,
+        String periodEndDate,
+        String settlementFrequency,
+        Map<String, Object> grossRevenue,
+        Map<String, Object> platformCommission,
+        Map<String, Object> taxesWithheld,
+        Map<String, Object> supplierPayable,
+        Map<String, Object> adjustments
+    ) {
+        static SupplierSettlementResponse from(SupplierSettlement settlement) {
+            return new SupplierSettlementResponse(
+                settlement.supplierSettlementId(),
+                settlement.supplierId(),
+                settlement.period().startDate().toString(),
+                settlement.period().endDate().toString(),
+                settlement.period().frequency().name(),
+                DomainEventEnvelopeMapper.moneyPayload(settlement.grossRevenue()),
+                DomainEventEnvelopeMapper.moneyPayload(settlement.platformCommission()),
+                DomainEventEnvelopeMapper.moneyPayload(settlement.taxesWithheld()),
+                DomainEventEnvelopeMapper.moneyPayload(settlement.supplierPayable()),
+                DomainEventEnvelopeMapper.moneyPayload(settlement.adjustments())
             );
         }
     }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/ApplicationConfiguration.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/ApplicationConfiguration.java
@@ -30,11 +30,13 @@ public class ApplicationConfiguration {
         ReconciliationCaseRepository reconciliationCases,
         InvoiceRepository invoices,
         FinanceSettlementProjectionRepository projections,
+        ReconciliationBatchRepository reconciliationBatches,
+        SupplierSettlementRepository supplierSettlements,
         EventPublisher eventPublisher,
         DomainEventEnvelopeMapper envelopeMapper,
         Clock clock
     ) {
-        return new FinanceSettlementApplicationService(revenueRecognitions, reconciliationCases, invoices, projections, eventPublisher, envelopeMapper, clock);
+        return new FinanceSettlementApplicationService(revenueRecognitions, reconciliationCases, invoices, projections, reconciliationBatches, supplierSettlements, eventPublisher, envelopeMapper, clock);
     }
 
     @Bean

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/ApplicationConfiguration.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/ApplicationConfiguration.java
@@ -32,11 +32,12 @@ public class ApplicationConfiguration {
         FinanceSettlementProjectionRepository projections,
         ReconciliationBatchRepository reconciliationBatches,
         SupplierSettlementRepository supplierSettlements,
+        FeeAccrualRepository feeAccruals,
         EventPublisher eventPublisher,
         DomainEventEnvelopeMapper envelopeMapper,
         Clock clock
     ) {
-        return new FinanceSettlementApplicationService(revenueRecognitions, reconciliationCases, invoices, projections, reconciliationBatches, supplierSettlements, eventPublisher, envelopeMapper, clock);
+        return new FinanceSettlementApplicationService(revenueRecognitions, reconciliationCases, invoices, projections, reconciliationBatches, supplierSettlements, feeAccruals, eventPublisher, envelopeMapper, clock);
     }
 
     @Bean

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/ChannelStatementLineProjection.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/ChannelStatementLineProjection.java
@@ -1,0 +1,14 @@
+package com.trainticket.financesettlement.application;
+
+import com.trainticket.financesettlement.domain.Money;
+
+public record ChannelStatementLineProjection(
+    String statementLineId,
+    String channelStatementId,
+    String statementDate,
+    String orderId,
+    String paymentIntentId,
+    String channelOrderId,
+    Money actualAmount,
+    String sourceEventId
+) {}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/DomainEventEnvelopeMapper.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/DomainEventEnvelopeMapper.java
@@ -2,6 +2,7 @@ package com.trainticket.financesettlement.application;
 
 import com.trainticket.platformkit.messaging.EventEnvelope;
 import com.trainticket.platformkit.messaging.PrefixedIds;
+import com.trainticket.financesettlement.domain.FeeAccrued;
 import com.trainticket.financesettlement.domain.FinanceSettlementEvent;
 import com.trainticket.financesettlement.domain.Money;
 import com.trainticket.financesettlement.domain.InvoiceGenerated;
@@ -11,6 +12,7 @@ import com.trainticket.financesettlement.domain.ReconciliationCompleted;
 import com.trainticket.financesettlement.domain.RevenueRecognized;
 import com.trainticket.financesettlement.domain.RevenueRecognitionReversed;
 import com.trainticket.financesettlement.domain.SettlementViewRebuilt;
+import com.trainticket.financesettlement.domain.SupplierSettlementCalculated;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -37,6 +39,8 @@ public final class DomainEventEnvelopeMapper {
             case ReconciliationCaseOpened opened -> reconciliationCaseOpenedPayload(opened);
             case ReconciliationCaseResolved resolved -> reconciliationCaseResolvedPayload(resolved);
             case ReconciliationCompleted completed -> reconciliationCompletedPayload(completed);
+            case SupplierSettlementCalculated calculated -> supplierSettlementCalculatedPayload(calculated);
+            case FeeAccrued accrued -> feeAccruedPayload(accrued);
             case InvoiceGenerated generated -> invoiceGeneratedPayload(generated);
             case SettlementViewRebuilt rebuilt -> settlementViewRebuiltPayload(rebuilt);
         };
@@ -100,6 +104,46 @@ public final class DomainEventEnvelopeMapper {
         payload.put("actualAmount", moneyPayload(event.actualAmount()));
         payload.put("matchedRevenueRecognitionIds", event.matchedRevenueRecognitionIds());
         payload.put("sourceEventIds", event.sourceEventIds());
+        if (!event.batchId().isBlank()) {
+            payload.put("batchId", event.batchId());
+            payload.put("settlementDate", event.settlementDate());
+            payload.put("totalEntries", event.totalEntries());
+            payload.put("matchedEntries", event.matchedEntries());
+            payload.put("matchRate", event.matchRate());
+            payload.put("totalVariance", moneyPayload(event.totalVariance()));
+            payload.put("exceptionCount", event.exceptionCount());
+        }
+        payload.put("metadata", metadataPayload(event));
+        return payload;
+    }
+
+    private static Map<String, Object> supplierSettlementCalculatedPayload(SupplierSettlementCalculated event) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("supplierSettlementId", event.supplierSettlementId());
+        payload.put("supplierId", event.supplierId());
+        payload.put("periodStartDate", event.period().startDate().toString());
+        payload.put("periodEndDate", event.period().endDate().toString());
+        payload.put("settlementFrequency", event.period().frequency().name());
+        payload.put("grossRevenue", moneyPayload(event.grossRevenue()));
+        payload.put("platformCommission", moneyPayload(event.platformCommission()));
+        payload.put("taxesWithheld", moneyPayload(event.taxesWithheld()));
+        payload.put("supplierPayable", moneyPayload(event.supplierPayable()));
+        payload.put("adjustments", moneyPayload(event.adjustments()));
+        payload.put("metadata", metadataPayload(event));
+        return payload;
+    }
+
+    private static Map<String, Object> feeAccruedPayload(FeeAccrued event) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("feeAccrualId", event.feeAccrualId());
+        payload.put("orderId", event.orderId());
+        payload.put("platformServiceFee", moneyPayload(event.platformServiceFee()));
+        payload.put("supplierServiceFee", moneyPayload(event.supplierServiceFee()));
+        payload.put("retainedCancellationFee", moneyPayload(event.retainedCancellationFee()));
+        payload.put("vatOnServiceFees", moneyPayload(event.taxCalculation().vatOnServiceFees()));
+        payload.put("stampDutyOnTickets", moneyPayload(event.taxCalculation().stampDutyOnTickets()));
+        payload.put("withholdingOnSupplierPayment", moneyPayload(event.taxCalculation().withholdingOnSupplierPayment()));
+        payload.put("taxReversal", moneyPayload(event.taxCalculation().taxReversal()));
         payload.put("metadata", metadataPayload(event));
         return payload;
     }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FeeAccrualRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FeeAccrualRepository.java
@@ -1,0 +1,11 @@
+package com.trainticket.financesettlement.application;
+
+import com.trainticket.financesettlement.domain.FeeAccrual;
+import java.util.List;
+import java.util.Optional;
+
+public interface FeeAccrualRepository {
+    Optional<FeeAccrual> findById(String feeAccrualId);
+    List<FeeAccrual> findByOrderId(String orderId);
+    void save(FeeAccrual accrual);
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementApplicationService.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementApplicationService.java
@@ -2,6 +2,7 @@ package com.trainticket.financesettlement.application;
 
 import com.trainticket.financesettlement.domain.DomainRuleViolation;
 import com.trainticket.financesettlement.domain.EventMetadata;
+import com.trainticket.financesettlement.domain.FeeAccrual;
 import com.trainticket.financesettlement.domain.FinanceSettlementEvent;
 import com.trainticket.financesettlement.domain.Invoice;
 import com.trainticket.financesettlement.domain.ReconciliationBatch;
@@ -9,6 +10,7 @@ import com.trainticket.financesettlement.domain.ReconciliationEntry;
 import com.trainticket.financesettlement.domain.SettlementFrequency;
 import com.trainticket.financesettlement.domain.SettlementPeriod;
 import com.trainticket.financesettlement.domain.SupplierSettlement;
+import com.trainticket.financesettlement.domain.TaxCalculation;
 import com.trainticket.financesettlement.domain.RevenueAllocation;
 import com.trainticket.financesettlement.domain.Money;
 import com.trainticket.financesettlement.domain.ReconciliationCase;
@@ -25,6 +27,7 @@ import java.util.Currency;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class FinanceSettlementApplicationService {
     private final RevenueRecognitionRepository revenueRecognitions;
@@ -32,7 +35,12 @@ public class FinanceSettlementApplicationService {
     private final InvoiceRepository invoices;
     private final FinanceSettlementProjectionRepository projections;
     private final ReconciliationBatchRepository reconciliationBatches;
+    private static final BigDecimal PLATFORM_SERVICE_FEE_PCT = new BigDecimal("0.02");
+    private static final BigDecimal SUPPLIER_SERVICE_FEE_PCT = new BigDecimal("0.01");
+    private static final BigDecimal VOLUNTARY_CANCELLATION_RETAINED_FEE_PCT = new BigDecimal("0.10");
+
     private final SupplierSettlementRepository supplierSettlements;
+    private final FeeAccrualRepository feeAccruals;
     private final EventPublisher eventPublisher;
     private final DomainEventEnvelopeMapper envelopeMapper;
     private final Clock clock;
@@ -43,7 +51,7 @@ public class FinanceSettlementApplicationService {
         EventPublisher eventPublisher,
         DomainEventEnvelopeMapper envelopeMapper
     ) {
-        this(revenueRecognitions, reconciliationCases, new InMemoryInvoiceRepository(), new InMemoryFinanceSettlementProjectionRepository(), new InMemoryReconciliationBatchRepository(), new InMemorySupplierSettlementRepository(), eventPublisher, envelopeMapper, Clock.systemUTC());
+        this(revenueRecognitions, reconciliationCases, new InMemoryInvoiceRepository(), new InMemoryFinanceSettlementProjectionRepository(), new InMemoryReconciliationBatchRepository(), new InMemorySupplierSettlementRepository(), new InMemoryFeeAccrualRepository(), eventPublisher, envelopeMapper, Clock.systemUTC());
     }
 
     public FinanceSettlementApplicationService(
@@ -54,7 +62,7 @@ public class FinanceSettlementApplicationService {
         DomainEventEnvelopeMapper envelopeMapper,
         Clock clock
     ) {
-        this(revenueRecognitions, reconciliationCases, invoices, new InMemoryFinanceSettlementProjectionRepository(), new InMemoryReconciliationBatchRepository(), new InMemorySupplierSettlementRepository(), eventPublisher, envelopeMapper, clock);
+        this(revenueRecognitions, reconciliationCases, invoices, new InMemoryFinanceSettlementProjectionRepository(), new InMemoryReconciliationBatchRepository(), new InMemorySupplierSettlementRepository(), new InMemoryFeeAccrualRepository(), eventPublisher, envelopeMapper, clock);
     }
 
     public FinanceSettlementApplicationService(
@@ -66,7 +74,7 @@ public class FinanceSettlementApplicationService {
         DomainEventEnvelopeMapper envelopeMapper,
         Clock clock
     ) {
-        this(revenueRecognitions, reconciliationCases, invoices, projections, new InMemoryReconciliationBatchRepository(), new InMemorySupplierSettlementRepository(), eventPublisher, envelopeMapper, clock);
+        this(revenueRecognitions, reconciliationCases, invoices, projections, new InMemoryReconciliationBatchRepository(), new InMemorySupplierSettlementRepository(), new InMemoryFeeAccrualRepository(), eventPublisher, envelopeMapper, clock);
     }
 
     public FinanceSettlementApplicationService(
@@ -80,12 +88,28 @@ public class FinanceSettlementApplicationService {
         DomainEventEnvelopeMapper envelopeMapper,
         Clock clock
     ) {
+        this(revenueRecognitions, reconciliationCases, invoices, projections, reconciliationBatches, supplierSettlements, new InMemoryFeeAccrualRepository(), eventPublisher, envelopeMapper, clock);
+    }
+
+    public FinanceSettlementApplicationService(
+        RevenueRecognitionRepository revenueRecognitions,
+        ReconciliationCaseRepository reconciliationCases,
+        InvoiceRepository invoices,
+        FinanceSettlementProjectionRepository projections,
+        ReconciliationBatchRepository reconciliationBatches,
+        SupplierSettlementRepository supplierSettlements,
+        FeeAccrualRepository feeAccruals,
+        EventPublisher eventPublisher,
+        DomainEventEnvelopeMapper envelopeMapper,
+        Clock clock
+    ) {
         this.revenueRecognitions = revenueRecognitions;
         this.reconciliationCases = reconciliationCases;
         this.invoices = invoices;
         this.projections = projections;
         this.reconciliationBatches = reconciliationBatches;
         this.supplierSettlements = supplierSettlements;
+        this.feeAccruals = feeAccruals;
         this.eventPublisher = eventPublisher;
         this.envelopeMapper = envelopeMapper;
         this.clock = clock;
@@ -201,25 +225,37 @@ public class FinanceSettlementApplicationService {
         LocalDate date = settlementDate == null ? LocalDate.now(clock).minusDays(1) : settlementDate;
         return reconciliationBatches.findBySettlementDate(date).orElseGet(() -> {
             Currency[] currency = {Currency.getInstance("CNY")};
-            Map<String, FinanceSettlementEventHandler.PaymentCaptureFact> captures = new LinkedHashMap<>();
+            Map<String, PlatformReconciliationFact> captures = new LinkedHashMap<>();
             for (FinanceSettlementEventHandler.PaymentCaptureFact capture : projections.findCapturesForSettlementDate(date)) {
-                captures.put(capture.orderId().isBlank() ? capture.paymentIntentId() : capture.orderId(), capture);
+                String key = reconciliationKey(capture.orderId(), capture.paymentIntentId());
+                captures.merge(key, new PlatformReconciliationFact(capture.orderId(), capture.paymentIntentId(), capture.amount(), List.of(capture.sourceEventId())), PlatformReconciliationFact::merge);
                 currency[0] = capture.amount().currency();
             }
-            Map<String, ChannelStatementProjection> statements = new LinkedHashMap<>();
-            for (ChannelStatementProjection statement : projections.findChannelStatementsForSettlementDate(date)) {
-                statements.put(statement.channelStatementId(), statement);
-                currency[0] = Currency.getInstance(statement.currency());
+            Map<String, ChannelReconciliationFact> channelLines = new LinkedHashMap<>();
+            for (ChannelStatementLineProjection line : projections.findChannelStatementLinesForSettlementDate(date)) {
+                String key = reconciliationKey(line.orderId(), line.paymentIntentId());
+                channelLines.merge(key, new ChannelReconciliationFact(line.orderId(), line.paymentIntentId(), line.actualAmount(), List.of(line.sourceEventId())), ChannelReconciliationFact::merge);
+                currency[0] = line.actualAmount().currency();
+            }
+            if (channelLines.isEmpty()) {
+                for (ChannelStatementProjection statement : projections.findChannelStatementsForSettlementDate(date)) {
+                    Money channelAmount = statement.grossPaymentAmount().minus(statement.grossRefundAmount());
+                    channelLines.put(statement.channelStatementId(), new ChannelReconciliationFact(statement.channelStatementId(), "", channelAmount, List.of(statement.sourceEventId())));
+                    currency[0] = Currency.getInstance(statement.currency());
+                }
             }
             List<ReconciliationEntry> entries = new ArrayList<>();
             for (var item : captures.entrySet()) {
-                ChannelStatementProjection statement = statements.remove(item.getKey());
-                Money channelAmount = statement == null ? Money.zero(item.getValue().amount().currency()) : statement.grossPaymentAmount().minus(statement.grossRefundAmount());
-                entries.add(ReconciliationEntry.compare("re-" + item.getKey(), item.getKey(), item.getValue().paymentIntentId(), item.getValue().amount(), channelAmount, true, statement != null, List.of(item.getValue().sourceEventId())));
+                ChannelReconciliationFact channel = channelLines.remove(item.getKey());
+                Money channelAmount = channel == null ? Money.zero(item.getValue().amount().currency()) : channel.amount();
+                List<String> sourceEventIds = new ArrayList<>(item.getValue().sourceEventIds());
+                if (channel != null) {
+                    sourceEventIds.addAll(channel.sourceEventIds());
+                }
+                entries.add(ReconciliationEntry.compare("re-" + item.getKey(), item.getValue().orderId(), item.getValue().paymentIntentId(), item.getValue().amount(), channelAmount, true, channel != null, sourceEventIds));
             }
-            for (var item : statements.entrySet()) {
-                Money channelAmount = item.getValue().grossPaymentAmount().minus(item.getValue().grossRefundAmount());
-                entries.add(ReconciliationEntry.compare("re-" + item.getKey(), item.getKey(), "", Money.zero(channelAmount.currency()), channelAmount, false, true, List.of(item.getValue().sourceEventId())));
+            for (var item : channelLines.entrySet()) {
+                entries.add(ReconciliationEntry.compare("re-" + item.getKey(), item.getValue().orderId(), item.getValue().paymentIntentId(), Money.zero(item.getValue().amount().currency()), item.getValue().amount(), false, true, item.getValue().sourceEventIds()));
             }
             ReconciliationBatch batch = ReconciliationBatch.complete(date, date.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC), currency[0], entries,
                 clock.instant(), PrefixedIds.newCommandId(), PrefixedIds.newCommandId(), canonicalCorrelationId(correlationId));
@@ -235,17 +271,57 @@ public class FinanceSettlementApplicationService {
         SettlementPeriod period = new SettlementPeriod(startDate, endDate, frequency == null ? SettlementFrequency.DAILY : frequency);
         return supplierSettlements.findBySupplierAndPeriod(supplierId, startDate, endDate).orElseGet(() -> {
             Currency currency = Currency.getInstance("CNY");
-            List<RevenueAllocation> allocations = revenueRecognitions.findByOrderId(supplierId).stream()
-                .filter(recognition -> !recognition.recognizedAt().atZone(ZoneOffset.UTC).toLocalDate().isBefore(startDate))
-                .filter(recognition -> !recognition.recognizedAt().atZone(ZoneOffset.UTC).toLocalDate().isAfter(endDate))
-                .map(recognition -> RevenueAllocation.calculate(recognition.orderId(), recognition.netAmount(), commissionPct, withholdingPct, Money.zero(recognition.amount().currency())))
+            List<RevenueAllocation> allocations = revenueRecognitions.findBySupplierAndPeriod(supplierId, startDate, endDate).stream()
+                .map(recognition -> RevenueAllocation.calculate(recognition.orderId(), recognition.netAmount(), commissionPct, withholdingPct, refundAdjustmentsForOrder(recognition.orderId(), recognition.amount().currency())))
                 .toList();
+            if (!allocations.isEmpty()) {
+                currency = allocations.getFirst().grossRevenue().currency();
+            }
             SupplierSettlement settlement = SupplierSettlement.calculate(supplierId, period, commissionPct, withholdingPct, allocations, currency,
                 clock.instant(), PrefixedIds.newCommandId(), PrefixedIds.newCommandId(), canonicalCorrelationId(correlationId));
             supplierSettlements.save(settlement);
             publish(settlement.domainEvents());
             return settlement;
         });
+    }
+
+    public FeeAccrual accrueFeesForPaymentCapture(String orderId, Money capturedAmount, Money refundedAmount, String sourceEventId, Instant now, String causationId, String correlationId) {
+        requireText(orderId, "orderId");
+        if (feeAccruals.findByOrderId(orderId).stream().anyMatch(accrual -> accrual.sourceEventId().equals(sourceEventId))) {
+            return feeAccruals.findByOrderId(orderId).stream().filter(accrual -> accrual.sourceEventId().equals(sourceEventId)).findFirst().orElseThrow();
+        }
+        Money platformServiceFee = RevenueAllocation.multiply(capturedAmount, PLATFORM_SERVICE_FEE_PCT);
+        Money supplierServiceFee = RevenueAllocation.multiply(capturedAmount, SUPPLIER_SERVICE_FEE_PCT);
+        Money serviceFees = platformServiceFee.plus(supplierServiceFee);
+        TaxCalculation tax = TaxCalculation.calculate(serviceFees, capturedAmount, capturedAmount.minus(platformServiceFee), BigDecimal.ZERO, refundedAmount);
+        FeeAccrual accrual = FeeAccrual.accrue(orderId, platformServiceFee, supplierServiceFee, Money.zero(capturedAmount.currency()), tax, sourceEventId, now, PrefixedIds.newCommandId(), causationId, canonicalCorrelationId(correlationId));
+        feeAccruals.save(accrual);
+        publish(accrual.domainEvents());
+        return accrual;
+    }
+
+    public FeeAccrual accrueFeesForRefund(String orderId, Money refundAmount, Currency currency, String sourceEventId, Instant now, String causationId, String correlationId) {
+        requireText(orderId, "orderId");
+        if (feeAccruals.findByOrderId(orderId).stream().anyMatch(accrual -> accrual.sourceEventId().equals(sourceEventId))) {
+            return feeAccruals.findByOrderId(orderId).stream().filter(accrual -> accrual.sourceEventId().equals(sourceEventId)).findFirst().orElseThrow();
+        }
+        Currency effectiveCurrency = Objects.requireNonNull(currency, "currency is required");
+        Money zero = Money.zero(effectiveCurrency);
+        Money retainedCancellationFee = RevenueAllocation.multiply(refundAmount, VOLUNTARY_CANCELLATION_RETAINED_FEE_PCT);
+        TaxCalculation tax = TaxCalculation.calculate(zero, zero, zero, BigDecimal.ZERO, refundAmount);
+        FeeAccrual accrual = FeeAccrual.accrue(orderId, zero, zero, retainedCancellationFee, tax, sourceEventId, now, PrefixedIds.newCommandId(), causationId, canonicalCorrelationId(correlationId));
+        feeAccruals.save(accrual);
+        publish(accrual.domainEvents());
+        return accrual;
+    }
+
+    private Money refundAdjustmentsForOrder(String orderId, Currency currency) {
+        List<FeeAccrual> orderFees = feeAccruals.findByOrderId(orderId);
+        return orderFees.stream()
+            .map(FeeAccrual::taxCalculation)
+            .map(TaxCalculation::taxReversal)
+            .filter(amount -> amount.currency().equals(currency))
+            .reduce(Money.zero(currency), Money::plus);
     }
 
     public String describeWiring() {
@@ -297,6 +373,28 @@ public class FinanceSettlementApplicationService {
             } catch (PublishFailedException | DomainRuleViolation ex) {
                 throw ex;
             }
+        }
+    }
+
+    private static String reconciliationKey(String orderId, String paymentIntentId) {
+        String normalizedOrderId = orderId == null ? "" : orderId;
+        String normalizedPaymentIntentId = paymentIntentId == null ? "" : paymentIntentId;
+        return normalizedOrderId.isBlank() ? normalizedPaymentIntentId : normalizedOrderId;
+    }
+
+    private record PlatformReconciliationFact(String orderId, String paymentIntentId, Money amount, List<String> sourceEventIds) {
+        private PlatformReconciliationFact merge(PlatformReconciliationFact other) {
+            List<String> mergedEvents = new ArrayList<>(sourceEventIds);
+            mergedEvents.addAll(other.sourceEventIds);
+            return new PlatformReconciliationFact(orderId, paymentIntentId.isBlank() ? other.paymentIntentId : paymentIntentId, amount.plus(other.amount), mergedEvents);
+        }
+    }
+
+    private record ChannelReconciliationFact(String orderId, String paymentIntentId, Money amount, List<String> sourceEventIds) {
+        private ChannelReconciliationFact merge(ChannelReconciliationFact other) {
+            List<String> mergedEvents = new ArrayList<>(sourceEventIds);
+            mergedEvents.addAll(other.sourceEventIds);
+            return new ChannelReconciliationFact(orderId, paymentIntentId.isBlank() ? other.paymentIntentId : paymentIntentId, amount.plus(other.amount), mergedEvents);
         }
     }
 

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementApplicationService.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementApplicationService.java
@@ -4,13 +4,25 @@ import com.trainticket.financesettlement.domain.DomainRuleViolation;
 import com.trainticket.financesettlement.domain.EventMetadata;
 import com.trainticket.financesettlement.domain.FinanceSettlementEvent;
 import com.trainticket.financesettlement.domain.Invoice;
+import com.trainticket.financesettlement.domain.ReconciliationBatch;
+import com.trainticket.financesettlement.domain.ReconciliationEntry;
+import com.trainticket.financesettlement.domain.SettlementFrequency;
+import com.trainticket.financesettlement.domain.SettlementPeriod;
+import com.trainticket.financesettlement.domain.SupplierSettlement;
+import com.trainticket.financesettlement.domain.RevenueAllocation;
 import com.trainticket.financesettlement.domain.Money;
 import com.trainticket.financesettlement.domain.ReconciliationCase;
 import com.trainticket.financesettlement.domain.ReconciliationCompleted;
 import com.trainticket.financesettlement.domain.RevenueRecognition;
 import com.trainticket.platformkit.messaging.PrefixedIds;
 import java.time.Clock;
+import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Currency;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -19,6 +31,8 @@ public class FinanceSettlementApplicationService {
     private final ReconciliationCaseRepository reconciliationCases;
     private final InvoiceRepository invoices;
     private final FinanceSettlementProjectionRepository projections;
+    private final ReconciliationBatchRepository reconciliationBatches;
+    private final SupplierSettlementRepository supplierSettlements;
     private final EventPublisher eventPublisher;
     private final DomainEventEnvelopeMapper envelopeMapper;
     private final Clock clock;
@@ -29,7 +43,7 @@ public class FinanceSettlementApplicationService {
         EventPublisher eventPublisher,
         DomainEventEnvelopeMapper envelopeMapper
     ) {
-        this(revenueRecognitions, reconciliationCases, new InMemoryInvoiceRepository(), new InMemoryFinanceSettlementProjectionRepository(), eventPublisher, envelopeMapper, Clock.systemUTC());
+        this(revenueRecognitions, reconciliationCases, new InMemoryInvoiceRepository(), new InMemoryFinanceSettlementProjectionRepository(), new InMemoryReconciliationBatchRepository(), new InMemorySupplierSettlementRepository(), eventPublisher, envelopeMapper, Clock.systemUTC());
     }
 
     public FinanceSettlementApplicationService(
@@ -40,7 +54,7 @@ public class FinanceSettlementApplicationService {
         DomainEventEnvelopeMapper envelopeMapper,
         Clock clock
     ) {
-        this(revenueRecognitions, reconciliationCases, invoices, new InMemoryFinanceSettlementProjectionRepository(), eventPublisher, envelopeMapper, clock);
+        this(revenueRecognitions, reconciliationCases, invoices, new InMemoryFinanceSettlementProjectionRepository(), new InMemoryReconciliationBatchRepository(), new InMemorySupplierSettlementRepository(), eventPublisher, envelopeMapper, clock);
     }
 
     public FinanceSettlementApplicationService(
@@ -52,10 +66,26 @@ public class FinanceSettlementApplicationService {
         DomainEventEnvelopeMapper envelopeMapper,
         Clock clock
     ) {
+        this(revenueRecognitions, reconciliationCases, invoices, projections, new InMemoryReconciliationBatchRepository(), new InMemorySupplierSettlementRepository(), eventPublisher, envelopeMapper, clock);
+    }
+
+    public FinanceSettlementApplicationService(
+        RevenueRecognitionRepository revenueRecognitions,
+        ReconciliationCaseRepository reconciliationCases,
+        InvoiceRepository invoices,
+        FinanceSettlementProjectionRepository projections,
+        ReconciliationBatchRepository reconciliationBatches,
+        SupplierSettlementRepository supplierSettlements,
+        EventPublisher eventPublisher,
+        DomainEventEnvelopeMapper envelopeMapper,
+        Clock clock
+    ) {
         this.revenueRecognitions = revenueRecognitions;
         this.reconciliationCases = reconciliationCases;
         this.invoices = invoices;
         this.projections = projections;
+        this.reconciliationBatches = reconciliationBatches;
+        this.supplierSettlements = supplierSettlements;
         this.eventPublisher = eventPublisher;
         this.envelopeMapper = envelopeMapper;
         this.clock = clock;
@@ -74,6 +104,21 @@ public class FinanceSettlementApplicationService {
     public Invoice getInvoice(String invoiceId) {
         return invoices.findById(invoiceId)
             .orElseThrow(() -> new ResourceNotFoundException("invoice not found"));
+    }
+
+    public ReconciliationBatch getReconciliationBatch(String batchId) {
+        return reconciliationBatches.findById(batchId)
+            .orElseThrow(() -> new ResourceNotFoundException("reconciliation batch not found"));
+    }
+
+    public ReconciliationBatch getDailySettlement(LocalDate settlementDate) {
+        return reconciliationBatches.findBySettlementDate(settlementDate)
+            .orElseThrow(() -> new ResourceNotFoundException("daily settlement not found"));
+    }
+
+    public SupplierSettlement getSupplierSettlement(String supplierId, LocalDate startDate, LocalDate endDate) {
+        return supplierSettlements.findBySupplierAndPeriod(requireText(supplierId, "supplierId"), startDate, endDate)
+            .orElseThrow(() -> new ResourceNotFoundException("supplier settlement not found"));
     }
 
     List<RevenueRecognition> findRevenueRecognitionsByOrderId(String orderId) {
@@ -152,6 +197,57 @@ public class FinanceSettlementApplicationService {
         });
     }
 
+    public ReconciliationBatch runDailyReconciliation(LocalDate settlementDate, String correlationId) {
+        LocalDate date = settlementDate == null ? LocalDate.now(clock).minusDays(1) : settlementDate;
+        return reconciliationBatches.findBySettlementDate(date).orElseGet(() -> {
+            Currency[] currency = {Currency.getInstance("CNY")};
+            Map<String, FinanceSettlementEventHandler.PaymentCaptureFact> captures = new LinkedHashMap<>();
+            for (FinanceSettlementEventHandler.PaymentCaptureFact capture : projections.findCapturesForSettlementDate(date)) {
+                captures.put(capture.orderId().isBlank() ? capture.paymentIntentId() : capture.orderId(), capture);
+                currency[0] = capture.amount().currency();
+            }
+            Map<String, ChannelStatementProjection> statements = new LinkedHashMap<>();
+            for (ChannelStatementProjection statement : projections.findChannelStatementsForSettlementDate(date)) {
+                statements.put(statement.channelStatementId(), statement);
+                currency[0] = Currency.getInstance(statement.currency());
+            }
+            List<ReconciliationEntry> entries = new ArrayList<>();
+            for (var item : captures.entrySet()) {
+                ChannelStatementProjection statement = statements.remove(item.getKey());
+                Money channelAmount = statement == null ? Money.zero(item.getValue().amount().currency()) : statement.grossPaymentAmount().minus(statement.grossRefundAmount());
+                entries.add(ReconciliationEntry.compare("re-" + item.getKey(), item.getKey(), item.getValue().paymentIntentId(), item.getValue().amount(), channelAmount, true, statement != null, List.of(item.getValue().sourceEventId())));
+            }
+            for (var item : statements.entrySet()) {
+                Money channelAmount = item.getValue().grossPaymentAmount().minus(item.getValue().grossRefundAmount());
+                entries.add(ReconciliationEntry.compare("re-" + item.getKey(), item.getKey(), "", Money.zero(channelAmount.currency()), channelAmount, false, true, List.of(item.getValue().sourceEventId())));
+            }
+            ReconciliationBatch batch = ReconciliationBatch.complete(date, date.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC), currency[0], entries,
+                clock.instant(), PrefixedIds.newCommandId(), PrefixedIds.newCommandId(), canonicalCorrelationId(correlationId));
+            reconciliationBatches.save(batch);
+            publish(batch.domainEvents());
+            return batch;
+        });
+    }
+
+    public SupplierSettlement calculateSupplierSettlement(String supplierId, LocalDate startDate, LocalDate endDate, SettlementFrequency frequency,
+                                                          BigDecimal commissionPct, BigDecimal withholdingPct, String correlationId) {
+        requireText(supplierId, "supplierId");
+        SettlementPeriod period = new SettlementPeriod(startDate, endDate, frequency == null ? SettlementFrequency.DAILY : frequency);
+        return supplierSettlements.findBySupplierAndPeriod(supplierId, startDate, endDate).orElseGet(() -> {
+            Currency currency = Currency.getInstance("CNY");
+            List<RevenueAllocation> allocations = revenueRecognitions.findByOrderId(supplierId).stream()
+                .filter(recognition -> !recognition.recognizedAt().atZone(ZoneOffset.UTC).toLocalDate().isBefore(startDate))
+                .filter(recognition -> !recognition.recognizedAt().atZone(ZoneOffset.UTC).toLocalDate().isAfter(endDate))
+                .map(recognition -> RevenueAllocation.calculate(recognition.orderId(), recognition.netAmount(), commissionPct, withholdingPct, Money.zero(recognition.amount().currency())))
+                .toList();
+            SupplierSettlement settlement = SupplierSettlement.calculate(supplierId, period, commissionPct, withholdingPct, allocations, currency,
+                clock.instant(), PrefixedIds.newCommandId(), PrefixedIds.newCommandId(), canonicalCorrelationId(correlationId));
+            supplierSettlements.save(settlement);
+            publish(settlement.domainEvents());
+            return settlement;
+        });
+    }
+
     public String describeWiring() {
         return revenueRecognitions.getClass().getSimpleName() + "/" + reconciliationCases.getClass().getSimpleName()
             + "/" + invoices.getClass().getSimpleName() + "/" + eventPublisher.getClass().getSimpleName();
@@ -169,6 +265,11 @@ public class FinanceSettlementApplicationService {
     public void saveAndPublish(ReconciliationCase reconciliationCase) {
         reconciliationCases.save(reconciliationCase);
         publish(reconciliationCase.domainEvents());
+    }
+
+    public void saveAndPublish(SupplierSettlement settlement) {
+        supplierSettlements.save(settlement);
+        publish(settlement.domainEvents());
     }
 
     public void publishReconciliationCompleted(String orderId, String paymentIntentId, Money expectedAmount, Money actualAmount,

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
@@ -284,7 +284,7 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
             .orElseThrow(() -> new OutOfOrderEventException("PaymentCaptured received before order reference"));
         paymentIntentOrderReferences.save(paymentIntentId, orderId);
         Money captured = money(payload.get("capturedAmount"), "capturedAmount");
-        projections.saveCapture(orderId, new PaymentCaptureFact(paymentIntentId, captured, envelope.eventId()));
+        projections.saveCapture(orderId, new PaymentCaptureFact(orderId, paymentIntentId, captured, envelope.eventId()));
         RevenueRecognition recognition = RevenueRecognition.recognize(
             orderId,
             orderItemReference(payload, orderId),
@@ -506,7 +506,11 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
         return Money.of(currencyCode, majorUnits.toPlainString());
     }
 
-    public record PaymentCaptureFact(String paymentIntentId, Money amount, String sourceEventId) {}
+    public record PaymentCaptureFact(String orderId, String paymentIntentId, Money amount, String sourceEventId) {
+        public PaymentCaptureFact(String paymentIntentId, Money amount, String sourceEventId) {
+            this("", paymentIntentId, amount, sourceEventId);
+        }
+    }
 
     private static final class OutOfOrderEventException extends RuntimeException {
         private OutOfOrderEventException(String message) {

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
@@ -143,6 +143,7 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
         Map<String, Object> payload = (Map<String, Object>) envelope.payload();
         switch (envelope.eventType()) {
             case "PaymentIntentCreated" -> rememberPaymentIntentOrderReference(payload);
+            case "JourneyOrderCreated" -> rememberOrderSupplierReference(payload);
             case "SegmentReservationRequested" -> rememberSegmentBookingOrderReference(payload);
             case "PaymentCaptured" -> {
                 LOGGER.info("service=finance-settlement PaymentCaptured eventId={} serviceWired={} projections={} serviceRepos={}",
@@ -159,6 +160,7 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
             }
             case "BenefitIssued", "BenefitRedeemed", "BenefitRedemptionReversed", "BenefitRevoked", "BenefitExpired" -> recordBenefitCostEntry(envelope, payload);
             case "ChannelStatementGenerated", "ChannelStatementFrozen" -> recordChannelStatement(envelope, payload);
+            case "ChannelStatementLineMatched" -> recordChannelStatementLine(envelope, payload);
             case "ReconciliationDiscrepancyOpened" -> openChannelDiscrepancy(envelope, payload);
             case "ReconciliationDiscrepancyResolved" -> {
                 // Finance owns final accounting case resolution; channel-side resolution is recorded by consumed-event dedup.
@@ -166,6 +168,30 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
             default -> {
                 // Streams contain event types that do not affect finance settlement.
             }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void rememberOrderSupplierReference(Map<String, Object> payload) {
+        String orderId = text(payload, "orderId");
+        Object supplierValue = payload.get("supplierId");
+        if (supplierValue instanceof String supplierId && !supplierId.isBlank()) {
+            segmentBookingOrderReferences.save("supplier:" + orderId, supplierId);
+            return;
+        }
+        Object refsValue = payload.get("supplierRefs");
+        if (refsValue instanceof List<?> refs) {
+            refs.stream()
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .filter(ref -> !ref.isBlank())
+                .findFirst()
+                .ifPresent(ref -> segmentBookingOrderReferences.save("supplier:" + orderId, ref));
+            return;
+        }
+        Object monetarySummary = payload.get("monetarySummary");
+        if (monetarySummary instanceof Map<?, ?> rawSummary && rawSummary.get("supplierId") instanceof String supplierId && !supplierId.isBlank()) {
+            segmentBookingOrderReferences.save("supplier:" + orderId, supplierId);
         }
     }
 
@@ -185,6 +211,25 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
             text(payload, "status"),
             existing == null ? Instant.parse(text(payload, "generatedAt")) : existing.generatedAt(),
             optionalText(payload, "frozenAt").map(Instant::parse).orElse(existing == null ? null : existing.frozenAt()),
+            envelope.eventId()
+        ));
+    }
+
+    private void recordChannelStatementLine(EventEnvelope envelope, Map<String, Object> payload) {
+        String channelStatementId = text(payload, "channelStatementId");
+        ChannelStatementProjection statement = projections.findChannelStatement(channelStatementId).orElse(null);
+        String paymentIntentId = optionalText(payload, "paymentIntentId").orElse("");
+        String orderId = optionalText(payload, "orderId")
+            .or(() -> paymentIntentId.isBlank() ? Optional.empty() : paymentIntentOrderReferences.findOrderReference(paymentIntentId))
+            .orElse(optionalText(payload, "channelOrderId").orElse(optionalText(payload, "channelRefundId").orElse("")));
+        projections.saveChannelStatementLine(new ChannelStatementLineProjection(
+            text(payload, "statementLineId"),
+            channelStatementId,
+            statement == null ? optionalText(payload, "statementDate").orElse("") : statement.statementDate(),
+            orderId,
+            paymentIntentId,
+            optionalText(payload, "channelOrderId").orElse(""),
+            money(payload.get("actualAmount"), "actualAmount"),
             envelope.eventId()
         ));
     }
@@ -284,10 +329,11 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
             .orElseThrow(() -> new OutOfOrderEventException("PaymentCaptured received before order reference"));
         paymentIntentOrderReferences.save(paymentIntentId, orderId);
         Money captured = money(payload.get("capturedAmount"), "capturedAmount");
-        projections.saveCapture(orderId, new PaymentCaptureFact(orderId, paymentIntentId, captured, envelope.eventId()));
+        projections.saveCapture(orderId, new PaymentCaptureFact(orderId, paymentIntentId, captured, envelope.eventId(), envelope.occurredAt()));
+        String supplierId = supplierReferenceForOrder(orderId);
         RevenueRecognition recognition = RevenueRecognition.recognize(
             orderId,
-            orderItemReference(payload, orderId),
+            supplierId,
             "fare",
             captured,
             "payment-capture-v1",
@@ -298,6 +344,7 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
             envelope.correlationId()
         );
         service.saveAndPublish(recognition);
+        service.accrueFeesForPaymentCapture(orderId, captured, Money.zero(captured.currency()), envelope.eventId(), clock.instant(), causationIdOrEventId(envelope), envelope.correlationId());
     }
 
     private void reconcileOperationalFact(EventEnvelope envelope, Map<String, Object> payload) {
@@ -425,6 +472,7 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
             envelope.correlationId()
         );
         service.saveAndPublish(originalRecognition, firstUnpublishedEventIndex);
+        service.accrueFeesForRefund(orderId, refund, capture == null ? refund.currency() : capture.amount().currency(), envelope.eventId(), clock.instant(), causationIdOrEventId(envelope), envelope.correlationId());
         Money expected = capture == null ? refund.negate() : capture.amount().minus(refund);
         service.publishReconciliationCompleted(
             orderId,
@@ -438,6 +486,10 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
             causationIdOrEventId(envelope),
             envelope.correlationId()
         );
+    }
+
+    private String supplierReferenceForOrder(String orderId) {
+        return segmentBookingOrderReferences.findOrderReference("supplier:" + orderId).orElse(orderId);
     }
 
     private List<RevenueRecognition> serviceRevenue(String orderId) {
@@ -506,9 +558,13 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
         return Money.of(currencyCode, majorUnits.toPlainString());
     }
 
-    public record PaymentCaptureFact(String orderId, String paymentIntentId, Money amount, String sourceEventId) {
+    public record PaymentCaptureFact(String orderId, String paymentIntentId, Money amount, String sourceEventId, Instant occurredAt) {
         public PaymentCaptureFact(String paymentIntentId, Money amount, String sourceEventId) {
-            this("", paymentIntentId, amount, sourceEventId);
+            this("", paymentIntentId, amount, sourceEventId, Instant.EPOCH);
+        }
+
+        public PaymentCaptureFact(String orderId, String paymentIntentId, Money amount, String sourceEventId) {
+            this(orderId, paymentIntentId, amount, sourceEventId, Instant.EPOCH);
         }
     }
 

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementProjectionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementProjectionRepository.java
@@ -1,6 +1,7 @@
 package com.trainticket.financesettlement.application;
 
 import com.trainticket.financesettlement.domain.Money;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,6 +13,10 @@ public interface FinanceSettlementProjectionRepository {
     Optional<Money> findApprovedRefund(String caseId);
 
     void saveApprovedRefund(String caseId, Money amount);
+
+    default List<FinanceSettlementEventHandler.PaymentCaptureFact> findCapturesForSettlementDate(LocalDate settlementDate) { return List.of(); }
+
+    default List<ChannelStatementProjection> findChannelStatementsForSettlementDate(LocalDate settlementDate) { return List.of(); }
 
     void saveBenefitCostEntry(BenefitCostEntry entry);
 

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementProjectionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementProjectionRepository.java
@@ -16,6 +16,10 @@ public interface FinanceSettlementProjectionRepository {
 
     default List<FinanceSettlementEventHandler.PaymentCaptureFact> findCapturesForSettlementDate(LocalDate settlementDate) { return List.of(); }
 
+    default void saveChannelStatementLine(ChannelStatementLineProjection line) {}
+
+    default List<ChannelStatementLineProjection> findChannelStatementLinesForSettlementDate(LocalDate settlementDate) { return List.of(); }
+
     default List<ChannelStatementProjection> findChannelStatementsForSettlementDate(LocalDate settlementDate) { return List.of(); }
 
     void saveBenefitCostEntry(BenefitCostEntry entry);

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryFeeAccrualRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryFeeAccrualRepository.java
@@ -1,0 +1,32 @@
+package com.trainticket.financesettlement.application;
+
+import com.trainticket.financesettlement.domain.FeeAccrual;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryFeeAccrualRepository implements FeeAccrualRepository {
+    private final ConcurrentMap<String, FeeAccrual> accruals = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<FeeAccrual> findById(String feeAccrualId) {
+        return Optional.ofNullable(accruals.get(feeAccrualId));
+    }
+
+    @Override
+    public List<FeeAccrual> findByOrderId(String orderId) {
+        return accruals.values().stream()
+            .filter(accrual -> accrual.orderId().equals(orderId))
+            .sorted(Comparator.comparing(FeeAccrual::feeAccrualId))
+            .toList();
+    }
+
+    @Override
+    public void save(FeeAccrual accrual) {
+        accruals.put(accrual.feeAccrualId(), accrual);
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryFinanceSettlementProjectionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryFinanceSettlementProjectionRepository.java
@@ -15,6 +15,7 @@ public class InMemoryFinanceSettlementProjectionRepository implements FinanceSet
     private final ConcurrentMap<String, Money> approvedRefundsByCaseId = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, BenefitCostEntry> benefitCostEntriesByEventId = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, ChannelStatementProjection> channelStatementsById = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ChannelStatementLineProjection> channelStatementLinesById = new ConcurrentHashMap<>();
 
     @Override
     public Optional<FinanceSettlementEventHandler.PaymentCaptureFact> findCapture(String orderId) {
@@ -38,7 +39,22 @@ public class InMemoryFinanceSettlementProjectionRepository implements FinanceSet
 
     @Override
     public List<FinanceSettlementEventHandler.PaymentCaptureFact> findCapturesForSettlementDate(LocalDate settlementDate) {
-        return capturesByOrderId.values().stream().toList();
+        return capturesByOrderId.values().stream()
+            .filter(capture -> settlementDate.equals(capture.occurredAt().atZone(java.time.ZoneOffset.UTC).toLocalDate()))
+            .toList();
+    }
+
+    @Override
+    public void saveChannelStatementLine(ChannelStatementLineProjection line) {
+        channelStatementLinesById.put(line.statementLineId(), line);
+    }
+
+    @Override
+    public List<ChannelStatementLineProjection> findChannelStatementLinesForSettlementDate(LocalDate settlementDate) {
+        return channelStatementLinesById.values().stream()
+            .filter(line -> settlementDate.toString().equals(line.statementDate()))
+            .sorted(Comparator.comparing(ChannelStatementLineProjection::statementLineId))
+            .toList();
     }
 
     @Override

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryFinanceSettlementProjectionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryFinanceSettlementProjectionRepository.java
@@ -1,6 +1,7 @@
 package com.trainticket.financesettlement.application;
 
 import com.trainticket.financesettlement.domain.Money;
+import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -33,6 +34,18 @@ public class InMemoryFinanceSettlementProjectionRepository implements FinanceSet
     @Override
     public void saveApprovedRefund(String caseId, Money amount) {
         approvedRefundsByCaseId.put(caseId, amount);
+    }
+
+    @Override
+    public List<FinanceSettlementEventHandler.PaymentCaptureFact> findCapturesForSettlementDate(LocalDate settlementDate) {
+        return capturesByOrderId.values().stream().toList();
+    }
+
+    @Override
+    public List<ChannelStatementProjection> findChannelStatementsForSettlementDate(LocalDate settlementDate) {
+        return channelStatementsById.values().stream()
+            .filter(statement -> settlementDate.toString().equals(statement.statementDate()))
+            .toList();
     }
 
     @Override

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryReconciliationBatchRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryReconciliationBatchRepository.java
@@ -1,0 +1,30 @@
+package com.trainticket.financesettlement.application;
+
+import com.trainticket.financesettlement.domain.ReconciliationBatch;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryReconciliationBatchRepository implements ReconciliationBatchRepository {
+    private final ConcurrentMap<String, ReconciliationBatch> byId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<LocalDate, String> byDate = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<ReconciliationBatch> findById(String batchId) {
+        return Optional.ofNullable(byId.get(batchId));
+    }
+
+    @Override
+    public Optional<ReconciliationBatch> findBySettlementDate(LocalDate settlementDate) {
+        return Optional.ofNullable(byDate.get(settlementDate)).map(byId::get);
+    }
+
+    @Override
+    public void save(ReconciliationBatch batch) {
+        byId.put(batch.batchId(), batch);
+        byDate.put(batch.settlementDate(), batch.batchId());
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryRevenueRecognitionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryRevenueRecognitionRepository.java
@@ -1,6 +1,8 @@
 package com.trainticket.financesettlement.application;
 
 import com.trainticket.financesettlement.domain.RevenueRecognition;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -21,6 +23,16 @@ public class InMemoryRevenueRecognitionRepository implements RevenueRecognitionR
     public List<RevenueRecognition> findByOrderId(String orderId) {
         return revenueRecognitions.values().stream()
             .filter(recognition -> recognition.orderId().equals(orderId))
+            .sorted(Comparator.comparing(RevenueRecognition::recognizedAt).thenComparing(RevenueRecognition::revenueRecognitionId))
+            .toList();
+    }
+
+    @Override
+    public List<RevenueRecognition> findBySupplierAndPeriod(String supplierId, LocalDate startDate, LocalDate endDate) {
+        return revenueRecognitions.values().stream()
+            .filter(recognition -> recognition.orderItemId().equals(supplierId))
+            .filter(recognition -> !recognition.recognizedAt().atZone(ZoneOffset.UTC).toLocalDate().isBefore(startDate))
+            .filter(recognition -> !recognition.recognizedAt().atZone(ZoneOffset.UTC).toLocalDate().isAfter(endDate))
             .sorted(Comparator.comparing(RevenueRecognition::recognizedAt).thenComparing(RevenueRecognition::revenueRecognitionId))
             .toList();
     }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemorySupplierSettlementRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemorySupplierSettlementRepository.java
@@ -1,0 +1,34 @@
+package com.trainticket.financesettlement.application;
+
+import com.trainticket.financesettlement.domain.SupplierSettlement;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemorySupplierSettlementRepository implements SupplierSettlementRepository {
+    private final ConcurrentMap<String, SupplierSettlement> byId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, String> bySupplierPeriod = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<SupplierSettlement> findById(String supplierSettlementId) {
+        return Optional.ofNullable(byId.get(supplierSettlementId));
+    }
+
+    @Override
+    public Optional<SupplierSettlement> findBySupplierAndPeriod(String supplierId, LocalDate startDate, LocalDate endDate) {
+        return Optional.ofNullable(bySupplierPeriod.get(key(supplierId, startDate, endDate))).map(byId::get);
+    }
+
+    @Override
+    public void save(SupplierSettlement settlement) {
+        byId.put(settlement.supplierSettlementId(), settlement);
+        bySupplierPeriod.put(key(settlement.supplierId(), settlement.period().startDate(), settlement.period().endDate()), settlement.supplierSettlementId());
+    }
+
+    private static String key(String supplierId, LocalDate startDate, LocalDate endDate) {
+        return supplierId + "|" + startDate + "|" + endDate;
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/ReconciliationBatchRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/ReconciliationBatchRepository.java
@@ -1,0 +1,11 @@
+package com.trainticket.financesettlement.application;
+
+import com.trainticket.financesettlement.domain.ReconciliationBatch;
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface ReconciliationBatchRepository {
+    Optional<ReconciliationBatch> findById(String batchId);
+    Optional<ReconciliationBatch> findBySettlementDate(LocalDate settlementDate);
+    void save(ReconciliationBatch batch);
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/RevenueRecognitionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/RevenueRecognitionRepository.java
@@ -1,11 +1,13 @@
 package com.trainticket.financesettlement.application;
 
 import com.trainticket.financesettlement.domain.RevenueRecognition;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 public interface RevenueRecognitionRepository {
     Optional<RevenueRecognition> findById(String revenueRecognitionId);
     List<RevenueRecognition> findByOrderId(String orderId);
+    default List<RevenueRecognition> findBySupplierAndPeriod(String supplierId, LocalDate startDate, LocalDate endDate) { return List.of(); }
     void save(RevenueRecognition recognition);
 }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/SupplierSettlementRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/SupplierSettlementRepository.java
@@ -1,0 +1,11 @@
+package com.trainticket.financesettlement.application;
+
+import com.trainticket.financesettlement.domain.SupplierSettlement;
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface SupplierSettlementRepository {
+    Optional<SupplierSettlement> findById(String supplierSettlementId);
+    Optional<SupplierSettlement> findBySupplierAndPeriod(String supplierId, LocalDate startDate, LocalDate endDate);
+    void save(SupplierSettlement settlement);
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/FeeAccrual.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/FeeAccrual.java
@@ -1,0 +1,78 @@
+package com.trainticket.financesettlement.domain;
+
+import com.trainticket.platformkit.idempotency.UuidV7;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class FeeAccrual {
+    private final String feeAccrualId;
+    private final String orderId;
+    private final Money platformServiceFee;
+    private final Money supplierServiceFee;
+    private final Money retainedCancellationFee;
+    private final TaxCalculation taxCalculation;
+    private final List<FinanceSettlementEvent> domainEvents;
+    private long version;
+
+    private FeeAccrual(String feeAccrualId, String orderId, Money platformServiceFee, Money supplierServiceFee, Money retainedCancellationFee, TaxCalculation taxCalculation) {
+        this.feeAccrualId = requireText(feeAccrualId, "feeAccrualId");
+        this.orderId = requireText(orderId, "orderId");
+        this.platformServiceFee = Objects.requireNonNull(platformServiceFee, "platformServiceFee is required");
+        this.supplierServiceFee = Objects.requireNonNull(supplierServiceFee, "supplierServiceFee is required");
+        this.retainedCancellationFee = Objects.requireNonNull(retainedCancellationFee, "retainedCancellationFee is required");
+        this.taxCalculation = Objects.requireNonNull(taxCalculation, "taxCalculation is required");
+        this.domainEvents = new ArrayList<>();
+    }
+
+    public static FeeAccrual accrue(
+        String orderId,
+        Money platformServiceFee,
+        Money supplierServiceFee,
+        Money retainedCancellationFee,
+        TaxCalculation taxCalculation,
+        Instant now,
+        String sourceCommandId,
+        String causationId,
+        String correlationId
+    ) {
+        FeeAccrual accrual = new FeeAccrual("fee-" + UuidV7.generate(), orderId, platformServiceFee, supplierServiceFee, retainedCancellationFee, taxCalculation);
+        accrual.domainEvents.add(new FeeAccrued(
+            accrual.feeAccrualId,
+            orderId,
+            platformServiceFee,
+            supplierServiceFee,
+            retainedCancellationFee,
+            taxCalculation,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId, Map.of("feeAccrualId", accrual.feeAccrualId, "orderId", orderId))
+        ));
+        return accrual;
+    }
+
+    public static FeeAccrual rehydrate(String feeAccrualId, String orderId, Money platformServiceFee, Money supplierServiceFee, Money retainedCancellationFee, TaxCalculation taxCalculation) {
+        return new FeeAccrual(feeAccrualId, orderId, platformServiceFee, supplierServiceFee, retainedCancellationFee, taxCalculation);
+    }
+
+    public FeeAccrual withVersion(long version) {
+        if (version < 0) throw new DomainRuleViolation("version must not be negative");
+        this.version = version;
+        return this;
+    }
+
+    public String feeAccrualId() { return feeAccrualId; }
+    public String orderId() { return orderId; }
+    public Money platformServiceFee() { return platformServiceFee; }
+    public Money supplierServiceFee() { return supplierServiceFee; }
+    public Money retainedCancellationFee() { return retainedCancellationFee; }
+    public TaxCalculation taxCalculation() { return taxCalculation; }
+    public List<FinanceSettlementEvent> domainEvents() { return Collections.unmodifiableList(domainEvents); }
+    public long version() { return version; }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) throw new DomainRuleViolation(name + " must not be blank");
+        return value;
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/FeeAccrual.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/FeeAccrual.java
@@ -15,16 +15,18 @@ public final class FeeAccrual {
     private final Money supplierServiceFee;
     private final Money retainedCancellationFee;
     private final TaxCalculation taxCalculation;
+    private final String sourceEventId;
     private final List<FinanceSettlementEvent> domainEvents;
     private long version;
 
-    private FeeAccrual(String feeAccrualId, String orderId, Money platformServiceFee, Money supplierServiceFee, Money retainedCancellationFee, TaxCalculation taxCalculation) {
+    private FeeAccrual(String feeAccrualId, String orderId, Money platformServiceFee, Money supplierServiceFee, Money retainedCancellationFee, TaxCalculation taxCalculation, String sourceEventId) {
         this.feeAccrualId = requireText(feeAccrualId, "feeAccrualId");
         this.orderId = requireText(orderId, "orderId");
         this.platformServiceFee = Objects.requireNonNull(platformServiceFee, "platformServiceFee is required");
         this.supplierServiceFee = Objects.requireNonNull(supplierServiceFee, "supplierServiceFee is required");
         this.retainedCancellationFee = Objects.requireNonNull(retainedCancellationFee, "retainedCancellationFee is required");
         this.taxCalculation = Objects.requireNonNull(taxCalculation, "taxCalculation is required");
+        this.sourceEventId = requireText(sourceEventId, "sourceEventId");
         this.domainEvents = new ArrayList<>();
     }
 
@@ -34,12 +36,13 @@ public final class FeeAccrual {
         Money supplierServiceFee,
         Money retainedCancellationFee,
         TaxCalculation taxCalculation,
+        String sourceEventId,
         Instant now,
         String sourceCommandId,
         String causationId,
         String correlationId
     ) {
-        FeeAccrual accrual = new FeeAccrual("fee-" + UuidV7.generate(), orderId, platformServiceFee, supplierServiceFee, retainedCancellationFee, taxCalculation);
+        FeeAccrual accrual = new FeeAccrual("fee-" + UuidV7.generate(), orderId, platformServiceFee, supplierServiceFee, retainedCancellationFee, taxCalculation, sourceEventId);
         accrual.domainEvents.add(new FeeAccrued(
             accrual.feeAccrualId,
             orderId,
@@ -53,7 +56,11 @@ public final class FeeAccrual {
     }
 
     public static FeeAccrual rehydrate(String feeAccrualId, String orderId, Money platformServiceFee, Money supplierServiceFee, Money retainedCancellationFee, TaxCalculation taxCalculation) {
-        return new FeeAccrual(feeAccrualId, orderId, platformServiceFee, supplierServiceFee, retainedCancellationFee, taxCalculation);
+        return rehydrate(feeAccrualId, orderId, platformServiceFee, supplierServiceFee, retainedCancellationFee, taxCalculation, feeAccrualId);
+    }
+
+    public static FeeAccrual rehydrate(String feeAccrualId, String orderId, Money platformServiceFee, Money supplierServiceFee, Money retainedCancellationFee, TaxCalculation taxCalculation, String sourceEventId) {
+        return new FeeAccrual(feeAccrualId, orderId, platformServiceFee, supplierServiceFee, retainedCancellationFee, taxCalculation, sourceEventId);
     }
 
     public FeeAccrual withVersion(long version) {
@@ -68,6 +75,7 @@ public final class FeeAccrual {
     public Money supplierServiceFee() { return supplierServiceFee; }
     public Money retainedCancellationFee() { return retainedCancellationFee; }
     public TaxCalculation taxCalculation() { return taxCalculation; }
+    public String sourceEventId() { return sourceEventId; }
     public List<FinanceSettlementEvent> domainEvents() { return Collections.unmodifiableList(domainEvents); }
     public long version() { return version; }
 

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/FeeAccrued.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/FeeAccrued.java
@@ -1,0 +1,37 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+
+public record FeeAccrued(
+    String feeAccrualId,
+    String orderId,
+    Money platformServiceFee,
+    Money supplierServiceFee,
+    Money retainedCancellationFee,
+    TaxCalculation taxCalculation,
+    EventMetadata metadata
+) implements FinanceSettlementEvent {
+    public FeeAccrued {
+        requireText(feeAccrualId, "feeAccrualId");
+        requireText(orderId, "orderId");
+        Objects.requireNonNull(platformServiceFee, "platformServiceFee is required");
+        Objects.requireNonNull(supplierServiceFee, "supplierServiceFee is required");
+        Objects.requireNonNull(retainedCancellationFee, "retainedCancellationFee is required");
+        Objects.requireNonNull(taxCalculation, "taxCalculation is required");
+        Objects.requireNonNull(metadata, "metadata is required");
+    }
+
+    private static void requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) throw new DomainRuleViolation(name + " must not be blank");
+    }
+
+    public String eventId() { return metadata.eventId(); }
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    public String causationId() { return metadata.causationId(); }
+    public String correlationId() { return metadata.correlationId(); }
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/FinanceSettlementEvent.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/FinanceSettlementEvent.java
@@ -9,6 +9,8 @@ public sealed interface FinanceSettlementEvent permits
     ReconciliationCaseOpened,
     ReconciliationCaseResolved,
     ReconciliationCompleted,
+    SupplierSettlementCalculated,
+    FeeAccrued,
     InvoiceGenerated,
     SettlementViewRebuilt {
     String eventId();

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationBatch.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationBatch.java
@@ -1,0 +1,104 @@
+package com.trainticket.financesettlement.domain;
+
+import com.trainticket.platformkit.idempotency.UuidV7;
+import com.trainticket.platformkit.messaging.PrefixedIds;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Currency;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class ReconciliationBatch {
+    private final String batchId;
+    private final LocalDate settlementDate;
+    private final Instant cutoffAt;
+    private final Currency currency;
+    private final List<ReconciliationEntry> entries;
+    private final List<FinanceSettlementEvent> domainEvents;
+    private ReconciliationReport report;
+    private long version;
+
+    private ReconciliationBatch(String batchId, LocalDate settlementDate, Instant cutoffAt, Currency currency, List<ReconciliationEntry> entries) {
+        this.batchId = requireText(batchId, "batchId");
+        this.settlementDate = Objects.requireNonNull(settlementDate, "settlementDate is required");
+        this.cutoffAt = Objects.requireNonNull(cutoffAt, "cutoffAt is required");
+        this.currency = Objects.requireNonNull(currency, "currency is required");
+        this.entries = new ArrayList<>(List.copyOf(entries));
+        this.domainEvents = new ArrayList<>();
+        this.report = ReconciliationReport.from(batchId, settlementDate.toString(), this.entries, currency);
+    }
+
+    public static ReconciliationBatch complete(
+        LocalDate settlementDate,
+        Instant cutoffAt,
+        Currency currency,
+        List<ReconciliationEntry> entries,
+        Instant now,
+        String sourceCommandId,
+        String causationId,
+        String correlationId
+    ) {
+        ReconciliationBatch batch = new ReconciliationBatch("rb-" + UuidV7.generate(), settlementDate, cutoffAt, currency, entries);
+        batch.domainEvents.add(batch.completedEvent(now, sourceCommandId, causationId, correlationId));
+        return batch;
+    }
+
+    public static ReconciliationBatch rehydrate(String batchId, LocalDate settlementDate, Instant cutoffAt, Currency currency, List<ReconciliationEntry> entries) {
+        return new ReconciliationBatch(batchId, settlementDate, cutoffAt, currency, entries);
+    }
+
+    public ReconciliationBatch withVersion(long version) {
+        if (version < 0) {
+            throw new DomainRuleViolation("version must not be negative");
+        }
+        this.version = version;
+        return this;
+    }
+
+    private ReconciliationCompleted completedEvent(Instant now, String sourceCommandId, String causationId, String correlationId) {
+        return ReconciliationCompleted.forBatch(
+            batchId,
+            settlementDate.toString(),
+            report.totalEntries(),
+            report.matchedEntries(),
+            report.matchRate(),
+            report.totalVariance(),
+            report.exceptions().size(),
+            EventMetadata.create(
+                now,
+                sourceCommandId,
+                causationId,
+                correlationId,
+                Map.of("batchId", batchId, "settlementDate", settlementDate.toString())
+            )
+        );
+    }
+
+    public Map<String, Long> statusCounts() {
+        Map<String, Long> counts = new LinkedHashMap<>();
+        for (ReconciliationStatus status : ReconciliationStatus.values()) {
+            counts.put(status.name(), entries.stream().filter(entry -> entry.status() == status).count());
+        }
+        return Collections.unmodifiableMap(counts);
+    }
+
+    public String batchId() { return batchId; }
+    public LocalDate settlementDate() { return settlementDate; }
+    public Instant cutoffAt() { return cutoffAt; }
+    public Currency currency() { return currency; }
+    public List<ReconciliationEntry> entries() { return Collections.unmodifiableList(entries); }
+    public ReconciliationReport report() { return report; }
+    public List<FinanceSettlementEvent> domainEvents() { return Collections.unmodifiableList(domainEvents); }
+    public long version() { return version; }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationCompleted.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationCompleted.java
@@ -1,5 +1,6 @@
 package com.trainticket.financesettlement.domain;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -14,17 +15,74 @@ public record ReconciliationCompleted(
     Money actualAmount,
     List<String> matchedRevenueRecognitionIds,
     List<String> sourceEventIds,
+    String batchId,
+    String settlementDate,
+    int totalEntries,
+    int matchedEntries,
+    BigDecimal matchRate,
+    Money totalVariance,
+    int exceptionCount,
     EventMetadata metadata
 ) implements FinanceSettlementEvent {
+    public ReconciliationCompleted(
+        String reconciliationId,
+        String orderId,
+        String paymentIntentId,
+        String reconciliationStatus,
+        Money expectedAmount,
+        Money actualAmount,
+        List<String> matchedRevenueRecognitionIds,
+        List<String> sourceEventIds,
+        EventMetadata metadata
+    ) {
+        this(reconciliationId, orderId, paymentIntentId, reconciliationStatus, expectedAmount, actualAmount,
+            matchedRevenueRecognitionIds, sourceEventIds, "", "", 0, 0, BigDecimal.ZERO.setScale(4), Money.zero(expectedAmount.currency()), 0, metadata);
+    }
+
     public ReconciliationCompleted {
         requireText(reconciliationId, "reconciliationId");
-        requireText(orderId, "orderId");
+        orderId = orderId == null ? "" : orderId;
+        paymentIntentId = paymentIntentId == null ? "" : paymentIntentId;
         requireText(reconciliationStatus, "reconciliationStatus");
         Objects.requireNonNull(expectedAmount, "expectedAmount is required");
         Objects.requireNonNull(actualAmount, "actualAmount is required");
+        matchedRevenueRecognitionIds = List.copyOf(matchedRevenueRecognitionIds == null ? List.of() : matchedRevenueRecognitionIds);
+        sourceEventIds = List.copyOf(sourceEventIds == null ? List.of() : sourceEventIds);
+        batchId = batchId == null ? "" : batchId;
+        settlementDate = settlementDate == null ? "" : settlementDate;
+        matchRate = Objects.requireNonNull(matchRate, "matchRate is required");
+        totalVariance = Objects.requireNonNull(totalVariance, "totalVariance is required");
         Objects.requireNonNull(metadata, "metadata is required");
-        matchedRevenueRecognitionIds = List.copyOf(matchedRevenueRecognitionIds);
-        sourceEventIds = List.copyOf(sourceEventIds);
+    }
+
+    public static ReconciliationCompleted forBatch(
+        String batchId,
+        String settlementDate,
+        int totalEntries,
+        int matchedEntries,
+        BigDecimal matchRate,
+        Money totalVariance,
+        int exceptionCount,
+        EventMetadata metadata
+    ) {
+        return new ReconciliationCompleted(
+            batchId,
+            "",
+            "",
+            "COMPLETED",
+            Money.zero(totalVariance.currency()),
+            Money.zero(totalVariance.currency()),
+            List.of(),
+            List.of(),
+            batchId,
+            settlementDate,
+            totalEntries,
+            matchedEntries,
+            matchRate,
+            totalVariance,
+            exceptionCount,
+            metadata
+        );
     }
 
     private static void requireText(String value, String name) {

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationEntry.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationEntry.java
@@ -1,0 +1,58 @@
+package com.trainticket.financesettlement.domain;
+
+import java.util.List;
+import java.util.Objects;
+
+public record ReconciliationEntry(
+    String entryId,
+    String orderId,
+    String paymentIntentId,
+    Money platformAmount,
+    Money channelAmount,
+    ReconciliationStatus status,
+    Money variance,
+    List<String> sourceEventIds
+) {
+    public ReconciliationEntry {
+        requireText(entryId, "entryId");
+        orderId = orderId == null ? "" : orderId;
+        paymentIntentId = paymentIntentId == null ? "" : paymentIntentId;
+        Objects.requireNonNull(platformAmount, "platformAmount is required");
+        Objects.requireNonNull(channelAmount, "channelAmount is required");
+        Objects.requireNonNull(status, "status is required");
+        Objects.requireNonNull(variance, "variance is required");
+        sourceEventIds = List.copyOf(sourceEventIds == null ? List.of() : sourceEventIds);
+    }
+
+    public static ReconciliationEntry compare(
+        String entryId,
+        String orderId,
+        String paymentIntentId,
+        Money platformAmount,
+        Money channelAmount,
+        boolean platformPresent,
+        boolean channelPresent,
+        List<String> sourceEventIds
+    ) {
+        ReconciliationStatus status;
+        if (platformPresent && channelPresent) {
+            status = platformAmount.compareTo(channelAmount) == 0 ? ReconciliationStatus.MATCHED : ReconciliationStatus.AMOUNT_MISMATCH;
+        } else if (platformPresent) {
+            status = ReconciliationStatus.PLATFORM_ONLY;
+        } else {
+            status = ReconciliationStatus.CHANNEL_ONLY;
+        }
+        return new ReconciliationEntry(entryId, orderId, paymentIntentId, platformAmount, channelAmount, status, platformAmount.minus(channelAmount), sourceEventIds);
+    }
+
+    public boolean isException() {
+        return status != ReconciliationStatus.MATCHED;
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationReport.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationReport.java
@@ -1,0 +1,55 @@
+package com.trainticket.financesettlement.domain;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Currency;
+import java.util.List;
+import java.util.Objects;
+
+public record ReconciliationReport(
+    String batchId,
+    String settlementDate,
+    int totalEntries,
+    int matchedEntries,
+    BigDecimal matchRate,
+    Money totalVariance,
+    List<ReconciliationEntry> exceptions
+) {
+    public ReconciliationReport {
+        requireText(batchId, "batchId");
+        requireText(settlementDate, "settlementDate");
+        if (totalEntries < 0 || matchedEntries < 0 || matchedEntries > totalEntries) {
+            throw new DomainRuleViolation("invalid reconciliation report counts");
+        }
+        Objects.requireNonNull(matchRate, "matchRate is required");
+        Objects.requireNonNull(totalVariance, "totalVariance is required");
+        exceptions = List.copyOf(exceptions == null ? List.of() : exceptions);
+    }
+
+    static ReconciliationReport from(String batchId, String settlementDate, List<ReconciliationEntry> entries, Currency currency) {
+        int total = entries.size();
+        int matched = (int) entries.stream().filter(entry -> entry.status() == ReconciliationStatus.MATCHED).count();
+        BigDecimal rate = total == 0
+            ? BigDecimal.ONE.setScale(4)
+            : BigDecimal.valueOf(matched).divide(BigDecimal.valueOf(total), 4, RoundingMode.HALF_UP);
+        Money variance = entries.stream()
+            .map(ReconciliationEntry::variance)
+            .reduce(Money.zero(currency), Money::plus);
+        return new ReconciliationReport(
+            batchId,
+            settlementDate,
+            total,
+            matched,
+            rate,
+            variance,
+            entries.stream().filter(ReconciliationEntry::isException).toList()
+        );
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationStatus.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationStatus.java
@@ -1,0 +1,8 @@
+package com.trainticket.financesettlement.domain;
+
+public enum ReconciliationStatus {
+    MATCHED,
+    PLATFORM_ONLY,
+    CHANNEL_ONLY,
+    AMOUNT_MISMATCH
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueAllocation.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueAllocation.java
@@ -31,7 +31,7 @@ public record RevenueAllocation(
         return new RevenueAllocation(orderId, grossRevenue, commission, withheld, payable, adjustments);
     }
 
-    static Money multiply(Money money, BigDecimal pct) {
+    public static Money multiply(Money money, BigDecimal pct) {
         BigDecimal amount = money.amount().multiply(pct).setScale(money.currency().getDefaultFractionDigits(), RoundingMode.HALF_UP);
         return new Money(money.currency(), amount);
     }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueAllocation.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueAllocation.java
@@ -1,0 +1,38 @@
+package com.trainticket.financesettlement.domain;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Objects;
+
+public record RevenueAllocation(
+    String orderId,
+    Money grossRevenue,
+    Money platformCommission,
+    Money taxesWithheld,
+    Money supplierPayable,
+    Money adjustments
+) {
+    public RevenueAllocation {
+        orderId = orderId == null ? "" : orderId;
+        Objects.requireNonNull(grossRevenue, "grossRevenue is required");
+        Objects.requireNonNull(platformCommission, "platformCommission is required");
+        Objects.requireNonNull(taxesWithheld, "taxesWithheld is required");
+        Objects.requireNonNull(supplierPayable, "supplierPayable is required");
+        Objects.requireNonNull(adjustments, "adjustments is required");
+        grossRevenue.plus(platformCommission).plus(taxesWithheld).plus(supplierPayable).plus(adjustments);
+    }
+
+    public static RevenueAllocation calculate(String orderId, Money grossRevenue, BigDecimal commissionPct, BigDecimal withholdingPct, Money adjustments) {
+        Objects.requireNonNull(commissionPct, "commissionPct is required");
+        Objects.requireNonNull(withholdingPct, "withholdingPct is required");
+        Money commission = multiply(grossRevenue, commissionPct);
+        Money withheld = multiply(grossRevenue, withholdingPct);
+        Money payable = grossRevenue.minus(commission).minus(withheld).plus(adjustments);
+        return new RevenueAllocation(orderId, grossRevenue, commission, withheld, payable, adjustments);
+    }
+
+    static Money multiply(Money money, BigDecimal pct) {
+        BigDecimal amount = money.amount().multiply(pct).setScale(money.currency().getDefaultFractionDigits(), RoundingMode.HALF_UP);
+        return new Money(money.currency(), amount);
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/SettlementFrequency.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/SettlementFrequency.java
@@ -1,0 +1,7 @@
+package com.trainticket.financesettlement.domain;
+
+public enum SettlementFrequency {
+    DAILY,
+    WEEKLY,
+    MONTHLY
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/SettlementPeriod.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/SettlementPeriod.java
@@ -1,0 +1,19 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+public record SettlementPeriod(LocalDate startDate, LocalDate endDate, SettlementFrequency frequency) {
+    public SettlementPeriod {
+        Objects.requireNonNull(startDate, "startDate is required");
+        Objects.requireNonNull(endDate, "endDate is required");
+        Objects.requireNonNull(frequency, "frequency is required");
+        if (endDate.isBefore(startDate)) {
+            throw new DomainRuleViolation("settlement period endDate must not be before startDate");
+        }
+    }
+
+    public boolean contains(LocalDate date) {
+        return !date.isBefore(startDate) && !date.isAfter(endDate);
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/SupplierSettlement.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/SupplierSettlement.java
@@ -1,0 +1,127 @@
+package com.trainticket.financesettlement.domain;
+
+import com.trainticket.platformkit.idempotency.UuidV7;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Currency;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class SupplierSettlement {
+    private final String supplierSettlementId;
+    private final String supplierId;
+    private final SettlementPeriod period;
+    private final BigDecimal platformCommissionPct;
+    private final BigDecimal withholdingTaxPct;
+    private final List<RevenueAllocation> allocations;
+    private final List<FinanceSettlementEvent> domainEvents;
+    private final Money grossRevenue;
+    private final Money platformCommission;
+    private final Money taxesWithheld;
+    private final Money supplierPayable;
+    private final Money adjustments;
+    private long version;
+
+    private SupplierSettlement(
+        String supplierSettlementId,
+        String supplierId,
+        SettlementPeriod period,
+        BigDecimal platformCommissionPct,
+        BigDecimal withholdingTaxPct,
+        List<RevenueAllocation> allocations,
+        Currency currency
+    ) {
+        this.supplierSettlementId = requireText(supplierSettlementId, "supplierSettlementId");
+        this.supplierId = requireText(supplierId, "supplierId");
+        this.period = Objects.requireNonNull(period, "period is required");
+        this.platformCommissionPct = validPct(platformCommissionPct, "platformCommissionPct");
+        this.withholdingTaxPct = validPct(withholdingTaxPct, "withholdingTaxPct");
+        this.allocations = new ArrayList<>(List.copyOf(allocations));
+        this.domainEvents = new ArrayList<>();
+        this.grossRevenue = sum(currency, this.allocations.stream().map(RevenueAllocation::grossRevenue).toList());
+        this.platformCommission = sum(currency, this.allocations.stream().map(RevenueAllocation::platformCommission).toList());
+        this.taxesWithheld = sum(currency, this.allocations.stream().map(RevenueAllocation::taxesWithheld).toList());
+        this.supplierPayable = sum(currency, this.allocations.stream().map(RevenueAllocation::supplierPayable).toList());
+        this.adjustments = sum(currency, this.allocations.stream().map(RevenueAllocation::adjustments).toList());
+    }
+
+    public static SupplierSettlement calculate(
+        String supplierId,
+        SettlementPeriod period,
+        BigDecimal platformCommissionPct,
+        BigDecimal withholdingTaxPct,
+        List<RevenueAllocation> allocations,
+        Currency currency,
+        Instant now,
+        String sourceCommandId,
+        String causationId,
+        String correlationId
+    ) {
+        SupplierSettlement settlement = new SupplierSettlement(
+            "ss-" + UuidV7.generate(), supplierId, period, platformCommissionPct, withholdingTaxPct, allocations, currency);
+        settlement.domainEvents.add(new SupplierSettlementCalculated(
+            settlement.supplierSettlementId,
+            supplierId,
+            period,
+            settlement.grossRevenue,
+            settlement.platformCommission,
+            settlement.taxesWithheld,
+            settlement.supplierPayable,
+            settlement.adjustments,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId, Map.of("supplierSettlementId", settlement.supplierSettlementId, "supplierId", supplierId))
+        ));
+        return settlement;
+    }
+
+    public static SupplierSettlement rehydrate(
+        String supplierSettlementId,
+        String supplierId,
+        SettlementPeriod period,
+        BigDecimal platformCommissionPct,
+        BigDecimal withholdingTaxPct,
+        List<RevenueAllocation> allocations,
+        Currency currency
+    ) {
+        return new SupplierSettlement(supplierSettlementId, supplierId, period, platformCommissionPct, withholdingTaxPct, allocations, currency);
+    }
+
+    public SupplierSettlement withVersion(long version) {
+        if (version < 0) throw new DomainRuleViolation("version must not be negative");
+        this.version = version;
+        return this;
+    }
+
+    private static Money sum(Currency currency, List<Money> amounts) {
+        return amounts.stream().reduce(Money.zero(currency), Money::plus);
+    }
+
+    private static BigDecimal validPct(BigDecimal value, String name) {
+        Objects.requireNonNull(value, name + " is required");
+        if (value.signum() < 0 || value.compareTo(BigDecimal.ONE) > 0) {
+            throw new DomainRuleViolation(name + " must be between 0 and 1");
+        }
+        return value;
+    }
+
+    public String supplierSettlementId() { return supplierSettlementId; }
+    public String supplierId() { return supplierId; }
+    public SettlementPeriod period() { return period; }
+    public BigDecimal platformCommissionPct() { return platformCommissionPct; }
+    public BigDecimal withholdingTaxPct() { return withholdingTaxPct; }
+    public List<RevenueAllocation> allocations() { return Collections.unmodifiableList(allocations); }
+    public Money grossRevenue() { return grossRevenue; }
+    public Money platformCommission() { return platformCommission; }
+    public Money taxesWithheld() { return taxesWithheld; }
+    public Money supplierPayable() { return supplierPayable; }
+    public Money adjustments() { return adjustments; }
+    public List<FinanceSettlementEvent> domainEvents() { return Collections.unmodifiableList(domainEvents); }
+    public long version() { return version; }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) throw new DomainRuleViolation(name + " must not be blank");
+        return value;
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/SupplierSettlementCalculated.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/SupplierSettlementCalculated.java
@@ -1,0 +1,41 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+
+public record SupplierSettlementCalculated(
+    String supplierSettlementId,
+    String supplierId,
+    SettlementPeriod period,
+    Money grossRevenue,
+    Money platformCommission,
+    Money taxesWithheld,
+    Money supplierPayable,
+    Money adjustments,
+    EventMetadata metadata
+) implements FinanceSettlementEvent {
+    public SupplierSettlementCalculated {
+        requireText(supplierSettlementId, "supplierSettlementId");
+        requireText(supplierId, "supplierId");
+        Objects.requireNonNull(period, "period is required");
+        Objects.requireNonNull(grossRevenue, "grossRevenue is required");
+        Objects.requireNonNull(platformCommission, "platformCommission is required");
+        Objects.requireNonNull(taxesWithheld, "taxesWithheld is required");
+        Objects.requireNonNull(supplierPayable, "supplierPayable is required");
+        Objects.requireNonNull(adjustments, "adjustments is required");
+        Objects.requireNonNull(metadata, "metadata is required");
+    }
+
+    private static void requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) throw new DomainRuleViolation(name + " must not be blank");
+    }
+
+    public String eventId() { return metadata.eventId(); }
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    public String causationId() { return metadata.causationId(); }
+    public String correlationId() { return metadata.correlationId(); }
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/TaxCalculation.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/TaxCalculation.java
@@ -1,0 +1,23 @@
+package com.trainticket.financesettlement.domain;
+
+import java.math.BigDecimal;
+
+public record TaxCalculation(
+    Money vatOnServiceFees,
+    Money stampDutyOnTickets,
+    Money withholdingOnSupplierPayment,
+    Money taxReversal
+) {
+    private static final BigDecimal VAT_RATE = new BigDecimal("0.06");
+    private static final BigDecimal STAMP_DUTY_RATE = new BigDecimal("0.0005");
+
+    public static TaxCalculation calculate(Money serviceFees, Money ticketAmount, Money supplierPayment, BigDecimal withholdingPct, Money refundedTicketAmount) {
+        Money vat = RevenueAllocation.multiply(serviceFees, VAT_RATE);
+        Money stampDuty = RevenueAllocation.multiply(ticketAmount, STAMP_DUTY_RATE);
+        Money withholding = RevenueAllocation.multiply(supplierPayment, withholdingPct);
+        Money reversal = refundedTicketAmount.isZero()
+            ? Money.zero(refundedTicketAmount.currency())
+            : RevenueAllocation.multiply(refundedTicketAmount, STAMP_DUTY_RATE).negate();
+        return new TaxCalculation(vat, stampDuty, withholding, reversal);
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/JacksonFinanceSettlementJson.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/JacksonFinanceSettlementJson.java
@@ -7,10 +7,18 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.trainticket.financesettlement.domain.Invoice;
 import com.trainticket.financesettlement.domain.Money;
+import com.trainticket.financesettlement.domain.ReconciliationBatch;
 import com.trainticket.financesettlement.domain.ReconciliationCase;
+import com.trainticket.financesettlement.domain.ReconciliationEntry;
+import com.trainticket.financesettlement.domain.ReconciliationStatus;
+import com.trainticket.financesettlement.domain.RevenueAllocation;
+import com.trainticket.financesettlement.domain.SettlementFrequency;
+import com.trainticket.financesettlement.domain.SettlementPeriod;
+import com.trainticket.financesettlement.domain.SupplierSettlement;
 import com.trainticket.financesettlement.domain.RevenueRecognition;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Currency;
 import java.util.List;
@@ -20,6 +28,8 @@ final class JacksonFinanceSettlementJson {
 
     record RevenueRecognitionSnapshot(@JsonValue ObjectNode data) { @JsonCreator(mode = JsonCreator.Mode.DELEGATING) static RevenueRecognitionSnapshot of(ObjectNode data) { return new RevenueRecognitionSnapshot(data); } }
     record ReconciliationCaseSnapshot(@JsonValue ObjectNode data) { @JsonCreator(mode = JsonCreator.Mode.DELEGATING) static ReconciliationCaseSnapshot of(ObjectNode data) { return new ReconciliationCaseSnapshot(data); } }
+    record ReconciliationBatchSnapshot(@JsonValue ObjectNode data) { @JsonCreator(mode = JsonCreator.Mode.DELEGATING) static ReconciliationBatchSnapshot of(ObjectNode data) { return new ReconciliationBatchSnapshot(data); } }
+    record SupplierSettlementSnapshot(@JsonValue ObjectNode data) { @JsonCreator(mode = JsonCreator.Mode.DELEGATING) static SupplierSettlementSnapshot of(ObjectNode data) { return new SupplierSettlementSnapshot(data); } }
     record InvoiceSnapshot(@JsonValue ObjectNode data) { @JsonCreator(mode = JsonCreator.Mode.DELEGATING) static InvoiceSnapshot of(ObjectNode data) { return new InvoiceSnapshot(data); } }
 
     static RevenueRecognitionSnapshot revenueSnapshot(RevenueRecognition recognition, ObjectMapper mapper) {
@@ -66,6 +76,79 @@ final class JacksonFinanceSettlementJson {
         return ReconciliationCase.rehydrate(n.path("reconciliationCaseId").asText(), n.path("orderId").asText(), n.path("paymentIntentId").asText(), n.path("differenceType").asText(),
             money(n.withObject("expectedAmount")), money(n.withObject("actualAmount")), n.path("description").asText(), Instant.parse(n.path("openedAt").asText()),
             ReconciliationCase.ReconciliationCaseStatus.valueOf(n.path("status").asText()), textOrNull(n, "resolution"), textOrNull(n, "resolutionNote"));
+    }
+
+    static ReconciliationBatchSnapshot batchSnapshot(ReconciliationBatch batch, ObjectMapper mapper) {
+        ObjectNode n = mapper.createObjectNode();
+        n.put("batchId", batch.batchId());
+        n.put("settlementDate", batch.settlementDate().toString());
+        n.put("cutoffAt", batch.cutoffAt().toString());
+        n.put("currency", batch.currency().getCurrencyCode());
+        ArrayNode entries = n.putArray("entries");
+        for (ReconciliationEntry entry : batch.entries()) {
+            ObjectNode e = entries.addObject();
+            e.put("entryId", entry.entryId());
+            e.put("orderId", entry.orderId());
+            e.put("paymentIntentId", entry.paymentIntentId());
+            money(e.putObject("platformAmount"), entry.platformAmount());
+            money(e.putObject("channelAmount"), entry.channelAmount());
+            e.put("status", entry.status().name());
+            money(e.putObject("variance"), entry.variance());
+            ArrayNode sourceEventIds = e.putArray("sourceEventIds");
+            entry.sourceEventIds().forEach(sourceEventIds::add);
+        }
+        return new ReconciliationBatchSnapshot(n);
+    }
+
+    static ReconciliationBatch toBatch(ReconciliationBatchSnapshot snapshot, ObjectMapper mapper) {
+        ObjectNode n = snapshot.data();
+        List<ReconciliationEntry> entries = new ArrayList<>();
+        n.withArray("entries").forEach(item -> {
+            ObjectNode e = (ObjectNode) item;
+            List<String> sourceEventIds = new ArrayList<>();
+            e.withArray("sourceEventIds").forEach(id -> sourceEventIds.add(id.asText()));
+            entries.add(new ReconciliationEntry(e.path("entryId").asText(), e.path("orderId").asText(), e.path("paymentIntentId").asText(),
+                money(e.withObject("platformAmount")), money(e.withObject("channelAmount")), ReconciliationStatus.valueOf(e.path("status").asText()),
+                money(e.withObject("variance")), sourceEventIds));
+        });
+        return ReconciliationBatch.rehydrate(n.path("batchId").asText(), LocalDate.parse(n.path("settlementDate").asText()),
+            Instant.parse(n.path("cutoffAt").asText()), Currency.getInstance(n.path("currency").asText()), entries);
+    }
+
+    static SupplierSettlementSnapshot supplierSnapshot(SupplierSettlement settlement, ObjectMapper mapper) {
+        ObjectNode n = mapper.createObjectNode();
+        n.put("supplierSettlementId", settlement.supplierSettlementId());
+        n.put("supplierId", settlement.supplierId());
+        n.put("startDate", settlement.period().startDate().toString());
+        n.put("endDate", settlement.period().endDate().toString());
+        n.put("frequency", settlement.period().frequency().name());
+        n.put("platformCommissionPct", settlement.platformCommissionPct().toPlainString());
+        n.put("withholdingTaxPct", settlement.withholdingTaxPct().toPlainString());
+        n.put("currency", settlement.grossRevenue().currency().getCurrencyCode());
+        ArrayNode allocations = n.putArray("allocations");
+        for (RevenueAllocation allocation : settlement.allocations()) {
+            ObjectNode a = allocations.addObject();
+            a.put("orderId", allocation.orderId());
+            money(a.putObject("grossRevenue"), allocation.grossRevenue());
+            money(a.putObject("platformCommission"), allocation.platformCommission());
+            money(a.putObject("taxesWithheld"), allocation.taxesWithheld());
+            money(a.putObject("supplierPayable"), allocation.supplierPayable());
+            money(a.putObject("adjustments"), allocation.adjustments());
+        }
+        return new SupplierSettlementSnapshot(n);
+    }
+
+    static SupplierSettlement toSupplier(SupplierSettlementSnapshot snapshot, ObjectMapper mapper) {
+        ObjectNode n = snapshot.data();
+        List<RevenueAllocation> allocations = new ArrayList<>();
+        n.withArray("allocations").forEach(item -> {
+            ObjectNode a = (ObjectNode) item;
+            allocations.add(new RevenueAllocation(a.path("orderId").asText(), money(a.withObject("grossRevenue")), money(a.withObject("platformCommission")),
+                money(a.withObject("taxesWithheld")), money(a.withObject("supplierPayable")), money(a.withObject("adjustments"))));
+        });
+        return SupplierSettlement.rehydrate(n.path("supplierSettlementId").asText(), n.path("supplierId").asText(),
+            new SettlementPeriod(LocalDate.parse(n.path("startDate").asText()), LocalDate.parse(n.path("endDate").asText()), SettlementFrequency.valueOf(n.path("frequency").asText())),
+            new BigDecimal(n.path("platformCommissionPct").asText()), new BigDecimal(n.path("withholdingTaxPct").asText()), allocations, Currency.getInstance(n.path("currency").asText()));
     }
 
     static InvoiceSnapshot invoiceSnapshot(Invoice invoice, ObjectMapper mapper) {

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/JacksonFinanceSettlementJson.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/JacksonFinanceSettlementJson.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.trainticket.financesettlement.domain.FeeAccrual;
 import com.trainticket.financesettlement.domain.Invoice;
 import com.trainticket.financesettlement.domain.Money;
 import com.trainticket.financesettlement.domain.ReconciliationBatch;
@@ -15,6 +16,7 @@ import com.trainticket.financesettlement.domain.RevenueAllocation;
 import com.trainticket.financesettlement.domain.SettlementFrequency;
 import com.trainticket.financesettlement.domain.SettlementPeriod;
 import com.trainticket.financesettlement.domain.SupplierSettlement;
+import com.trainticket.financesettlement.domain.TaxCalculation;
 import com.trainticket.financesettlement.domain.RevenueRecognition;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -30,6 +32,7 @@ final class JacksonFinanceSettlementJson {
     record ReconciliationCaseSnapshot(@JsonValue ObjectNode data) { @JsonCreator(mode = JsonCreator.Mode.DELEGATING) static ReconciliationCaseSnapshot of(ObjectNode data) { return new ReconciliationCaseSnapshot(data); } }
     record ReconciliationBatchSnapshot(@JsonValue ObjectNode data) { @JsonCreator(mode = JsonCreator.Mode.DELEGATING) static ReconciliationBatchSnapshot of(ObjectNode data) { return new ReconciliationBatchSnapshot(data); } }
     record SupplierSettlementSnapshot(@JsonValue ObjectNode data) { @JsonCreator(mode = JsonCreator.Mode.DELEGATING) static SupplierSettlementSnapshot of(ObjectNode data) { return new SupplierSettlementSnapshot(data); } }
+    record FeeAccrualSnapshot(@JsonValue ObjectNode data) { @JsonCreator(mode = JsonCreator.Mode.DELEGATING) static FeeAccrualSnapshot of(ObjectNode data) { return new FeeAccrualSnapshot(data); } }
     record InvoiceSnapshot(@JsonValue ObjectNode data) { @JsonCreator(mode = JsonCreator.Mode.DELEGATING) static InvoiceSnapshot of(ObjectNode data) { return new InvoiceSnapshot(data); } }
 
     static RevenueRecognitionSnapshot revenueSnapshot(RevenueRecognition recognition, ObjectMapper mapper) {
@@ -149,6 +152,41 @@ final class JacksonFinanceSettlementJson {
         return SupplierSettlement.rehydrate(n.path("supplierSettlementId").asText(), n.path("supplierId").asText(),
             new SettlementPeriod(LocalDate.parse(n.path("startDate").asText()), LocalDate.parse(n.path("endDate").asText()), SettlementFrequency.valueOf(n.path("frequency").asText())),
             new BigDecimal(n.path("platformCommissionPct").asText()), new BigDecimal(n.path("withholdingTaxPct").asText()), allocations, Currency.getInstance(n.path("currency").asText()));
+    }
+
+    static FeeAccrualSnapshot feeSnapshot(FeeAccrual accrual, ObjectMapper mapper) {
+        ObjectNode n = mapper.createObjectNode();
+        n.put("feeAccrualId", accrual.feeAccrualId());
+        n.put("orderId", accrual.orderId());
+        money(n.putObject("platformServiceFee"), accrual.platformServiceFee());
+        money(n.putObject("supplierServiceFee"), accrual.supplierServiceFee());
+        money(n.putObject("retainedCancellationFee"), accrual.retainedCancellationFee());
+        ObjectNode tax = n.putObject("taxCalculation");
+        money(tax.putObject("vatOnServiceFees"), accrual.taxCalculation().vatOnServiceFees());
+        money(tax.putObject("stampDutyOnTickets"), accrual.taxCalculation().stampDutyOnTickets());
+        money(tax.putObject("withholdingOnSupplierPayment"), accrual.taxCalculation().withholdingOnSupplierPayment());
+        money(tax.putObject("taxReversal"), accrual.taxCalculation().taxReversal());
+        n.put("sourceEventId", accrual.sourceEventId());
+        return new FeeAccrualSnapshot(n);
+    }
+
+    static FeeAccrual toFee(FeeAccrualSnapshot snapshot, ObjectMapper mapper) {
+        ObjectNode n = snapshot.data();
+        ObjectNode tax = n.withObject("taxCalculation");
+        return FeeAccrual.rehydrate(
+            n.path("feeAccrualId").asText(),
+            n.path("orderId").asText(),
+            money(n.withObject("platformServiceFee")),
+            money(n.withObject("supplierServiceFee")),
+            money(n.withObject("retainedCancellationFee")),
+            new TaxCalculation(
+                money(tax.withObject("vatOnServiceFees")),
+                money(tax.withObject("stampDutyOnTickets")),
+                money(tax.withObject("withholdingOnSupplierPayment")),
+                money(tax.withObject("taxReversal"))
+            ),
+            n.path("sourceEventId").asText(n.path("feeAccrualId").asText())
+        );
     }
 
     static InvoiceSnapshot invoiceSnapshot(Invoice invoice, ObjectMapper mapper) {

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/PostgresFinanceRepositories.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/PostgresFinanceRepositories.java
@@ -2,12 +2,17 @@ package com.trainticket.financesettlement.infrastructure.persistence;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trainticket.financesettlement.application.InvoiceRepository;
+import com.trainticket.financesettlement.application.ReconciliationBatchRepository;
+import com.trainticket.financesettlement.application.SupplierSettlementRepository;
 import com.trainticket.financesettlement.application.ReconciliationCaseRepository;
 import com.trainticket.financesettlement.application.RevenueRecognitionRepository;
 import com.trainticket.financesettlement.domain.Invoice;
+import com.trainticket.financesettlement.domain.ReconciliationBatch;
 import com.trainticket.financesettlement.domain.ReconciliationCase;
 import com.trainticket.financesettlement.domain.RevenueRecognition;
+import com.trainticket.financesettlement.domain.SupplierSettlement;
 import com.trainticket.platformkit.persistence.SnapshotRepository;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
@@ -123,6 +128,76 @@ final class PostgresFinanceRepositories {
                 JacksonFinanceSettlementJson.caseSnapshot(c, mapper)
             );
             c.withVersion(newVersion);
+        }
+    }
+
+    @Repository
+    @Primary
+    @ConditionalOnBean(DataSource.class)
+    static class Batches implements ReconciliationBatchRepository {
+        private final ObjectMapper mapper;
+        private final SnapshotRepository<JacksonFinanceSettlementJson.ReconciliationBatchSnapshot> snapshots;
+        private final JdbcTemplate jdbc;
+
+        Batches(DataSource ds, ObjectMapper mapper) {
+            this.mapper = mapper;
+            this.snapshots = new SnapshotRepository<>(ds, mapper, "reconciliation_batch_snapshots", JacksonFinanceSettlementJson.ReconciliationBatchSnapshot.class);
+            this.jdbc = new JdbcTemplate(ds);
+        }
+
+        @Override
+        public Optional<ReconciliationBatch> findById(String id) {
+            return snapshots.get(id).map(snapshot -> JacksonFinanceSettlementJson.toBatch(snapshot.data(), mapper).withVersion(snapshot.version()));
+        }
+
+        @Override
+        public Optional<ReconciliationBatch> findBySettlementDate(LocalDate settlementDate) {
+            return jdbc.query(
+                "SELECT id FROM reconciliation_batch_snapshots WHERE data->>'settlementDate' = ? LIMIT 1",
+                rs -> rs.next() ? findById(rs.getString("id")) : Optional.empty(),
+                settlementDate.toString()
+            );
+        }
+
+        @Override
+        public void save(ReconciliationBatch batch) {
+            long newVersion = snapshots.save(batch.batchId(), batch.version(), JacksonFinanceSettlementJson.batchSnapshot(batch, mapper));
+            batch.withVersion(newVersion);
+        }
+    }
+
+    @Repository
+    @Primary
+    @ConditionalOnBean(DataSource.class)
+    static class Suppliers implements SupplierSettlementRepository {
+        private final ObjectMapper mapper;
+        private final SnapshotRepository<JacksonFinanceSettlementJson.SupplierSettlementSnapshot> snapshots;
+        private final JdbcTemplate jdbc;
+
+        Suppliers(DataSource ds, ObjectMapper mapper) {
+            this.mapper = mapper;
+            this.snapshots = new SnapshotRepository<>(ds, mapper, "supplier_settlement_snapshots", JacksonFinanceSettlementJson.SupplierSettlementSnapshot.class);
+            this.jdbc = new JdbcTemplate(ds);
+        }
+
+        @Override
+        public Optional<SupplierSettlement> findById(String id) {
+            return snapshots.get(id).map(snapshot -> JacksonFinanceSettlementJson.toSupplier(snapshot.data(), mapper).withVersion(snapshot.version()));
+        }
+
+        @Override
+        public Optional<SupplierSettlement> findBySupplierAndPeriod(String supplierId, LocalDate startDate, LocalDate endDate) {
+            return jdbc.query(
+                "SELECT id FROM supplier_settlement_snapshots WHERE data->>'supplierId' = ? AND data->>'startDate' = ? AND data->>'endDate' = ? LIMIT 1",
+                rs -> rs.next() ? findById(rs.getString("id")) : Optional.empty(),
+                supplierId, startDate.toString(), endDate.toString()
+            );
+        }
+
+        @Override
+        public void save(SupplierSettlement settlement) {
+            long newVersion = snapshots.save(settlement.supplierSettlementId(), settlement.version(), JacksonFinanceSettlementJson.supplierSnapshot(settlement, mapper));
+            settlement.withVersion(newVersion);
         }
     }
 

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/PostgresFinanceRepositories.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/PostgresFinanceRepositories.java
@@ -1,11 +1,13 @@
 package com.trainticket.financesettlement.infrastructure.persistence;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.financesettlement.application.FeeAccrualRepository;
 import com.trainticket.financesettlement.application.InvoiceRepository;
 import com.trainticket.financesettlement.application.ReconciliationBatchRepository;
 import com.trainticket.financesettlement.application.SupplierSettlementRepository;
 import com.trainticket.financesettlement.application.ReconciliationCaseRepository;
 import com.trainticket.financesettlement.application.RevenueRecognitionRepository;
+import com.trainticket.financesettlement.domain.FeeAccrual;
 import com.trainticket.financesettlement.domain.Invoice;
 import com.trainticket.financesettlement.domain.ReconciliationBatch;
 import com.trainticket.financesettlement.domain.ReconciliationCase;
@@ -13,6 +15,7 @@ import com.trainticket.financesettlement.domain.RevenueRecognition;
 import com.trainticket.financesettlement.domain.SupplierSettlement;
 import com.trainticket.platformkit.persistence.SnapshotRepository;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
@@ -55,6 +58,23 @@ final class PostgresFinanceRepositories {
                 "SELECT id FROM revenue_recognition_snapshots WHERE data->>'orderId' = ? ORDER BY (data->>'recognizedAt')::timestamptz",
                 (rs, rowNum) -> findById(rs.getString("id")).orElseThrow(),
                 orderId
+            );
+        }
+
+        @Override
+        public List<RevenueRecognition> findBySupplierAndPeriod(String supplierId, LocalDate startDate, LocalDate endDate) {
+            return jdbc.query(
+                """
+                    SELECT id FROM revenue_recognition_snapshots
+                    WHERE data->>'orderItemId' = ?
+                      AND (data->>'recognizedAt')::timestamptz >= ?::timestamptz
+                      AND (data->>'recognizedAt')::timestamptz < ?::timestamptz
+                    ORDER BY (data->>'recognizedAt')::timestamptz, id
+                    """,
+                (rs, rowNum) -> findById(rs.getString("id")).orElseThrow(),
+                supplierId,
+                startDate.atStartOfDay().toInstant(ZoneOffset.UTC).toString(),
+                endDate.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toString()
             );
         }
 
@@ -198,6 +218,41 @@ final class PostgresFinanceRepositories {
         public void save(SupplierSettlement settlement) {
             long newVersion = snapshots.save(settlement.supplierSettlementId(), settlement.version(), JacksonFinanceSettlementJson.supplierSnapshot(settlement, mapper));
             settlement.withVersion(newVersion);
+        }
+    }
+
+    @Repository
+    @Primary
+    @ConditionalOnBean(DataSource.class)
+    static class FeeAccruals implements FeeAccrualRepository {
+        private final ObjectMapper mapper;
+        private final SnapshotRepository<JacksonFinanceSettlementJson.FeeAccrualSnapshot> snapshots;
+        private final JdbcTemplate jdbc;
+
+        FeeAccruals(DataSource ds, ObjectMapper mapper) {
+            this.mapper = mapper;
+            this.snapshots = new SnapshotRepository<>(ds, mapper, "fee_accrual_snapshots", JacksonFinanceSettlementJson.FeeAccrualSnapshot.class);
+            this.jdbc = new JdbcTemplate(ds);
+        }
+
+        @Override
+        public Optional<FeeAccrual> findById(String id) {
+            return snapshots.get(id).map(snapshot -> JacksonFinanceSettlementJson.toFee(snapshot.data(), mapper).withVersion(snapshot.version()));
+        }
+
+        @Override
+        public List<FeeAccrual> findByOrderId(String orderId) {
+            return jdbc.query(
+                "SELECT id FROM fee_accrual_snapshots WHERE data->>'orderId' = ? ORDER BY id",
+                (rs, rowNum) -> findById(rs.getString("id")).orElseThrow(),
+                orderId
+            );
+        }
+
+        @Override
+        public void save(FeeAccrual accrual) {
+            long newVersion = snapshots.save(accrual.feeAccrualId(), accrual.version(), JacksonFinanceSettlementJson.feeSnapshot(accrual, mapper));
+            accrual.withVersion(newVersion);
         }
     }
 

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/PostgresFinanceSettlementProjectionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/PostgresFinanceSettlementProjectionRepository.java
@@ -39,6 +39,7 @@ public class PostgresFinanceSettlementProjectionRepository implements FinanceSet
         return jdbc.query(
             "SELECT payment_intent_id, currency, amount, source_event_id FROM captures_by_order_id WHERE order_id = ?",
             rs -> rs.next() ? Optional.of(new FinanceSettlementEventHandler.PaymentCaptureFact(
+                orderId,
                 rs.getString("payment_intent_id"),
                 money(rs.getString("currency"), rs.getString("amount")),
                 rs.getString("source_event_id")
@@ -91,6 +92,28 @@ public class PostgresFinanceSettlementProjectionRepository implements FinanceSet
             caseId,
             amount.currency().getCurrencyCode(),
             amount.amount()
+        );
+    }
+
+    @Override
+    public List<FinanceSettlementEventHandler.PaymentCaptureFact> findCapturesForSettlementDate(java.time.LocalDate settlementDate) {
+        return jdbc.query(
+            "SELECT order_id, payment_intent_id, currency, amount, source_event_id FROM captures_by_order_id ORDER BY order_id",
+            (rs, rowNum) -> new FinanceSettlementEventHandler.PaymentCaptureFact(
+                rs.getString("order_id"),
+                rs.getString("payment_intent_id"),
+                money(rs.getString("currency"), rs.getString("amount")),
+                rs.getString("source_event_id")
+            )
+        );
+    }
+
+    @Override
+    public List<ChannelStatementProjection> findChannelStatementsForSettlementDate(java.time.LocalDate settlementDate) {
+        return jdbc.query(
+            "SELECT * FROM channel_statements WHERE statement_date = ? ORDER BY channel_statement_id",
+            (rs, rowNum) -> mapStatement(rs),
+            settlementDate.toString()
         );
     }
 

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/PostgresFinanceSettlementProjectionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/PostgresFinanceSettlementProjectionRepository.java
@@ -2,6 +2,7 @@ package com.trainticket.financesettlement.infrastructure.persistence;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import com.trainticket.financesettlement.application.BenefitCostEntry;
+import com.trainticket.financesettlement.application.ChannelStatementLineProjection;
 import com.trainticket.financesettlement.application.ChannelStatementProjection;
 import com.trainticket.financesettlement.application.FinanceSettlementEventHandler;
 import com.trainticket.financesettlement.application.FinanceSettlementProjectionRepository;
@@ -9,6 +10,7 @@ import com.trainticket.financesettlement.domain.Money;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Currency;
 import java.util.List;
 import java.util.Optional;
@@ -37,12 +39,13 @@ public class PostgresFinanceSettlementProjectionRepository implements FinanceSet
     @Override
     public Optional<FinanceSettlementEventHandler.PaymentCaptureFact> findCapture(String orderId) {
         return jdbc.query(
-            "SELECT payment_intent_id, currency, amount, source_event_id FROM captures_by_order_id WHERE order_id = ?",
+            "SELECT payment_intent_id, currency, amount, source_event_id, occurred_at FROM captures_by_order_id WHERE order_id = ?",
             rs -> rs.next() ? Optional.of(new FinanceSettlementEventHandler.PaymentCaptureFact(
                 orderId,
                 rs.getString("payment_intent_id"),
                 money(rs.getString("currency"), rs.getString("amount")),
-                rs.getString("source_event_id")
+                rs.getString("source_event_id"),
+                rs.getTimestamp("occurred_at").toInstant()
             )) : Optional.empty(),
             orderId
         );
@@ -52,20 +55,22 @@ public class PostgresFinanceSettlementProjectionRepository implements FinanceSet
     public void saveCapture(String orderId, FinanceSettlementEventHandler.PaymentCaptureFact capture) {
         jdbc.update(
             """
-                INSERT INTO captures_by_order_id(order_id, payment_intent_id, currency, amount, source_event_id)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT INTO captures_by_order_id(order_id, payment_intent_id, currency, amount, source_event_id, occurred_at)
+                VALUES (?, ?, ?, ?, ?, ?)
                 ON CONFLICT (order_id) DO UPDATE SET
                   payment_intent_id = EXCLUDED.payment_intent_id,
                   currency = EXCLUDED.currency,
                   amount = EXCLUDED.amount,
                   source_event_id = EXCLUDED.source_event_id,
+                  occurred_at = EXCLUDED.occurred_at,
                   updated_at = now()
                 """,
             orderId,
             capture.paymentIntentId(),
             capture.amount().currency().getCurrencyCode(),
             capture.amount().amount(),
-            capture.sourceEventId()
+            capture.sourceEventId(),
+            Timestamp.from(capture.occurredAt())
         );
     }
 
@@ -98,13 +103,73 @@ public class PostgresFinanceSettlementProjectionRepository implements FinanceSet
     @Override
     public List<FinanceSettlementEventHandler.PaymentCaptureFact> findCapturesForSettlementDate(java.time.LocalDate settlementDate) {
         return jdbc.query(
-            "SELECT order_id, payment_intent_id, currency, amount, source_event_id FROM captures_by_order_id ORDER BY order_id",
+            """
+                SELECT order_id, payment_intent_id, currency, amount, source_event_id, occurred_at
+                FROM captures_by_order_id
+                WHERE occurred_at >= ? AND occurred_at < ?
+                ORDER BY order_id
+                """,
             (rs, rowNum) -> new FinanceSettlementEventHandler.PaymentCaptureFact(
                 rs.getString("order_id"),
                 rs.getString("payment_intent_id"),
                 money(rs.getString("currency"), rs.getString("amount")),
+                rs.getString("source_event_id"),
+                rs.getTimestamp("occurred_at").toInstant()
+            ),
+            Timestamp.from(settlementDate.atStartOfDay().toInstant(ZoneOffset.UTC)),
+            Timestamp.from(settlementDate.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC))
+        );
+    }
+
+    @Override
+    public void saveChannelStatementLine(ChannelStatementLineProjection line) {
+        jdbc.update(
+            """
+                INSERT INTO channel_statement_lines(statement_line_id, channel_statement_id, statement_date, order_id, payment_intent_id, channel_order_id, currency, amount, source_event_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (statement_line_id) DO UPDATE SET
+                  channel_statement_id = EXCLUDED.channel_statement_id,
+                  statement_date = EXCLUDED.statement_date,
+                  order_id = EXCLUDED.order_id,
+                  payment_intent_id = EXCLUDED.payment_intent_id,
+                  channel_order_id = EXCLUDED.channel_order_id,
+                  currency = EXCLUDED.currency,
+                  amount = EXCLUDED.amount,
+                  source_event_id = EXCLUDED.source_event_id,
+                  updated_at = now()
+                """,
+            line.statementLineId(),
+            line.channelStatementId(),
+            line.statementDate(),
+            line.orderId(),
+            line.paymentIntentId(),
+            line.channelOrderId(),
+            line.actualAmount().currency().getCurrencyCode(),
+            line.actualAmount().amount(),
+            line.sourceEventId()
+        );
+    }
+
+    @Override
+    public List<ChannelStatementLineProjection> findChannelStatementLinesForSettlementDate(java.time.LocalDate settlementDate) {
+        return jdbc.query(
+            """
+                SELECT statement_line_id, channel_statement_id, statement_date, order_id, payment_intent_id, channel_order_id, currency, amount, source_event_id
+                FROM channel_statement_lines
+                WHERE statement_date = ?
+                ORDER BY statement_line_id
+                """,
+            (rs, rowNum) -> new ChannelStatementLineProjection(
+                rs.getString("statement_line_id"),
+                rs.getString("channel_statement_id"),
+                rs.getString("statement_date"),
+                rs.getString("order_id"),
+                rs.getString("payment_intent_id"),
+                rs.getString("channel_order_id"),
+                money(rs.getString("currency"), rs.getString("amount")),
                 rs.getString("source_event_id")
-            )
+            ),
+            settlementDate.toString()
         );
     }
 

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/FinanceSettlementRepairTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/FinanceSettlementRepairTest.java
@@ -1,0 +1,115 @@
+package com.trainticket.financesettlement.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.trainticket.financesettlement.domain.FeeAccrual;
+import com.trainticket.financesettlement.domain.Money;
+import com.trainticket.financesettlement.domain.ReconciliationBatch;
+import com.trainticket.financesettlement.domain.ReconciliationStatus;
+import com.trainticket.financesettlement.domain.RevenueRecognition;
+import com.trainticket.financesettlement.domain.SettlementFrequency;
+import com.trainticket.financesettlement.domain.SupplierSettlement;
+import com.trainticket.platformkit.messaging.EventEnvelope;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Currency;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class FinanceSettlementRepairTest {
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-07-03T00:05:00Z"), ZoneOffset.UTC);
+
+    @Test
+    void dailyReconciliationUsesSettlementDateAndOrderPaymentKey() {
+        InMemoryFinanceSettlementProjectionRepository projections = new InMemoryFinanceSettlementProjectionRepository();
+        projections.saveCapture("ord-1", new FinanceSettlementEventHandler.PaymentCaptureFact(
+            "ord-1", "pi-1", Money.of("CNY", "10.00"), "evt-cap-1", Instant.parse("2026-07-02T10:00:00Z")));
+        projections.saveCapture("ord-2", new FinanceSettlementEventHandler.PaymentCaptureFact(
+            "ord-2", "pi-2", Money.of("CNY", "20.00"), "evt-cap-2", Instant.parse("2026-07-01T10:00:00Z")));
+        projections.saveChannelStatementLine(new ChannelStatementLineProjection(
+            "line-1", "stmt-1", "2026-07-02", "ord-1", "pi-1", "cho-1", Money.of("CNY", "10.00"), "evt-line-1"));
+        projections.saveChannelStatementLine(new ChannelStatementLineProjection(
+            "line-2", "stmt-2", "2026-07-01", "ord-2", "pi-2", "cho-2", Money.of("CNY", "20.00"), "evt-line-2"));
+
+        ReconciliationBatch batch = service(new InMemoryRevenueRecognitionRepository(), projections, new InMemoryFeeAccrualRepository(), new RecordingPublisher())
+            .runDailyReconciliation(LocalDate.parse("2026-07-02"), "corr-1");
+
+        assertEquals(1, batch.entries().size());
+        assertEquals("ord-1", batch.entries().getFirst().orderId());
+        assertEquals(ReconciliationStatus.MATCHED, batch.entries().getFirst().status());
+        assertEquals(Money.of("CNY", "0.00"), batch.report().totalVariance());
+    }
+
+    @Test
+    void supplierSettlementUsesSupplierAgreementReferenceAndPeriod() {
+        InMemoryRevenueRecognitionRepository recognitions = new InMemoryRevenueRecognitionRepository();
+        recognitions.save(recognize("ord-1", "sup-1", "100.00", "2026-07-02T08:00:00Z"));
+        recognitions.save(recognize("ord-2", "sup-2", "200.00", "2026-07-02T08:00:00Z"));
+        recognitions.save(recognize("ord-3", "sup-1", "300.00", "2026-07-01T08:00:00Z"));
+
+        SupplierSettlement settlement = service(recognitions, new InMemoryFinanceSettlementProjectionRepository(), new InMemoryFeeAccrualRepository(), new RecordingPublisher())
+            .calculateSupplierSettlement("sup-1", LocalDate.parse("2026-07-02"), LocalDate.parse("2026-07-02"), SettlementFrequency.DAILY,
+                new BigDecimal("0.05"), BigDecimal.ZERO, "corr-1");
+
+        assertEquals(1, settlement.allocations().size());
+        assertEquals(Money.of("CNY", "100.00"), settlement.grossRevenue());
+        assertEquals(Money.of("CNY", "5.00"), settlement.platformCommission());
+        assertEquals(Money.of("CNY", "95.00"), settlement.supplierPayable());
+    }
+
+    @Test
+    void feeAccrualIsPersistedAndPublishedForApplicationFlow() {
+        InMemoryFeeAccrualRepository feeAccruals = new InMemoryFeeAccrualRepository();
+        RecordingPublisher publisher = new RecordingPublisher();
+        FinanceSettlementApplicationService service = service(new InMemoryRevenueRecognitionRepository(), new InMemoryFinanceSettlementProjectionRepository(), feeAccruals, publisher);
+
+        FeeAccrual accrual = service.accrueFeesForPaymentCapture(
+            "ord-1", Money.of("CNY", "100.00"), Money.of("CNY", "0.00"), "evt-payment", CLOCK.instant(), "evt-payment", "corr-1");
+
+        assertEquals(List.of(accrual), feeAccruals.findByOrderId("ord-1"));
+        assertEquals(Money.of("CNY", "2.00"), accrual.platformServiceFee());
+        assertEquals(Money.of("CNY", "1.00"), accrual.supplierServiceFee());
+        assertEquals(Money.of("CNY", "0.18"), accrual.taxCalculation().vatOnServiceFees());
+        assertTrue(publisher.published.stream().anyMatch(envelope -> envelope.eventType().equals("FeeAccrued")));
+    }
+
+    private static RevenueRecognition recognize(String orderId, String supplierId, String amount, String recognizedAt) {
+        return RevenueRecognition.recognize(
+            orderId, supplierId, "fare", Money.of("CNY", amount), "policy-v1", "evt-" + orderId,
+            Instant.parse(recognizedAt), CLOCK.instant(), "cmd-1", "corr-1");
+    }
+
+    private static FinanceSettlementApplicationService service(
+        RevenueRecognitionRepository recognitions,
+        FinanceSettlementProjectionRepository projections,
+        FeeAccrualRepository feeAccruals,
+        EventPublisher publisher
+    ) {
+        return new FinanceSettlementApplicationService(
+            recognitions,
+            new InMemoryReconciliationCaseRepository(),
+            new InMemoryInvoiceRepository(),
+            projections,
+            new InMemoryReconciliationBatchRepository(),
+            new InMemorySupplierSettlementRepository(),
+            feeAccruals,
+            publisher,
+            new DomainEventEnvelopeMapper(),
+            CLOCK
+        );
+    }
+
+    private static final class RecordingPublisher implements EventPublisher {
+        private final List<EventEnvelope> published = new ArrayList<>();
+
+        @Override
+        public void publish(EventEnvelope envelope) {
+            published.add(envelope);
+        }
+    }
+}

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/InMemoryRevenueRepository.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/InMemoryRevenueRepository.java
@@ -1,6 +1,8 @@
 package com.trainticket.financesettlement.application;
 
 import com.trainticket.financesettlement.domain.RevenueRecognition;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -19,6 +21,16 @@ final class InMemoryRevenueRepository implements RevenueRecognitionRepository {
     public List<RevenueRecognition> findByOrderId(String orderId) {
         return recognitions.values().stream()
             .filter(recognition -> recognition.orderId().equals(orderId))
+            .sorted(Comparator.comparing(RevenueRecognition::recognizedAt).thenComparing(RevenueRecognition::revenueRecognitionId))
+            .toList();
+    }
+
+    @Override
+    public List<RevenueRecognition> findBySupplierAndPeriod(String supplierId, LocalDate startDate, LocalDate endDate) {
+        return recognitions.values().stream()
+            .filter(recognition -> recognition.orderItemId().equals(supplierId))
+            .filter(recognition -> !recognition.recognizedAt().atZone(ZoneOffset.UTC).toLocalDate().isBefore(startDate))
+            .filter(recognition -> !recognition.recognizedAt().atZone(ZoneOffset.UTC).toLocalDate().isAfter(endDate))
             .sorted(Comparator.comparing(RevenueRecognition::recognizedAt).thenComparing(RevenueRecognition::revenueRecognitionId))
             .toList();
     }

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/FinanceSettlementEnrichmentTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/FinanceSettlementEnrichmentTest.java
@@ -1,0 +1,63 @@
+package com.trainticket.financesettlement.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Currency;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class FinanceSettlementEnrichmentTest {
+    private static final Instant NOW = Instant.parse("2026-07-03T12:00:00Z");
+
+    @Test
+    void oneHundredPaymentsCreateReconciliationBatchWithAllEntries() {
+        List<ReconciliationEntry> entries = java.util.stream.IntStream.range(0, 100)
+            .mapToObj(index -> ReconciliationEntry.compare(
+                "entry-" + index,
+                "order-" + index,
+                "payment-" + index,
+                Money.of("CNY", "10.00"),
+                Money.of("CNY", "10.00"),
+                true,
+                true,
+                List.of("evt-" + index)))
+            .toList();
+        ReconciliationBatch batch = ReconciliationBatch.complete(LocalDate.parse("2026-07-02"), NOW, Currency.getInstance("CNY"), entries, NOW, "cmd-1", "evt-1", "corr-1");
+        assertEquals(100, batch.entries().size());
+        assertEquals(100, batch.report().matchedEntries());
+        assertEquals(new BigDecimal("1.0000"), batch.report().matchRate());
+        assertInstanceOf(ReconciliationCompleted.class, batch.domainEvents().getFirst());
+    }
+
+    @Test
+    void amountMismatchIsFlaggedInReconciliationReport() {
+        ReconciliationEntry entry = ReconciliationEntry.compare("entry-1", "order-1", "payment-1",
+            Money.of("CNY", "12.00"), Money.of("CNY", "10.00"), true, true, List.of("evt-1"));
+        ReconciliationBatch batch = ReconciliationBatch.complete(LocalDate.parse("2026-07-02"), NOW, Currency.getInstance("CNY"), List.of(entry), NOW, "cmd-1", "evt-1", "corr-1");
+        assertEquals(ReconciliationStatus.AMOUNT_MISMATCH, entry.status());
+        assertEquals(1, batch.report().exceptions().size());
+        assertEquals(Money.of("CNY", "2.00"), batch.report().totalVariance());
+    }
+
+    @Test
+    void supplierWithFivePercentCommissionCalculatesNet() {
+        RevenueAllocation allocation = RevenueAllocation.calculate("order-1", Money.of("CNY", "100.00"), new BigDecimal("0.05"), BigDecimal.ZERO, Money.of("CNY", "0.00"));
+        SupplierSettlement settlement = SupplierSettlement.calculate("supplier-1", new SettlementPeriod(LocalDate.parse("2026-07-01"), LocalDate.parse("2026-07-01"), SettlementFrequency.DAILY),
+            new BigDecimal("0.05"), BigDecimal.ZERO, List.of(allocation), Currency.getInstance("CNY"), NOW, "cmd-1", "evt-1", "corr-1");
+        assertEquals(Money.of("CNY", "5.00"), settlement.platformCommission());
+        assertEquals(Money.of("CNY", "95.00"), settlement.supplierPayable());
+        assertInstanceOf(SupplierSettlementCalculated.class, settlement.domainEvents().getFirst());
+    }
+
+    @Test
+    void refundReversesTaxAndAdjustsSupplierPayable() {
+        RevenueAllocation allocation = RevenueAllocation.calculate("order-1", Money.of("CNY", "100.00"), new BigDecimal("0.05"), BigDecimal.ZERO, Money.of("CNY", "-20.00"));
+        TaxCalculation tax = TaxCalculation.calculate(Money.of("CNY", "5.00"), Money.of("CNY", "100.00"), allocation.supplierPayable(), BigDecimal.ZERO, Money.of("CNY", "20.00"));
+        assertEquals(Money.of("CNY", "75.00"), allocation.supplierPayable());
+        assertEquals(Money.of("CNY", "-0.01"), tax.taxReversal());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds daily reconciliation batch/report domain model with MATCHED/PLATFORM_ONLY/CHANNEL_ONLY/AMOUNT_MISMATCH entries and ReconciliationCompleted outbox event mapping.
- Adds supplier settlement split domain logic, fee/tax accrual models, event payload mapping, persistence repositories/migration, and settlement read APIs.
- Adds domain tests for 100-payment batch creation, 5% supplier commission, refund tax reversal, and amount mismatch reporting.

## Validation
- mvn -f platform/java-kit/pom.xml install -DskipTests
- cd services/finance-settlement && mvn test -q