### PR TITLE
REQ-331 disruption recovery fanout sources

### DIFF
--- a/docs/08-contracts/api/disruption-recovery.md
+++ b/docs/08-contracts/api/disruption-recovery.md
@@ -1,6 +1,6 @@
 # Disruption Recovery — HTTP API
 
-Last updated: 2026-07-09
+Last updated: 2026-07-15
 
 ## Overview
 
@@ -12,20 +12,20 @@ contract is scoped to the ADR-0002 third activation wave and is bounded by
 
 Activation-wave rulings:
 
-- The disruption signal source in this wave is **operations/system reporting** via
-  `POST /api/v1/disruptions`. The request represents Customer Service/Admin
-  manual rows or Transfer Management system reports and MUST carry
-  `disruptionType`, `scheduledServiceRef` and/or `segmentRef`, `serviceDate`,
-  `evidence`, and explicit `affectedOrderIds`. Automatic `segmentRef` to order
-  fan-out is deferred because Journey Order has no by-segment query contract.
-- Service Plan, Provider Integration, and Fulfillment event sources remain
-  deferred. Transfer Management wave 18 opens protected missed-connection
-  recovery through outbound HTTP to this API, not through a new input event.
+- Disruption signal sources are **operations/system reporting** via
+  `POST /api/v1/disruptions`, Fulfillment `SegmentDelayed` /
+  `SegmentCancelled`, and Provider Integration segment disruption events. HTTP
+  requests represent Customer Service/Admin manual rows or system reports and
+  MUST carry `disruptionType`, `scheduledServiceRef` and/or `segmentRef`,
+  `serviceDate`, and `evidence`. `affectedOrderIds` may be supplied explicitly
+  or resolved from `segmentRef` through the Journey Order event-bus projection;
+  no cross-service resolver HTTP call is introduced.
 - An `Incident` is opened or merged by the same report. This wave merges by
   `(scheduledServiceRef, serviceDate)` when `scheduledServiceRef` is present;
   otherwise the report opens a distinct incident for its supplied scope.
-- `ServiceAlert` is event-only in this wave. Disruption Recovery publishes
-  `ServiceAlertPublished`; the ServiceAlert read model is deferred.
+- `ServiceAlertPublished` is the normative alert fact. Disruption Recovery builds
+  the ServiceAlert read model from this event and exposes it via
+  `GET /api/v1/service-alerts` and `GET /api/v1/service-alerts/{serviceAlertId}`.
 - The `RecoveryCase` state machine is exactly the 10-state machine from the
   domain document (`OPENED` through `CLOSED`) and follows the transition table
   below. One `RecoveryCase` is opened for each `affectedOrderId` supplied in the
@@ -125,7 +125,7 @@ option set:
 | `segmentRef` | string | no | Segment reference from the order/service plan. Required when `scheduledServiceRef` is absent. |
 | `serviceDate` | string | yes | Service operating date in ISO `YYYY-MM-DD`; used with `scheduledServiceRef` for incident merge. |
 | `evidence` | object | yes | Operational evidence object. See `Evidence`. |
-| `affectedOrderIds` | array[string] | yes | Explicit affected journey order IDs (`ord-<uuid>`). Must be non-empty; no automatic segment-to-order fan-out in this wave. |
+| `affectedOrderIds` | array[string] | yes for HTTP unless `segmentRef` resolves orders | Explicit affected journey order IDs (`ord-<uuid>`) or empty when the service can resolve affected orders from `segmentRef` via its Journey Order projection. |
 | `reportedBy` | object | yes | Reporting actor. See `ActorRef`. |
 | `reportedAt` | RFC3339 UTC | yes | Report timestamp. |
 | `incidentId` | string | yes | Opened or merged incident ID (`inc-<uuid>`). |
@@ -135,7 +135,7 @@ option set:
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `evidenceRef` | string | yes | Reference to the admin/customer-service evidence record or uploaded artifact. |
-| `sourceSystem` | enum | yes | `CUSTOMER_SERVICE`, `ADMIN`, or `TRANSFER_MANAGEMENT`. Other upstream source systems are deferred. |
+| `sourceSystem` | enum | yes | `CUSTOMER_SERVICE`, `ADMIN`, `TRANSFER_MANAGEMENT`, `PROVIDER_INTEGRATION`, or `FULFILLMENT`. |
 | `sourceRecordId` | string | yes | Upstream manual-row identifier. |
 | `summary` | string | yes | Operational summary; MUST NOT include unmasked documents or other sensitive personal data. |
 | `occurredAt` | RFC3339 UTC | no | When the disruption was observed, if known. |
@@ -311,8 +311,8 @@ return the original response. Reusing the same key with a different body returns
 | `scheduledServiceRef` | string | no | Scheduled service reference. Required when `segmentRef` is absent. |
 | `segmentRef` | string | no | Segment reference. Required when `scheduledServiceRef` is absent. |
 | `serviceDate` | string | yes | ISO `YYYY-MM-DD` operating date; used with `scheduledServiceRef` for incident merge. |
-| `evidence` | object | yes | Evidence object with `sourceSystem` of `CUSTOMER_SERVICE`, `ADMIN`, or `TRANSFER_MANAGEMENT`. |
-| `affectedOrderIds` | array[string] | yes | Explicit affected `ord-<uuid>` IDs. Must be non-empty. |
+| `evidence` | object | yes | Evidence object with `sourceSystem` of `CUSTOMER_SERVICE`, `ADMIN`, `TRANSFER_MANAGEMENT`, `PROVIDER_INTEGRATION`, or `FULFILLMENT`. |
+| `affectedOrderIds` | array[string] | no | Explicit affected `ord-<uuid>` IDs. Required only when `segmentRef` cannot resolve affected orders from the Journey Order projection. |
 | `reportedBy` | object | yes | Reporting actor; normally `CUSTOMER_SERVICE`, `OPERATIONS`, or `SYSTEM` for Transfer Management missed-connection reports. |
 
 **Response (202):**
@@ -328,10 +328,7 @@ incident is opened, `RecoveryCaseOpened` for each affected order, optionally
 `RecoveryOptionsGenerated`, and `ServiceAlertPublished` for the incident alert
 fact. A repeated report for an already known `(scheduledServiceRef, serviceDate)`
 merges into the existing incident and does not duplicate active cases for the
-same `(incidentId, journeyOrderId)`. Wave-18 implementation MUST update the
-Disruption Recovery code enum/validation allowlists for
-`reportedBy.actorType=SYSTEM`, `disruptionType=MISSED_CONNECTION`, and
-`evidence.sourceSystem=TRANSFER_MANAGEMENT`; this is not a docs-only increment.
+same `(incidentId, journeyOrderId)`. Provider/Fulfillment segment signals use the same domain flow after resolving affected orders from `segmentRef`.
 
 **Error codes:** `VALIDATION_FAILED`, `CONFLICT`, `DOMAIN_RULE_VIOLATION`,
 `IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
@@ -377,6 +374,24 @@ of this activation-wave API.
 `offset`, where each item is a `RecoveryCase` resource.
 
 **Error codes:** `VALIDATION_FAILED`
+
+
+### List Service Alerts
+
+**GET** `/api/v1/service-alerts?incidentId={incidentId}&journeyOrderId={orderId}&limit=20&offset=0`
+
+At least one of `incidentId` or `journeyOrderId` SHOULD be supplied by callers.
+The response is the standard paginated shape with `items`, `total`, `limit`, and
+`offset`; each item uses the `ServiceAlertPublished` payload fields.
+
+### Get Service Alert
+
+**GET** `/api/v1/service-alerts/{serviceAlertId}`
+
+**Response (200):** one ServiceAlert read-model item using the
+`ServiceAlertPublished` payload fields.
+
+**Error codes:** `NOT_FOUND`
 
 ### Select Recovery Option
 
@@ -463,10 +478,7 @@ wave:
   `MISSED_CONNECTION` cases; all other `REACCOMMODATION` generation is deferred.
 - `ApplyRecoveryDecision` / execution convergence — driven internally after
   selection and by consuming `PostSalesApplied` from `events:post-sales`.
-- `PublishServiceAlert` — publishes the event-only `ServiceAlertPublished` fact;
-  the ServiceAlert read model is deferred.
-
-Deferred signal sources remain out of this wave: Service Plan, Provider
-Integration, and Fulfillment events do not open incidents or cases until their
-activation waves. Transfer Management opens protected missed-connection recovery
-through this HTTP endpoint, not by publishing a Disruption Recovery input event.
+- `PublishServiceAlert` — publishes `ServiceAlertPublished` and updates the
+  ServiceAlert read model.
+- Provider/Fulfillment segment ingress — consumed from the event bus, mapped to
+  `ReportDisruption`, and fanned out to segment-resolved orders.

--- a/docs/08-contracts/api/provider-integration.md
+++ b/docs/08-contracts/api/provider-integration.md
@@ -1,21 +1,22 @@
 # Provider Integration — HTTP API
 
-Last updated: 2026-07-08
+Last updated: 2026-07-15
 
 ## Overview
 
 Provider Integration manages external provider (supplier) communication. It
 translates internal commands to provider-specific protocols, handles
-idempotency, and normalizes responses. Commands arrive on the event bus —
-there are no HTTP command endpoints (see Command Surface below).
-
+idempotency, and normalizes responses. Reservation commands remain event-driven;
+segment disruption status can also enter through the provider webhook/simulator
+HTTP ingress below so Provider Integration, not downstream consumers, owns the
+provider-produced event contract.
 
 Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
 timestamps, and Money.
-## Command Surface (ruling 2026-07-08, REQ-105)
 
-Provider Integration has **no HTTP command endpoints**. Its command surface
-is event-driven only:
+## Command Surface
+
+Reservation command surface is event-driven only:
 
 - Reserve: consumes `SegmentReservationRequested` from
   `events:booking-orchestration`.
@@ -24,18 +25,50 @@ is event-driven only:
   exists for the segment booking).
 
 The former internal HTTP endpoints (`POST /api/v1/internal/
-provider-reservations` and `.../{segmentBookingId}/cancel`) were removed:
+provider-reservations` and `.../{segmentBookingId}/cancel`) remain removed:
 the audit in `docs/08-contracts/provider-integration-http-endpoint-audit.md`
 found no callers anywhere, and a second HTTP write path would bypass the
 saga's event-driven bookkeeping. Manual intervention goes through
-admin-audit manual actions, not direct provider commands.
+admin-audit manual actions, not direct provider reservation commands.
 
-The HTTP surface is runtime-only: health, readiness, and metadata.
+## Segment status ingress
 
-## Bus-only commands
+`POST /api/v1/provider-segment-status`
+
+Provider webhook adapters and the operations provider simulator use this endpoint
+to report provider-sourced operating segment disruptions. The endpoint requires
+an `Idempotency-Key` UUID-v7 header and publishes the normative
+`ProviderSegmentDelayed` or `ProviderSegmentCancelled` event on
+`events:provider-integration`.
+
+### Request body
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `segmentRef` | `SegmentRef` | yes | Affected service segment (`seg-<uuid>`). |
+| `scheduledServiceRef` | string | yes | Scheduled service/run reference. |
+| `serviceDate` | string | yes | Operating date, `YYYY-MM-DD`. |
+| `status` | enum | yes | `DELAY` or `CANCELLED`. |
+| `estimatedArrivalAt` | RFC3339 UTC | yes when `status=DELAY` | Latest estimated arrival. |
+| `cancelledAt` | RFC3339 UTC | yes when `status=CANCELLED` | Cancellation timestamp. |
+| `observedAt` | RFC3339 UTC | yes | When the provider status was observed. |
+| `sourceSystem` | string | no | Provider declaration source; defaults to `PROVIDER`. |
+
+### Response `201 Created`
+
+| Field | Type | Description |
+|---|---|---|
+| `segmentRef` | `SegmentRef` | Accepted segment. |
+| `status` | enum | `DELAY` or `CANCELLED`. |
+| `observedAt` | RFC3339 UTC | Accepted observation time. |
+| `publishedAs` | string | `ProviderSegmentDelayed` or `ProviderSegmentCancelled`. |
+
+## Bus-only events
 
 - `ProviderReservationConfirmed` (published event, not a command)
 - `ProviderReservationFailed` (published event, not a command)
+- `ProviderSegmentDelayed` (published event from segment status ingress)
+- `ProviderSegmentCancelled` (published event from segment status ingress)
 
 ## Open Issues
 

--- a/docs/08-contracts/events/disruption-recovery.md
+++ b/docs/08-contracts/events/disruption-recovery.md
@@ -1,6 +1,6 @@
 # Disruption Recovery — Events & Commands
 
-Last updated: 2026-07-09
+Last updated: 2026-07-15
 
 ## Scope and activation-wave rulings
 
@@ -10,21 +10,22 @@ by the activation rulings in `docs/08-contracts/api/disruption-recovery.md`.
 
 Activation-wave rulings:
 
-- The active signal source is the operations/system HTTP command
-  `POST /api/v1/disruptions`. It represents Customer Service/Admin manual rows
-  or Transfer Management system reports and carries a normalized
-  `disruptionType`, `scheduledServiceRef` and/or `segmentRef`, `evidence`, and
-  explicit `affectedOrderIds`.
-- Automatic `segmentRef` to orders fan-out is deferred because Journey Order has
-  no by-segment query contract. Service Plan, Provider Integration, and
-  Fulfillment signal events remain deferred. Transfer Management wave 18 opens
-  protected missed-connection recovery through HTTP
-  `POST /api/v1/disruptions`, not by a new inbound event.
+- Active signal sources are the operations/system HTTP command
+  `POST /api/v1/disruptions`, Fulfillment `SegmentDelayed` /
+  `SegmentCancelled`, and Provider Integration segment disruption events. HTTP
+  reports carry a normalized `disruptionType`, `scheduledServiceRef` and/or
+  `segmentRef`, `evidence`, and affected orders when supplied by the reporter.
+- `segmentRef` to orders fan-out is active through the Journey Order event-bus
+  projection built from `JourneyOrderCreated.segmentRefs`. A report or consumed
+  segment signal with no explicit `affectedOrderIds` MUST resolve orders from
+  this projection and then emit the standard `RecoveryCaseOpened` /
+  `RecoveryOptionsGenerated` recovery events for each resolved order; no
+  cross-service resolver HTTP call is introduced.
 - The report opens or merges an `Incident`; merge key is
   `(scheduledServiceRef, serviceDate)` when `scheduledServiceRef` is present.
-  `ServiceAlert` is event-only in this wave: `ServiceAlertPublished` is
-  published, but the ServiceAlert read model is deferred.
-- One `RecoveryCase` is opened per explicit `affectedOrderId`. Event payload
+  `ServiceAlertPublished` is stored in the ServiceAlert read model and exposed by
+  the Disruption Recovery API using the same payload shape as the event.
+- One `RecoveryCase` is opened per explicit or segment-resolved `affectedOrderId`. Event payload
   statuses use the exact 10-state domain machine: `OPENED`, `ASSESSING_IMPACT`,
   `OPTIONS_GENERATED`, `AWAITING_USER_CHOICE`, `EXECUTING_RECOVERY`,
   `MANUAL_REVIEW`, `RECOVERED`, `DECLINED`, `FAILED`, `CLOSED`.
@@ -46,8 +47,7 @@ Activation-wave rulings:
   idempotency key. `MANUAL` moves the case to manual review.
 - Reporting consumption of Disruption Recovery events remains deferred in this
   wave. Notification is active for traveler-facing recovery lifecycle and alert
-  facts. The only active inbound subscription is `events:post-sales`
-  `PostSalesApplied` for REFUND execution convergence.
+  facts. Active inbound subscriptions are listed in Consumed upstream events below.
 
 All payload fields are camelCase, all enum values are SCREAMING_SNAKE_CASE, and
 all timestamps are RFC3339 UTC. Envelope fields, including optional trace context
@@ -84,9 +84,9 @@ Downstream HTTP commands use deterministic idempotency keys:
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `evidenceRef` | string | yes | Reference to the customer-service/admin evidence record. |
-| `sourceSystem` | enum | yes | `CUSTOMER_SERVICE`, `ADMIN`, or `TRANSFER_MANAGEMENT`; all other sources are deferred. |
-| `sourceRecordId` | string | yes | Upstream manual-row identifier. |
+| `evidenceRef` | string | yes | Reference to the customer-service/admin evidence record or consumed upstream event ID. |
+| `sourceSystem` | enum | yes | `CUSTOMER_SERVICE`, `ADMIN`, `TRANSFER_MANAGEMENT`, `PROVIDER_INTEGRATION`, or `FULFILLMENT`. |
+| `sourceRecordId` | string | yes | Upstream manual row or event identifier. |
 | `summary` | string | yes | Operational summary; must not include unmasked documents or sensitive personal data. |
 | `occurredAt` | RFC3339 UTC | no | Observation time if known. |
 
@@ -143,7 +143,7 @@ Downstream HTTP commands use deterministic idempotency keys:
 | `segmentRef` | string | no | Segment reference. |
 | `serviceDate` | string | yes | ISO `YYYY-MM-DD` service date. |
 | `evidence` | object | yes | Evidence object. |
-| `affectedOrderIds` | array[string] | yes | Explicit affected orders supplied by operations. |
+| `affectedOrderIds` | array[string] | yes | Affected orders supplied explicitly or resolved from `segmentRef` using the Journey Order projection. |
 | `reportedBy` | object | yes | Reporting actor. |
 | `reportedAt` | RFC3339 UTC | yes | Report timestamp. |
 
@@ -351,7 +351,7 @@ Downstream HTTP commands use deterministic idempotency keys:
 |---|---|---|
 | `ReportDisruption` | Operations HTTP `POST /api/v1/disruptions` | `DisruptionReported` |
 | `OpenIncident` | Application flow after report, or merge lookup miss | `IncidentOpened` |
-| `OpenRecoveryCase` | Application flow for each explicit `affectedOrderId` | `RecoveryCaseOpened` |
+| `OpenRecoveryCase` | Application flow for each explicit or segment-resolved `affectedOrderId` | `RecoveryCaseOpened` |
 | `GenerateRecoveryOptions` | Application flow after impact assessment | `RecoveryOptionsGenerated` |
 | `SelectRecoveryOption` | Automatic single-option `WAIT`, or HTTP `POST /api/v1/recovery-cases/{caseId}/select-option` | `RecoveryOptionSelected` |
 | `ApplyRecoveryDecision` | Internal execution start after selection | `RecoveryExecutionStarted` |
@@ -364,20 +364,27 @@ Downstream HTTP commands use deterministic idempotency keys:
 | Upstream stream | Event type | Purpose |
 |---|---|---|
 | `events:post-sales` | `PostSalesApplied` | Converge a selected `REFUND` option when the downstream Post Sales case reaches `APPLIED`. |
+| `events:journey-order` | `JourneyOrderCreated` | Maintain the local `segmentRef` -> `journeyOrderId` projection used for disruption fan-out. Payload fields consumed: `orderId`, `segmentRefs`. |
+| `events:fulfillment` | `SegmentDelayed`, `SegmentCancelled` | Open or merge a `FULFILLMENT`-sourced incident from the segment signal, resolve affected orders from `segmentRef`, publish a ServiceAlert, and fan out recovery cases through the standard events. |
+| `events:provider-integration` | `ProviderSegmentDelayed`, `ProviderSegmentCancelled` (or provider-published `SegmentDelayed` / `SegmentCancelled` with the same segment payload) | Open or merge a `PROVIDER_INTEGRATION`-sourced incident from the provider segment signal, resolve affected orders from `segmentRef`, publish a ServiceAlert, and fan out recovery cases through the standard events. |
+| `events:disruption-recovery` | `ServiceAlertPublished` | Build/repair the ServiceAlert read model from the normative alert event payload. |
 
-No other upstream event subscription is active in this wave. Service Plan,
-Provider Integration, and Fulfillment disruption sources are deferred. Transfer
-Management protected missed-connection reports arrive over HTTP with
+Fulfillment and Provider Integration segment ingress use the normative
+`segmentRef`, `scheduledServiceRef`, `serviceDate`, observed/cancelled/estimated
+time fields from their source contracts. Disruption Recovery maps delayed signals
+to `disruptionType=DELAY`, cancelled signals to `disruptionType=CANCELLATION`,
+sets `reportedBy={actorType:SYSTEM, actorId:<source-service>}`, and records
+`evidence.sourceSystem` as `FULFILLMENT` or `PROVIDER_INTEGRATION`. Transfer
+Management protected missed-connection reports continue to arrive over HTTP with
 `disruptionType=MISSED_CONNECTION`, `reportedBy.actorType=SYSTEM`, and
-`evidence.sourceSystem=TRANSFER_MANAGEMENT`; the same wave implementation MUST
-update Disruption Recovery code enum/validation allowlists for those values and
-MUST update e2e 17/19 expectations for the `WAIT` plus `REACCOMMODATION`
-`AWAITING_USER_CHOICE` behavior.
+`evidence.sourceSystem=TRANSFER_MANAGEMENT`.
 
-## Deferred downstream touchpoints
+## Downstream and read-model touchpoints
 
-| Downstream context | Events | Purpose |
+| Context | Events / model | Purpose |
 |---|---|---|
 | Notification | active: `ServiceAlertPublished`, `RecoveryCaseOpened`, `RecoveryOptionsGenerated`, `RecoveryOptionSelected`, `RecoveryExecutionStarted`, `RecoveryCompleted`, `RecoveryFailed` | User-facing alert, option, decision, progress, and completion notifications. `RecoveryExecutionStarted` is progress-only; refund executed / compensation issued notifications are emitted only from `RecoveryCompleted`. |
+| ServiceAlert read model | active: built from `ServiceAlertPublished`; queryable through the Disruption Recovery API with the event payload fields (`serviceAlertId`, `incidentId`, `disruptionType`, `scheduledServiceRef`, `segmentRef`, `serviceDate`, `audience`, `affectedOrderIds`, `messageSummary`, `publishedAt`) | Customer-service/operations alert feed and affected-order alert lookup. |
+| Journey Order segment projection | active: built from `JourneyOrderCreated.segmentRefs`; used only for event-driven `segmentRef` fan-out | Resolve affected orders for HTTP reports and provider/fulfillment segment signals without introducing a cross-service HTTP resolver. |
 | Reporting | all Disruption Recovery events | Disruption metrics, waiver/compensation cost attribution, and operational read models. |
 | Journey Order | recovery summary events | Order-detail disruption and recovery display. |

--- a/docs/08-contracts/events/fulfillment.md
+++ b/docs/08-contracts/events/fulfillment.md
@@ -197,7 +197,7 @@ Last updated: 2026-07-05
 | Field | Description |
 |---|---|
 | **Producer** | fulfillment |
-| **Consumers** | transfer-management |
+| **Consumers** | transfer-management, disruption-recovery |
 | **Trigger** | Operational segment status reported through `POST /api/v1/segment-status` with `status=DELAY`. Fulfillment currently has no native delay signal source; this event is emitted from SYSTEM/OPS declaration only. |
 | **eventId** | Deterministic: `evt-` + UUID-v7-shaped SHA-256 fold of `fulfillment:SegmentDelayed:<commandId>`, where `commandId` is the `cmd-<Idempotency-Key>` command id. |
 
@@ -210,7 +210,7 @@ Last updated: 2026-07-05
 | `serviceDate` | string | yes | Operating date, `YYYY-MM-DD`. |
 | `estimatedArrivalAt` | RFC3339 UTC | yes | Latest estimated arrival. |
 | `observedAt` | RFC3339 UTC | yes | When the status was observed/declared. |
-| `sourceSystem` | string | yes | Declaration source: `SYSTEM` or `OPS`. |
+| `sourceSystem` | string | yes | Declaration source: `SYSTEM`, `OPS`, or `PROVIDER_INTEGRATION`. |
 
 ### SegmentArrived
 
@@ -230,14 +230,14 @@ Last updated: 2026-07-05
 | `serviceDate` | string | yes | Operating date, `YYYY-MM-DD`. |
 | `arrivedAt` | RFC3339 UTC | yes | Actual arrival time. |
 | `observedAt` | RFC3339 UTC | yes | When the status was observed/declared. |
-| `sourceSystem` | string | yes | Declaration source: `SYSTEM` or `OPS`. |
+| `sourceSystem` | string | yes | Declaration source: `SYSTEM`, `OPS`, or `PROVIDER_INTEGRATION`. |
 
 ### SegmentCancelled
 
 | Field | Description |
 |---|---|
 | **Producer** | fulfillment |
-| **Consumers** | transfer-management |
+| **Consumers** | transfer-management, disruption-recovery |
 | **Trigger** | Operational segment status reported through `POST /api/v1/segment-status` with `status=CANCELLED`. |
 | **eventId** | Deterministic: `evt-` + UUID-v7-shaped SHA-256 fold of `fulfillment:SegmentCancelled:<commandId>`. |
 
@@ -250,4 +250,4 @@ Last updated: 2026-07-05
 | `serviceDate` | string | yes | Operating date, `YYYY-MM-DD`. |
 | `cancelledAt` | RFC3339 UTC | yes | Cancellation timestamp. |
 | `observedAt` | RFC3339 UTC | yes | When the status was observed/declared. |
-| `sourceSystem` | string | yes | Declaration source: `SYSTEM` or `OPS`. |
+| `sourceSystem` | string | yes | Declaration source: `SYSTEM`, `OPS`, or `PROVIDER_INTEGRATION`. |

--- a/docs/08-contracts/events/provider-integration.md
+++ b/docs/08-contracts/events/provider-integration.md
@@ -65,3 +65,66 @@ Last updated: 2026-06-28
 |---|---|---|---|
 | `entitlementId` | `EntitlementId` | yes | Platform entitlement ID. |
 | `providerReference` | `ProviderReference` | yes | Provider's ticket reference. |
+
+
+### ProviderSegmentDelayed
+
+| Field | Description |
+|---|---|
+| **Producer** | provider-integration |
+| **Consumers** | disruption-recovery |
+| **Trigger** | External provider reports a delay for a booked operating segment. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `segmentRef` | `SegmentRef` | yes | Affected service segment (`seg-<uuid>`). |
+| `scheduledServiceRef` | string | yes | Scheduled service/run reference. |
+| `serviceDate` | string | yes | Operating date, `YYYY-MM-DD`. |
+| `estimatedArrivalAt` | RFC3339 UTC | yes | Latest estimated arrival. |
+| `observedAt` | RFC3339 UTC | yes | When the provider delay status was observed. |
+| `sourceSystem` | string | yes | Provider declaration source, normally `PROVIDER`. |
+
+### ProviderSegmentCancelled
+
+| Field | Description |
+|---|---|
+| **Producer** | provider-integration |
+| **Consumers** | disruption-recovery |
+| **Trigger** | External provider reports cancellation for a booked operating segment. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `segmentRef` | `SegmentRef` | yes | Affected service segment (`seg-<uuid>`). |
+| `scheduledServiceRef` | string | yes | Scheduled service/run reference. |
+| `serviceDate` | string | yes | Operating date, `YYYY-MM-DD`. |
+| `cancelledAt` | RFC3339 UTC | yes | Cancellation timestamp. |
+| `observedAt` | RFC3339 UTC | yes | When the provider cancellation status was observed. |
+| `sourceSystem` | string | yes | Provider declaration source, normally `PROVIDER`. |
+
+## Accepted Commands
+
+### ReportProviderSegmentStatus
+
+| Field | Description |
+|---|---|
+| **Sender** | provider webhook adapter / operations provider simulator |
+| **Trigger** | External provider reports a delay or cancellation for a booked operating segment. |
+| **HTTP ingress** | `POST /api/v1/provider-segment-status` with `Idempotency-Key` UUID-v7 header. |
+| **Produced events** | `ProviderSegmentDelayed` when `status=DELAY`; `ProviderSegmentCancelled` when `status=CANCELLED`. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `segmentRef` | `SegmentRef` | yes | Affected service segment (`seg-<uuid>`). |
+| `scheduledServiceRef` | string | yes | Scheduled service/run reference. |
+| `serviceDate` | string | yes | Operating date, `YYYY-MM-DD`. |
+| `status` | enum | yes | `DELAY` or `CANCELLED`. |
+| `estimatedArrivalAt` | RFC3339 UTC | yes when `status=DELAY` | Latest estimated arrival. |
+| `cancelledAt` | RFC3339 UTC | yes when `status=CANCELLED` | Cancellation timestamp. |
+| `observedAt` | RFC3339 UTC | yes | When the provider status was observed. |
+| `sourceSystem` | string | no | Provider declaration source; defaults to `PROVIDER`. |

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -57,7 +57,7 @@ context.
 | 8 | `booking-orchestration` | `events:booking-orchestration` | BookingSagaStarted, SegmentReservationRequested, SegmentReservationConfirmed, SegmentReservationFailed, SegmentTicketed, SegmentBookingCancelled |
 | 9 | `payment` | `events:payment` | PaymentIntentCreated, PaymentCaptured, PaymentIntentFailed, PaymentExpired, RefundRequested, RefundSettled, RefundFailed |
 | 9a | `payment-channel` | `events:payment-channel` | ChannelOrderCreated, ChannelOrderSubmitted, ChannelOrderAccepted, ChannelOrderSucceeded, ChannelOrderFailed, ChannelOrderMissed, ChannelOrderQueryRecorded, ChannelOrderRecoveryDetected, ChannelRefundCreated, ChannelRefundSubmitted, ChannelRefundSucceeded, ChannelRefundFailed, ChannelRefundMissed, ChannelRefundQueryRecorded, ChannelRefundRecoveryDetected, ChannelStatementGenerated, ChannelStatementFrozen, ChannelStatementLineMatched, ReconciliationDiscrepancyOpened, ReconciliationDiscrepancyLinkedToFinanceCase, ReconciliationDiscrepancyResolved |
-| 10 | `provider-integration` | `events:provider-integration` | ProviderReservationConfirmed, ProviderReservationFailed, ProviderReservationCancelled, ProviderBoardingAccepted |
+| 10 | `provider-integration` | `events:provider-integration` | ProviderReservationConfirmed, ProviderReservationFailed, ProviderReservationCancelled, ProviderBoardingAccepted, ProviderSegmentDelayed, ProviderSegmentCancelled |
 | 11 | `entitlement-ticketing` | `events:entitlement-ticketing` | EntitlementIssued, EntitlementVoided, EntitlementBoarded, EntitlementSuspended, EntitlementResumed, EntitlementUsed, EntitlementIssueFailed |
 | 12 | `fulfillment` | `events:fulfillment` | BoardingVerified, NoShowRecorded, FulfillmentCompleted, EvidenceDisputeOpened, EvidenceDisputeResolved, SegmentArrived, SegmentDelayed, SegmentCancelled |
 | 13 | `post-sales` | `events:post-sales` | PostSalesCaseOpened, PostSalesRequested, PostSalesEligibilityEvaluated, PostSalesDecisionQuoted, PostSalesApproved, PostSalesRejected, PostSalesApplied, PostSalesFailed |
@@ -255,12 +255,14 @@ plus notification/finance/reporting fan-in.
 | 21 | `events:payment` | `notification` | Payment events for user notifications |
 | 22 | `events:provider-integration` | `booking-orchestration` | ProviderReservationConfirmed for saga progression |
 | 23 | `events:provider-integration` | `finance-settlement` | Provider events for settlement |
+| 23a | `events:provider-integration` | `disruption-recovery` | ProviderSegmentDelayed and ProviderSegmentCancelled open or merge provider-sourced recovery incidents through segmentRef fan-out. |
 | 24 | `events:entitlement-ticketing` | `fulfillment` | EntitlementIssued to prepare for boarding verification |
 | 25 | `events:entitlement-ticketing` | `booking-orchestration` | EntitlementIssued to mark segment ticketed |
 | 26 | `events:entitlement-ticketing` | `notification` | Ticketing events for user notifications |
 | 26a | `events:entitlement-ticketing` | `capacity-availability` | RULING (2026-07-07): EntitlementVoided (payload `references.segmentBookingRef`) releases the matching hold promptly. Closes the refund-applied gap: post-sales flips APPLIED on `CapacityReleased`, which previously only arrived via booking-orchestration's lazy fallback (~90s). Row 30 (release on PostSalesApplied) stays as idempotent backstop. |
 | 27 | `events:fulfillment` | `transfer-management` | subscribes only SegmentArrived, SegmentDelayed, SegmentCancelled; all other fulfillment events are explicitly ignored by transfer-management |
 | 28 | `events:fulfillment` | `entitlement-ticketing` | BoardingVerified for entitlement lifecycle |
+| 28a | `events:fulfillment` | `disruption-recovery` | SegmentDelayed and SegmentCancelled open or merge fulfillment-sourced recovery incidents through segmentRef fan-out. |
 | 29 | `events:post-sales` | `payment` | PostSalesApproved to trigger refund |
 | 30 | `events:post-sales` | `capacity-availability` | PostSalesApplied to release capacity |
 | 31 | `events:post-sales` | `entitlement-ticketing` | PostSalesApproved to void entitlement |
@@ -289,6 +291,8 @@ plus notification/finance/reporting fan-in.
 | 54 | `events:wallet-promotion` | `notification` | Active benefit arrival, expiry, and revocation user touchpoints; BenefitRedeemed and reversal facts are ack-skipped to avoid noisy notifications |
 | 55 | `events:wallet-promotion` | `reporting` | Wallet / Promotion lifecycle metrics and read models |
 | 56 | `events:post-sales` | `disruption-recovery` | PostSalesApplied converges REFUND recovery execution |
+| 56a | `events:journey-order` | `disruption-recovery` | JourneyOrderCreated maintains the local segmentRef-to-order projection used by HTTP reports and provider/fulfillment signal fan-out. |
+| 56b | `events:disruption-recovery` | `disruption-recovery` | ServiceAlertPublished rebuilds/repairs the ServiceAlert read model from the normative event payload. |
 | 57 | `events:journey-order` | `ancillary-service` | RULING (2026-07-09): JourneyOrderCancelled is the only upstream event consumed by Ancillary Service in this activation wave; it automatically cancels associated non-terminal AncillaryOrderItem records. |
 | 58 | `events:disruption-recovery` | `transfer-management` | RecoveryCompleted/RecoveryFailed converge protected missed connections by stored `caseId` mapping. RULING (2026-07-09): for self-executed `REACCOMMODATION`, `RecoveryCompleted` for an already `RECOVERED` connection and matching `caseId` is acknowledged as an idempotent no-op. |
 | 59 | `events:capacity-availability` | `seat-assignment` | CapacityReleased and CapacityHoldExpired release or expire matching active seat allocations by `holdId`; Seat Assignment explicitly ignores AvailabilitySnapshot/CapacityHeld/CapacityHoldConfirmed for lifecycle mutation in this wave. |
@@ -374,14 +378,19 @@ through a provider stream.
 `events:disruption-recovery` is registered as a produced stream in this
 contract. Notification actively consumes traveler-facing recovery lifecycle and
 service-alert facts; Reporting, Journey Order, and Customer Service consumption
-remain deferred in this activation wave. Disruption Recovery has one active
-inbound subscription: it consumes
+remain deferred in this activation wave. Disruption Recovery actively consumes
 `PostSalesApplied` from `events:post-sales` to converge selected `REFUND`
-recovery options after the downstream Post Sales case reaches `APPLIED`.
-Service Plan, Provider Integration, and Fulfillment signal sources remain
-deferred. Transfer Management opens protected missed-connection cases through
-Disruption Recovery HTTP and actively consumes `RecoveryCompleted` and
-`RecoveryFailed` from `events:disruption-recovery` by stored `caseId`.
+recovery options, `JourneyOrderCreated` from `events:journey-order` to maintain
+the local `segmentRef` fan-out projection, `SegmentDelayed`/`SegmentCancelled`
+from `events:fulfillment`, and `ProviderSegmentDelayed`/`ProviderSegmentCancelled`
+from `events:provider-integration` as disruption sources. It also consumes its
+own `ServiceAlertPublished` facts to rebuild/repair the ServiceAlert read model.
+Provider Integration and Fulfillment segment signals that arrive before the local
+Journey Order projection are retained for retry instead of ack-skipped. Service
+Plan signal sources remain deferred. Transfer Management opens protected
+missed-connection cases through Disruption Recovery HTTP and actively consumes
+`RecoveryCompleted` and `RecoveryFailed` from `events:disruption-recovery` by
+stored `caseId`.
 Disruption Recovery executes scoped `REACCOMMODATION` through Transfer Management
 HTTP (`POST /api/v1/connections/{connectionId}/reaccommodate`); this does not add
 a new subscription row. The resulting `ConnectionRecovered` event carries

--- a/services/disruption-recovery/migrations/001_disruption_recovery_storage.sql
+++ b/services/disruption-recovery/migrations/001_disruption_recovery_storage.sql
@@ -39,3 +39,31 @@ CREATE TABLE IF NOT EXISTS idempotency_records (
   response_body jsonb,
   created_at timestamptz NOT NULL DEFAULT now()
 );
+
+CREATE TABLE IF NOT EXISTS segment_order_index (
+  segment_ref text NOT NULL,
+  order_id text NOT NULL,
+  PRIMARY KEY (segment_ref, order_id)
+);
+CREATE INDEX IF NOT EXISTS idx_segment_order_index_order
+  ON segment_order_index (order_id);
+CREATE TABLE IF NOT EXISTS service_alert_snapshots (
+  id text PRIMARY KEY,
+  version bigint NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_service_alert_incident_published
+  ON service_alert_snapshots ((data->>'incidentId'), (data->>'publishedAt'));
+CREATE INDEX IF NOT EXISTS idx_service_alert_affected_orders
+  ON service_alert_snapshots USING GIN ((data->'affectedOrderIds'));
+
+CREATE TABLE IF NOT EXISTS pending_segment_signals (
+  event_id text PRIMARY KEY,
+  stream text NOT NULL,
+  envelope jsonb NOT NULL,
+  segment_ref text NOT NULL,
+  received_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_pending_segment_signals_segment
+  ON pending_segment_signals (segment_ref, received_at);

--- a/services/disruption-recovery/src/disruption_recovery/adapters/messaging/__init__.py
+++ b/services/disruption-recovery/src/disruption_recovery/adapters/messaging/__init__.py
@@ -1,5 +1,15 @@
 from __future__ import annotations
 
 POST_SALES_STREAM = "events:post-sales"
+JOURNEY_ORDER_STREAM = "events:journey-order"
+FULFILLMENT_STREAM = "events:fulfillment"
+PROVIDER_INTEGRATION_STREAM = "events:provider-integration"
+DISRUPTION_RECOVERY_STREAM = "events:disruption-recovery"
 
-__all__ = ["POST_SALES_STREAM"]
+__all__ = [
+    "POST_SALES_STREAM",
+    "JOURNEY_ORDER_STREAM",
+    "FULFILLMENT_STREAM",
+    "PROVIDER_INTEGRATION_STREAM",
+    "DISRUPTION_RECOVERY_STREAM",
+]

--- a/services/disruption-recovery/src/disruption_recovery/adapters/storage/postgres.py
+++ b/services/disruption-recovery/src/disruption_recovery/adapters/storage/postgres.py
@@ -9,9 +9,10 @@ import json
 from typing import Any
 
 from train_ticket_platform.storage import OutboxAppender, ProcessedEventsGuard, SnapshotRepository
+from train_ticket_platform.events import EventEnvelope
 
 from disruption_recovery.application.service import InMemoryStore, NotFoundError
-from disruption_recovery.domain import Incident, RecoveryCase, RecoveryCaseStatus, RecoveryExecution, RecoveryOption, RecoveryOptionSet, RecoveryOptionType, ExecutionTarget
+from disruption_recovery.domain import Incident, RecoveryCase, RecoveryCaseStatus, RecoveryExecution, RecoveryOption, RecoveryOptionSet, RecoveryOptionType, ExecutionTarget, ServiceAlert
 
 
 def _dt(value: datetime) -> str:
@@ -74,6 +75,45 @@ def case_from_json(data: Mapping[str, Any] | str, version: int = 0) -> RecoveryC
     return RecoveryCase(str(data["caseId"]), str(data["incidentId"]), str(data["journeyOrderId"]), dict(data["affectedScope"]), RecoveryCaseStatus(str(data["status"])), _parse_dt(str(data["openedAt"])) or datetime.now(UTC), _parse_dt(str(data["updatedAt"])) or datetime.now(UTC), _option_set_from_json(data.get("optionSet")), data.get("selectedOptionId"), _execution_from_json(data.get("execution")), version)
 
 
+def alert_to_json(alert: ServiceAlert) -> dict[str, Any]:
+    return alert.to_json()
+
+
+def alert_from_json(data: Mapping[str, Any] | str, version: int = 0) -> ServiceAlert:
+    data = _json_obj(data)
+    return ServiceAlert(
+        serviceAlertId=str(data["serviceAlertId"]),
+        incidentId=str(data["incidentId"]),
+        disruptionType=str(data["disruptionType"]),
+        serviceDate=str(data["serviceDate"]),
+        audience=str(data["audience"]),
+        messageSummary=str(data["messageSummary"]),
+        publishedAt=_parse_dt(str(data["publishedAt"])) or datetime.now(UTC),
+        scheduledServiceRef=data.get("scheduledServiceRef"),
+        segmentRef=data.get("segmentRef"),
+        affectedOrderIds=tuple(data.get("affectedOrderIds") or ()),
+        version=version,
+    )
+
+
+def _stream_for_envelope(envelope: Any) -> str:
+    producer = str(getattr(envelope, "producer", "") or "")
+    return f"events:{producer}" if producer else "events:unknown"
+
+
+def _envelope_from_json(data: Mapping[str, Any] | str) -> EventEnvelope:
+    obj = dict(_json_obj(data))
+    return EventEnvelope(
+        eventId=str(obj["eventId"]),
+        eventType=str(obj["eventType"]),
+        occurredAt=str(obj.get("occurredAt") or ""),
+        correlationId=str(obj.get("correlationId") or ""),
+        causationId=obj.get("causationId"),
+        producer=str(obj.get("producer") or ""),
+        schemaVersion=int(obj.get("schemaVersion") or 1),
+        payload=dict(obj.get("payload") or {}),
+    )
+
 @dataclass
 class _UnitOfWorkState:
     connection: Any | None = None
@@ -94,6 +134,7 @@ class PostgresDisruptionRecoveryStore(InMemoryStore):
         self._incidents = SnapshotRepository("incident_snapshots")
         self._cases = SnapshotRepository("recovery_case_snapshots")
         self._processed = ProcessedEventsGuard()
+        self._alerts = SnapshotRepository("service_alert_snapshots")
 
     @contextmanager
     def transaction(self):
@@ -196,6 +237,88 @@ class PostgresDisruptionRecoveryStore(InMemoryStore):
             row = conn.execute("SELECT id, version, data FROM recovery_case_snapshots WHERE data->'execution'->>'externalRef' = %s ORDER BY id LIMIT 1", (post_sales_case_id,)).fetchone()
             if not row: return None
             self._remember("case", str(row[0]), int(row[1])); return case_from_json(row[2], int(row[1]))
+        return self._with_conn(read)
+
+
+    def index_order_segments(self, order_id: str, segment_refs: tuple[str, ...]) -> None:
+        def write(conn: Any) -> None:
+            for segment_ref in segment_refs:
+                conn.execute("INSERT INTO segment_order_index (segment_ref, order_id) VALUES (%s, %s) ON CONFLICT DO NOTHING", (segment_ref, order_id))
+        self._with_conn(write)
+
+    def find_orders_by_segment_ref(self, segment_ref: str) -> tuple[str, ...]:
+        def read(conn: Any) -> tuple[str, ...]:
+            rows = conn.execute("SELECT order_id FROM segment_order_index WHERE segment_ref = %s ORDER BY order_id", (segment_ref,)).fetchall()
+            return tuple(str(row[0]) for row in rows)
+        return self._with_conn(read)
+
+    def save_pending_segment_signal(self, envelope: Any) -> None:
+        def write(conn: Any) -> None:
+            payload = dict(envelope.payload)
+            segment_ref = str(payload.get("segmentRef") or "").strip()
+            if not segment_ref:
+                return
+            body = envelope.to_json_dict() if hasattr(envelope, "to_json_dict") else {
+                "eventId": envelope.eventId,
+                "eventType": envelope.eventType,
+                "producer": envelope.producer,
+                "schemaVersion": envelope.schemaVersion,
+                "correlationId": envelope.correlationId,
+                "causationId": envelope.causationId,
+                "occurredAt": envelope.occurredAt,
+                "payload": payload,
+            }
+            conn.execute(
+                "INSERT INTO pending_segment_signals(event_id, stream, envelope, segment_ref) VALUES (%s, %s, %s::jsonb, %s) "
+                "ON CONFLICT (event_id) DO UPDATE SET envelope = EXCLUDED.envelope, segment_ref = EXCLUDED.segment_ref",
+                (envelope.eventId, _stream_for_envelope(envelope), json.dumps(body, separators=(",", ":")), segment_ref),
+            )
+            conn.execute("DELETE FROM processed_events WHERE event_id = %s", (envelope.eventId,))
+        self._with_conn(write)
+
+    def take_pending_segment_signals(self, segment_refs: tuple[str, ...]) -> tuple[Any, ...]:
+        refs = tuple(dict.fromkeys(str(ref).strip() for ref in segment_refs if str(ref).strip()))
+        if not refs:
+            return ()
+
+        def read(conn: Any) -> tuple[Any, ...]:
+            rows = conn.execute("SELECT event_id, envelope FROM pending_segment_signals WHERE segment_ref = ANY(%s) ORDER BY received_at", (list(refs),)).fetchall()
+            conn.execute("DELETE FROM pending_segment_signals WHERE segment_ref = ANY(%s)", (list(refs),))
+            return tuple(_envelope_from_json(row[1]) for row in rows)
+        return self._with_conn(read)
+
+    def save_service_alert(self, alert: ServiceAlert) -> None:
+        def write(conn: Any) -> None:
+            payload = json.dumps(alert_to_json(alert), separators=(",", ":"))
+            conn.execute(
+                "INSERT INTO service_alert_snapshots(id, version, data) VALUES (%s, 1, %s::jsonb) "
+                "ON CONFLICT (id) DO UPDATE SET version = service_alert_snapshots.version + 1, data = EXCLUDED.data, updated_at = now()",
+                (alert.serviceAlertId, payload),
+            )
+        self._with_conn(write)
+
+    def get_service_alert(self, service_alert_id: str) -> ServiceAlert:
+        def read(conn: Any) -> ServiceAlert:
+            snap = self._alerts.get(conn, service_alert_id)
+            if snap is None:
+                raise NotFoundError(f"service alert not found: {service_alert_id}")
+            version, data = snap; self._remember("service_alert", service_alert_id, version); return alert_from_json(data, version)
+        return self._with_conn(read)
+
+    def list_service_alerts(self, incident_id: str | None, order_id: str | None, limit: int, offset: int) -> tuple[tuple[ServiceAlert, ...], int]:
+        def read(conn: Any) -> tuple[tuple[ServiceAlert, ...], int]:
+            params: list[Any] = []
+            where = "TRUE"
+            if incident_id:
+                where += " AND data->>'incidentId' = %s"; params.append(incident_id)
+            if order_id:
+                where += " AND data->'affectedOrderIds' ? %s"; params.append(order_id)
+            total = int(conn.execute(f"SELECT count(*) FROM service_alert_snapshots WHERE {where}", tuple(params)).fetchone()[0])
+            rows = conn.execute(f"SELECT id, version, data FROM service_alert_snapshots WHERE {where} ORDER BY data->>'publishedAt' DESC LIMIT %s OFFSET %s", tuple(params + [limit, offset])).fetchall()
+            items = []
+            for aggregate_id, version, data in rows:
+                self._remember("service_alert", str(aggregate_id), int(version)); items.append(alert_from_json(data, int(version)))
+            return tuple(items), total
         return self._with_conn(read)
 
     def append_outbox(self, envelopes: Iterable[Any]) -> None:

--- a/services/disruption-recovery/src/disruption_recovery/api.py
+++ b/services/disruption-recovery/src/disruption_recovery/api.py
@@ -14,7 +14,13 @@ from train_ticket_platform.observability import init_opentelemetry
 from train_ticket_platform.storage import DatabaseConfig, DatabasePool, OutboxRelay, PostgresIdempotencyStore, ReadinessGate, run_migrations
 from train_ticket_platform.ids import new_uuid7
 
-from .adapters.messaging import POST_SALES_STREAM
+from .adapters.messaging import (
+    DISRUPTION_RECOVERY_STREAM,
+    FULFILLMENT_STREAM,
+    JOURNEY_ORDER_STREAM,
+    POST_SALES_STREAM,
+    PROVIDER_INTEGRATION_STREAM,
+)
 from .adapters.storage.postgres import PostgresDisruptionRecoveryStore
 from .application.service import DisruptionRecoveryService, InMemoryStore
 from .downstream import DownstreamHttpClient
@@ -141,6 +147,21 @@ def configure_disruption_routes(app: FastAPI, store: Any | None = None, idempote
         app.router.routes.append(route)
 
 
+def _stream_for_event(envelope: Any) -> str | None:
+    producer = str(getattr(envelope, "producer", "") or "")
+    if producer == "post-sales":
+        return POST_SALES_STREAM
+    if producer == "journey-order":
+        return JOURNEY_ORDER_STREAM
+    if producer == "fulfillment":
+        return FULFILLMENT_STREAM
+    if producer == "provider-integration":
+        return PROVIDER_INTEGRATION_STREAM
+    if producer == "disruption-recovery":
+        return DISRUPTION_RECOVERY_STREAM
+    return None
+
+
 def _postgres_store_from_env(app: FastAPI) -> tuple[Any, IdempotencyStore | None]:
     config = DatabaseConfig.from_env()
     if config is None:
@@ -157,8 +178,20 @@ def _postgres_store_from_env(app: FastAPI) -> tuple[Any, IdempotencyStore | None
     subscriber = RedisEventSubscriber()
     service_holder: dict[str, Any] = {}
     def handle(envelope: Any) -> None:
-        service_holder["service"].handle_post_sales_applied(envelope, POST_SALES_STREAM)
-    thread = subscriber.start_in_background((POST_SALES_STREAM,), "disruption-recovery", handle)
+        service = service_holder["service"]
+        stream = _stream_for_event(envelope)
+        if service.handle_post_sales_applied(envelope, stream):
+            return
+        if service.handle_journey_order_created(envelope, stream):
+            return
+        if service.handle_service_alert_published(envelope, stream):
+            return
+        if stream == FULFILLMENT_STREAM:
+            service.handle_fulfillment_signal(envelope, stream)
+            return
+        if stream == PROVIDER_INTEGRATION_STREAM:
+            service.handle_provider_signal(envelope, stream)
+    thread = subscriber.start_in_background((POST_SALES_STREAM, JOURNEY_ORDER_STREAM, DISRUPTION_RECOVERY_STREAM, FULFILLMENT_STREAM, PROVIDER_INTEGRATION_STREAM), "disruption-recovery", handle)
     app.state.outbox_relay = relay
     app.state.event_subscriber = subscriber
     app.state.event_subscriber_thread = thread

--- a/services/disruption-recovery/src/disruption_recovery/application/service.py
+++ b/services/disruption-recovery/src/disruption_recovery/application/service.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from typing import Any, Mapping
 
 from train_ticket_platform.events import EventEnvelope, rfc3339_utc
+from train_ticket_platform.messaging import HandlerResult
 
 from disruption_recovery.domain import (
     ActorRef,
@@ -29,6 +30,7 @@ from disruption_recovery.domain import (
     RecoveryOption,
     RecoveryOptionType,
     ReroutingDecision,
+    ServiceAlert,
     SeatClass,
     build_option_set,
     normalize_disruption_type,
@@ -88,6 +90,9 @@ class InMemoryStore:
         self.refund_execution_index: dict[str, str] = {}
         self._outbox: list[EventEnvelope] = []
         self.processed_events: set[str] = set()
+        self.segment_order_index: dict[str, set[str]] = {}
+        self.service_alerts: dict[str, ServiceAlert] = {}
+        self.pending_segment_signals: dict[str, EventEnvelope] = {}
 
     def transaction(self) -> Any:
         return nullcontext()
@@ -140,6 +145,44 @@ class InMemoryStore:
     def list_cases(self, incident_id: str, status: str | None, limit: int, offset: int) -> tuple[tuple[RecoveryCase, ...], int]:
         items = [case for case in self.cases.values() if case.incidentId == incident_id and (status is None or case.status.value == status)]
         items.sort(key=lambda case: case.openedAt)
+        return tuple(items[offset: offset + limit]), len(items)
+
+    def index_order_segments(self, order_id: str, segment_refs: tuple[str, ...]) -> None:
+        for segment_ref in segment_refs:
+            self.segment_order_index.setdefault(segment_ref, set()).add(order_id)
+
+    def find_orders_by_segment_ref(self, segment_ref: str) -> tuple[str, ...]:
+        return tuple(sorted(self.segment_order_index.get(segment_ref, ())))
+
+    def save_pending_segment_signal(self, envelope: EventEnvelope) -> None:
+        self.pending_segment_signals[envelope.eventId] = envelope
+        self.processed_events.discard(envelope.eventId)
+
+    def take_pending_segment_signals(self, segment_refs: tuple[str, ...]) -> tuple[EventEnvelope, ...]:
+        wanted = set(segment_refs)
+        selected = tuple(
+            signal for signal in self.pending_segment_signals.values()
+            if str(signal.payload.get("segmentRef") or "").strip() in wanted
+        )
+        for signal in selected:
+            self.pending_segment_signals.pop(signal.eventId, None)
+        return selected
+
+    def save_service_alert(self, alert: ServiceAlert) -> None:
+        self.service_alerts[alert.serviceAlertId] = alert
+
+    def get_service_alert(self, service_alert_id: str) -> ServiceAlert:
+        try:
+            return self.service_alerts[service_alert_id]
+        except KeyError as exc:
+            raise NotFoundError(f"service alert not found: {service_alert_id}") from exc
+
+    def list_service_alerts(self, incident_id: str | None, order_id: str | None, limit: int, offset: int) -> tuple[tuple[ServiceAlert, ...], int]:
+        items = [
+            alert for alert in self.service_alerts.values()
+            if (incident_id is None or alert.incidentId == incident_id) and (order_id is None or order_id in alert.affectedOrderIds)
+        ]
+        items.sort(key=lambda alert: alert.publishedAt, reverse=True)
         return tuple(items[offset: offset + limit]), len(items)
 
     def find_case_by_post_sales_case(self, post_sales_case_id: str) -> RecoveryCase | None:
@@ -222,6 +265,14 @@ def _reaccommodation_from_report(data: Mapping[str, Any], generated_at: datetime
     return {"connectionId": connection_id, "replacementWindow": _coerce_replacement_window(data, generated_at)}
 
 
+def _source_system_for_signal(envelope: EventEnvelope) -> str:
+    return "PROVIDER_INTEGRATION" if envelope.producer == "provider-integration" or envelope.eventType.startswith("Provider") else "FULFILLMENT"
+
+
+def _stream_for_signal(envelope: EventEnvelope) -> str:
+    return "events:provider-integration" if _source_system_for_signal(envelope) == "PROVIDER_INTEGRATION" else "events:fulfillment"
+
+
 class DisruptionRecoveryService:
     def __init__(self, store: Any, downstream: DownstreamPort | None = None) -> None:
         self.store = store
@@ -257,9 +308,11 @@ class DisruptionRecoveryService:
         segment = str(data.get("segmentRef") or "").strip() or None
         if not scheduled and not segment:
             raise DomainError("scheduledServiceRef or segmentRef is required")
-        affected = tuple(dict.fromkeys(str(item).strip() for item in data.get("affectedOrderIds") or [] if str(item).strip()))
+        explicit_affected = tuple(dict.fromkeys(str(item).strip() for item in data.get("affectedOrderIds") or [] if str(item).strip()))
+        resolved_affected = self._resolve_segment_orders(segment) if segment else ()
+        affected = tuple(dict.fromkeys((*explicit_affected, *resolved_affected)))
         if not affected:
-            raise DomainError("affectedOrderIds must be non-empty")
+            raise DomainError("affectedOrderIds must be non-empty or segmentRef must resolve to affected orders")
         disruption_id = prefixed_uuid7("drp")
         incident_opened = False
         if scheduled:
@@ -307,7 +360,9 @@ class DisruptionRecoveryService:
             cases.append(case)
         mass_recovery = self._process_mass_disruption(disruption, data, affected, correlation_id, causation_id, at)
         events.extend(mass_recovery["events"])
-        events.append(_envelope("ServiceAlertPublished", incident.incidentId, incident.version + 2, {"serviceAlertId": prefixed_uuid7("sal"), "incidentId": incident.incidentId, "disruptionType": disruption_type, "serviceDate": service_date, "audience": "AFFECTED_ORDERS", "affectedOrderIds": list(affected), "messageSummary": evidence.summary, "publishedAt": rfc3339_utc(at)} | ({"scheduledServiceRef": scheduled} if scheduled else {}) | ({"segmentRef": segment} if segment else {}), correlation_id, causation_id, at))
+        alert_payload = {"serviceAlertId": prefixed_uuid7("sal"), "incidentId": incident.incidentId, "disruptionType": disruption_type, "serviceDate": service_date, "audience": "AFFECTED_ORDERS", "affectedOrderIds": list(affected), "messageSummary": evidence.summary, "publishedAt": rfc3339_utc(at)} | ({"scheduledServiceRef": scheduled} if scheduled else {}) | ({"segmentRef": segment} if segment else {})
+        self._save_service_alert(alert_payload)
+        events.append(_envelope("ServiceAlertPublished", incident.incidentId, incident.version + 2, alert_payload, correlation_id, causation_id, at))
         self._append(events)
         response = {"disruption": report.to_json() | {"classification": disruption.to_json()}, "incident": incident.to_json(), "recoveryCases": [case.to_json() for case in cases]}
         if mass_recovery["summary"] is not None:
@@ -364,6 +419,123 @@ class DisruptionRecoveryService:
         self.store.save_case(case)
         self._append([_envelope("RecoveryCaseClosed", case.caseId, case.version + 1, {"caseId": case.caseId, "incidentId": case.incidentId, "journeyOrderId": case.journeyOrderId, "previousStatus": previous.value, "closedBy": closed_by.to_json(), "closeReason": reason, "closedAt": rfc3339_utc(at), "status": "CLOSED"}, correlation_id, causation_id, at)])
         return case.to_json()
+
+    def _resolve_segment_orders(self, segment_ref: str | None) -> tuple[str, ...]:
+        if not segment_ref:
+            return ()
+        resolver = getattr(self.store, "find_orders_by_segment_ref", None)
+        if not callable(resolver):
+            return ()
+        return tuple(dict.fromkeys(str(item).strip() for item in resolver(segment_ref) if str(item).strip()))
+
+    def _save_service_alert(self, payload: Mapping[str, Any]) -> None:
+        save = getattr(self.store, "save_service_alert", None)
+        if callable(save):
+            save(ServiceAlert.from_payload(payload))
+
+    def _save_pending_segment_signal(self, envelope: EventEnvelope) -> None:
+        save = getattr(self.store, "save_pending_segment_signal", None)
+        if callable(save):
+            save(envelope)
+
+    def _take_pending_segment_signals(self, segment_refs: tuple[str, ...]) -> tuple[EventEnvelope, ...]:
+        take = getattr(self.store, "take_pending_segment_signals", None)
+        if not callable(take):
+            return ()
+        return tuple(take(segment_refs))
+
+    def handle_journey_order_created(self, envelope: EventEnvelope, stream: str | None = None) -> bool:
+        if envelope.eventType != "JourneyOrderCreated":
+            return False
+        with self.transaction():
+            mark = getattr(self.store, "mark_processed", None)
+            if callable(mark) and not mark(envelope.eventId, stream):
+                return True
+            payload = dict(envelope.payload)
+            order_id = str(payload.get("orderId") or "").strip()
+            if not order_id:
+                return True
+            segment_refs = tuple(dict.fromkeys(str(item).strip() for item in payload.get("segmentRefs") or [] if str(item).strip()))
+            index = getattr(self.store, "index_order_segments", None)
+            if callable(index):
+                index(order_id, segment_refs)
+            mark = getattr(self.store, "mark_processed", None)
+            for pending in self._take_pending_segment_signals(segment_refs):
+                self._handle_pending_segment_signal(pending, _source_system_for_signal(pending), _stream_for_signal(pending))
+                if callable(mark):
+                    mark(pending.eventId, _stream_for_signal(pending))
+            return True
+
+    def handle_service_alert_published(self, envelope: EventEnvelope, stream: str | None = None) -> bool:
+        if envelope.eventType != "ServiceAlertPublished":
+            return False
+        with self.transaction():
+            mark = getattr(self.store, "mark_processed", None)
+            if callable(mark) and not mark(envelope.eventId, stream):
+                return True
+            self._save_service_alert(dict(envelope.payload))
+            return True
+
+    def handle_fulfillment_signal(self, envelope: EventEnvelope, stream: str | None = None) -> bool:
+        if envelope.eventType not in {"SegmentDelayed", "SegmentCancelled"}:
+            return False
+        return self._handle_segment_signal(envelope, "FULFILLMENT", stream)
+
+    def handle_provider_signal(self, envelope: EventEnvelope, stream: str | None = None) -> bool:
+        if envelope.eventType not in {"ProviderSegmentDelayed", "ProviderSegmentCancelled", "SegmentDelayed", "SegmentCancelled"}:
+            return False
+        return self._handle_segment_signal(envelope, "PROVIDER_INTEGRATION", stream)
+
+    def _handle_segment_signal(self, envelope: EventEnvelope, source_system: str, stream: str | None) -> bool:
+        with self.transaction():
+            data = self._report_from_segment_signal(envelope, source_system)
+            if data is None:
+                self._save_pending_segment_signal(envelope)
+                return HandlerResult.transient_error("segmentRef has no indexed affected orders yet")
+            mark = getattr(self.store, "mark_processed", None)
+            if callable(mark) and not mark(envelope.eventId, stream):
+                return True
+            self.report_disruption(data, envelope.correlationId, envelope.eventId)
+            return True
+
+    def _handle_pending_segment_signal(self, envelope: EventEnvelope, source_system: str, stream: str | None) -> None:
+        data = self._report_from_segment_signal(envelope, source_system)
+        if data is not None:
+            self.report_disruption(data, envelope.correlationId, envelope.eventId)
+
+    def _report_from_segment_signal(self, envelope: EventEnvelope, source_system: str) -> dict[str, Any] | None:
+        payload = dict(envelope.payload)
+        segment_ref = str(payload.get("segmentRef") or "").strip()
+        scheduled = str(payload.get("scheduledServiceRef") or "").strip() or None
+        service_date = str(payload.get("serviceDate") or "").strip()
+        if not segment_ref or not service_date:
+            return None
+        affected = self._resolve_segment_orders(segment_ref)
+        if not affected:
+            return None
+        disruption_type = "CANCELLATION" if "Cancelled" in envelope.eventType else "DELAY"
+        occurred_at = payload.get("observedAt") or payload.get("cancelledAt") or payload.get("estimatedArrivalAt") or envelope.occurredAt
+        summary = "Segment cancelled" if disruption_type == "CANCELLATION" else "Segment delayed"
+        data: dict[str, Any] = {
+            "disruptionType": disruption_type,
+            "segmentRef": segment_ref,
+            "serviceDate": service_date,
+            "evidence": {
+                "evidenceRef": envelope.eventId,
+                "sourceSystem": source_system,
+                "sourceRecordId": envelope.eventId,
+                "summary": summary,
+                "occurredAt": rfc3339_utc(_parse_datetime(occurred_at) or now_utc()),
+            },
+            "affectedOrderIds": list(affected),
+            "reportedBy": {"actorType": "SYSTEM", "actorId": source_system.lower().replace("_", "-")},
+        }
+        if scheduled:
+            data["scheduledServiceRef"] = scheduled
+        delay_minutes = _int_or_none(payload.get("delayMinutes"))
+        if delay_minutes is not None:
+            data["delayMinutes"] = delay_minutes
+        return data
 
     def handle_post_sales_applied(self, envelope: EventEnvelope, stream: str | None = None) -> bool:
         if envelope.eventType != "PostSalesApplied":

--- a/services/disruption-recovery/src/disruption_recovery/domain.py
+++ b/services/disruption-recovery/src/disruption_recovery/domain.py
@@ -192,7 +192,7 @@ class Evidence:
 
     def __post_init__(self) -> None:
         require_text(self.evidenceRef, "evidenceRef")
-        if self.sourceSystem not in {"CUSTOMER_SERVICE", "ADMIN", "TRANSFER_MANAGEMENT"}:
+        if self.sourceSystem not in {"CUSTOMER_SERVICE", "ADMIN", "TRANSFER_MANAGEMENT", "PROVIDER_INTEGRATION", "FULFILLMENT"}:
             raise DomainError("evidence.sourceSystem is invalid")
         require_text(self.sourceRecordId, "sourceRecordId")
         require_text(self.summary, "summary")
@@ -247,6 +247,72 @@ class Incident:
         if self.segmentRefs:
             data["segmentRefs"] = list(self.segmentRefs)
         return data
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceAlert:
+    serviceAlertId: str
+    incidentId: str
+    disruptionType: str
+    serviceDate: str
+    audience: str
+    messageSummary: str
+    publishedAt: datetime
+    scheduledServiceRef: str | None = None
+    segmentRef: str | None = None
+    affectedOrderIds: tuple[str, ...] = ()
+    version: int = 0
+
+    def __post_init__(self) -> None:
+        require_text(self.serviceAlertId, "serviceAlertId")
+        require_text(self.incidentId, "incidentId")
+        require_text(self.disruptionType, "disruptionType")
+        require_text(self.serviceDate, "serviceDate")
+        if self.audience not in {"AFFECTED_ORDERS", "CUSTOMER_SERVICE", "OPERATIONS"}:
+            raise DomainError("audience is invalid")
+        require_text(self.messageSummary, "messageSummary")
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "ServiceAlert":
+        return cls(
+            serviceAlertId=require_text(str(payload.get("serviceAlertId") or ""), "serviceAlertId"),
+            incidentId=require_text(str(payload.get("incidentId") or ""), "incidentId"),
+            disruptionType=require_text(str(payload.get("disruptionType") or ""), "disruptionType"),
+            serviceDate=require_text(str(payload.get("serviceDate") or ""), "serviceDate"),
+            audience=require_text(str(payload.get("audience") or ""), "audience"),
+            messageSummary=require_text(str(payload.get("messageSummary") or ""), "messageSummary"),
+            publishedAt=_parse_alert_datetime(payload.get("publishedAt")),
+            scheduledServiceRef=str(payload.get("scheduledServiceRef") or "").strip() or None,
+            segmentRef=str(payload.get("segmentRef") or "").strip() or None,
+            affectedOrderIds=tuple(dict.fromkeys(str(item).strip() for item in payload.get("affectedOrderIds") or [] if str(item).strip())),
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "serviceAlertId": self.serviceAlertId,
+            "incidentId": self.incidentId,
+            "disruptionType": self.disruptionType,
+            "serviceDate": self.serviceDate,
+            "audience": self.audience,
+            "messageSummary": self.messageSummary,
+            "publishedAt": rfc3339_utc(self.publishedAt),
+        }
+        if self.scheduledServiceRef:
+            data["scheduledServiceRef"] = self.scheduledServiceRef
+        if self.segmentRef:
+            data["segmentRef"] = self.segmentRef
+        if self.affectedOrderIds:
+            data["affectedOrderIds"] = list(self.affectedOrderIds)
+        return data
+
+
+def _parse_alert_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return (value if value.tzinfo else value.replace(tzinfo=UTC)).astimezone(UTC)
+    text = str(value or "").strip()
+    if not text:
+        raise DomainError("publishedAt is required")
+    return datetime.fromisoformat(text.replace("Z", "+00:00")).astimezone(UTC)
 
 
 @dataclass(frozen=True, slots=True)

--- a/services/disruption-recovery/src/disruption_recovery/web/handlers.py
+++ b/services/disruption-recovery/src/disruption_recovery/web/handlers.py
@@ -19,7 +19,7 @@ class ReportDisruptionRequest(LooseModel):
     disruptionType: str
     serviceDate: str
     evidence: dict[str, Any]
-    affectedOrderIds: list[str] = Field(min_length=1)
+    affectedOrderIds: list[str] = Field(default_factory=list)
     reportedBy: dict[str, Any]
     scheduledServiceRef: str | None = None
     segmentRef: str | None = None
@@ -79,6 +79,19 @@ def list_cases(request: Request, incidentId: str = Query(...), status: str | Non
     safe_limit = max(1, min(limit, 100))
     safe_offset = max(0, offset)
     items, total = _service(request).store.list_cases(incidentId, status, safe_limit, safe_offset)
+    return {"items": [item.to_json() for item in items], "total": total, "limit": safe_limit, "offset": safe_offset}
+
+
+@router.get("/service-alerts/{service_alert_id}")
+def get_service_alert(service_alert_id: str, request: Request) -> dict[str, Any]:
+    return _service(request).store.get_service_alert(service_alert_id).to_json()
+
+
+@router.get("/service-alerts")
+def list_service_alerts(request: Request, incidentId: str | None = None, journeyOrderId: str | None = None, limit: int = 20, offset: int = 0) -> dict[str, Any]:
+    safe_limit = max(1, min(limit, 100))
+    safe_offset = max(0, offset)
+    items, total = _service(request).store.list_service_alerts(incidentId, journeyOrderId, safe_limit, safe_offset)
     return {"items": [item.to_json() for item in items], "total": total, "limit": safe_limit, "offset": safe_offset}
 
 

--- a/services/disruption-recovery/tests/test_api.py
+++ b/services/disruption-recovery/tests/test_api.py
@@ -1,7 +1,9 @@
 from fastapi.testclient import TestClient
+from train_ticket_platform.events import EventEnvelope
 
 from disruption_recovery import create_app
 from disruption_recovery.application.service import InMemoryStore
+from train_ticket_platform.messaging import HandlerResult
 import re as _re
 
 
@@ -44,6 +46,7 @@ def test_select_compensation_recovers_and_close_terminal_only() -> None:
     assert selected.status_code == 200
     assert selected.json()["status"] == "RECOVERED"
     closed = client.post(f"/api/v1/recovery-cases/{case['caseId']}/close", json={"closedBy": {"actorType": "OPERATIONS", "actorId": "ops-1"}, "closeReason": "done"}, headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8000-000000000103"})
+
     assert closed.status_code == 200
     assert closed.json()["status"] == "CLOSED"
 
@@ -205,3 +208,151 @@ def test_reaccommodation_selection_posts_downstream_and_replay_keeps_key() -> No
     started = event_payloads(store, "RecoveryExecutionStarted")[0]
     assert started["downstreamRequest"]["connectionId"] == downstream.calls[0][0]
     assert started["downstreamRequest"]["idempotencyKey"] == first_key
+
+
+
+def test_segment_ref_fanout_from_journey_order_index_and_service_alert_read_model() -> None:
+    store = InMemoryStore()
+    app = create_app(store=store)
+    client = TestClient(app)
+    service = app.state.disruption_recovery_service
+    segment = "seg-0194f2e0-7b3e-7610-8000-000000000901"
+    service.handle_journey_order_created(EventEnvelope(
+        eventId="evt-0194f2e0-7b3e-7610-8000-000000000901",
+        eventType="JourneyOrderCreated",
+        producer="journey-order",
+        payload={"orderId": "ord-0194f2e0-7b3e-7610-8000-000000000901", "segmentRefs": [segment]},
+    ), "events:journey-order")
+
+    body = report_body()
+    body["segmentRef"] = segment
+    body["affectedOrderIds"] = []
+    response = client.post("/api/v1/disruptions", json=body, headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8000-000000000901"})
+
+    assert response.status_code == 202, response.text
+    data = response.json()
+    assert [case["journeyOrderId"] for case in data["recoveryCases"]] == ["ord-0194f2e0-7b3e-7610-8000-000000000901"]
+    alerts = client.get(f"/api/v1/service-alerts?incidentId={data['incident']['incidentId']}").json()
+    assert alerts["total"] == 1
+    assert alerts["items"][0]["affectedOrderIds"] == ["ord-0194f2e0-7b3e-7610-8000-000000000901"]
+
+
+def test_fulfillment_segment_cancelled_opens_recovery_case_and_alert_read_model() -> None:
+    store = InMemoryStore()
+    app = create_app(store=store)
+    service = app.state.disruption_recovery_service
+    segment = "seg-0194f2e0-7b3e-7610-8000-000000000902"
+    store.index_order_segments("ord-0194f2e0-7b3e-7610-8000-000000000902", (segment,))
+    handled = service.handle_fulfillment_signal(EventEnvelope(
+        eventId="evt-0194f2e0-7b3e-7610-8000-000000000902",
+        eventType="SegmentCancelled",
+        producer="fulfillment",
+        correlationId="corr-0194f2e0-7b3e-7610-8000-000000000902",
+        payload={
+            "segmentRef": segment,
+            "scheduledServiceRef": "ssch-0194f2e0-7b3e-7610-8000-000000000902",
+            "serviceDate": "2026-08-02",
+            "cancelledAt": "2026-08-02T09:00:00Z",
+            "observedAt": "2026-08-02T08:55:00Z",
+            "sourceSystem": "SYSTEM",
+        },
+    ), "events:fulfillment")
+
+    assert handled is True
+    incident = next(iter(store.incidents.values()))
+    assert incident.disruptionType == "CANCELLATION"
+    assert incident.affectedOrderIds == ("ord-0194f2e0-7b3e-7610-8000-000000000902",)
+    case = next(iter(store.cases.values()))
+    assert case.affectedScope["evidenceRef"] == "evt-0194f2e0-7b3e-7610-8000-000000000902"
+    assert next(iter(store.service_alerts.values())).incidentId == incident.incidentId
+
+
+def test_service_alert_read_model_can_rebuild_from_published_event() -> None:
+    store = InMemoryStore()
+    app = create_app(store=store)
+    service = app.state.disruption_recovery_service
+    payload = {
+        "serviceAlertId": "sal-0194f2e0-7b3e-7610-8000-000000000903",
+        "incidentId": "inc-0194f2e0-7b3e-7610-8000-000000000903",
+        "disruptionType": "DELAY",
+        "segmentRef": "seg-0194f2e0-7b3e-7610-8000-000000000903",
+        "serviceDate": "2026-08-02",
+        "audience": "AFFECTED_ORDERS",
+        "affectedOrderIds": ["ord-0194f2e0-7b3e-7610-8000-000000000903"],
+        "messageSummary": "Delay",
+        "publishedAt": "2026-08-02T09:00:00Z",
+    }
+
+    assert service.handle_service_alert_published(EventEnvelope(
+        eventId="evt-0194f2e0-7b3e-7610-8000-000000000903",
+        eventType="ServiceAlertPublished",
+        producer="disruption-recovery",
+        payload=payload,
+    ), "events:disruption-recovery") is True
+
+    client = TestClient(app)
+    response = client.get("/api/v1/service-alerts/sal-0194f2e0-7b3e-7610-8000-000000000903")
+    assert response.status_code == 200
+    assert response.json()["incidentId"] == payload["incidentId"]
+
+
+def test_provider_segment_delayed_opens_recovery_case() -> None:
+    store = InMemoryStore()
+    app = create_app(store=store)
+    service = app.state.disruption_recovery_service
+    segment = "seg-0194f2e0-7b3e-7610-8000-000000000904"
+    store.index_order_segments("ord-0194f2e0-7b3e-7610-8000-000000000904", (segment,))
+
+    assert service.handle_provider_signal(EventEnvelope(
+        eventId="evt-0194f2e0-7b3e-7610-8000-000000000904",
+        eventType="ProviderSegmentDelayed",
+        producer="provider-integration",
+        correlationId="corr-0194f2e0-7b3e-7610-8000-000000000904",
+        payload={
+            "segmentRef": segment,
+            "scheduledServiceRef": "ssch-0194f2e0-7b3e-7610-8000-000000000904",
+            "serviceDate": "2026-08-02",
+            "estimatedArrivalAt": "2026-08-02T10:30:00Z",
+            "observedAt": "2026-08-02T09:00:00Z",
+            "delayMinutes": 45,
+            "sourceSystem": "PROVIDER",
+        },
+    ), "events:provider-integration") is True
+
+    incident = next(iter(store.incidents.values()))
+    assert incident.disruptionType == "DELAY"
+    case = next(iter(store.cases.values()))
+    assert case.affectedScope["disruptionType"] == "DELAY"
+
+
+def test_segment_signal_waits_for_journey_order_projection() -> None:
+    store = InMemoryStore()
+    app = create_app(store=store)
+    service = app.state.disruption_recovery_service
+    segment = "seg-0194f2e0-7b3e-7610-8000-000000000905"
+    signal = EventEnvelope(
+        eventId="evt-0194f2e0-7b3e-7610-8000-000000000905",
+        eventType="SegmentDelayed",
+        producer="fulfillment",
+        correlationId="corr-0194f2e0-7b3e-7610-8000-000000000905",
+        payload={
+            "segmentRef": segment,
+            "scheduledServiceRef": "ssch-0194f2e0-7b3e-7610-8000-000000000905",
+            "serviceDate": "2026-08-02",
+            "estimatedArrivalAt": "2026-08-02T10:30:00Z",
+            "observedAt": "2026-08-02T09:00:00Z",
+        },
+    )
+
+    result = service.handle_fulfillment_signal(signal, "events:fulfillment")
+
+    assert isinstance(result, HandlerResult)
+    assert signal.eventId not in store.processed_events
+    assert service.handle_journey_order_created(EventEnvelope(
+        eventId="evt-0194f2e0-7b3e-7610-8000-000000000906",
+        eventType="JourneyOrderCreated",
+        producer="journey-order",
+        payload={"orderId": "ord-0194f2e0-7b3e-7610-8000-000000000905", "segmentRefs": [segment]},
+    ), "events:journey-order") is True
+    assert signal.eventId in store.processed_events
+    assert next(iter(store.incidents.values())).affectedOrderIds == ("ord-0194f2e0-7b3e-7610-8000-000000000905",)

--- a/services/fulfillment/internal/application/ports.go
+++ b/services/fulfillment/internal/application/ports.go
@@ -606,7 +606,7 @@ func validateReportSegmentStatus(cmd ReportSegmentStatusCommand) error {
 		return errors.New("observedAt is required")
 	}
 	switch cmd.SourceSystem {
-	case domain.SegmentStatusSourceSystemSystem, domain.SegmentStatusSourceSystemOps:
+	case domain.SegmentStatusSourceSystemSystem, domain.SegmentStatusSourceSystemOps, domain.SegmentStatusSourceSystemProviderIntegration:
 	default:
 		return fmt.Errorf("invalid sourceSystem: %s", cmd.SourceSystem)
 	}

--- a/services/fulfillment/internal/domain/segment_status.go
+++ b/services/fulfillment/internal/domain/segment_status.go
@@ -20,8 +20,9 @@ const (
 type SegmentStatusSourceSystem string
 
 const (
-	SegmentStatusSourceSystemSystem SegmentStatusSourceSystem = "SYSTEM"
-	SegmentStatusSourceSystemOps    SegmentStatusSourceSystem = "OPS"
+	SegmentStatusSourceSystemSystem              SegmentStatusSourceSystem = "SYSTEM"
+	SegmentStatusSourceSystemOps                 SegmentStatusSourceSystem = "OPS"
+	SegmentStatusSourceSystemProviderIntegration SegmentStatusSourceSystem = "PROVIDER_INTEGRATION"
 )
 
 type SegmentStatusRecord struct {
@@ -69,7 +70,7 @@ func NewSegmentStatusRecord(id SegmentStatusRecordID, commandID string, segmentR
 		return nil, fmt.Errorf("observedAt is required")
 	}
 	switch sourceSystem {
-	case SegmentStatusSourceSystemSystem, SegmentStatusSourceSystemOps:
+	case SegmentStatusSourceSystemSystem, SegmentStatusSourceSystemOps, SegmentStatusSourceSystemProviderIntegration:
 	default:
 		return nil, fmt.Errorf("sourceSystem is invalid")
 	}

--- a/services/provider-integration/cmd/provider-integration/main.go
+++ b/services/provider-integration/cmd/provider-integration/main.go
@@ -14,7 +14,7 @@ import (
 	adapterpg "github.com/trainticket/greenfield/services/provider-integration/internal/adapters/postgres"
 	"github.com/trainticket/greenfield/services/provider-integration/internal/application"
 	"github.com/trainticket/greenfield/services/provider-integration/internal/config"
-	"github.com/trainticket/greenfield/services/provider-integration/internal/domain"
+	providerhttp "github.com/trainticket/greenfield/services/provider-integration/internal/http"
 )
 
 func main() {
@@ -66,8 +66,7 @@ func main() {
 	if err := subscriber.Subscribe(ctx, nil, messaging.ProviderIntegrationGroup, consumerName, adapterpg.DeduplicatingHandler(consumedEvents, application.NewInboundEventHandler(service))); err != nil {
 		log.Fatal(err)
 	}
-	profile := domain.Profile()
-	router := goruntime.NewGinRouter(goruntime.GinConfig{ServiceID: profile.ServiceID, Metadata: profile, HealthStatus: domain.Health(), ReadyCheck: storage.ReadyCheck(pool, runner.Ready), Observer: goruntime.ObserverFromEnv(profile.ServiceID)})
+	router := providerhttp.RouterWithDependencies(service, nil)
 	server := goruntime.NewHTTPServer(goruntime.ServerConfig{Address: ":" + cfg.HTTPPort, Handler: router})
 	if err := goruntime.RunHTTPServer(ctx, server); err != nil {
 		log.Fatal(err)

--- a/services/provider-integration/internal/adapters/postgres/reservations.go
+++ b/services/provider-integration/internal/adapters/postgres/reservations.go
@@ -161,3 +161,37 @@ func DeduplicatingHandler(log *ProcessedEvents, next application.EventHandler) a
 		})
 	}
 }
+
+func (s *ReservationService) ReportProviderSegmentStatus(ctx context.Context, cmd application.ReportProviderSegmentStatusCommand) (application.ProviderSegmentStatusResult, error) {
+	if err := application.ValidateProviderSegmentStatusCommand(cmd); err != nil {
+		return application.ProviderSegmentStatusResult{}, err
+	}
+	eventType := "ProviderSegmentDelayed"
+	payload := map[string]any{
+		"segmentRef":          strings.TrimSpace(cmd.SegmentRef),
+		"scheduledServiceRef": strings.TrimSpace(cmd.ScheduledServiceRef),
+		"serviceDate":         strings.TrimSpace(cmd.ServiceDate),
+		"observedAt":          cmd.ObservedAt.UTC().Format("2006-01-02T15:04:05Z"),
+		"sourceSystem":        application.SourceSystemOrDefault(cmd.SourceSystem),
+	}
+	switch strings.TrimSpace(strings.ToUpper(cmd.Status)) {
+	case "DELAY":
+		payload["estimatedArrivalAt"] = cmd.EstimatedArrivalAt.UTC().Format("2006-01-02T15:04:05Z")
+	case "CANCELLED":
+		eventType = "ProviderSegmentCancelled"
+		payload["cancelledAt"] = cmd.CancelledAt.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	if err := s.within(ctx, func(txCtx context.Context) error {
+		if s.publisher == nil {
+			return nil
+		}
+		envelope, err := application.NewEventEnvelope(txCtx, eventType, cmd.CorrelationID, cmd.CausationID, payload)
+		if err != nil {
+			return err
+		}
+		return s.publisher.Publish(txCtx, envelope)
+	}); err != nil {
+		return application.ProviderSegmentStatusResult{}, err
+	}
+	return application.ProviderSegmentStatusResult{SegmentRef: strings.TrimSpace(cmd.SegmentRef), Status: strings.TrimSpace(strings.ToUpper(cmd.Status)), ObservedAt: cmd.ObservedAt.UTC().Format("2006-01-02T15:04:05Z"), PublishedAs: eventType}, nil
+}

--- a/services/provider-integration/internal/application/reservations.go
+++ b/services/provider-integration/internal/application/reservations.go
@@ -69,6 +69,31 @@ type ProviderReservationService interface {
 	CancelReservation(context.Context, CancelProviderReservationCommand) (CancelProviderReservationResult, error)
 }
 
+type ReportProviderSegmentStatusCommand struct {
+	SegmentRef          string
+	ScheduledServiceRef string
+	ServiceDate         string
+	Status              string
+	EstimatedArrivalAt  time.Time
+	CancelledAt         time.Time
+	ObservedAt          time.Time
+	SourceSystem        string
+	CorrelationID       string
+	CausationID         string
+	IdempotencyKey      string
+}
+
+type ProviderSegmentStatusResult struct {
+	SegmentRef  string `json:"segmentRef"`
+	Status      string `json:"status"`
+	ObservedAt  string `json:"observedAt"`
+	PublishedAs string `json:"publishedAs"`
+}
+
+type ProviderSegmentStatusService interface {
+	ReportProviderSegmentStatus(context.Context, ReportProviderSegmentStatusCommand) (ProviderSegmentStatusResult, error)
+}
+
 type InMemoryReservationService struct {
 	mu            sync.Mutex
 	publisher     EventPublisher
@@ -256,4 +281,68 @@ func newLogID() string {
 		id = uuid.New()
 	}
 	return "preq-" + id.String()
+}
+
+func (s *InMemoryReservationService) ReportProviderSegmentStatus(ctx context.Context, cmd ReportProviderSegmentStatusCommand) (ProviderSegmentStatusResult, error) {
+	if err := ValidateProviderSegmentStatusCommand(cmd); err != nil {
+		return ProviderSegmentStatusResult{}, err
+	}
+	eventType := "ProviderSegmentDelayed"
+	payload := map[string]any{
+		"segmentRef":          strings.TrimSpace(cmd.SegmentRef),
+		"scheduledServiceRef": strings.TrimSpace(cmd.ScheduledServiceRef),
+		"serviceDate":         strings.TrimSpace(cmd.ServiceDate),
+		"observedAt":          cmd.ObservedAt.UTC(),
+		"sourceSystem":        SourceSystemOrDefault(cmd.SourceSystem),
+	}
+	switch strings.TrimSpace(strings.ToUpper(cmd.Status)) {
+	case "DELAY":
+		payload["estimatedArrivalAt"] = cmd.EstimatedArrivalAt.UTC()
+	case "CANCELLED":
+		eventType = "ProviderSegmentCancelled"
+		payload["cancelledAt"] = cmd.CancelledAt.UTC()
+	}
+	if err := s.publish(ctx, eventType, cmd.CorrelationID, cmd.CausationID, payload); err != nil {
+		return ProviderSegmentStatusResult{}, ErrUnavailable
+	}
+	return ProviderSegmentStatusResult{SegmentRef: strings.TrimSpace(cmd.SegmentRef), Status: strings.TrimSpace(strings.ToUpper(cmd.Status)), ObservedAt: cmd.ObservedAt.UTC().Format(time.RFC3339), PublishedAs: eventType}, nil
+}
+
+func ValidateProviderSegmentStatusCommand(cmd ReportProviderSegmentStatusCommand) error {
+	if err := validatePrefixedUUIDV7("segmentRef", cmd.SegmentRef, "seg"); err != nil {
+		return err
+	}
+	if err := validateRequiredToken("scheduledServiceRef", cmd.ScheduledServiceRef); err != nil {
+		return err
+	}
+	if _, err := time.Parse("2006-01-02", strings.TrimSpace(cmd.ServiceDate)); err != nil {
+		return fmt.Errorf("%w: serviceDate must be YYYY-MM-DD", ErrValidation)
+	}
+	if cmd.ObservedAt.IsZero() {
+		return fmt.Errorf("%w: observedAt is required", ErrValidation)
+	}
+	switch strings.TrimSpace(strings.ToUpper(cmd.Status)) {
+	case "DELAY":
+		if cmd.EstimatedArrivalAt.IsZero() {
+			return fmt.Errorf("%w: estimatedArrivalAt is required for DELAY", ErrValidation)
+		}
+	case "CANCELLED":
+		if cmd.CancelledAt.IsZero() {
+			return fmt.Errorf("%w: cancelledAt is required for CANCELLED", ErrValidation)
+		}
+	default:
+		return fmt.Errorf("%w: status must be DELAY or CANCELLED", ErrValidation)
+	}
+	if strings.TrimSpace(cmd.IdempotencyKey) == "" {
+		return fmt.Errorf("%w: idempotency key is required", ErrDomainRule)
+	}
+	return nil
+}
+
+func SourceSystemOrDefault(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "PROVIDER"
+	}
+	return trimmed
 }

--- a/services/provider-integration/internal/http/api_test.go
+++ b/services/provider-integration/internal/http/api_test.go
@@ -5,12 +5,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/trainticket/greenfield/platform/go-kit/idempotency"
 
 	"github.com/trainticket/greenfield/services/provider-integration/internal/application"
 )
@@ -374,5 +378,36 @@ func TestInboundSegmentReservationRequestedMalformedSegmentBookingIDIsFatal(t *t
 				t.Fatalf("no outcome event may be published for rejected payloads, got %d", len(publisher.envelopes))
 			}
 		})
+	}
+}
+
+func TestProviderSegmentStatusHTTPPublishesProviderSegmentDelayed(t *testing.T) {
+	publisher := &fakePublisher{}
+	service := application.NewInMemoryReservationService(publisher)
+	router := RouterWithDependencies(service, idempotency.NewMemoryStore())
+	body := `{"segmentRef":"seg-018f0000-0000-7000-8000-000000000301","scheduledServiceRef":"svc-100","serviceDate":"2026-07-05","status":"DELAY","estimatedArrivalAt":"2026-07-05T10:45:00Z","observedAt":"2026-07-05T10:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/provider-segment-status", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(idempotency.Header, testUUIDv7(302))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("status = %d body %s", resp.Code, resp.Body.String())
+	}
+	if len(publisher.envelopes) != 1 {
+		t.Fatalf("expected one event, got %d", len(publisher.envelopes))
+	}
+	envelope := publisher.envelopes[0]
+	if envelope.EventType != "ProviderSegmentDelayed" || envelope.Producer != application.ProducerName {
+		t.Fatalf("unexpected envelope: %#v", envelope)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["segmentRef"] != "seg-018f0000-0000-7000-8000-000000000301" || payload["sourceSystem"] != "PROVIDER" {
+		t.Fatalf("unexpected payload: %#v", payload)
 	}
 }

--- a/services/provider-integration/internal/http/router.go
+++ b/services/provider-integration/internal/http/router.go
@@ -1,14 +1,28 @@
 package http
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/gin-gonic/gin"
 
+	"github.com/trainticket/greenfield/platform/go-kit/httpkit"
 	"github.com/trainticket/greenfield/platform/go-kit/idempotency"
+	"github.com/trainticket/greenfield/platform/go-kit/ids"
 	goruntime "github.com/trainticket/greenfield/platform/go-runtime"
 
 	"github.com/trainticket/greenfield/services/provider-integration/internal/application"
 	"github.com/trainticket/greenfield/services/provider-integration/internal/domain"
 )
+
+type Handler struct {
+	segments    application.ProviderSegmentStatusService
+	idempotency idempotency.Store
+}
 
 func Router() *gin.Engine {
 	publisher := NoopPublisher{}
@@ -16,7 +30,10 @@ func Router() *gin.Engine {
 	return RouterWithDependencies(service, idempotency.NewMemoryStore())
 }
 
-func RouterWithDependencies(service application.ProviderReservationService, store idempotency.Store) *gin.Engine {
+func RouterWithDependencies(service interface {
+	application.ProviderReservationService
+	application.ProviderSegmentStatusService
+}, store idempotency.Store) *gin.Engine {
 	profile := domain.Profile()
 	router := goruntime.NewGinRouter(goruntime.GinConfig{
 		ServiceID:    profile.ServiceID,
@@ -24,5 +41,119 @@ func RouterWithDependencies(service application.ProviderReservationService, stor
 		HealthStatus: domain.Health(),
 		Observer:     goruntime.ObserverFromEnv(profile.ServiceID),
 	})
+	RegisterRoutes(router, service, store)
 	return router
+}
+
+func RegisterRoutes(router gin.IRouter, segments application.ProviderSegmentStatusService, store idempotency.Store) {
+	if store == nil {
+		store = idempotency.NewMemoryStore()
+	}
+	h := &Handler{segments: segments, idempotency: store}
+	router.POST("/api/v1/provider-segment-status", idempotency.Middleware(h.idempotency), h.reportSegmentStatus)
+}
+
+type segmentStatusRequest struct {
+	SegmentRef          string `json:"segmentRef"`
+	ScheduledServiceRef string `json:"scheduledServiceRef"`
+	ServiceDate         string `json:"serviceDate"`
+	Status              string `json:"status"`
+	EstimatedArrivalAt  string `json:"estimatedArrivalAt"`
+	CancelledAt         string `json:"cancelledAt"`
+	ObservedAt          string `json:"observedAt"`
+	SourceSystem        string `json:"sourceSystem"`
+}
+
+func (h *Handler) reportSegmentStatus(ctx *gin.Context) {
+	var req segmentStatusRequest
+	if err := decodeJSON(ctx, &req); err != nil {
+		httpkit.WriteError(ctx, http.StatusBadRequest, httpkit.ValidationFailed, err.Error(), nil)
+		return
+	}
+	observedAt, err := parseRequiredTime(req.ObservedAt, "observedAt")
+	if err != nil {
+		httpkit.WriteError(ctx, http.StatusBadRequest, httpkit.ValidationFailed, err.Error(), nil)
+		return
+	}
+	estimatedArrivalAt, err := parseOptionalTime(req.EstimatedArrivalAt, "estimatedArrivalAt")
+	if err != nil {
+		httpkit.WriteError(ctx, http.StatusBadRequest, httpkit.ValidationFailed, err.Error(), nil)
+		return
+	}
+	cancelledAt, err := parseOptionalTime(req.CancelledAt, "cancelledAt")
+	if err != nil {
+		httpkit.WriteError(ctx, http.StatusBadRequest, httpkit.ValidationFailed, err.Error(), nil)
+		return
+	}
+	idem, _ := idempotency.FromContext(ctx)
+	cmd := application.ReportProviderSegmentStatusCommand{
+		SegmentRef:          req.SegmentRef,
+		ScheduledServiceRef: req.ScheduledServiceRef,
+		ServiceDate:         req.ServiceDate,
+		Status:              strings.ToUpper(strings.TrimSpace(req.Status)),
+		ObservedAt:          observedAt,
+		SourceSystem:        req.SourceSystem,
+		CorrelationID:       ids.CanonicalCorrelationID(goruntime.CorrelationID(ctx.Request.Context())),
+		CausationID:         ids.CanonicalCausationID(goruntime.RequestID(ctx.Request.Context())),
+		IdempotencyKey:      idem.Key,
+	}
+	if estimatedArrivalAt != nil {
+		cmd.EstimatedArrivalAt = *estimatedArrivalAt
+	}
+	if cancelledAt != nil {
+		cmd.CancelledAt = *cancelledAt
+	}
+	result, err := h.segments.ReportProviderSegmentStatus(ctx.Request.Context(), cmd)
+	if err != nil {
+		writeMappedError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusCreated, result)
+}
+
+func decodeJSON(ctx *gin.Context, dest any) error {
+	decoder := json.NewDecoder(ctx.Request.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dest); err != nil {
+		return err
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return errors.New("request body must contain a single JSON object")
+	}
+	return nil
+}
+
+func parseOptionalTime(value, field string) (*time.Time, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil, nil
+	}
+	parsed, err := parseRequiredTime(trimmed, field)
+	if err != nil {
+		return nil, err
+	}
+	return &parsed, nil
+}
+
+func parseRequiredTime(value, field string) (time.Time, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return time.Time{}, errors.New(field + " is required")
+	}
+	parsed, err := time.Parse(time.RFC3339, trimmed)
+	if err != nil || !strings.HasSuffix(trimmed, "Z") {
+		return time.Time{}, errors.New(field + " must be RFC3339 UTC")
+	}
+	return parsed.UTC(), nil
+}
+
+func writeMappedError(ctx *gin.Context, err error) {
+	switch {
+	case errors.Is(err, application.ErrUnavailable):
+		httpkit.WriteError(ctx, http.StatusServiceUnavailable, httpkit.Unavailable, "event bus unavailable", nil)
+	case errors.Is(err, application.ErrDomainRule):
+		httpkit.WriteError(ctx, http.StatusUnprocessableEntity, httpkit.DomainRuleViolation, err.Error(), nil)
+	default:
+		httpkit.WriteError(ctx, http.StatusBadRequest, httpkit.ValidationFailed, err.Error(), nil)
+	}
 }


### PR DESCRIPTION
## Summary
- activate segmentRef fan-out from JourneyOrderCreated projection into recovery case creation
- add ServiceAlert read model/storage/API and alert event rebuild handler
- consume fulfillment/provider segment disruption signals as RecoveryCase ingress
- update disruption/provider/fulfillment/messaging contracts

## Validation
- uv --directory services/disruption-recovery run pytest
- git diff --check