### PR TITLE
REQ-334 waitlist archival sweep

### DIFF
--- a/services/waitlist/migrations/002_archived_waitlist_entries.sql
+++ b/services/waitlist/migrations/002_archived_waitlist_entries.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS archived_waitlist_entries (
+    entry_id text PRIMARY KEY,
+    account_id text NOT NULL,
+    traveler_refs jsonb NOT NULL,
+    segment_ref text NOT NULL,
+    departure_date date NOT NULL,
+    seat_class text NOT NULL,
+    terminal_status text NOT NULL CHECK (terminal_status IN ('ACCEPTED', 'EXPIRED', 'CANCELLED')),
+    archived_at timestamptz NOT NULL,
+    data jsonb NOT NULL,
+    source_version bigint NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS archived_waitlist_entries_traveler_idx
+    ON archived_waitlist_entries USING gin (traveler_refs jsonb_path_ops);
+
+CREATE INDEX IF NOT EXISTS archived_waitlist_entries_archived_at_idx
+    ON archived_waitlist_entries (archived_at DESC, entry_id);

--- a/services/waitlist/src/app.ts
+++ b/services/waitlist/src/app.ts
@@ -65,6 +65,9 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   app.get("/api/v1/waitlist/entries/:entryId", async (request, reply) => handleRead(reply, request, () => (
     runCommand((repository, publisher) => commandService(repository, publisher).get(param(request, "entryId")))
   )));
+  app.get("/api/v1/waitlist-requests/:waitlistRequestId", async (request, reply) => handleRead(reply, request, () => (
+    runCommand((repository, publisher) => commandService(repository, publisher).getActiveOrArchived(param(request, "waitlistRequestId")))
+  )));
   stateChanging(app, idempotencyStore, "DELETE", "/api/v1/waitlist/entries/:entryId", async (request) => ({
     statusCode: 200,
     body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "entryId"))),
@@ -72,6 +75,10 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist/entries/:entryId/accept", async (request, ctx) => ({
     statusCode: 200,
     body: await runCommand((repository, publisher) => commandService(repository, publisher).accept(param(request, "entryId"), request.body as any, ctx.correlationId)),
+  }));
+  stateChanging(app, idempotencyStore, "POST", "/internal/waitlist/archive-sweep", async (request) => ({
+    statusCode: 200,
+    body: await runCommand((repository, publisher) => commandService(repository, publisher).sweepArchived(requestLimit(request.body))),
   }));
   app.get("/api/v1/waitlist/segments/:segmentRef/:departureDate/queue", async (request, reply) => handleRead(reply, request, () => (
     runCommand((repository, publisher) => commandService(repository, publisher).queueInfo(param(request, "segmentRef"), param(request, "departureDate"), query(request).seatClass, query(request).entryId))
@@ -122,3 +129,8 @@ async function handleRead(reply: FastifyReply, request: FastifyRequest, operatio
 function requestContext(request: FastifyRequest): RequestContext { return kitRequestContext({ headers: request.headers, id: request.id }); }
 function param(request: FastifyRequest, name: string): string { return (request.params as Record<string, string>)[name] ?? ""; }
 function query(request: FastifyRequest): Record<string, string | undefined> { return request.query as Record<string, string | undefined>; }
+function requestLimit(body: unknown): number {
+  if (typeof body !== "object" || body === null || !("limit" in body)) return 100;
+  const limit = Number((body as { limit?: unknown }).limit);
+  return Number.isFinite(limit) ? limit : 100;
+}

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -1,6 +1,6 @@
 import { type EventPublisher } from "@trainticket/ts-kit";
 import { DomainError, WaitlistEntry, WaitlistQueue, type CreateWaitlistEntry, type FareClass, type PriorityInput, type WaitlistEntrySnapshot } from "./domain.js";
-import { HttpCapacityAvailabilityClient, HttpFarePricingClient, HttpOfferManagementClient, PromotionOrchestrator, type CapacityAvailabilityClient, type FarePricingClient, type OfferManagementClient, type WaitlistCapacityFreed, type WaitlistRepository } from "./promotion.js";
+import { HttpCapacityAvailabilityClient, HttpFarePricingClient, HttpOfferManagementClient, PromotionOrchestrator, type ArchiveResult, type CapacityAvailabilityClient, type FarePricingClient, type OfferManagementClient, type WaitlistCapacityFreed, type WaitlistRepository } from "./promotion.js";
 import { publishAll, waitlistEntryAccepted, waitlistEntryCreated } from "./publisher.js";
 
 export type JoinWaitlistRequest = Readonly<{
@@ -52,6 +52,7 @@ export class HttpJourneyOrderClient implements JourneyOrderClient {
 
 export class InMemoryWaitlistRepository implements WaitlistRepository {
   private readonly entries = new Map<string, WaitlistEntry>();
+  private readonly archived = new Map<string, WaitlistEntrySnapshot>();
 
   async add(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     this.entries.set(entry.entryId, entry);
@@ -59,6 +60,8 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   }
 
   async get(entryId: string): Promise<WaitlistEntry | undefined> { return this.entries.get(entryId); }
+
+  async getArchived(entryId: string): Promise<WaitlistEntrySnapshot | undefined> { return this.archived.get(entryId); }
 
   async save(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     this.entries.set(entry.entryId, entry);
@@ -74,12 +77,28 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
     return [...this.entries.values()].filter((entry) => entry.status === "OFFERED" && entry.offerExpiresAt !== null && entry.offerExpiresAt <= now);
   }
 
+  async findArchivableTerminal(limit: number): Promise<readonly WaitlistEntry[]> {
+    return [...this.entries.values()]
+      .filter((entry) => entry.isArchivableTerminal())
+      .sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime() || left.entryId.localeCompare(right.entryId))
+      .slice(0, Math.max(0, Math.floor(limit)));
+  }
+
+  async archive(entry: WaitlistEntry, archivedAt: Date): Promise<WaitlistEntrySnapshot | undefined> {
+    if (!this.entries.has(entry.entryId)) return this.archived.get(entry.entryId);
+    entry.closeForArchive(archivedAt);
+    const snapshot = entry.toSnapshot(0);
+    this.archived.set(entry.entryId, snapshot);
+    this.entries.delete(entry.entryId);
+    return snapshot;
+  }
+
   async queueFor(segmentRef: string, departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> {
     const queue = this.buildQueue(segmentRef, departureDate, seatClass);
     return queue.allEntries().map((entry) => this.snapshot(entry));
   }
 
-  clear(): void { this.entries.clear(); }
+  clear(): void { this.entries.clear(); this.archived.clear(); }
 
   private buildQueue(segmentRef: string, departureDate: string, seatClass?: string): WaitlistQueue {
     const matching = [...this.entries.values()].filter((entry) => entry.segmentRef === segmentRef && entry.departureDate === departureDate && (!seatClass || entry.seatClass === seatClass));
@@ -123,6 +142,20 @@ export class WaitlistApplicationService {
     return this.snapshot(entry);
   }
 
+  async getArchived(entryId: string): Promise<WaitlistEntrySnapshot> {
+    const snapshot = await this.repository.getArchived(entryId);
+    if (!snapshot) throw new DomainError("NOT_FOUND", "Archived waitlist entry was not found");
+    return snapshot;
+  }
+
+  async getActiveOrArchived(entryId: string): Promise<WaitlistEntrySnapshot> {
+    const entry = await this.repository.get(entryId);
+    if (entry) return this.snapshot(entry);
+    const archived = await this.repository.getArchived(entryId);
+    if (!archived) throw new DomainError("NOT_FOUND", "Waitlist entry was not found");
+    return archived;
+  }
+
   async cancel(entryId: string): Promise<{ cancelled: true }> {
     const entry = await this.requireEntry(entryId);
     entry.cancel();
@@ -153,6 +186,22 @@ export class WaitlistApplicationService {
 
   async expireDueOffers(correlationId?: string) {
     return this.promotion.expireDueOffers(correlationId);
+  }
+
+  async sweepArchived(limit = 100): Promise<ArchiveResult> {
+    const batchLimit = Math.max(1, Math.min(500, Math.floor(limit)));
+    const archived: WaitlistEntrySnapshot[] = [];
+    let skipped = 0;
+    const archivedAt = this.now();
+    for (const entry of await this.repository.findArchivableTerminal(batchLimit)) {
+      const snapshot = await this.repository.archive(entry, archivedAt);
+      if (!snapshot) {
+        skipped += 1;
+        continue;
+      }
+      archived.push(snapshot);
+    }
+    return { archived, skipped };
   }
 
   private toCreateCommand(request: JoinWaitlistRequest): CreateWaitlistEntry {

--- a/services/waitlist/src/bootstrap.ts
+++ b/services/waitlist/src/bootstrap.ts
@@ -34,8 +34,17 @@ export async function bootstrap(options: BootstrapOptions = {}) {
     operation.catch((error: unknown) => app.log.error({ err: error }, "waitlist offer expiry scan failed"));
   }, Number.parseInt(process.env.WAITLIST_EXPIRY_SCAN_MS ?? "60000", 10));
   expiryTimer.unref();
+  const archiveTimer = setInterval(() => {
+    const limit = Number.parseInt(process.env.WAITLIST_ARCHIVE_SWEEP_LIMIT ?? "100", 10);
+    const operation = storage
+      ? storage.runCommand((repository, publisher) => new WaitlistApplicationService(repository, publisher).sweepArchived(limit))
+      : memoryEventService.sweepArchived(limit);
+    operation.catch((error: unknown) => app.log.error({ err: error }, "waitlist archival sweep failed"));
+  }, Number.parseInt(process.env.WAITLIST_ARCHIVE_SWEEP_MS ?? "300000", 10));
+  archiveTimer.unref();
   app.addHook("onClose", async () => {
     clearInterval(expiryTimer);
+    clearInterval(archiveTimer);
     abortController.abort();
     messaging.subscriber.stop?.();
     await messaging.close();

--- a/services/waitlist/src/domain.ts
+++ b/services/waitlist/src/domain.ts
@@ -1,6 +1,7 @@
 import { uuidV7 } from "@trainticket/ts-kit";
 
-export type WaitlistStatus = "QUEUED" | "OFFERED" | "ACCEPTED" | "EXPIRED" | "CANCELLED";
+export type WaitlistStatus = "QUEUED" | "OFFERED" | "ACCEPTED" | "EXPIRED" | "CANCELLED" | "CLOSED";
+export type WaitlistTerminalStatus = Exclude<WaitlistStatus, "QUEUED" | "OFFERED" | "CLOSED">;
 export type LoyaltyTier = "PLATINUM" | "GOLD" | "SILVER" | "NONE";
 export type FareClass = "BUSINESS" | "FIRST" | "SECOND" | "SECOND_CLASS" | "STANDING";
 export type SpecialStatus = "MILITARY" | "DISABLED" | "STUDENT" | "NONE";
@@ -23,6 +24,7 @@ export type WaitlistEntrySnapshot = Readonly<{
   seatClass: FareClass;
   priorityScore: number;
   status: WaitlistStatus;
+  terminalStatus?: WaitlistTerminalStatus;
   queuePosition: number;
   createdAt: string;
   offeredAt: string | null;
@@ -32,6 +34,7 @@ export type WaitlistEntrySnapshot = Readonly<{
   offerId?: string;
   offerVersion?: number;
   itineraryRef?: string;
+  archivedAt?: string;
   fareQuoteIdempotencyKey?: string;
   offerIdempotencyKey?: string;
   capacityHoldIdempotencyKey?: string;
@@ -77,6 +80,8 @@ export class WaitlistEntry {
     private _offerId?: string,
     private _offerVersion?: number,
     public readonly itineraryRef?: string,
+    private _archivedAt: Date | null = null,
+    private _terminalStatus?: WaitlistTerminalStatus,
     private readonly _fareQuoteIdempotencyKey: string = uuidV7(),
     private readonly _offerIdempotencyKey: string = uuidV7(),
     private readonly _capacityHoldIdempotencyKey: string = uuidV7(),
@@ -110,6 +115,8 @@ export class WaitlistEntry {
       undefined,
       undefined,
       command.itineraryRef,
+      null,
+      undefined,
     );
   }
 
@@ -131,6 +138,8 @@ export class WaitlistEntry {
       snapshot.offerId,
       snapshot.offerVersion,
       snapshot.itineraryRef,
+      snapshot.archivedAt ? new Date(snapshot.archivedAt) : null,
+      snapshot.terminalStatus,
       snapshot.fareQuoteIdempotencyKey,
       snapshot.offerIdempotencyKey,
       snapshot.capacityHoldIdempotencyKey,
@@ -147,12 +156,18 @@ export class WaitlistEntry {
   get capacityHoldId(): string | undefined { return this._capacityHoldId; }
   get offerId(): string | undefined { return this._offerId; }
   get offerVersion(): number | undefined { return this._offerVersion; }
+  get archivedAt(): Date | null { return this._archivedAt; }
+  get terminalStatus(): WaitlistTerminalStatus | undefined { return this._terminalStatus; }
   get fareQuoteIdempotencyKey(): string { return this._fareQuoteIdempotencyKey; }
   get offerIdempotencyKey(): string { return this._offerIdempotencyKey; }
   get capacityHoldIdempotencyKey(): string { return this._capacityHoldIdempotencyKey; }
   get capacityReleaseIdempotencyKey(): string { return this._capacityReleaseIdempotencyKey; }
   get journeyOrderIdempotencyKey(): string { return this._journeyOrderIdempotencyKey; }
   get capacitySegmentBookingId(): string { return this._capacitySegmentBookingId; }
+
+  isArchivableTerminal(): boolean {
+    return this._status === "ACCEPTED" || this._status === "EXPIRED" || this._status === "CANCELLED";
+  }
 
   offer(offerId: string, offerVersion: number, fareQuoteId: string, capacityHoldId: string, now: Date, expiresAt: Date): void {
     this.assertStatus("QUEUED", "Only queued waitlist entries can be offered");
@@ -190,10 +205,20 @@ export class WaitlistEntry {
   }
 
   cancel(): void {
-    if (this._status === "ACCEPTED" || this._status === "EXPIRED") {
+    if (this._status === "ACCEPTED" || this._status === "EXPIRED" || this._status === "CLOSED") {
       throw new DomainError("INVALID_TRANSITION", `Cannot cancel ${this._status} waitlist entry`);
     }
     this._status = "CANCELLED";
+  }
+
+  closeForArchive(now: Date): void {
+    if (this._status === "CLOSED") return;
+    if (!this.isArchivableTerminal()) {
+      throw new DomainError("INVALID_TRANSITION", `Cannot archive ${this._status} waitlist entry`);
+    }
+    this._terminalStatus = this._status as WaitlistTerminalStatus;
+    this._status = "CLOSED";
+    this._archivedAt = now;
   }
 
   toSnapshot(queuePosition = 0): WaitlistEntrySnapshot {
@@ -206,6 +231,7 @@ export class WaitlistEntry {
       seatClass: this.seatClass,
       priorityScore: this.priorityScore,
       status: this._status,
+      terminalStatus: this._terminalStatus,
       queuePosition,
       createdAt: this.createdAt.toISOString(),
       offeredAt: this._offeredAt?.toISOString() ?? null,
@@ -215,6 +241,7 @@ export class WaitlistEntry {
       offerId: this._offerId,
       offerVersion: this._offerVersion,
       itineraryRef: this.itineraryRef,
+      archivedAt: this._archivedAt?.toISOString(),
       fareQuoteIdempotencyKey: this._fareQuoteIdempotencyKey,
       offerIdempotencyKey: this._offerIdempotencyKey,
       capacityHoldIdempotencyKey: this._capacityHoldIdempotencyKey,

--- a/services/waitlist/src/promotion.ts
+++ b/services/waitlist/src/promotion.ts
@@ -23,12 +23,20 @@ export type PromotionResult = Readonly<{
   offers: readonly WaitlistOffer[];
 }>;
 
+export type ArchiveResult = Readonly<{
+  archived: readonly WaitlistEntrySnapshot[];
+  skipped: number;
+}>;
+
 export interface WaitlistRepository {
   add(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> | WaitlistEntrySnapshot;
   get(entryId: string): Promise<WaitlistEntry | undefined> | WaitlistEntry | undefined;
+  getArchived(entryId: string): Promise<WaitlistEntrySnapshot | undefined> | WaitlistEntrySnapshot | undefined;
   save(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> | WaitlistEntrySnapshot;
   findTopQueued(segmentRef: string, departureDate: string, seatClass?: string): Promise<WaitlistEntry | undefined> | WaitlistEntry | undefined;
   findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> | readonly WaitlistEntry[];
+  findArchivableTerminal(limit: number): Promise<readonly WaitlistEntry[]> | readonly WaitlistEntry[];
+  archive(entry: WaitlistEntry, archivedAt: Date): Promise<WaitlistEntrySnapshot | undefined> | WaitlistEntrySnapshot | undefined;
   queueFor(segmentRef: string, departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> | readonly WaitlistEntrySnapshot[];
 }
 

--- a/services/waitlist/src/storage.ts
+++ b/services/waitlist/src/storage.ts
@@ -24,6 +24,11 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
     return result.rows[0] ? entryFromRow(result.rows[0]) : undefined;
   }
 
+  async getArchived(entryId: string): Promise<WaitlistEntrySnapshot | undefined> {
+    const result = await this.db.query(`SELECT data FROM archived_waitlist_entries WHERE entry_id = $1`, [entryId]) as QueryResult<{ data: WaitlistEntrySnapshot }>;
+    return result.rows[0]?.data;
+  }
+
   async save(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     const snapshot = entry.toSnapshot(0);
     await this.db.query(
@@ -49,6 +54,37 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
   async findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> {
     const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE status = 'OFFERED' AND offer_expires_at <= $1 ORDER BY offer_expires_at ASC`, [now.toISOString()]) as QueryResult<WaitlistRow>;
     return result.rows.map(entryFromRow);
+  }
+
+  async findArchivableTerminal(limit: number): Promise<readonly WaitlistEntry[]> {
+    const result = await this.db.query(
+      `SELECT * FROM waitlist_entries
+       WHERE status IN ('ACCEPTED', 'EXPIRED', 'CANCELLED')
+       ORDER BY updated_at ASC, entry_id ASC
+       LIMIT $1`,
+      [Math.max(1, Math.floor(limit))],
+    ) as QueryResult<WaitlistRow>;
+    return result.rows.map(entryFromRow);
+  }
+
+  async archive(entry: WaitlistEntry, archivedAt: Date): Promise<WaitlistEntrySnapshot | undefined> {
+    const current = await this.db.query(`SELECT * FROM waitlist_entries WHERE entry_id = $1 FOR UPDATE`, [entry.entryId]) as QueryResult<WaitlistRow>;
+    const row = current.rows[0];
+    if (!row) return this.getArchived(entry.entryId);
+    const activeEntry = entryFromRow(row);
+    activeEntry.closeForArchive(archivedAt);
+    const snapshot = activeEntry.toSnapshot(0);
+    const inserted = await this.db.query(
+      `INSERT INTO archived_waitlist_entries (entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, terminal_status, archived_at, data, source_version)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+       ON CONFLICT (entry_id) DO NOTHING
+       RETURNING data`,
+      [snapshot.entryId, snapshot.accountId, JSON.stringify(snapshot.travelerRefs), snapshot.segmentRef, snapshot.departureDate, snapshot.seatClass, snapshot.terminalStatus ?? row.status, snapshot.archivedAt ?? archivedAt.toISOString(), snapshot, row.version],
+    ) as QueryResult<{ data: WaitlistEntrySnapshot }>;
+    const archivedSnapshot = (inserted.rowCount ?? 0) === 0 ? await this.getArchived(entry.entryId) : inserted.rows[0]?.data ?? snapshot;
+    const deleted = await this.db.query(`DELETE FROM waitlist_entries WHERE entry_id = $1 AND version = $2`, [entry.entryId, row.version]);
+    if ((deleted.rowCount ?? 0) !== 1) throw new Error("Waitlist archival delete lost optimistic concurrency race");
+    return archivedSnapshot;
   }
 
   async queueFor(segmentRef: string, departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> {
@@ -110,6 +146,7 @@ function entryFromRow(row: WaitlistRow): WaitlistEntry {
     seatClass: row.seat_class as WaitlistEntrySnapshot["seatClass"],
     priorityScore: row.priority_score,
     status: row.status as WaitlistEntrySnapshot["status"],
+    terminalStatus: typeof data.terminalStatus === "string" ? data.terminalStatus as WaitlistEntrySnapshot["terminalStatus"] : undefined,
     queuePosition: 0,
     createdAt: instantString(row.created_at),
     offeredAt: row.offered_at ? instantString(row.offered_at) : null,
@@ -119,6 +156,7 @@ function entryFromRow(row: WaitlistRow): WaitlistEntry {
     offerId: typeof data.offerId === "string" ? data.offerId : undefined,
     offerVersion: typeof data.offerVersion === "number" ? data.offerVersion : undefined,
     itineraryRef: typeof data.itineraryRef === "string" ? data.itineraryRef : undefined,
+    archivedAt: typeof data.archivedAt === "string" ? data.archivedAt : undefined,
     fareQuoteIdempotencyKey: typeof data.fareQuoteIdempotencyKey === "string" ? data.fareQuoteIdempotencyKey : undefined,
     offerIdempotencyKey: typeof data.offerIdempotencyKey === "string" ? data.offerIdempotencyKey : undefined,
     capacityHoldIdempotencyKey: typeof data.capacityHoldIdempotencyKey === "string" ? data.capacityHoldIdempotencyKey : undefined,
@@ -152,5 +190,6 @@ type WaitlistRow = Readonly<{
   fare_quote_id: string | null;
   capacity_hold_id: string | null;
   data: Record<string, unknown> | null;
+  version: string | number | bigint;
   created_at: Date | string;
 }>;

--- a/services/waitlist/tests/archive.test.ts
+++ b/services/waitlist/tests/archive.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { InMemoryEventPublisher, uuidV7 } from "@trainticket/ts-kit";
+import { createApp } from "../src/app.js";
+import { InMemoryWaitlistRepository, WaitlistApplicationService, type JourneyOrderClient } from "../src/application.js";
+import type { CapacityAvailabilityClient, FarePricingClient, OfferManagementClient } from "../src/promotion.js";
+import { WaitlistEntry, type WaitlistEntrySnapshot } from "../src/domain.js";
+import { PostgresWaitlistRepository } from "../src/storage.js";
+
+class StubFarePricing implements FarePricingClient {
+  async quote(entry: WaitlistEntry) { return { fareQuoteId: `fq-${entry.entryId}` }; }
+}
+
+class StubOfferManagement implements OfferManagementClient {
+  async createOffer(entry: WaitlistEntry) { return { offerId: `off-${entry.entryId}`, offerVersion: 1 }; }
+}
+
+class StubCapacity implements CapacityAvailabilityClient {
+  async hold(entry: WaitlistEntry) { return { capacityHoldId: `hold-${entry.entryId}` }; }
+  async releaseHold() { return undefined; }
+}
+
+class StubJourneyOrder implements JourneyOrderClient {
+  async createOrder(entry: WaitlistEntry) { return { orderId: `ord-${entry.entryId}`, seatAssignment: { segmentRef: entry.segmentRef } }; }
+}
+
+test("archival sweep removes terminal entries from active set and keeps archived snapshot retrievable", async () => {
+  const repository = new InMemoryWaitlistRepository();
+  const publisher = new InMemoryEventPublisher();
+  const service = new WaitlistApplicationService(repository, publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
+  const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
+  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
+  await service.accept(entry.entryId);
+
+  const result = await service.sweepArchived();
+
+  assert.equal(result.archived.length, 1);
+  assert.equal(result.archived[0]?.entryId, entry.entryId);
+  assert.equal(result.archived[0]?.status, "CLOSED");
+  assert.equal(result.archived[0]?.terminalStatus, "ACCEPTED");
+  await assert.rejects(() => service.get(entry.entryId), /not found/i);
+  assert.equal((await service.getArchived(entry.entryId)).entryId, entry.entryId);
+  assert.equal(publisher.findByEventType("WaitlistEntryArchived").length, 0);
+});
+
+test("archived entry is retrievable through contract waitlist request GET after on-demand sweep", async () => {
+  const repository = new InMemoryWaitlistRepository();
+  const app = createApp({ repository, farePricing: new StubFarePricing(), capacityAvailability: new StubCapacity(), journeyOrder: new StubJourneyOrder(), offerManagement: new StubOfferManagement(), now: () => new Date("2026-01-01T00:00:00.000Z") });
+  const join = await app.inject({
+    method: "POST",
+    url: "/api/v1/waitlist/entries",
+    headers: { "Idempotency-Key": uuidV7() },
+    payload: { accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 },
+  });
+  const entryId = join.json().entryId as string;
+  const service = new WaitlistApplicationService(repository, undefined, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
+  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
+  await app.inject({ method: "POST", url: `/api/v1/waitlist/entries/${entryId}/accept`, headers: { "Idempotency-Key": uuidV7() }, payload: {} });
+
+  const sweep = await app.inject({ method: "POST", url: "/internal/waitlist/archive-sweep", headers: { "Idempotency-Key": uuidV7() }, payload: { limit: 10 } });
+  const active = await app.inject({ method: "GET", url: `/api/v1/waitlist/entries/${entryId}` });
+  const archived = await app.inject({ method: "GET", url: `/api/v1/waitlist-requests/${entryId}` });
+  const inventedArchivePath = await app.inject({ method: "GET", url: `/api/v1/waitlist/archived-entries/${entryId}` });
+
+  assert.equal(sweep.statusCode, 200);
+  assert.equal(sweep.json().archived.length, 1);
+  assert.equal(active.statusCode, 404);
+  assert.equal(inventedArchivePath.statusCode, 404);
+  assert.equal(archived.statusCode, 200);
+  assert.equal(archived.json().entryId, entryId);
+  assert.equal(archived.json().status, "CLOSED");
+  assert.equal(archived.json().terminalStatus, "ACCEPTED");
+  await app.close();
+});
+
+test("postgres archive retry deletes active row when archive snapshot already exists", async () => {
+  const entry = WaitlistEntry.create({
+    entryId: "wl-retry",
+    accountId: "acc",
+    travelerRefs: ["t1"],
+    segmentRef: "seg",
+    departureDate: "2026-07-20",
+    seatClass: "SECOND",
+    priority: { groupSize: 1, fareClass: "SECOND" },
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  });
+  entry.cancel();
+  const archived = WaitlistEntry.fromSnapshot(entry.toSnapshot(0));
+  archived.closeForArchive(new Date("2026-01-02T00:00:00.000Z"));
+  const archivedSnapshot = archived.toSnapshot(0);
+  const db = new ArchiveRetryDb(entry.toSnapshot(0), archivedSnapshot);
+  const repository = new PostgresWaitlistRepository(db as never);
+
+  const result = await repository.archive(entry, new Date("2026-01-02T00:00:00.000Z"));
+
+  assert.equal(result?.entryId, entry.entryId);
+  assert.equal(result?.status, "CLOSED");
+  assert.equal(db.deletedEntryId, entry.entryId);
+});
+
+class ArchiveRetryDb {
+  deletedEntryId?: string;
+
+  constructor(
+    private readonly active: WaitlistEntrySnapshot,
+    private readonly archived: WaitlistEntrySnapshot,
+  ) {}
+
+  async query(sql: string, params: readonly unknown[]) {
+    if (sql.includes("SELECT * FROM waitlist_entries")) {
+      return { rows: [this.activeRow()], rowCount: 1 };
+    }
+    if (sql.includes("INSERT INTO archived_waitlist_entries")) {
+      return { rows: [], rowCount: 0 };
+    }
+    if (sql.includes("SELECT data FROM archived_waitlist_entries")) {
+      return { rows: [{ data: this.archived }], rowCount: 1 };
+    }
+    if (sql.includes("DELETE FROM waitlist_entries")) {
+      this.deletedEntryId = String(params[0]);
+      return { rows: [], rowCount: 1 };
+    }
+    throw new Error(`Unexpected query in archive retry test: ${sql}`);
+  }
+
+  private activeRow() {
+    return {
+      entry_id: this.active.entryId,
+      account_id: this.active.accountId,
+      traveler_refs: this.active.travelerRefs,
+      segment_ref: this.active.segmentRef,
+      departure_date: this.active.departureDate,
+      seat_class: this.active.seatClass,
+      priority_score: this.active.priorityScore,
+      status: this.active.status,
+      offered_at: this.active.offeredAt,
+      offer_expires_at: this.active.offerExpiresAt,
+      fare_quote_id: this.active.fareQuoteId ?? null,
+      capacity_hold_id: this.active.capacityHoldId ?? null,
+      data: this.active,
+      version: 7,
+      created_at: this.active.createdAt,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add waitlist archival sweep for terminal entries with in-memory and Postgres repository support
- persist closed snapshots in archived_waitlist_entries and remove them from the active table using OCC checks
- expose on-demand sweep and archived-entry read path; add e2e coverage

## Validation
- npm --prefix services/waitlist run build
- npm --prefix services/waitlist test