### PR TITLE
REQ-330 legacy-acl multi-leg rebook

### DIFF
--- a/deploy/e2e/11-legacy-acl.sh
+++ b/deploy/e2e/11-legacy-acl.sh
@@ -117,19 +117,38 @@ REFUNDABLE=$(jget "['data']['refundAmount']['minorUnits']")
 [ "$REFUNDABLE" = "8750" ] && ok "legacy cancel refundable amount is 8750" || bad "legacy cancel refundable amount $REFUNDABLE, expected 8750"
 
 ACCT3="acc-$(uuid7)"
-echo "== 6. rebook creates complete replacement itinerary"
+echo "== 6. multi-leg rebook does not silently stop after first leg"
 legacy_step PRESERVE /api/v1/legacy/preserve "{\"accountId\":\"$ACCT3\",\"contactsId\":\"$TVL\",\"tripId\":\"G1234\",\"seatType\":\"SECOND\",\"date\":\"2026-08-01\",\"from\":\"$P_BJ\",\"to\":\"$P_SH\"}"
 ORDER3=$(jget "['data']['orderId']"); TOTAL3=$(jget "['data']['total']['minorUnits']")
 legacy_step INSIDE_PAYMENT /api/v1/legacy/inside_payment "{\"orderId\":\"$ORDER3\",\"price\":{\"currency\":\"CNY\",\"minorUnits\":${TOTAL3:-10750}}}"
 sleep 8
 legacy_step TICKET_ISSUE /api/v1/legacy/ticket_issue "{\"orderId\":\"$ORDER3\"}"
+
+# Add a second original entitlement so the legacy rebook input is genuinely
+# multi-segment even in the standard e2e seed, which only has one scheduled
+# service segment. The assertion below forbids a successful one-leg rebook: the
+# facade must either reserve all replacement legs or fail deterministically.
+req POST service-plan /api/v1/service-segments "{\"scheduledServiceRef\":\"$SS\",\"originStopRef\":\"$N_BJ\",\"destinationStopRef\":\"$N_SH\",\"departureTime\":\"2026-08-01T15:00:00Z\",\"arrivalTime\":\"2026-08-01T20:30:00Z\"}"
+check_code 201 "create second original segment for multi-leg rebook"
+SEG_EXTRA=$(jget "['segmentRef']")
+SB_EXTRA="sb-$(uuid7)"
+req POST entitlement-ticketing /api/v1/entitlements "{\"segmentBookingId\":\"$SB_EXTRA\",\"journeyOrderId\":\"$ORDER3\",\"travelerRef\":\"$TVL\",\"segmentRef\":\"$SEG_EXTRA\",\"issuePurpose\":\"INITIAL\"}"
+check_code 201 "issue second entitlement for multi-leg rebook"
 sleep 5
-legacy_step REBOOK /api/v1/legacy/rebook "{\"orderId\":\"$ORDER3\",\"date\":\"2026-08-01\",\"seatType\":\"SECOND\",\"from\":\"$P_BJ\",\"to\":\"$P_SH\"}"
-REBOOK_ORDER=$(jget "['data']['replacementOrderId']")
-REBOOK_SEGMENTS=$(jget "['data']['rebookedSegmentCount']")
-REBOOK_BOOKINGS=$(echo "$RESP" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(len(d.get("data", {}).get("replacementSegmentBookingIds", [])))' 2>/dev/null || echo 0)
-[ -n "$REBOOK_ORDER" ] && ok "legacy rebook replacement order returned" || bad "legacy rebook replacement order missing"
-[ "${REBOOK_SEGMENTS:-0}" -ge 1 ] && ok "legacy rebook replacement segment count returned" || bad "legacy rebook replacement segment count missing"
-[ "${REBOOK_BOOKINGS:-0}" -ge "${REBOOK_SEGMENTS:-1}" ] && ok "legacy rebook reserved every returned segment" || bad "legacy rebook reserved $REBOOK_BOOKINGS of $REBOOK_SEGMENTS segments"
+MULTI_REBOOK_KEY=$(uuid7)
+legacy_req /api/v1/legacy/rebook "{\"orderId\":\"$ORDER3\",\"date\":\"2026-08-01\",\"seatType\":\"SECOND\",\"from\":\"$P_BJ\",\"to\":\"$P_SH\"}" "$MULTI_REBOOK_KEY"
+REBOOK_STATUS=$(echo "$RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("status", ""))' 2>/dev/null || true)
+REBOOK_SEGMENTS=$(echo "$RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("data", {}).get("rebookedSegmentCount", 0))' 2>/dev/null || echo 0)
+REBOOK_BOOKINGS=$(echo "$RESP" | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("data", {}).get("replacementSegmentBookingIds", [])))' 2>/dev/null || echo 0)
+if [ "$LAST_CODE" = "200" ]; then ok "multi-leg legacy rebook HTTP 200"; else bad "multi-leg legacy rebook HTTP got $LAST_CODE"; fi
+if [ "$REBOOK_STATUS" = "1" ]; then
+  [ "$REBOOK_SEGMENTS" = "2" ] && [ "$REBOOK_BOOKINGS" = "2" ] && ok "multi-leg legacy rebook reserved both replacement legs" || bad "multi-leg legacy rebook success reserved $REBOOK_BOOKINGS of $REBOOK_SEGMENTS replacement legs"
+else
+  PARTIAL=$(echo "$RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("data", {}).get("partialOutcome", ""))' 2>/dev/null || true)
+  MSG=$(echo "$RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("msg", ""))' 2>/dev/null || true)
+  [ "$PARTIAL" = "PARTIAL_REBOOK_FAILED" ] && echo "$MSG" | grep -q "replacement itinerary covers" && ok "multi-leg legacy rebook failed deterministically instead of first-leg-only success" || bad "multi-leg legacy rebook unexpected failure partial=$PARTIAL msg=$MSG"
+fi
+wait_legacy_event REBOOK "$MULTI_REBOOK_KEY"
+wait_audit "$MULTI_REBOOK_KEY"
 
 summary

--- a/deploy/e2e/11-legacy-acl.sh
+++ b/deploy/e2e/11-legacy-acl.sh
@@ -116,4 +116,20 @@ legacy_step CANCEL /api/v1/legacy/cancel "{\"orderId\":\"$ORDER2\"}"
 REFUNDABLE=$(jget "['data']['refundAmount']['minorUnits']")
 [ "$REFUNDABLE" = "8750" ] && ok "legacy cancel refundable amount is 8750" || bad "legacy cancel refundable amount $REFUNDABLE, expected 8750"
 
+ACCT3="acc-$(uuid7)"
+echo "== 6. rebook creates complete replacement itinerary"
+legacy_step PRESERVE /api/v1/legacy/preserve "{\"accountId\":\"$ACCT3\",\"contactsId\":\"$TVL\",\"tripId\":\"G1234\",\"seatType\":\"SECOND\",\"date\":\"2026-08-01\",\"from\":\"$P_BJ\",\"to\":\"$P_SH\"}"
+ORDER3=$(jget "['data']['orderId']"); TOTAL3=$(jget "['data']['total']['minorUnits']")
+legacy_step INSIDE_PAYMENT /api/v1/legacy/inside_payment "{\"orderId\":\"$ORDER3\",\"price\":{\"currency\":\"CNY\",\"minorUnits\":${TOTAL3:-10750}}}"
+sleep 8
+legacy_step TICKET_ISSUE /api/v1/legacy/ticket_issue "{\"orderId\":\"$ORDER3\"}"
+sleep 5
+legacy_step REBOOK /api/v1/legacy/rebook "{\"orderId\":\"$ORDER3\",\"date\":\"2026-08-01\",\"seatType\":\"SECOND\",\"from\":\"$P_BJ\",\"to\":\"$P_SH\"}"
+REBOOK_ORDER=$(jget "['data']['replacementOrderId']")
+REBOOK_SEGMENTS=$(jget "['data']['rebookedSegmentCount']")
+REBOOK_BOOKINGS=$(echo "$RESP" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(len(d.get("data", {}).get("replacementSegmentBookingIds", [])))' 2>/dev/null || echo 0)
+[ -n "$REBOOK_ORDER" ] && ok "legacy rebook replacement order returned" || bad "legacy rebook replacement order missing"
+[ "${REBOOK_SEGMENTS:-0}" -ge 1 ] && ok "legacy rebook replacement segment count returned" || bad "legacy rebook replacement segment count missing"
+[ "${REBOOK_BOOKINGS:-0}" -ge "${REBOOK_SEGMENTS:-1}" ] && ok "legacy rebook reserved every returned segment" || bad "legacy rebook reserved $REBOOK_BOOKINGS of $REBOOK_SEGMENTS segments"
+
 summary

--- a/docs/00-current-status.md
+++ b/docs/00-current-status.md
@@ -169,8 +169,9 @@ under kustomize)~~ — resolved: `loadgen-config-*` is generated from
 Wallet/Promotion's finance/notification consumers remain documented-deferred.
 
 Known accepted gaps after Phase 2: payment remains a simulated provider
-boundary; legacy-acl rebook books the first leg only (caller follows up) — both
-by explicit ruling.
+boundary. The former legacy-acl first-leg-only rebook gap is closed: one legacy
+rebook now drives replacement booking for every itinerary leg and reports a
+deterministic partial/compensated outcome on later-leg failure.
 
 ## Historical note
 

--- a/docs/08-contracts/api/legacy-acl.md
+++ b/docs/08-contracts/api/legacy-acl.md
@@ -77,11 +77,23 @@ Maps to: post-sales REFUND case open → evaluate → approve. Returns
 
 **POST** `/api/v1/legacy/rebook`
 
-**Request:** `{ "orderId", "date", "seatType" }`
+**Request:** `{ "orderId", "date", "seatType", optional "from", optional "to" }`
 
 Maps to: post-sales CHANGE case open → evaluate → approve (old ticket
-teardown); rebooking the replacement journey is the caller's follow-up
-`preserve` (phase-1 scope). Returns `data.caseId`, `data.amountDue`.
+teardown) → replacement trip search → fare quote → offer → CreateJourneyOrder →
+request-reservation for every replacement itinerary leg/traveler → collect and
+capture `amountDue` when positive. Returns `data.caseId`, `data.amountDue`,
+`data.replacementOrderId`, `data.replacementOfferId`,
+`data.rebookedSegmentCount`, and replacement segment-booking refs. Existing
+single-leg callers still receive `caseId` and `amountDue` in the same legacy
+response shape.
+
+If a downstream failure occurs after a replacement order is created, the ACL
+attempts deterministic compensation by cancelling the replacement journey order
+with reason `REBOOK_PARTIAL_FAILURE`. The legacy response is `status: 0` with
+already-created references in `data` and `data.partialOutcome` set to
+`COMPENSATED` or `COMPENSATION_FAILED`; earlier failures use
+`PARTIAL_REBOOK_FAILED` when any post-sales references were created.
 
 ## Rules
 

--- a/services/legacy-acl/src/legacy_acl/application.py
+++ b/services/legacy-acl/src/legacy_acl/application.py
@@ -314,6 +314,11 @@ class LegacyAclService:
             itinerary = _first_mapping(search, "itineraries", "no replacement itinerary found")
             itinerary_ref = _required_text(itinerary, "itineraryRef")
             segment_refs = _segment_refs_from_itinerary(itinerary)
+            original_segment_count = len(scope["segmentRefs"])
+            if len(segment_refs) < original_segment_count:
+                raise DownstreamError(
+                    f"replacement itinerary covers {len(segment_refs)} of {original_segment_count} original segments"
+                )
 
             fare_quote = self.client.post(
                 "fare-pricing",
@@ -372,6 +377,7 @@ class LegacyAclService:
                     )
                     commands.append("RequestSegmentReservation")
                     segment_booking_ids.append(segment_booking_id)
+                    result_refs["replacementSegmentBookingIds"] = list(segment_booking_ids)
             result_refs["replacementSegmentBookingIds"] = segment_booking_ids
 
             amount_due_minor_units = _money_minor_units(amount_due)

--- a/services/legacy-acl/src/legacy_acl/application.py
+++ b/services/legacy-acl/src/legacy_acl/application.py
@@ -251,7 +251,139 @@ class LegacyAclService:
         return self._post_sales(payload, ctx, LegacyOperation.CANCEL, "REFUND", "CUSTOMER_REQUEST", "refundableAmount", "refundAmount")
 
     def rebook(self, payload: Mapping[str, Any], ctx: LegacyContext) -> LegacyResult:
-        return self._post_sales(payload, ctx, LegacyOperation.REBOOK, "CHANGE", "CUSTOMER_CHANGE", "amountDue", "amountDue")
+        commands: list[str] = []
+        result_refs: dict[str, Any] = {}
+        replacement_order_id: str | None = None
+        try:
+            original_order_id = _required_text(payload, "orderId")
+            departure_date = _required_text(payload, "date")
+            order = self._get_order(original_order_id)
+            account_id = _required_text(order, "accountId")
+            entitlements = self._entitlements_for_order(original_order_id)
+            scope = _post_sales_scope(entitlements)
+
+            opened = self.client.post(
+                "post-sales",
+                "/api/v1/post-sales-cases",
+                {
+                    "journeyOrderId": original_order_id,
+                    "caseType": "CHANGE",
+                    "scope": scope,
+                    "reasonCode": "CUSTOMER_CHANGE",
+                    "actorRef": account_id,
+                },
+                _headers(ctx, "rebook-case"),
+            )
+            commands.append("OpenPostSalesCase")
+            case_id = _required_text(opened, "caseId")
+            result_refs["caseId"] = case_id
+
+            evaluated = self.client.post(
+                "post-sales",
+                f"/api/v1/post-sales-cases/{quote(case_id)}/evaluate",
+                {},
+                _headers(ctx, "rebook-evaluate"),
+            )
+            commands.append("EvaluatePostSalesEligibility")
+            amount_due = _required_mapping(evaluated, "amountDue")
+            result_refs["amountDue"] = amount_due
+
+            self.client.post(
+                "post-sales",
+                f"/api/v1/post-sales-cases/{quote(case_id)}/approve",
+                {},
+                _headers(ctx, "rebook-approve"),
+            )
+            commands.append("ApprovePostSalesCase")
+
+            traveler_refs = _unique_ordered(scope["travelerRefs"])
+            origin_ref, destination_ref = self._replacement_bounds(payload, order, ctx)
+            search = self.client.post(
+                "trip-planning",
+                "/api/v1/itineraries/search",
+                {
+                    "originRef": origin_ref,
+                    "destinationRef": destination_ref,
+                    "departureDate": departure_date,
+                    "travelerRefs": traveler_refs,
+                    "channel": "WEB",
+                },
+                _headers(ctx, "rebook-search"),
+            )
+            commands.append("SearchItineraries")
+            itinerary = _first_mapping(search, "itineraries", "no replacement itinerary found")
+            itinerary_ref = _required_text(itinerary, "itineraryRef")
+            segment_refs = _segment_refs_from_itinerary(itinerary)
+
+            fare_quote = self.client.post(
+                "fare-pricing",
+                "/api/v1/fare-quotes",
+                {"travelerRefs": traveler_refs, "channel": "WEB", "segmentRefs": segment_refs},
+                _headers(ctx, "rebook-fare-quote"),
+            )
+            commands.append("CreateFareQuote")
+
+            offer = self._post_awaiting_projections(
+                "offer-management",
+                "/api/v1/offers",
+                {
+                    "accountId": account_id,
+                    "channelId": "WEB",
+                    "itineraryRef": itinerary_ref,
+                    "travelerRefs": traveler_refs,
+                    "quoteRequestId": str(fare_quote.get("quoteId", ctx.source_ref)),
+                },
+                _headers(ctx, "rebook-offer"),
+            )
+            commands.append("CreateOffer")
+            offer_id = _required_text(offer, "offerId")
+            offer_version = _required_int(offer, "offerVersion")
+            result_refs["replacementOfferId"] = offer_id
+
+            replacement_order = self.client.post(
+                "journey-order",
+                "/api/v1/journey-orders",
+                {
+                    "accountId": account_id,
+                    "offerId": offer_id,
+                    "offerVersion": offer_version,
+                    "travelerRefs": traveler_refs,
+                    "segmentRefs": segment_refs,
+                },
+                _headers(ctx, "rebook-order"),
+            )
+            commands.append("CreateJourneyOrder")
+            replacement_order_id = _required_text(replacement_order, "orderId")
+            result_refs["replacementOrderId"] = replacement_order_id
+            result_refs["rebookedSegmentCount"] = len(segment_refs)
+
+            saga_id = self._resolve_saga(replacement_order_id, account_id, offer_id, traveler_refs, segment_refs, ctx, commands)
+            segment_booking_ids: list[str] = []
+            reservation_index = 0
+            for segment_ref in segment_refs:
+                for traveler_ref in traveler_refs:
+                    reservation_index += 1
+                    segment_booking_id = deterministic_prefixed_uuid("sb", f"{replacement_order_id}:{segment_ref}:{traveler_ref}")
+                    self.client.post(
+                        "booking-orchestration",
+                        f"/api/v1/internal/booking-sagas/{quote(saga_id)}/request-reservation",
+                        {"segmentRef": segment_ref, "travelerRef": traveler_ref, "segmentBookingId": segment_booking_id},
+                        _headers(ctx, f"rebook-reservation-{reservation_index}"),
+                    )
+                    commands.append("RequestSegmentReservation")
+                    segment_booking_ids.append(segment_booking_id)
+            result_refs["replacementSegmentBookingIds"] = segment_booking_ids
+
+            amount_due_minor_units = _money_minor_units(amount_due)
+            if amount_due_minor_units > 0:
+                payment_intent_id = self._capture_rebook_payment(replacement_order_id, account_id, amount_due, ctx, commands)
+                result_refs["paymentIntentId"] = payment_intent_id
+            elif amount_due_minor_units == 0:
+                result_refs["paymentStatus"] = "NOT_REQUIRED"
+
+            return self._finish(LegacyOperation.REBOOK, Outcome.SUCCEEDED, ctx, commands, result_refs, None)
+        except Exception as exc:
+            return self._partial_rebook_failure(ctx, commands, result_refs, replacement_order_id, exc)
 
     def _post_sales(
         self,
@@ -319,6 +451,96 @@ class LegacyAclService:
         message = str(exc) or exc.__class__.__name__
         self._publish(operation, Outcome.FAILED, ctx, commands, {}, message)
         return LegacyResult(0, message, {})
+
+    def _partial_rebook_failure(
+        self,
+        ctx: LegacyContext,
+        commands: list[str],
+        result_refs: dict[str, Any],
+        replacement_order_id: str | None,
+        exc: Exception,
+    ) -> LegacyResult:
+        message = str(exc) or exc.__class__.__name__
+        if replacement_order_id:
+            result_refs["partialOutcome"] = self._compensate_replacement_order(replacement_order_id, ctx, commands, result_refs)
+        elif result_refs:
+            result_refs["partialOutcome"] = "PARTIAL_REBOOK_FAILED"
+        self._publish(LegacyOperation.REBOOK, Outcome.FAILED, ctx, commands, result_refs, message)
+        return LegacyResult(0, message, result_refs)
+
+    def _compensate_replacement_order(
+        self,
+        replacement_order_id: str,
+        ctx: LegacyContext,
+        commands: list[str],
+        result_refs: dict[str, Any],
+    ) -> str:
+        try:
+            self.client.post(
+                "journey-order",
+                f"/api/v1/journey-orders/{quote(replacement_order_id)}/cancel",
+                {"reason": "REBOOK_PARTIAL_FAILURE"},
+                _headers(ctx, "rebook-compensate-order"),
+            )
+            commands.append("CancelReplacementJourneyOrder")
+            return "COMPENSATED"
+        except Exception as compensation_exc:
+            result_refs["compensationFailureMessage"] = str(compensation_exc) or compensation_exc.__class__.__name__
+            return "COMPENSATION_FAILED"
+
+    def _capture_rebook_payment(
+        self,
+        replacement_order_id: str,
+        account_id: str,
+        amount_due: Mapping[str, Any],
+        ctx: LegacyContext,
+        commands: list[str],
+    ) -> str:
+        intent = self.client.post(
+            "payment",
+            "/api/v1/payment-intents",
+            {
+                "businessRef": replacement_order_id,
+                "purpose": "purchase",
+                "amount": amount_due,
+                "payerRef": account_id,
+            },
+            _headers(ctx, "rebook-payment-intent"),
+        )
+        commands.append("CreatePaymentIntent")
+        payment_intent_id = _required_text(intent, "paymentIntentId")
+        self.client.post(
+            "payment",
+            f"/api/v1/payment-intents/{quote(payment_intent_id)}/capture",
+            {},
+            _headers(ctx, "rebook-capture"),
+        )
+        commands.append("CapturePayment")
+        return payment_intent_id
+
+    def _replacement_bounds(self, payload: Mapping[str, Any], order: Mapping[str, Any], ctx: LegacyContext) -> tuple[str, str]:
+        supplied_origin = _optional_text(payload, "from")
+        supplied_destination = _optional_text(payload, "to")
+        if supplied_origin and supplied_destination:
+            return supplied_origin, supplied_destination
+        if supplied_origin or supplied_destination:
+            raise ValueError("from and to must be supplied together")
+
+        offer_id = _required_text(order, "offerId")
+        offer = self.client.get("offer-management", f"/api/v1/offers/{quote(offer_id)}", _headers(ctx, "rebook-get-offer"))
+        itinerary_ref = _required_text(offer, "itineraryRef")
+        itinerary = self.client.get("trip-planning", f"/api/v1/itineraries/{quote(itinerary_ref)}", _headers(ctx, "rebook-get-itinerary"))
+        return _bounds_from_itinerary(itinerary)
+
+    def _entitlements_for_order(self, order_id: str) -> list[Mapping[str, Any]]:
+        page = self.client.get("entitlement-ticketing", f"/api/v1/entitlements?journeyOrderId={quote(order_id)}&limit=100&offset=0")
+        items = page.get("items")
+        if not isinstance(items, list):
+            raise DownstreamError("no entitlement found for order")
+        entitlements = [item for item in items if isinstance(item, Mapping)]
+        if not entitlements:
+            raise DownstreamError("no entitlement found for order")
+        return entitlements
 
     def _post_awaiting_projections(
         self,
@@ -462,6 +684,81 @@ class LegacyAclService:
         page = self.client.get("entitlement-ticketing", f"/api/v1/entitlements?journeyOrderId={quote(order_id)}&limit=20&offset=0")
         item = _first_mapping(page, "items", "no entitlement found for order")
         return item
+
+
+def _optional_text(payload: Mapping[str, Any], field: str) -> str | None:
+    value = payload.get(field)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _post_sales_scope(entitlements: list[Mapping[str, Any]]) -> dict[str, list[str]]:
+    return {
+        "orderItemRefs": _unique_ordered(_required_text(item, "segmentBookingId") for item in entitlements),
+        "segmentRefs": _unique_ordered(_required_text(item, "segmentRef") for item in entitlements),
+        "travelerRefs": _unique_ordered(_required_text(item, "travelerRef") for item in entitlements),
+        "entitlementRefs": _unique_ordered(_required_text(item, "entitlementId") for item in entitlements),
+    }
+
+
+def _bounds_from_itinerary(itinerary: Mapping[str, Any]) -> tuple[str, str]:
+    origin_ref = _optional_text(itinerary, "originRef")
+    destination_ref = _optional_text(itinerary, "destinationRef")
+    if origin_ref and destination_ref:
+        return origin_ref, destination_ref
+    legs = itinerary.get("legs")
+    if isinstance(legs, list) and legs:
+        first_leg = legs[0]
+        last_leg = legs[-1]
+        if isinstance(first_leg, Mapping) and isinstance(last_leg, Mapping):
+            origin_ref = _optional_text(first_leg, "originStopRef")
+            destination_ref = _optional_text(last_leg, "destinationStopRef")
+            if origin_ref and destination_ref:
+                return origin_ref, destination_ref
+    raise ValueError("replacement origin/destination could not be resolved; supply from and to")
+
+
+def _segment_refs_from_itinerary(itinerary: Mapping[str, Any]) -> list[str]:
+    legs = itinerary.get("legs")
+    if not isinstance(legs, list) or not legs:
+        raise DownstreamError("replacement itinerary contains no legs")
+    refs: list[str] = []
+    for leg in legs:
+        if not isinstance(leg, Mapping):
+            continue
+        service_segment_ref = leg.get("serviceSegmentRef")
+        if isinstance(service_segment_ref, str) and service_segment_ref.strip():
+            refs.append(service_segment_ref.strip())
+            continue
+        nested_refs = leg.get("segmentRefs")
+        if isinstance(nested_refs, list):
+            refs.extend(item.strip() for item in nested_refs if isinstance(item, str) and item.strip())
+    segment_refs = _unique_ordered(refs)
+    if not segment_refs:
+        raise DownstreamError("replacement itinerary contains no segments")
+    return segment_refs
+
+
+def _unique_ordered(values: Any) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if isinstance(value, str):
+            candidate = value.strip()
+            if candidate and candidate not in seen:
+                seen.add(candidate)
+                result.append(candidate)
+    if not result:
+        raise ValueError("at least one reference is required")
+    return result
+
+
+def _money_minor_units(value: Mapping[str, Any]) -> int:
+    minor_units = value.get("minorUnits")
+    if isinstance(minor_units, int) and not isinstance(minor_units, bool):
+        return minor_units
+    raise ValueError("amountDue.minorUnits is required")
 
 
 def _headers(ctx: LegacyContext, suffix: str) -> dict[str, str]:

--- a/services/legacy-acl/tests/test_api.py
+++ b/services/legacy-acl/tests/test_api.py
@@ -299,6 +299,50 @@ def test_rebook_rebooks_every_replacement_leg_in_one_legacy_call() -> None:
     assert publisher.envelopes[-1].payload["mappedCommands"].count("RequestSegmentReservation") == 2
 
 
+def test_rebook_rejects_short_replacement_for_multi_segment_original() -> None:
+    class ShortReplacementDownstream(FakeDownstream):
+        def post(self, service: str, path: str, body: Mapping[str, Any], headers: Mapping[str, str] | None = None) -> dict[str, Any]:
+            self.calls.append(("POST", service, path, dict(body), dict(headers or {})))
+            if service == "post-sales" and path == "/api/v1/post-sales-cases":
+                return {"caseId": "psc-change"}
+            if service == "post-sales" and path.endswith("/evaluate"):
+                return {"caseId": "psc-change", "amountDue": {"currency": "CNY", "minorUnits": 0}}
+            if service == "post-sales" and path.endswith("/approve"):
+                return {"caseId": "psc-change", "status": "APPROVED"}
+            if service == "trip-planning":
+                return {"itineraries": [{"itineraryRef": "itin-short", "legs": [{"serviceSegmentRef": "new-seg-1"}]}]}
+            raise AssertionError((service, path, body))
+
+        def get(self, service: str, path: str, headers: Mapping[str, str] | None = None) -> dict[str, Any]:
+            self.calls.append(("GET", service, path, {}, dict(headers or {})))
+            if service == "journey-order":
+                return {"orderId": "ord-original", "accountId": "acc-1", "offerId": "off-original", "travelerRefs": ["tvl-1"], "segmentRefs": ["old-seg-1", "old-seg-2"]}
+            if service == "entitlement-ticketing":
+                return {"items": [
+                    {"entitlementId": "ent-1", "segmentBookingId": "sb-old-1", "journeyOrderId": "ord-original", "travelerRef": "tvl-1", "segmentRef": "old-seg-1"},
+                    {"entitlementId": "ent-2", "segmentBookingId": "sb-old-2", "journeyOrderId": "ord-original", "travelerRef": "tvl-1", "segmentRef": "old-seg-2"},
+                ], "total": 2, "limit": 20, "offset": 0}
+            raise AssertionError((service, path))
+
+    fake = ShortReplacementDownstream()
+    publisher = InMemoryEventPublisher()
+    response = client(fake, publisher).post(
+        "/api/v1/legacy/rebook",
+        headers=HEADERS,
+        json={"orderId": "ord-original", "date": "2026-08-03", "seatType": "FIRST", "from": "p-bj", "to": "p-sh"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == 0
+    assert body["msg"] == "replacement itinerary covers 1 of 2 original segments"
+    assert body["data"]["partialOutcome"] == "PARTIAL_REBOOK_FAILED"
+    assert not [call for call in fake.calls if call[1] == "fare-pricing"]
+    assert publisher.envelopes[-1].payload["legacyOperation"] == "REBOOK"
+    assert publisher.envelopes[-1].payload["outcome"] == "FAILED"
+    assert publisher.envelopes[-1].payload["resultRefs"]["partialOutcome"] == "PARTIAL_REBOOK_FAILED"
+
+
 def test_rebook_later_leg_failure_reports_partial_and_compensates_replacement_order() -> None:
     class FailingReservationDownstream(FakeDownstream):
         def post(self, service: str, path: str, body: Mapping[str, Any], headers: Mapping[str, str] | None = None) -> dict[str, Any]:
@@ -351,6 +395,11 @@ def test_rebook_later_leg_failure_reports_partial_and_compensates_replacement_or
     assert body["status"] == 0
     assert body["msg"] == "capacity unavailable"
     assert body["data"]["replacementOrderId"] == "ord-repl"
+    assert body["data"]["replacementSegmentBookingIds"] == [
+        call[3]["segmentBookingId"]
+        for call in fake.calls
+        if call[1] == "booking-orchestration" and call[2].endswith("/request-reservation") and call[3]["segmentRef"] == "new-seg-1"
+    ]
     assert body["data"]["partialOutcome"] == "COMPENSATED"
     cancel_calls = [call for call in fake.calls if call[1] == "journey-order" and call[2].endswith("/cancel")]
     assert len(cancel_calls) == 1

--- a/services/legacy-acl/tests/test_api.py
+++ b/services/legacy-acl/tests/test_api.py
@@ -25,13 +25,13 @@ class FakeDownstream:
         if self.fail_on == (service, path):
             raise DownstreamError("downstream rejected")
         if service == "trip-planning":
-            return {"itineraries": [{"itineraryRef": "itin_1", "legs": [{"serviceSegmentRef": "seg-1"}]}]}
+            return {"itineraries": [{"itineraryRef": "itin_1", "originRef": "p-bj", "destinationRef": "p-sh", "legs": [{"serviceSegmentRef": "seg-1"}]}]}
         if service == "fare-pricing" and path == "/api/v1/fare-quotes":
             return {"quoteId": "fq-1", "breakdown": {"total": {"currency": "CNY", "minorUnits": 10750}}}
         if service == "offer-management":
-            return {"offerId": "off-1", "offerVersion": 1, "total": {"currency": "CNY", "minorUnits": 10750}}
+            return {"offerId": "off-1", "offerVersion": 1, "itineraryRef": "itin_1", "total": {"currency": "CNY", "minorUnits": 10750}}
         if service == "journey-order" and path == "/api/v1/journey-orders":
-            return {"orderId": "ord-1", "accountId": "acc-1", "travelerRefs": ["tvl-1"], "segmentRefs": ["seg-1"]}
+            return {"orderId": "ord-1", "accountId": "acc-1", "offerId": "off-1", "travelerRefs": ["tvl-1"], "segmentRefs": ["seg-1"]}
         if service == "booking-orchestration" and path == "/api/v1/internal/booking-sagas":
             return {"sagaId": "saga-1"}
         if service == "booking-orchestration" and path.endswith("/request-reservation"):
@@ -55,7 +55,11 @@ class FakeDownstream:
     def get(self, service: str, path: str, headers: Mapping[str, str] | None = None) -> dict[str, Any]:
         self.calls.append(("GET", service, path, {}, dict(headers or {})))
         if service == "journey-order":
-            return {"orderId": "ord-1", "accountId": "acc-1", "travelerRefs": ["tvl-1"], "segmentRefs": ["seg-1"]}
+            return {"orderId": "ord-1", "accountId": "acc-1", "offerId": "off-1", "travelerRefs": ["tvl-1"], "segmentRefs": ["seg-1"]}
+        if service == "offer-management" and path == "/api/v1/offers/off-1":
+            return {"offerId": "off-1", "itineraryRef": "itin_1"}
+        if service == "trip-planning" and path == "/api/v1/itineraries/itin_1":
+            return {"itineraryRef": "itin_1", "originRef": "p-bj", "destinationRef": "p-sh"}
         if service == "entitlement-ticketing":
             return {"items": [{"entitlementId": "ent-1", "segmentBookingId": "sb-1", "journeyOrderId": "ord-1", "travelerRef": "tvl-1", "segmentRef": "seg-1"}], "total": 1, "limit": 20, "offset": 0}
         raise AssertionError((service, path))
@@ -226,3 +230,131 @@ def test_preserve_does_not_retry_non_projection_errors(monkeypatch) -> None:
     assert response.status_code == 200
     assert response.json()["status"] == 0
     assert len([c for c in fake.calls if c[1] == "offer-management"]) == 1
+
+
+def test_rebook_rebooks_every_replacement_leg_in_one_legacy_call() -> None:
+    class MultiLegDownstream(FakeDownstream):
+        def post(self, service: str, path: str, body: Mapping[str, Any], headers: Mapping[str, str] | None = None) -> dict[str, Any]:
+            self.calls.append(("POST", service, path, dict(body), dict(headers or {})))
+            if service == "post-sales" and path == "/api/v1/post-sales-cases":
+                assert body["scope"]["segmentRefs"] == ["old-seg-1", "old-seg-2"]
+                assert body["scope"]["entitlementRefs"] == ["ent-1", "ent-2"]
+                return {"caseId": "psc-change"}
+            if service == "post-sales" and path.endswith("/evaluate"):
+                return {"caseId": "psc-change", "amountDue": {"currency": "CNY", "minorUnits": 0}}
+            if service == "post-sales" and path.endswith("/approve"):
+                return {"caseId": "psc-change", "status": "APPROVED"}
+            if service == "trip-planning":
+                return {"itineraries": [{"itineraryRef": "itin-repl", "legs": [{"serviceSegmentRef": "new-seg-1"}, {"serviceSegmentRef": "new-seg-2"}]}]}
+            if service == "fare-pricing":
+                assert body["segmentRefs"] == ["new-seg-1", "new-seg-2"]
+                return {"quoteId": "fq-repl", "breakdown": {"total": {"currency": "CNY", "minorUnits": 21000}}}
+            if service == "offer-management":
+                assert body["itineraryRef"] == "itin-repl"
+                return {"offerId": "off-repl", "offerVersion": 3, "total": {"currency": "CNY", "minorUnits": 21000}}
+            if service == "journey-order" and path == "/api/v1/journey-orders":
+                assert body["segmentRefs"] == ["new-seg-1", "new-seg-2"]
+                return {"orderId": "ord-repl", "accountId": "acc-1", "offerId": "off-repl", "travelerRefs": ["tvl-1"], "segmentRefs": ["new-seg-1", "new-seg-2"]}
+            if service == "booking-orchestration" and path == "/api/v1/internal/booking-sagas":
+                assert body["segmentRefs"] == ["new-seg-1", "new-seg-2"]
+                return {"sagaId": "saga-repl"}
+            if service == "booking-orchestration" and path.endswith("/request-reservation"):
+                return {"segmentBookingId": body["segmentBookingId"], "status": "REQUESTED"}
+            raise AssertionError((service, path, body))
+
+        def get(self, service: str, path: str, headers: Mapping[str, str] | None = None) -> dict[str, Any]:
+            self.calls.append(("GET", service, path, {}, dict(headers or {})))
+            if service == "journey-order":
+                return {"orderId": "ord-original", "accountId": "acc-1", "offerId": "off-original", "travelerRefs": ["tvl-1"], "segmentRefs": ["old-seg-1", "old-seg-2"]}
+            if service == "entitlement-ticketing":
+                return {"items": [
+                    {"entitlementId": "ent-1", "segmentBookingId": "sb-old-1", "journeyOrderId": "ord-original", "travelerRef": "tvl-1", "segmentRef": "old-seg-1"},
+                    {"entitlementId": "ent-2", "segmentBookingId": "sb-old-2", "journeyOrderId": "ord-original", "travelerRef": "tvl-1", "segmentRef": "old-seg-2"},
+                ], "total": 2, "limit": 20, "offset": 0}
+            raise AssertionError((service, path))
+
+    fake = MultiLegDownstream()
+    publisher = InMemoryEventPublisher()
+    response = client(fake, publisher).post(
+        "/api/v1/legacy/rebook",
+        headers=HEADERS,
+        json={"orderId": "ord-original", "date": "2026-08-03", "seatType": "FIRST", "from": "p-bj", "to": "p-sh"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == 1
+    assert body["msg"] == "success"
+    assert body["data"]["caseId"] == "psc-change"
+    assert body["data"]["amountDue"] == {"currency": "CNY", "minorUnits": 0}
+    assert body["data"]["replacementOrderId"] == "ord-repl"
+    assert body["data"]["rebookedSegmentCount"] == 2
+    reservation_calls = [call for call in fake.calls if call[1] == "booking-orchestration" and call[2].endswith("/request-reservation")]
+    assert [call[3]["segmentRef"] for call in reservation_calls] == ["new-seg-1", "new-seg-2"]
+    post_keys = [call[4]["Idempotency-Key"] for call in fake.calls if call[0] == "POST"]
+    assert len(post_keys) == len(set(post_keys))
+    assert all(is_uuid7(key) for key in post_keys)
+    assert publisher.envelopes[-1].payload["legacyOperation"] == "REBOOK"
+    assert publisher.envelopes[-1].payload["outcome"] == "SUCCEEDED"
+    assert publisher.envelopes[-1].payload["mappedCommands"].count("RequestSegmentReservation") == 2
+
+
+def test_rebook_later_leg_failure_reports_partial_and_compensates_replacement_order() -> None:
+    class FailingReservationDownstream(FakeDownstream):
+        def post(self, service: str, path: str, body: Mapping[str, Any], headers: Mapping[str, str] | None = None) -> dict[str, Any]:
+            self.calls.append(("POST", service, path, dict(body), dict(headers or {})))
+            if service == "post-sales" and path == "/api/v1/post-sales-cases":
+                return {"caseId": "psc-change"}
+            if service == "post-sales" and path.endswith("/evaluate"):
+                return {"caseId": "psc-change", "amountDue": {"currency": "CNY", "minorUnits": 0}}
+            if service == "post-sales" and path.endswith("/approve"):
+                return {"caseId": "psc-change", "status": "APPROVED"}
+            if service == "trip-planning":
+                return {"itineraries": [{"itineraryRef": "itin-repl", "legs": [{"serviceSegmentRef": "new-seg-1"}, {"serviceSegmentRef": "new-seg-2"}]}]}
+            if service == "fare-pricing":
+                return {"quoteId": "fq-repl", "breakdown": {"total": {"currency": "CNY", "minorUnits": 21000}}}
+            if service == "offer-management":
+                return {"offerId": "off-repl", "offerVersion": 3, "total": {"currency": "CNY", "minorUnits": 21000}}
+            if service == "journey-order" and path == "/api/v1/journey-orders":
+                return {"orderId": "ord-repl", "accountId": "acc-1", "offerId": "off-repl", "travelerRefs": ["tvl-1"], "segmentRefs": ["new-seg-1", "new-seg-2"]}
+            if service == "journey-order" and path == "/api/v1/journey-orders/ord-repl/cancel":
+                return {"orderId": "ord-repl", "status": "CANCELLED"}
+            if service == "booking-orchestration" and path == "/api/v1/internal/booking-sagas":
+                return {"sagaId": "saga-repl"}
+            if service == "booking-orchestration" and path.endswith("/request-reservation"):
+                if body["segmentRef"] == "new-seg-2":
+                    raise DownstreamError("capacity unavailable")
+                return {"segmentBookingId": body["segmentBookingId"], "status": "REQUESTED"}
+            raise AssertionError((service, path, body))
+
+        def get(self, service: str, path: str, headers: Mapping[str, str] | None = None) -> dict[str, Any]:
+            self.calls.append(("GET", service, path, {}, dict(headers or {})))
+            if service == "journey-order":
+                return {"orderId": "ord-original", "accountId": "acc-1", "offerId": "off-original", "travelerRefs": ["tvl-1"], "segmentRefs": ["old-seg-1", "old-seg-2"]}
+            if service == "entitlement-ticketing":
+                return {"items": [
+                    {"entitlementId": "ent-1", "segmentBookingId": "sb-old-1", "journeyOrderId": "ord-original", "travelerRef": "tvl-1", "segmentRef": "old-seg-1"},
+                    {"entitlementId": "ent-2", "segmentBookingId": "sb-old-2", "journeyOrderId": "ord-original", "travelerRef": "tvl-1", "segmentRef": "old-seg-2"},
+                ], "total": 2, "limit": 20, "offset": 0}
+            raise AssertionError((service, path))
+
+    fake = FailingReservationDownstream()
+    publisher = InMemoryEventPublisher()
+    response = client(fake, publisher).post(
+        "/api/v1/legacy/rebook",
+        headers=HEADERS,
+        json={"orderId": "ord-original", "date": "2026-08-03", "seatType": "FIRST", "from": "p-bj", "to": "p-sh"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == 0
+    assert body["msg"] == "capacity unavailable"
+    assert body["data"]["replacementOrderId"] == "ord-repl"
+    assert body["data"]["partialOutcome"] == "COMPENSATED"
+    cancel_calls = [call for call in fake.calls if call[1] == "journey-order" and call[2].endswith("/cancel")]
+    assert len(cancel_calls) == 1
+    assert cancel_calls[0][3] == {"reason": "REBOOK_PARTIAL_FAILURE"}
+    assert publisher.envelopes[-1].payload["legacyOperation"] == "REBOOK"
+    assert publisher.envelopes[-1].payload["outcome"] == "FAILED"
+    assert publisher.envelopes[-1].payload["resultRefs"]["partialOutcome"] == "COMPENSATED"


### PR DESCRIPTION
## Summary
- extend legacy-acl rebook to drive post-sales plus full replacement quote/offer/order/reservation/payment flow for every replacement leg
- return deterministic partial/compensated failure data when a later replacement step fails
- update contracts/status docs and add legacy ACL multi-leg rebook test/e2e assertions

## Validation
- uv run pytest tests -q (services/legacy-acl)
- bash -n deploy/e2e/11-legacy-acl.sh
- git diff --check