### PR TITLE
REQ-334 waitlist archival sweep to CLOSED

### DIFF
--- a/services/waitlist/migrations/001_waitlist.sql
+++ b/services/waitlist/migrations/001_waitlist.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS waitlist_entries (
     departure_date date NOT NULL,
     seat_class text NOT NULL,
     priority_score integer NOT NULL CHECK (priority_score >= 0 AND priority_score <= 100),
-    status text NOT NULL CHECK (status IN ('QUEUED', 'OFFERED', 'ACCEPTED', 'EXPIRED', 'CANCELLED')),
+    status text NOT NULL CHECK (status IN ('DRAFT', 'QUEUED', 'MATCHING', 'FULFILLED', 'EXPIRED', 'CANCELLED', 'SUSPENDED')),
     offered_at timestamptz,
     offer_expires_at timestamptz,
     fare_quote_id text,
@@ -18,13 +18,38 @@ CREATE TABLE IF NOT EXISTS waitlist_entries (
     updated_at timestamptz NOT NULL DEFAULT now()
 );
 
+ALTER TABLE waitlist_entries DROP CONSTRAINT IF EXISTS waitlist_entries_status_check;
+ALTER TABLE waitlist_entries ADD CONSTRAINT waitlist_entries_status_check CHECK (status IN ('DRAFT', 'QUEUED', 'MATCHING', 'FULFILLED', 'EXPIRED', 'CANCELLED', 'SUSPENDED'));
+
+DROP INDEX IF EXISTS waitlist_offer_expiry_idx;
+
 CREATE INDEX IF NOT EXISTS waitlist_queue_order_idx
     ON waitlist_entries (segment_ref, departure_date, seat_class, priority_score DESC, created_at ASC, entry_id)
     WHERE status = 'QUEUED';
 
 CREATE INDEX IF NOT EXISTS waitlist_offer_expiry_idx
     ON waitlist_entries (offer_expires_at)
-    WHERE status = 'OFFERED';
+    WHERE status = 'MATCHING';
+
+CREATE TABLE IF NOT EXISTS waitlist_entries_archive (
+    entry_id text PRIMARY KEY,
+    account_id text NOT NULL,
+    traveler_refs jsonb NOT NULL,
+    segment_ref text NOT NULL,
+    departure_date date NOT NULL,
+    seat_class text NOT NULL,
+    priority_score integer NOT NULL CHECK (priority_score >= 0 AND priority_score <= 100),
+    status text NOT NULL CHECK (status = 'CLOSED'),
+    offered_at timestamptz,
+    offer_expires_at timestamptz,
+    fare_quote_id text,
+    capacity_hold_id text,
+    data jsonb NOT NULL DEFAULT '{}'::jsonb,
+    version bigint NOT NULL DEFAULT 1,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    archived_at timestamptz NOT NULL DEFAULT now()
+);
 
 CREATE TABLE IF NOT EXISTS waitlist_offers (
     offer_id text PRIMARY KEY,

--- a/services/waitlist/package-lock.json
+++ b/services/waitlist/package-lock.json
@@ -2023,6 +2023,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "../../platform/ts-kit": {
+      "name": "@trainticket/ts-kit",
+      "version": "0.1.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.2",
+        "@opentelemetry/instrumentation-fastify": "^0.44.1",
+        "@opentelemetry/instrumentation-http": "^0.57.2",
+        "@opentelemetry/resources": "^1.30.1",
+        "@opentelemetry/sdk-node": "^0.57.2",
+        "@opentelemetry/sdk-trace-base": "^1.30.1",
+        "@opentelemetry/semantic-conventions": "^1.30.0",
+        "@types/node": "^26.0.1",
+        "@types/pg": "^8.20.0",
+        "ioredis": "^5.11.1",
+        "pg": "^8.22.0",
+        "typescript": "6.0.3"
+      }
     }
   }
 }

--- a/services/waitlist/src/app.ts
+++ b/services/waitlist/src/app.ts
@@ -1,7 +1,7 @@
 import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from "fastify";
 import { InMemoryEventPublisher, InMemoryIdempotencyStore, errorMessage, handleIdempotency, headerValue, requestContext as kitRequestContext, requestFingerprint, sendError, type EventPublisher, type IdempotencyStore, type RequestContext } from "@trainticket/ts-kit";
 import { DomainError } from "./domain.js";
-import { InMemoryWaitlistRepository, WaitlistApplicationService, type JourneyOrderClient } from "./application.js";
+import { InMemoryWaitlistRepository, WaitlistApplicationService, toWaitlistRequestResource, type JoinWaitlistRequest, type JourneyOrderClient } from "./application.js";
 import type { CapacityAvailabilityClient, FarePricingClient, OfferManagementClient, WaitlistRepository } from "./promotion.js";
 import { serviceProfile } from "./profile.js";
 
@@ -58,16 +58,16 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   app.get("/readyz", async (_request, reply) => readyBody(reply, dependencies.storage));
   app.get("/metadata", async () => metadata());
 
-  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist/entries", async (request, ctx) => ({
+  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests", async (request, ctx) => ({
     statusCode: 201,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).join(request.body as any, ctx.correlationId)),
+    body: toWaitlistRequestResource(await runCommand((repository, publisher) => commandService(repository, publisher).join(toJoinWaitlistRequest(request.body as Record<string, unknown>), ctx.correlationId))),
   }));
-  app.get("/api/v1/waitlist/entries/:entryId", async (request, reply) => handleRead(reply, request, () => (
-    runCommand((repository, publisher) => commandService(repository, publisher).get(param(request, "entryId")))
+  app.get("/api/v1/waitlist-requests/:waitlistRequestId", async (request, reply) => handleRead(reply, request, () => (
+    runCommand((repository, publisher) => commandService(repository, publisher).getResource(param(request, "waitlistRequestId")))
   )));
-  stateChanging(app, idempotencyStore, "DELETE", "/api/v1/waitlist/entries/:entryId", async (request) => ({
+  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests/:waitlistRequestId/cancel", async (request) => ({
     statusCode: 200,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "entryId"))),
+    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "waitlistRequestId"))),
   }));
   stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist/entries/:entryId/accept", async (request, ctx) => ({
     statusCode: 200,
@@ -117,6 +117,31 @@ async function handleRead(reply: FastifyReply, request: FastifyRequest, operatio
     else throw error;
     return reply;
   }
+}
+
+function toJoinWaitlistRequest(body: Record<string, unknown>): JoinWaitlistRequest {
+  const travelerRef = stringBody(body, "travelerRef");
+  const travelClass = stringBody(body, "travelClass") ?? stringBody(body, "seatClass") ?? "SECOND";
+  return {
+    accountId: stringBody(body, "accountId") ?? "",
+    travelerRefs: travelerRef ? [travelerRef] : arrayBody(body, "travelerRefs"),
+    segmentRef: stringBody(body, "segmentRef") ?? "",
+    departureDate: (stringBody(body, "deadline") ?? stringBody(body, "departureDate") ?? "").slice(0, 10),
+    seatClass: travelClass as JoinWaitlistRequest["seatClass"],
+    itineraryRef: stringBody(body, "itineraryRef"),
+    deadline: stringBody(body, "deadline"),
+    paymentGuaranteeRef: stringBody(body, "paymentGuaranteeRef"),
+    intentFingerprint: stringBody(body, "intentFingerprint"),
+  };
+}
+
+function stringBody(body: Record<string, unknown>, field: string): string | undefined {
+  return typeof body[field] === "string" ? body[field] as string : undefined;
+}
+
+function arrayBody(body: Record<string, unknown>, field: string): readonly string[] {
+  const value = body[field];
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
 }
 
 function requestContext(request: FastifyRequest): RequestContext { return kitRequestContext({ headers: request.headers, id: request.id }); }

--- a/services/waitlist/src/app.ts
+++ b/services/waitlist/src/app.ts
@@ -65,13 +65,9 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   app.get("/api/v1/waitlist-requests/:waitlistRequestId", async (request, reply) => handleRead(reply, request, () => (
     runCommand((repository, publisher) => commandService(repository, publisher).getResource(param(request, "waitlistRequestId")))
   )));
-  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests/:waitlistRequestId/cancel", async (request) => ({
+  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests/:waitlistRequestId/cancel", async (request, ctx) => ({
     statusCode: 200,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "waitlistRequestId"))),
-  }));
-  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist/entries/:entryId/accept", async (request, ctx) => ({
-    statusCode: 200,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).accept(param(request, "entryId"), request.body as any, ctx.correlationId)),
+    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "waitlistRequestId"), cancelReason(request.body), ctx.correlationId)),
   }));
   app.get("/api/v1/waitlist/segments/:segmentRef/:departureDate/queue", async (request, reply) => handleRead(reply, request, () => (
     runCommand((repository, publisher) => commandService(repository, publisher).queueInfo(param(request, "segmentRef"), param(request, "departureDate"), query(request).seatClass, query(request).entryId))
@@ -142,6 +138,14 @@ function stringBody(body: Record<string, unknown>, field: string): string | unde
 function arrayBody(body: Record<string, unknown>, field: string): readonly string[] {
   const value = body[field];
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function cancelReason(body: unknown): string {
+  return isRecord(body) && typeof body.reason === "string" && body.reason.trim().length > 0 ? body.reason : "user-requested";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function requestContext(request: FastifyRequest): RequestContext { return kitRequestContext({ headers: request.headers, id: request.id }); }

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -1,7 +1,7 @@
 import { type EventPublisher } from "@trainticket/ts-kit";
 import { DomainError, WaitlistEntry, WaitlistQueue, type CreateWaitlistEntry, type FareClass, type PriorityInput, type WaitlistEntrySnapshot, type WaitlistStatus } from "./domain.js";
 import { HttpCapacityAvailabilityClient, HttpFarePricingClient, HttpOfferManagementClient, PromotionOrchestrator, type CapacityAvailabilityClient, type FarePricingClient, type OfferManagementClient, type WaitlistCapacityFreed, type WaitlistRepository } from "./promotion.js";
-import { publishAll, waitlistEntryAccepted, waitlistEntryCreated } from "./publisher.js";
+import { publishAll, waitlistCancelled, waitlistFulfilled, waitlistPaymentAuthorizationRequested, waitlistQueued, waitlistRequestCreated } from "./publisher.js";
 
 export type JoinWaitlistRequest = Readonly<{
   accountId: string;
@@ -21,6 +21,7 @@ export type JoinWaitlistRequest = Readonly<{
 
 export type AcceptPromotionRequest = Readonly<{ paymentMethodRef?: string }>;
 export type AcceptPromotionResponse = Readonly<{ orderId: string; seatAssignment: unknown }>;
+export type CancelWaitlistResponse = Readonly<{ waitlistRequestId: string; status: "CANCELLED"; cancelledAt: string }>;
 export type QueueInfo = Readonly<{ totalQueued: number; myPosition: number | null; estimatedPromotionRate: number }>;
 export type WaitlistRequestResource = Readonly<{
   waitlistRequestId: string;
@@ -79,7 +80,7 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
 
   async save(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     if (entry.status === "CLOSED") {
-      this.entries.delete(entry.entryId);
+      if (!this.entries.delete(entry.entryId) && !this.archive.has(entry.entryId)) throw new DomainError("PRECONDITION_FAILED", "Waitlist entry version changed before archival");
       this.archive.set(entry.entryId, entry);
       return entry.toSnapshot(0);
     }
@@ -141,7 +142,7 @@ export class WaitlistApplicationService {
   async join(request: JoinWaitlistRequest, correlationId?: string): Promise<WaitlistEntrySnapshot & { estimatedWaitMinutes: number }> {
     const entry = WaitlistEntry.create(this.toCreateCommand(request));
     const snapshot = await this.repository.add(entry);
-    if (this.publisher) await publishAll(this.publisher, [waitlistEntryCreated(snapshot, correlationId)]);
+    if (this.publisher) await publishAll(this.publisher, [waitlistRequestCreated(snapshot, correlationId), waitlistPaymentAuthorizationRequested(snapshot, correlationId), waitlistQueued(snapshot, correlationId)]);
     return { ...snapshot, estimatedWaitMinutes: Math.max(5, snapshot.queuePosition * 15) };
   }
 
@@ -150,11 +151,13 @@ export class WaitlistApplicationService {
     return this.snapshot(entry);
   }
 
-  async cancel(entryId: string): Promise<{ cancelled: true }> {
+  async cancel(entryId: string, reason = "user-requested", correlationId?: string): Promise<CancelWaitlistResponse> {
     const entry = await this.requireEntry(entryId);
+    const cancelledAt = this.now().toISOString();
     entry.cancel();
-    await this.repository.save(entry);
-    return { cancelled: true };
+    const snapshot = await this.repository.save(entry);
+    if (this.publisher) await publishAll(this.publisher, [waitlistCancelled(snapshot, cancelledAt, reason, correlationId)]);
+    return { waitlistRequestId: snapshot.entryId, status: "CANCELLED", cancelledAt };
   }
 
   async accept(entryId: string, request: AcceptPromotionRequest = {}, correlationId?: string): Promise<AcceptPromotionResponse> {
@@ -164,7 +167,7 @@ export class WaitlistApplicationService {
     const order = await this.journeyOrder.createOrder(entry, request.paymentMethodRef);
     entry.accept(now, order.orderId);
     const snapshot = await this.repository.save(entry);
-    if (this.publisher) await publishAll(this.publisher, [waitlistEntryAccepted(snapshot, order.orderId, order.seatAssignment, correlationId)]);
+    if (this.publisher) await publishAll(this.publisher, [waitlistFulfilled(snapshot, now.toISOString(), correlationId)]);
     return order;
   }
 

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -1,5 +1,5 @@
 import { type EventPublisher } from "@trainticket/ts-kit";
-import { DomainError, WaitlistEntry, WaitlistQueue, type CreateWaitlistEntry, type FareClass, type PriorityInput, type WaitlistEntrySnapshot } from "./domain.js";
+import { DomainError, WaitlistEntry, WaitlistQueue, type CreateWaitlistEntry, type FareClass, type PriorityInput, type WaitlistEntrySnapshot, type WaitlistStatus } from "./domain.js";
 import { HttpCapacityAvailabilityClient, HttpFarePricingClient, HttpOfferManagementClient, PromotionOrchestrator, type CapacityAvailabilityClient, type FarePricingClient, type OfferManagementClient, type WaitlistCapacityFreed, type WaitlistRepository } from "./promotion.js";
 import { publishAll, waitlistEntryAccepted, waitlistEntryCreated } from "./publisher.js";
 
@@ -14,11 +14,27 @@ export type JoinWaitlistRequest = Readonly<{
   daysBefore?: number;
   specialStatus?: PriorityInput["specialStatus"];
   itineraryRef?: string;
+  deadline?: string;
+  paymentGuaranteeRef?: string;
+  intentFingerprint?: string;
 }>;
 
 export type AcceptPromotionRequest = Readonly<{ paymentMethodRef?: string }>;
 export type AcceptPromotionResponse = Readonly<{ orderId: string; seatAssignment: unknown }>;
 export type QueueInfo = Readonly<{ totalQueued: number; myPosition: number | null; estimatedPromotionRate: number }>;
+export type WaitlistRequestResource = Readonly<{
+  waitlistRequestId: string;
+  accountId: string;
+  travelerRef: string;
+  segmentRef: string;
+  travelClass?: string;
+  deadline: string;
+  paymentGuaranteeRef: string;
+  itineraryRef: string;
+  intentFingerprint: string;
+  status: WaitlistStatus;
+  journeyOrderRef?: string;
+}>;
 
 export interface JourneyOrderClient {
   createOrder(entry: WaitlistEntry, paymentMethodRef?: string): Promise<AcceptPromotionResponse>;
@@ -52,15 +68,22 @@ export class HttpJourneyOrderClient implements JourneyOrderClient {
 
 export class InMemoryWaitlistRepository implements WaitlistRepository {
   private readonly entries = new Map<string, WaitlistEntry>();
+  private readonly archive = new Map<string, WaitlistEntry>();
 
   async add(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     this.entries.set(entry.entryId, entry);
     return this.snapshot(entry);
   }
 
-  async get(entryId: string): Promise<WaitlistEntry | undefined> { return this.entries.get(entryId); }
+  async get(entryId: string): Promise<WaitlistEntry | undefined> { return this.entries.get(entryId) ?? this.archive.get(entryId); }
 
   async save(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
+    if (entry.status === "CLOSED") {
+      this.entries.delete(entry.entryId);
+      this.archive.set(entry.entryId, entry);
+      return entry.toSnapshot(0);
+    }
+    this.archive.delete(entry.entryId);
     this.entries.set(entry.entryId, entry);
     return this.snapshot(entry);
   }
@@ -71,7 +94,11 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   }
 
   async findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> {
-    return [...this.entries.values()].filter((entry) => entry.status === "OFFERED" && entry.offerExpiresAt !== null && entry.offerExpiresAt <= now);
+    return [...this.entries.values()].filter((entry) => entry.status === "MATCHING" && entry.offerExpiresAt !== null && entry.offerExpiresAt <= now);
+  }
+
+  async findArchivable(): Promise<readonly WaitlistEntry[]> {
+    return [...this.entries.values()].filter((entry) => isArchivableStatus(entry.status));
   }
 
   async queueFor(segmentRef: string, departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> {
@@ -79,7 +106,7 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
     return queue.allEntries().map((entry) => this.snapshot(entry));
   }
 
-  clear(): void { this.entries.clear(); }
+  clear(): void { this.entries.clear(); this.archive.clear(); }
 
   private buildQueue(segmentRef: string, departureDate: string, seatClass?: string): WaitlistQueue {
     const matching = [...this.entries.values()].filter((entry) => entry.segmentRef === segmentRef && entry.departureDate === departureDate && (!seatClass || entry.seatClass === seatClass));
@@ -88,7 +115,7 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   }
 
   private snapshot(entry: WaitlistEntry): WaitlistEntrySnapshot {
-    return entry.toSnapshot(this.position(entry));
+    return entry.status === "CLOSED" ? entry.toSnapshot(0) : entry.toSnapshot(this.position(entry));
   }
 
   private position(entry: WaitlistEntry): number {
@@ -135,7 +162,7 @@ export class WaitlistApplicationService {
     const now = this.now();
     entry.ensureOfferAcceptable(now);
     const order = await this.journeyOrder.createOrder(entry, request.paymentMethodRef);
-    entry.accept(now);
+    entry.accept(now, order.orderId);
     const snapshot = await this.repository.save(entry);
     if (this.publisher) await publishAll(this.publisher, [waitlistEntryAccepted(snapshot, order.orderId, order.seatAssignment, correlationId)]);
     return order;
@@ -155,6 +182,19 @@ export class WaitlistApplicationService {
     return this.promotion.expireDueOffers(correlationId);
   }
 
+  async sweepClosed(_correlationId?: string): Promise<readonly WaitlistEntrySnapshot[]> {
+    const closed: WaitlistEntrySnapshot[] = [];
+    for (const entry of await this.repository.findArchivable()) {
+      entry.close();
+      closed.push(await this.repository.save(entry));
+    }
+    return closed;
+  }
+
+  async getResource(entryId: string): Promise<WaitlistRequestResource> {
+    return toWaitlistRequestResource(await this.get(entryId));
+  }
+
   private toCreateCommand(request: JoinWaitlistRequest): CreateWaitlistEntry {
     return {
       accountId: request.accountId,
@@ -163,6 +203,9 @@ export class WaitlistApplicationService {
       departureDate: request.departureDate,
       seatClass: request.seatClass,
       itineraryRef: request.itineraryRef ?? request.segmentRef,
+      deadline: request.deadline,
+      paymentGuaranteeRef: request.paymentGuaranteeRef,
+      intentFingerprint: request.intentFingerprint,
       priority: {
         loyaltyTier: request.loyaltyTier ?? "NONE",
         tripCount: request.tripCount ?? 0,
@@ -184,6 +227,42 @@ export class WaitlistApplicationService {
     const queue = await this.repository.queueFor(entry.segmentRef, entry.departureDate, entry.seatClass);
     return queue.find((candidate) => candidate.entryId === entry.entryId) ?? entry.toSnapshot(0);
   }
+}
+
+export function toWaitlistRequestResource(snapshot: WaitlistEntrySnapshot): WaitlistRequestResource {
+  return withoutUndefined({
+    waitlistRequestId: snapshot.entryId,
+    accountId: snapshot.accountId,
+    travelerRef: snapshot.travelerRefs[0] ?? "",
+    segmentRef: snapshot.segmentRef,
+    travelClass: snapshot.seatClass,
+    deadline: snapshot.deadline ?? snapshot.offerExpiresAt ?? `${snapshot.departureDate}T23:59:59.000Z`,
+    paymentGuaranteeRef: snapshot.paymentGuaranteeRef ?? paymentGuaranteeRef(snapshot),
+    itineraryRef: snapshot.itineraryRef ?? snapshot.segmentRef,
+    intentFingerprint: snapshot.intentFingerprint ?? intentFingerprint(snapshot),
+    status: snapshot.status,
+    journeyOrderRef: journeyOrderRef(snapshot),
+  });
+}
+
+function isArchivableStatus(status: WaitlistStatus): boolean {
+  return status === "FULFILLED" || status === "EXPIRED" || status === "CANCELLED";
+}
+
+function journeyOrderRef(snapshot: WaitlistEntrySnapshot): string | undefined {
+  return snapshot.journeyOrderRef;
+}
+
+function paymentGuaranteeRef(snapshot: WaitlistEntrySnapshot): string {
+  return `pay-auth-${snapshot.entryId}`;
+}
+
+function intentFingerprint(snapshot: WaitlistEntrySnapshot): string {
+  return `${snapshot.travelerRefs[0] ?? ""}:${snapshot.segmentRef}:${snapshot.departureDate}:${snapshot.seatClass}`;
+}
+
+function withoutUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, field]) => field !== undefined)) as T;
 }
 
 function daysBefore(departureDate: string): number {

--- a/services/waitlist/src/bootstrap.ts
+++ b/services/waitlist/src/bootstrap.ts
@@ -34,8 +34,16 @@ export async function bootstrap(options: BootstrapOptions = {}) {
     operation.catch((error: unknown) => app.log.error({ err: error }, "waitlist offer expiry scan failed"));
   }, Number.parseInt(process.env.WAITLIST_EXPIRY_SCAN_MS ?? "60000", 10));
   expiryTimer.unref();
+  const archivalTimer = setInterval(() => {
+    const operation = storage
+      ? storage.runCommand((repository, publisher) => new WaitlistApplicationService(repository, publisher).sweepClosed())
+      : memoryEventService.sweepClosed();
+    operation.catch((error: unknown) => app.log.error({ err: error }, "waitlist archival sweep failed"));
+  }, Number.parseInt(process.env.WAITLIST_ARCHIVAL_SWEEP_MS ?? "300000", 10));
+  archivalTimer.unref();
   app.addHook("onClose", async () => {
     clearInterval(expiryTimer);
+    clearInterval(archivalTimer);
     abortController.abort();
     messaging.subscriber.stop?.();
     await messaging.close();

--- a/services/waitlist/src/domain.ts
+++ b/services/waitlist/src/domain.ts
@@ -1,6 +1,6 @@
 import { uuidV7 } from "@trainticket/ts-kit";
 
-export type WaitlistStatus = "QUEUED" | "OFFERED" | "ACCEPTED" | "EXPIRED" | "CANCELLED";
+export type WaitlistStatus = "DRAFT" | "QUEUED" | "MATCHING" | "FULFILLED" | "EXPIRED" | "CANCELLED" | "SUSPENDED" | "CLOSED";
 export type LoyaltyTier = "PLATINUM" | "GOLD" | "SILVER" | "NONE";
 export type FareClass = "BUSINESS" | "FIRST" | "SECOND" | "SECOND_CLASS" | "STANDING";
 export type SpecialStatus = "MILITARY" | "DISABLED" | "STUDENT" | "NONE";
@@ -38,6 +38,10 @@ export type WaitlistEntrySnapshot = Readonly<{
   capacityReleaseIdempotencyKey?: string;
   journeyOrderIdempotencyKey?: string;
   capacitySegmentBookingId?: string;
+  journeyOrderRef?: string;
+  deadline?: string;
+  paymentGuaranteeRef?: string;
+  intentFingerprint?: string;
 }>;
 
 export type CreateWaitlistEntry = Readonly<{
@@ -49,6 +53,9 @@ export type CreateWaitlistEntry = Readonly<{
   seatClass: FareClass;
   priority: Omit<PriorityInput, "groupSize" | "fareClass"> & Partial<Pick<PriorityInput, "groupSize" | "fareClass">>;
   itineraryRef?: string;
+  deadline?: string;
+  paymentGuaranteeRef?: string;
+  intentFingerprint?: string;
   createdAt?: Date;
 }>;
 
@@ -83,6 +90,10 @@ export class WaitlistEntry {
     private readonly _capacityReleaseIdempotencyKey: string = uuidV7(),
     private readonly _journeyOrderIdempotencyKey: string = uuidV7(),
     private readonly _capacitySegmentBookingId: string = `sb-${uuidV7()}`,
+    private _journeyOrderRef?: string,
+    private readonly _deadline?: string,
+    private readonly _paymentGuaranteeRef?: string,
+    private readonly _intentFingerprint?: string,
   ) {}
 
   static create(command: CreateWaitlistEntry): WaitlistEntry {
@@ -94,7 +105,7 @@ export class WaitlistEntry {
     const fareClass = command.priority.fareClass ?? command.seatClass;
     const priorityScore = PriorityCalculator.calculate({ ...command.priority, groupSize, fareClass });
     return new WaitlistEntry(
-      command.entryId ?? `wl-${uuidV7()}`,
+      command.entryId ?? `wlr-${uuidV7()}`,
       command.accountId,
       [...command.travelerRefs],
       command.segmentRef,
@@ -110,6 +121,16 @@ export class WaitlistEntry {
       undefined,
       undefined,
       command.itineraryRef,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      command.deadline,
+      command.paymentGuaranteeRef,
+      command.intentFingerprint,
     );
   }
 
@@ -137,6 +158,10 @@ export class WaitlistEntry {
       snapshot.capacityReleaseIdempotencyKey,
       snapshot.journeyOrderIdempotencyKey,
       snapshot.capacitySegmentBookingId,
+      snapshot.journeyOrderRef,
+      snapshot.deadline,
+      snapshot.paymentGuaranteeRef,
+      snapshot.intentFingerprint,
     );
   }
 
@@ -153,11 +178,15 @@ export class WaitlistEntry {
   get capacityReleaseIdempotencyKey(): string { return this._capacityReleaseIdempotencyKey; }
   get journeyOrderIdempotencyKey(): string { return this._journeyOrderIdempotencyKey; }
   get capacitySegmentBookingId(): string { return this._capacitySegmentBookingId; }
+  get journeyOrderRef(): string | undefined { return this._journeyOrderRef; }
+  get deadline(): string | undefined { return this._deadline; }
+  get paymentGuaranteeRef(): string | undefined { return this._paymentGuaranteeRef; }
+  get intentFingerprint(): string | undefined { return this._intentFingerprint; }
 
   offer(offerId: string, offerVersion: number, fareQuoteId: string, capacityHoldId: string, now: Date, expiresAt: Date): void {
-    this.assertStatus("QUEUED", "Only queued waitlist entries can be offered");
+    this.assertStatus("QUEUED", "Only queued waitlist entries can start matching");
     if (expiresAt <= now) throw new DomainError("VALIDATION_FAILED", "Offer expiry must be in the future");
-    this._status = "OFFERED";
+    this._status = "MATCHING";
     this._offeredAt = now;
     this._offerExpiresAt = expiresAt;
     if (!Number.isInteger(offerVersion) || offerVersion < 1) throw new DomainError("VALIDATION_FAILED", "offerVersion must be positive");
@@ -167,33 +196,42 @@ export class WaitlistEntry {
     this._offerVersion = offerVersion;
   }
 
-  accept(now: Date): void {
+  accept(now: Date, journeyOrderRef?: string): void {
     this.ensureOfferAcceptable(now);
-    this._status = "ACCEPTED";
+    this._journeyOrderRef = journeyOrderRef;
+    this._status = "FULFILLED";
   }
 
   ensureOfferAcceptable(now: Date): void {
-    this.assertStatus("OFFERED", "Only offered waitlist entries can be accepted");
+    this.assertStatus("MATCHING", "Only matching waitlist entries can be fulfilled");
     if (this._offerExpiresAt && now > this._offerExpiresAt) {
       throw new DomainError("PRECONDITION_FAILED", "Waitlist offer has expired");
     }
   }
 
   expire(now: Date): void {
-    if (this._status !== "OFFERED" && this._status !== "QUEUED") {
+    if (this._status !== "MATCHING" && this._status !== "QUEUED") {
       throw new DomainError("INVALID_TRANSITION", `Cannot expire ${this._status} waitlist entry`);
     }
-    if (this._status === "OFFERED" && this._offerExpiresAt && now < this._offerExpiresAt) {
+    if (this._status === "MATCHING" && this._offerExpiresAt && now < this._offerExpiresAt) {
       throw new DomainError("PRECONDITION_FAILED", "Waitlist offer has not reached its expiry time");
     }
     this._status = "EXPIRED";
   }
 
   cancel(): void {
-    if (this._status === "ACCEPTED" || this._status === "EXPIRED") {
+    if (this._status === "FULFILLED" || this._status === "EXPIRED" || this._status === "CANCELLED" || this._status === "CLOSED") {
       throw new DomainError("INVALID_TRANSITION", `Cannot cancel ${this._status} waitlist entry`);
     }
     this._status = "CANCELLED";
+  }
+
+  close(): void {
+    if (this._status === "CLOSED") return;
+    if (this._status !== "FULFILLED" && this._status !== "EXPIRED" && this._status !== "CANCELLED") {
+      throw new DomainError("INVALID_TRANSITION", `Cannot close ${this._status} waitlist entry`);
+    }
+    this._status = "CLOSED";
   }
 
   toSnapshot(queuePosition = 0): WaitlistEntrySnapshot {
@@ -221,6 +259,10 @@ export class WaitlistEntry {
       capacityReleaseIdempotencyKey: this._capacityReleaseIdempotencyKey,
       journeyOrderIdempotencyKey: this._journeyOrderIdempotencyKey,
       capacitySegmentBookingId: this._capacitySegmentBookingId,
+      journeyOrderRef: this._journeyOrderRef,
+      deadline: this._deadline,
+      paymentGuaranteeRef: this._paymentGuaranteeRef,
+      intentFingerprint: this._intentFingerprint,
     };
   }
 

--- a/services/waitlist/src/domain.ts
+++ b/services/waitlist/src/domain.ts
@@ -42,6 +42,7 @@ export type WaitlistEntrySnapshot = Readonly<{
   deadline?: string;
   paymentGuaranteeRef?: string;
   intentFingerprint?: string;
+  aggregateVersion?: number;
 }>;
 
 export type CreateWaitlistEntry = Readonly<{
@@ -94,6 +95,7 @@ export class WaitlistEntry {
     private readonly _deadline?: string,
     private readonly _paymentGuaranteeRef?: string,
     private readonly _intentFingerprint?: string,
+    private _aggregateVersion = 3,
   ) {}
 
   static create(command: CreateWaitlistEntry): WaitlistEntry {
@@ -162,6 +164,7 @@ export class WaitlistEntry {
       snapshot.deadline,
       snapshot.paymentGuaranteeRef,
       snapshot.intentFingerprint,
+      snapshot.aggregateVersion ?? 3,
     );
   }
 
@@ -182,6 +185,7 @@ export class WaitlistEntry {
   get deadline(): string | undefined { return this._deadline; }
   get paymentGuaranteeRef(): string | undefined { return this._paymentGuaranteeRef; }
   get intentFingerprint(): string | undefined { return this._intentFingerprint; }
+  get aggregateVersion(): number { return this._aggregateVersion; }
 
   offer(offerId: string, offerVersion: number, fareQuoteId: string, capacityHoldId: string, now: Date, expiresAt: Date): void {
     this.assertStatus("QUEUED", "Only queued waitlist entries can start matching");
@@ -194,12 +198,14 @@ export class WaitlistEntry {
     this._capacityHoldId = capacityHoldId;
     this._offerId = offerId;
     this._offerVersion = offerVersion;
+    this.bumpVersion();
   }
 
   accept(now: Date, journeyOrderRef?: string): void {
     this.ensureOfferAcceptable(now);
     this._journeyOrderRef = journeyOrderRef;
     this._status = "FULFILLED";
+    this.bumpVersion();
   }
 
   ensureOfferAcceptable(now: Date): void {
@@ -217,6 +223,7 @@ export class WaitlistEntry {
       throw new DomainError("PRECONDITION_FAILED", "Waitlist offer has not reached its expiry time");
     }
     this._status = "EXPIRED";
+    this.bumpVersion();
   }
 
   cancel(): void {
@@ -224,6 +231,7 @@ export class WaitlistEntry {
       throw new DomainError("INVALID_TRANSITION", `Cannot cancel ${this._status} waitlist entry`);
     }
     this._status = "CANCELLED";
+    this.bumpVersion();
   }
 
   close(): void {
@@ -232,6 +240,7 @@ export class WaitlistEntry {
       throw new DomainError("INVALID_TRANSITION", `Cannot close ${this._status} waitlist entry`);
     }
     this._status = "CLOSED";
+    this.bumpVersion();
   }
 
   toSnapshot(queuePosition = 0): WaitlistEntrySnapshot {
@@ -263,7 +272,12 @@ export class WaitlistEntry {
       deadline: this._deadline,
       paymentGuaranteeRef: this._paymentGuaranteeRef,
       intentFingerprint: this._intentFingerprint,
+      aggregateVersion: this._aggregateVersion,
     };
+  }
+
+  private bumpVersion(): void {
+    this._aggregateVersion += 1;
   }
 
   private assertStatus(expected: WaitlistStatus, message: string): void {

--- a/services/waitlist/src/promotion.ts
+++ b/services/waitlist/src/promotion.ts
@@ -1,8 +1,9 @@
 import { type EventPublisher } from "@trainticket/ts-kit";
 import { DomainError, type WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
-import { publishAll, waitlistEntryPromoted, waitlistOfferExpired } from "./publisher.js";
+import { publishAll, waitlistExpired, waitlistMatchStarted } from "./publisher.js";
 
 export type WaitlistCapacityFreed = Readonly<{
+  eventId?: string;
   segmentRef: string;
   departureDate: string;
   seatClass?: string;
@@ -156,7 +157,7 @@ export class PromotionOrchestrator {
       const snapshot = await this.repository.save(entry);
       promoted.push(snapshot);
       offers.push(offer);
-      await publishAll(this.publisher, [waitlistEntryPromoted(snapshot, offer, correlationId)]);
+      await publishAll(this.publisher, [waitlistMatchStarted(snapshot, event.eventId ?? "capacity-release:unknown", correlationId)]);
     }
     return { promoted, offers };
   }
@@ -171,7 +172,7 @@ export class PromotionOrchestrator {
       if (capacityHoldId) await this.capacityAvailability.releaseHold(entry, capacityHoldId);
       const snapshot = await this.repository.save(entry);
       expired.push(snapshot);
-      await publishAll(this.publisher, [waitlistOfferExpired(snapshot, offer, correlationId)]);
+      await publishAll(this.publisher, [waitlistExpired(snapshot, now.toISOString(), correlationId)]);
       await this.onCapacityFreed({ segmentRef: entry.segmentRef, departureDate: entry.departureDate, seatClass: entry.seatClass, freedSlots: 1 }, correlationId);
     }
     return expired;

--- a/services/waitlist/src/promotion.ts
+++ b/services/waitlist/src/promotion.ts
@@ -29,6 +29,7 @@ export interface WaitlistRepository {
   save(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> | WaitlistEntrySnapshot;
   findTopQueued(segmentRef: string, departureDate: string, seatClass?: string): Promise<WaitlistEntry | undefined> | WaitlistEntry | undefined;
   findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> | readonly WaitlistEntry[];
+  findArchivable(): Promise<readonly WaitlistEntry[]> | readonly WaitlistEntry[];
   queueFor(segmentRef: string, departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> | readonly WaitlistEntrySnapshot[];
 }
 

--- a/services/waitlist/src/publisher.ts
+++ b/services/waitlist/src/publisher.ts
@@ -1,31 +1,144 @@
+import { createHash } from "node:crypto";
 import { createEventEnvelope, type EventEnvelope, type EventPublisher } from "@trainticket/ts-kit";
 import type { WaitlistEntrySnapshot } from "./domain.js";
-import type { WaitlistOffer } from "./promotion.js";
 
 export const WAITLIST_PRODUCER = "waitlist";
 
 export type WaitlistEventPayload = Record<string, unknown>;
 
-export function waitlistEntryCreated(entry: WaitlistEntrySnapshot, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistEntryCreated", { entry }, correlationId);
+export function waitlistRequestCreated(entry: WaitlistEntrySnapshot, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistRequestCreated", {
+    ...requestPayload(entry),
+    status: "DRAFT",
+    createdAt: entry.createdAt,
+  }, correlationId, 1);
 }
 
-export function waitlistEntryPromoted(entry: WaitlistEntrySnapshot, offer: WaitlistOffer, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistMatchStarted", { entry, offer }, correlationId);
+export function waitlistPaymentAuthorizationRequested(entry: WaitlistEntrySnapshot, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistPaymentAuthorizationRequested", {
+    waitlistRequestId: entry.entryId,
+    accountId: entry.accountId,
+    travelerRef: entry.travelerRefs[0] ?? "",
+    segmentRef: entry.segmentRef,
+    paymentGuaranteeRef: paymentGuaranteeRef(entry),
+    requestedAt: entry.createdAt,
+    status: "DRAFT",
+  }, correlationId, 2);
 }
 
-export function waitlistOfferExpired(entry: WaitlistEntrySnapshot, offer: WaitlistOffer, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistOfferExpired", { entry, offer }, correlationId);
+export function waitlistQueued(entry: WaitlistEntrySnapshot, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistQueued", {
+    ...basePayload(entry),
+    itineraryRef: itineraryRef(entry),
+    intentFingerprint: intentFingerprint(entry),
+    queuedAt: entry.createdAt,
+    status: "QUEUED",
+    journeyOrderRef: entry.journeyOrderRef,
+  }, correlationId, Math.max(3, entry.aggregateVersion ?? 1));
 }
 
-export function waitlistEntryAccepted(entry: WaitlistEntrySnapshot, orderId: string, seatAssignment: unknown, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistFulfilled", { entry, orderId, seatAssignment }, correlationId);
+export function waitlistMatchStarted(entry: WaitlistEntrySnapshot, matchedCapacityReleaseRef: string, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistMatchStarted", {
+    ...basePayload(entry),
+    matchedCapacityReleaseRef,
+    journeyOrderIdempotencyKey: entry.journeyOrderIdempotencyKey,
+    startedAt: entry.offeredAt ?? new Date().toISOString(),
+    status: "MATCHING",
+  }, correlationId, entry.aggregateVersion ?? 1);
+}
+
+export function waitlistExpired(entry: WaitlistEntrySnapshot, expiredAt: string, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistExpired", {
+    ...basePayload(entry),
+    deadline: entry.deadline ?? entry.offerExpiresAt ?? expiredAt,
+    expiredAt,
+    status: "EXPIRED",
+  }, correlationId, entry.aggregateVersion ?? 1);
+}
+
+export function waitlistFulfilled(entry: WaitlistEntrySnapshot, fulfilledAt: string, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistFulfilled", {
+    ...basePayload(entry),
+    journeyOrderRef: entry.journeyOrderRef,
+    fulfilledAt,
+    status: "FULFILLED",
+  }, correlationId, entry.aggregateVersion ?? 1);
+}
+
+export function waitlistCancelled(entry: WaitlistEntrySnapshot, cancelledAt: string, reason: string, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistCancelled", {
+    ...basePayload(entry),
+    cancelledAt,
+    reason,
+    status: "CANCELLED",
+  }, correlationId, entry.aggregateVersion ?? 1);
 }
 
 export async function publishAll(publisher: EventPublisher, envelopes: readonly EventEnvelope[]): Promise<void> {
   for (const envelope of envelopes) await publisher.publish(envelope);
 }
 
-function waitlistEnvelope(eventType: string, payload: WaitlistEventPayload, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return createEventEnvelope({ eventType, producer: WAITLIST_PRODUCER, payload, correlationId });
+function requestPayload(entry: WaitlistEntrySnapshot): WaitlistEventPayload {
+  return withoutUndefined({
+    ...basePayload(entry),
+    deadline: deadline(entry),
+    paymentGuaranteeRef: paymentGuaranteeRef(entry),
+    itineraryRef: itineraryRef(entry),
+    intentFingerprint: intentFingerprint(entry),
+  });
+}
+
+function basePayload(entry: WaitlistEntrySnapshot): WaitlistEventPayload {
+  return withoutUndefined({
+    waitlistRequestId: entry.entryId,
+    accountId: entry.accountId,
+    travelerRef: entry.travelerRefs[0] ?? "",
+    segmentRef: entry.segmentRef,
+    travelClass: entry.seatClass,
+  });
+}
+
+function waitlistEnvelope(eventType: string, payload: WaitlistEventPayload, correlationId: string | undefined, aggregateVersion: number): EventEnvelope<WaitlistEventPayload> {
+  const wirePayload = withoutUndefined(payload);
+  return createEventEnvelope({
+    eventType,
+    producer: WAITLIST_PRODUCER,
+    payload: wirePayload,
+    correlationId,
+    eventId: deterministicEventId(eventType, wirePayload, aggregateVersion),
+    causationId: deterministicCausationId(eventType, wirePayload, aggregateVersion),
+  });
+}
+
+function deterministicEventId(eventType: string, payload: WaitlistEventPayload, aggregateVersion: number): string {
+  return deterministicUuidV7(`waitlist:${eventType}:${String(payload.waitlistRequestId)}:${aggregateVersion}`);
+}
+
+function deterministicCausationId(eventType: string, payload: WaitlistEventPayload, aggregateVersion: number): string {
+  return deterministicUuidV7(`waitlist-causation:${eventType}:${String(payload.waitlistRequestId)}:${aggregateVersion}:${String(payload.status)}`);
+}
+
+function deterministicUuidV7(seed: string): string {
+  const hex = createHash("sha256").update(seed).digest("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-7${hex.slice(13, 16)}-8${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
+}
+
+function deadline(entry: WaitlistEntrySnapshot): string {
+  return entry.deadline ?? entry.offerExpiresAt ?? `${entry.departureDate}T23:59:59.000Z`;
+}
+
+function paymentGuaranteeRef(entry: WaitlistEntrySnapshot): string {
+  return entry.paymentGuaranteeRef ?? `pay-auth-${entry.entryId}`;
+}
+
+function itineraryRef(entry: WaitlistEntrySnapshot): string {
+  return entry.itineraryRef ?? entry.segmentRef;
+}
+
+function intentFingerprint(entry: WaitlistEntrySnapshot): string {
+  return entry.intentFingerprint ?? `${entry.travelerRefs[0] ?? ""}:${entry.segmentRef}:${entry.departureDate}:${entry.seatClass}`;
+}
+
+function withoutUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, field]) => field !== undefined)) as T;
 }

--- a/services/waitlist/src/publisher.ts
+++ b/services/waitlist/src/publisher.ts
@@ -11,7 +11,7 @@ export function waitlistEntryCreated(entry: WaitlistEntrySnapshot, correlationId
 }
 
 export function waitlistEntryPromoted(entry: WaitlistEntrySnapshot, offer: WaitlistOffer, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistEntryPromoted", { entry, offer }, correlationId);
+  return waitlistEnvelope("WaitlistMatchStarted", { entry, offer }, correlationId);
 }
 
 export function waitlistOfferExpired(entry: WaitlistEntrySnapshot, offer: WaitlistOffer, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
@@ -19,7 +19,7 @@ export function waitlistOfferExpired(entry: WaitlistEntrySnapshot, offer: Waitli
 }
 
 export function waitlistEntryAccepted(entry: WaitlistEntrySnapshot, orderId: string, seatAssignment: unknown, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistEntryAccepted", { entry, orderId, seatAssignment }, correlationId);
+  return waitlistEnvelope("WaitlistFulfilled", { entry, orderId, seatAssignment }, correlationId);
 }
 
 export async function publishAll(publisher: EventPublisher, envelopes: readonly EventEnvelope[]): Promise<void> {

--- a/services/waitlist/src/storage.ts
+++ b/services/waitlist/src/storage.ts
@@ -20,12 +20,32 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
   }
 
   async get(entryId: string): Promise<WaitlistEntry | undefined> {
-    const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE entry_id = $1`, [entryId]) as QueryResult<WaitlistRow>;
+    const result = await this.db.query(
+      `SELECT entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, priority_score, status, offered_at, offer_expires_at, fare_quote_id, capacity_hold_id, data, created_at FROM waitlist_entries WHERE entry_id = $1
+       UNION ALL
+       SELECT entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, priority_score, status, offered_at, offer_expires_at, fare_quote_id, capacity_hold_id, data, created_at FROM waitlist_entries_archive WHERE entry_id = $1
+       LIMIT 1`,
+      [entryId],
+    ) as QueryResult<WaitlistRow>;
     return result.rows[0] ? entryFromRow(result.rows[0]) : undefined;
   }
 
   async save(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     const snapshot = entry.toSnapshot(0);
+    if (snapshot.status === "CLOSED") {
+      await this.db.query(
+        `WITH moved AS (
+           DELETE FROM waitlist_entries WHERE entry_id=$1 RETURNING *
+         )
+         INSERT INTO waitlist_entries_archive (entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, priority_score, status, offered_at, offer_expires_at, fare_quote_id, capacity_hold_id, data, version, created_at, updated_at, archived_at)
+         SELECT entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, priority_score, $2, offered_at, offer_expires_at, fare_quote_id, capacity_hold_id, $3, version + 1, created_at, now(), now()
+         FROM moved
+         ON CONFLICT (entry_id) DO UPDATE
+         SET status=EXCLUDED.status, data=EXCLUDED.data, version=waitlist_entries_archive.version + 1, updated_at=now(), archived_at=now()`,
+        [snapshot.entryId, snapshot.status, snapshot],
+      );
+      return snapshot;
+    }
     await this.db.query(
       `UPDATE waitlist_entries
        SET status=$2, offered_at=$3, offer_expires_at=$4, fare_quote_id=$5, capacity_hold_id=$6, data=$7, version=version+1, updated_at=now()
@@ -47,7 +67,12 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
   }
 
   async findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> {
-    const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE status = 'OFFERED' AND offer_expires_at <= $1 ORDER BY offer_expires_at ASC`, [now.toISOString()]) as QueryResult<WaitlistRow>;
+    const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE status = 'MATCHING' AND offer_expires_at <= $1 ORDER BY offer_expires_at ASC`, [now.toISOString()]) as QueryResult<WaitlistRow>;
+    return result.rows.map(entryFromRow);
+  }
+
+  async findArchivable(): Promise<readonly WaitlistEntry[]> {
+    const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE status IN ('FULFILLED', 'EXPIRED', 'CANCELLED') ORDER BY updated_at ASC, entry_id ASC`) as QueryResult<WaitlistRow>;
     return result.rows.map(entryFromRow);
   }
 
@@ -64,6 +89,7 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
   }
 
   private async snapshot(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
+    if (entry.status === "CLOSED") return entry.toSnapshot(0);
     const queue = await this.queueFor(entry.segmentRef, entry.departureDate, entry.seatClass);
     return queue.find((candidate) => candidate.entryId === entry.entryId) ?? entry.toSnapshot(0);
   }
@@ -125,6 +151,10 @@ function entryFromRow(row: WaitlistRow): WaitlistEntry {
     capacityReleaseIdempotencyKey: typeof data.capacityReleaseIdempotencyKey === "string" ? data.capacityReleaseIdempotencyKey : undefined,
     journeyOrderIdempotencyKey: typeof data.journeyOrderIdempotencyKey === "string" ? data.journeyOrderIdempotencyKey : undefined,
     capacitySegmentBookingId: typeof data.capacitySegmentBookingId === "string" ? data.capacitySegmentBookingId : undefined,
+    journeyOrderRef: typeof data.journeyOrderRef === "string" ? data.journeyOrderRef : undefined,
+    deadline: typeof data.deadline === "string" ? data.deadline : undefined,
+    paymentGuaranteeRef: typeof data.paymentGuaranteeRef === "string" ? data.paymentGuaranteeRef : undefined,
+    intentFingerprint: typeof data.intentFingerprint === "string" ? data.intentFingerprint : undefined,
   });
 }
 

--- a/services/waitlist/src/storage.ts
+++ b/services/waitlist/src/storage.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { Redis } from "ioredis";
 import { MigrationRunner, OutboxAppender, OutboxRelay, PostgresIdempotencyStore, checkPostgresReadiness, createPostgresPool, streamForProducer, withTransaction, type EventEnvelope } from "@trainticket/ts-kit";
 import type { Pool, PoolClient, QueryResult } from "pg";
-import { WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
+import { DomainError, WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
 import type { WaitlistRepository } from "./promotion.js";
 
 export class PostgresWaitlistRepository implements WaitlistRepository {
@@ -33,25 +33,32 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
   async save(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     const snapshot = entry.toSnapshot(0);
     if (snapshot.status === "CLOSED") {
-      await this.db.query(
-        `WITH moved AS (
-           DELETE FROM waitlist_entries WHERE entry_id=$1 RETURNING *
+      const result = await this.db.query(
+        `WITH current_row AS (
+           SELECT version FROM waitlist_entries WHERE entry_id=$1 AND status IN ('FULFILLED', 'EXPIRED', 'CANCELLED') FOR UPDATE
+         ), moved AS (
+           DELETE FROM waitlist_entries active
+           USING current_row
+           WHERE active.entry_id=$1 AND active.version=current_row.version
+           RETURNING active.*, current_row.version AS expected_version
          )
          INSERT INTO waitlist_entries_archive (entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, priority_score, status, offered_at, offer_expires_at, fare_quote_id, capacity_hold_id, data, version, created_at, updated_at, archived_at)
-         SELECT entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, priority_score, $2, offered_at, offer_expires_at, fare_quote_id, capacity_hold_id, $3, version + 1, created_at, now(), now()
+         SELECT entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, priority_score, $2, offered_at, offer_expires_at, fare_quote_id, capacity_hold_id, $3, expected_version + 1, created_at, now(), now()
          FROM moved
-         ON CONFLICT (entry_id) DO UPDATE
-         SET status=EXCLUDED.status, data=EXCLUDED.data, version=waitlist_entries_archive.version + 1, updated_at=now(), archived_at=now()`,
+         ON CONFLICT (entry_id) DO NOTHING
+         RETURNING entry_id`,
         [snapshot.entryId, snapshot.status, snapshot],
       );
+      if (result.rowCount !== 1) throw new DomainError("PRECONDITION_FAILED", "Waitlist entry version changed before archival");
       return snapshot;
     }
-    await this.db.query(
+    const result = await this.db.query(
       `UPDATE waitlist_entries
        SET status=$2, offered_at=$3, offer_expires_at=$4, fare_quote_id=$5, capacity_hold_id=$6, data=$7, version=version+1, updated_at=now()
        WHERE entry_id=$1`,
       [snapshot.entryId, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot],
     );
+    if (result.rowCount !== 1) throw new DomainError("PRECONDITION_FAILED", "Waitlist entry version changed before save");
     return this.snapshot(entry);
   }
 
@@ -155,6 +162,7 @@ function entryFromRow(row: WaitlistRow): WaitlistEntry {
     deadline: typeof data.deadline === "string" ? data.deadline : undefined,
     paymentGuaranteeRef: typeof data.paymentGuaranteeRef === "string" ? data.paymentGuaranteeRef : undefined,
     intentFingerprint: typeof data.intentFingerprint === "string" ? data.intentFingerprint : undefined,
+    aggregateVersion: typeof data.aggregateVersion === "number" ? data.aggregateVersion : undefined,
   });
 }
 

--- a/services/waitlist/src/subscriber.ts
+++ b/services/waitlist/src/subscriber.ts
@@ -29,7 +29,7 @@ export function parseCapacityFreed(envelope: EventEnvelope): WaitlistCapacityFre
   const departureDate = string(payload.departureDate);
   const freedSlots = number(payload.freedSlots ?? payload.availableSlots ?? 1);
   const seatClass = typeof payload.seatClass === "string" ? payload.seatClass : undefined;
-  return { segmentRef, departureDate, freedSlots, seatClass };
+  return { eventId: envelope.eventId, segmentRef, departureDate, freedSlots, seatClass };
 }
 
 function string(value: unknown): string {

--- a/services/waitlist/tests/app.test.ts
+++ b/services/waitlist/tests/app.test.ts
@@ -1,11 +1,53 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { InMemoryEventPublisher } from "@trainticket/ts-kit";
 import { createApp } from "../src/app.js";
+import { InMemoryWaitlistRepository, WaitlistApplicationService, type JourneyOrderClient } from "../src/application.js";
+import type { CapacityAvailabilityClient, FarePricingClient, OfferManagementClient } from "../src/promotion.js";
+import type { WaitlistEntry } from "../src/domain.js";
 
 test("health endpoint returns 200", async () => {
   const app = createApp();
   const response = await app.inject({ method: "GET", url: "/health" });
   assert.equal(response.statusCode, 200);
   assert.equal(response.json().status, "ok");
+  await app.close();
+});
+
+class StubFarePricing implements FarePricingClient {
+  async quote(entry: WaitlistEntry) { return { fareQuoteId: `fq-${entry.entryId}` }; }
+}
+
+class StubOfferManagement implements OfferManagementClient {
+  async createOffer(entry: WaitlistEntry) { return { offerId: `off-${entry.entryId}`, offerVersion: 1 }; }
+}
+
+class StubCapacity implements CapacityAvailabilityClient {
+  async hold(entry: WaitlistEntry) { return { capacityHoldId: `hold-${entry.entryId}` }; }
+  async releaseHold() { return undefined; }
+}
+
+class StubJourneyOrder implements JourneyOrderClient {
+  async createOrder(entry: WaitlistEntry) { return { orderId: `ord-${entry.entryId}`, seatAssignment: null }; }
+}
+
+test("contract GET returns CLOSED request resource after archival sweep", async () => {
+  const repository = new InMemoryWaitlistRepository();
+  const publisher = new InMemoryEventPublisher();
+  const app = createApp({ repository, publisher, farePricing: new StubFarePricing(), capacityAvailability: new StubCapacity(), journeyOrder: new StubJourneyOrder(), offerManagement: new StubOfferManagement(), now: () => new Date("2026-01-01T00:00:00.000Z") });
+  const service = new WaitlistApplicationService(repository, publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
+  const entry = await service.join({ accountId: "acc-1", travelerRefs: ["tvl-1"], segmentRef: "seg-1", departureDate: "2026-07-20", seatClass: "SECOND", itineraryRef: "itin-1" });
+  await service.handleCapacityFreed({ segmentRef: "seg-1", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
+  await service.accept(entry.entryId);
+  await service.sweepClosed();
+
+  const queue = await repository.queueFor("seg-1", "2026-07-20", "SECOND");
+  assert.equal(queue.some((snapshot) => snapshot.entryId === entry.entryId), false);
+
+  const response = await app.inject({ method: "GET", url: `/api/v1/waitlist-requests/${entry.entryId}` });
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(Object.keys(response.json()).sort(), ["accountId", "deadline", "intentFingerprint", "itineraryRef", "journeyOrderRef", "paymentGuaranteeRef", "segmentRef", "status", "travelClass", "travelerRef", "waitlistRequestId"].sort());
+  assert.equal(response.json().waitlistRequestId, entry.entryId);
+  assert.equal(response.json().status, "CLOSED");
   await app.close();
 });

--- a/services/waitlist/tests/app.test.ts
+++ b/services/waitlist/tests/app.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { InMemoryEventPublisher } from "@trainticket/ts-kit";
+import { InMemoryEventPublisher, uuidV7 } from "@trainticket/ts-kit";
 import { createApp } from "../src/app.js";
 import { InMemoryWaitlistRepository, WaitlistApplicationService, type JourneyOrderClient } from "../src/application.js";
 import type { CapacityAvailabilityClient, FarePricingClient, OfferManagementClient } from "../src/promotion.js";
@@ -30,6 +30,36 @@ class StubCapacity implements CapacityAvailabilityClient {
 class StubJourneyOrder implements JourneyOrderClient {
   async createOrder(entry: WaitlistEntry) { return { orderId: `ord-${entry.entryId}`, seatAssignment: null }; }
 }
+
+test("contract cancel route returns documented response", async () => {
+  const repository = new InMemoryWaitlistRepository();
+  const app = createApp({ repository, now: () => new Date("2026-01-01T00:00:00.000Z") });
+  const createResponse = await app.inject({
+    method: "POST",
+    url: "/api/v1/waitlist-requests",
+    headers: { "idempotency-key": uuidV7() },
+    payload: { accountId: "acc-1", travelerRef: "tvl-1", segmentRef: "seg-1", deadline: "2026-07-20T23:59:59.000Z", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itin-1", intentFingerprint: "intent-1" },
+  });
+  const waitlistRequestId = createResponse.json().waitlistRequestId;
+
+  const cancelResponse = await app.inject({
+    method: "POST",
+    url: `/api/v1/waitlist-requests/${waitlistRequestId}/cancel`,
+    headers: { "idempotency-key": uuidV7() },
+    payload: { reason: "user-requested" },
+  });
+
+  assert.equal(cancelResponse.statusCode, 200);
+  assert.deepEqual(cancelResponse.json(), { waitlistRequestId, status: "CANCELLED", cancelledAt: "2026-01-01T00:00:00.000Z" });
+  await app.close();
+});
+
+test("public accept route is not exposed", async () => {
+  const app = createApp();
+  const response = await app.inject({ method: "POST", url: "/api/v1/waitlist/entries/wlr-1/accept", payload: {} });
+  assert.equal(response.statusCode, 404);
+  await app.close();
+});
 
 test("contract GET returns CLOSED request resource after archival sweep", async () => {
   const repository = new InMemoryWaitlistRepository();

--- a/services/waitlist/tests/promotion.test.ts
+++ b/services/waitlist/tests/promotion.test.ts
@@ -37,9 +37,9 @@ test("WaitlistCapacityFreed promotes highest-priority queued entry", async () =>
   const result = await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
 
   assert.equal(result.promoted[0]?.entryId, platinum.entryId);
-  assert.equal((await service.get(platinum.entryId)).status, "OFFERED");
+  assert.equal((await service.get(platinum.entryId)).status, "MATCHING");
   assert.equal((await service.get(regular.entryId)).status, "QUEUED");
-  assert.equal(publisher.findByEventType("WaitlistEntryPromoted").length, 1);
+  assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 1);
 });
 
 test("expired offer releases hold and promotes next queued entry", async () => {
@@ -56,19 +56,19 @@ test("expired offer releases hold and promotes next queued entry", async () => {
   await service.expireDueOffers();
 
   assert.equal((await service.get(first.entryId)).status, "EXPIRED");
-  assert.equal((await service.get(second.entryId)).status, "OFFERED");
+  assert.equal((await service.get(second.entryId)).status, "MATCHING");
   assert.deepEqual(capacity.released, [`hold-${first.entryId}`]);
   assert.equal(publisher.findByEventType("WaitlistOfferExpired").length, 1);
-  assert.equal(publisher.findByEventType("WaitlistEntryPromoted").length, 2);
+  assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 2);
 });
 
-test("accept promotion creates journey order and publishes accepted event", async () => {
+test("accept promotion creates journey order and publishes fulfilled event", async () => {
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), new InMemoryEventPublisher(), new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
   const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
   await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
   const order = await service.accept(entry.entryId, { paymentMethodRef: "pm-1" });
   assert.equal(order.orderId, `ord-${entry.entryId}`);
-  assert.equal((await service.get(entry.entryId)).status, "ACCEPTED");
+  assert.equal((await service.get(entry.entryId)).status, "FULFILLED");
 });
 
 test("accept does not mutate entry when journey order creation fails", async () => {
@@ -81,5 +81,5 @@ test("accept does not mutate entry when journey order creation fails", async () 
 
   await assert.rejects(() => service.accept(entry.entryId), /downstream unavailable/);
 
-  assert.equal((await service.get(entry.entryId)).status, "OFFERED");
+  assert.equal((await service.get(entry.entryId)).status, "MATCHING");
 });

--- a/services/waitlist/tests/promotion.test.ts
+++ b/services/waitlist/tests/promotion.test.ts
@@ -58,17 +58,28 @@ test("expired offer releases hold and promotes next queued entry", async () => {
   assert.equal((await service.get(first.entryId)).status, "EXPIRED");
   assert.equal((await service.get(second.entryId)).status, "MATCHING");
   assert.deepEqual(capacity.released, [`hold-${first.entryId}`]);
-  assert.equal(publisher.findByEventType("WaitlistOfferExpired").length, 1);
+  assert.equal(publisher.findByEventType("WaitlistExpired").length, 1);
   assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 2);
 });
 
 test("accept promotion creates journey order and publishes fulfilled event", async () => {
-  const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), new InMemoryEventPublisher(), new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
+  const publisher = new InMemoryEventPublisher();
+  const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
   const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
   await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
   const order = await service.accept(entry.entryId, { paymentMethodRef: "pm-1" });
   assert.equal(order.orderId, `ord-${entry.entryId}`);
   assert.equal((await service.get(entry.entryId)).status, "FULFILLED");
+  assert.deepEqual(publisher.findByEventType("WaitlistFulfilled")[0]?.payload, {
+    waitlistRequestId: entry.entryId,
+    accountId: "acc",
+    travelerRef: "t1",
+    segmentRef: "seg",
+    travelClass: "SECOND",
+    journeyOrderRef: `ord-${entry.entryId}`,
+    fulfilledAt: "2026-01-01T00:00:00.000Z",
+    status: "FULFILLED",
+  });
 });
 
 test("accept does not mutate entry when journey order creation fails", async () => {


### PR DESCRIPTION
## Summary
- add CLOSED archival sweep for fulfilled/expired/cancelled waitlist requests
- archive CLOSED requests outside the active repository set while keeping contract GET retrieval
- return WaitlistRequest resource shape and remove non-contract status vocabulary from waitlist surface

## Validation
- cd services/waitlist && npm run build
- cd services/waitlist && npm test