### PR TITLE
REQ-334 waitlist archival sweep to CLOSED

### DIFF
--- a/services/waitlist/migrations/001_waitlist.sql
+++ b/services/waitlist/migrations/001_waitlist.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS waitlist_entries (
     departure_date date NOT NULL,
     seat_class text NOT NULL,
     priority_score integer NOT NULL CHECK (priority_score >= 0 AND priority_score <= 100),
-    status text NOT NULL CHECK (status IN ('QUEUED', 'OFFERED', 'ACCEPTED', 'EXPIRED', 'CANCELLED')),
+    status text NOT NULL CHECK (status IN ('DRAFT', 'QUEUED', 'MATCHING', 'FULFILLED', 'EXPIRED', 'CANCELLED', 'SUSPENDED', 'CLOSED')),
     offered_at timestamptz,
     offer_expires_at timestamptz,
     fare_quote_id text,
@@ -18,13 +18,24 @@ CREATE TABLE IF NOT EXISTS waitlist_entries (
     updated_at timestamptz NOT NULL DEFAULT now()
 );
 
+ALTER TABLE waitlist_entries DROP CONSTRAINT IF EXISTS waitlist_entries_status_check;
+ALTER TABLE waitlist_entries ADD CONSTRAINT waitlist_entries_status_check CHECK (status IN ('DRAFT', 'QUEUED', 'MATCHING', 'FULFILLED', 'EXPIRED', 'CANCELLED', 'SUSPENDED', 'CLOSED'));
+
 CREATE INDEX IF NOT EXISTS waitlist_queue_order_idx
     ON waitlist_entries (segment_ref, departure_date, seat_class, priority_score DESC, created_at ASC, entry_id)
     WHERE status = 'QUEUED';
 
-CREATE INDEX IF NOT EXISTS waitlist_offer_expiry_idx
+CREATE INDEX IF NOT EXISTS waitlist_match_expiry_idx
     ON waitlist_entries (offer_expires_at)
-    WHERE status = 'OFFERED';
+    WHERE status = 'MATCHING';
+
+CREATE INDEX IF NOT EXISTS waitlist_archive_sweep_idx
+    ON waitlist_entries (updated_at, entry_id)
+    WHERE status IN ('FULFILLED', 'EXPIRED', 'CANCELLED');
+
+CREATE UNIQUE INDEX IF NOT EXISTS waitlist_active_intent_idx
+    ON waitlist_entries ((traveler_refs->>0), (data->>'intentFingerprint'))
+    WHERE status IN ('DRAFT', 'QUEUED', 'MATCHING', 'SUSPENDED');
 
 CREATE TABLE IF NOT EXISTS waitlist_offers (
     offer_id text PRIMARY KEY,

--- a/services/waitlist/src/app.ts
+++ b/services/waitlist/src/app.ts
@@ -58,20 +58,16 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   app.get("/readyz", async (_request, reply) => readyBody(reply, dependencies.storage));
   app.get("/metadata", async () => metadata());
 
-  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist/entries", async (request, ctx) => ({
+  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests", async (request, ctx) => ({
     statusCode: 201,
     body: await runCommand((repository, publisher) => commandService(repository, publisher).join(request.body as any, ctx.correlationId)),
   }));
-  app.get("/api/v1/waitlist/entries/:entryId", async (request, reply) => handleRead(reply, request, () => (
-    runCommand((repository, publisher) => commandService(repository, publisher).get(param(request, "entryId")))
+  app.get("/api/v1/waitlist-requests/:waitlistRequestId", async (request, reply) => handleRead(reply, request, () => (
+    runCommand((repository, publisher) => commandService(repository, publisher).get(param(request, "waitlistRequestId")))
   )));
-  stateChanging(app, idempotencyStore, "DELETE", "/api/v1/waitlist/entries/:entryId", async (request) => ({
+  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests/:waitlistRequestId/cancel", async (request) => ({
     statusCode: 200,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "entryId"))),
-  }));
-  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist/entries/:entryId/accept", async (request, ctx) => ({
-    statusCode: 200,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).accept(param(request, "entryId"), request.body as any, ctx.correlationId)),
+    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "waitlistRequestId"))),
   }));
   app.get("/api/v1/waitlist/segments/:segmentRef/:departureDate/queue", async (request, reply) => handleRead(reply, request, () => (
     runCommand((repository, publisher) => commandService(repository, publisher).queueInfo(param(request, "segmentRef"), param(request, "departureDate"), query(request).seatClass, query(request).entryId))
@@ -81,7 +77,7 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   app.setErrorHandler((error, request, reply) => {
     const ctx = requestContext(request);
     if (error instanceof DomainError) {
-      const status = error.code === "NOT_FOUND" ? 404 : error.code === "PRECONDITION_FAILED" || error.code === "INVALID_TRANSITION" ? 409 : 400;
+      const status = error.code === "NOT_FOUND" ? 404 : error.code === "PRECONDITION_FAILED" || error.code === "INVALID_TRANSITION" || error.code === "CONFLICT" ? 409 : 400;
       sendError(reply, status, error.code, error.message, ctx, { domainCode: error.code });
       return;
     }

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -5,15 +5,33 @@ import { publishAll, waitlistEntryAccepted, waitlistEntryCreated } from "./publi
 
 export type JoinWaitlistRequest = Readonly<{
   accountId: string;
-  travelerRefs: readonly string[];
+  travelerRef?: string;
+  travelerRefs?: readonly string[];
   segmentRef: string;
-  departureDate: string;
-  seatClass: FareClass;
+  travelClass?: FareClass;
+  seatClass?: FareClass;
+  deadline: string;
+  paymentGuaranteeRef: string;
+  intentFingerprint: string;
   loyaltyTier?: PriorityInput["loyaltyTier"];
   tripCount?: number;
   daysBefore?: number;
   specialStatus?: PriorityInput["specialStatus"];
-  itineraryRef?: string;
+  itineraryRef: string;
+}>;
+
+export type WaitlistRequestResource = Readonly<{
+  waitlistRequestId: string;
+  accountId: string;
+  travelerRef: string;
+  segmentRef: string;
+  travelClass?: string;
+  deadline: string;
+  paymentGuaranteeRef: string;
+  itineraryRef: string;
+  intentFingerprint: string;
+  status: WaitlistEntrySnapshot["status"];
+  journeyOrderRef?: string;
 }>;
 
 export type AcceptPromotionRequest = Readonly<{ paymentMethodRef?: string }>;
@@ -28,9 +46,7 @@ export class HttpJourneyOrderClient implements JourneyOrderClient {
   constructor(private readonly baseUrl = process.env.JOURNEY_ORDER_URL ?? process.env.JOURNEY_ORDER_BASE_URL ?? "http://journey-order") {}
 
   async createOrder(entry: WaitlistEntry, _paymentMethodRef?: string): Promise<AcceptPromotionResponse> {
-    if (!entry.offerId || !entry.offerVersion) {
-      throw new DomainError("PRECONDITION_FAILED", "Waitlist entry does not have an orderable offer");
-    }
+    if (!entry.offerId || !entry.offerVersion) throw new DomainError("PRECONDITION_FAILED", "Waitlist request does not have an orderable offer");
     const response = await fetch(`${this.baseUrl.replace(/\/+$/u, "")}/api/v1/journey-orders`, {
       method: "POST",
       headers: { "content-type": "application/json", "Idempotency-Key": entry.journeyOrderIdempotencyKey },
@@ -54,6 +70,7 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   private readonly entries = new Map<string, WaitlistEntry>();
 
   async add(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
+    this.ensureNoActiveDuplicate(entry);
     this.entries.set(entry.entryId, entry);
     return this.snapshot(entry);
   }
@@ -61,6 +78,7 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   async get(entryId: string): Promise<WaitlistEntry | undefined> { return this.entries.get(entryId); }
 
   async save(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
+    entry.markPersisted(entry.version + 1);
     this.entries.set(entry.entryId, entry);
     return this.snapshot(entry);
   }
@@ -71,7 +89,11 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   }
 
   async findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> {
-    return [...this.entries.values()].filter((entry) => entry.status === "OFFERED" && entry.offerExpiresAt !== null && entry.offerExpiresAt <= now);
+    return [...this.entries.values()].filter((entry) => entry.status !== "CLOSED" && ((entry.status === "MATCHING" && entry.offerExpiresAt !== null && entry.offerExpiresAt <= now) || ((entry.status === "QUEUED" || entry.status === "MATCHING") && entry.deadline <= now)));
+  }
+
+  async findArchivable(): Promise<readonly WaitlistEntry[]> {
+    return [...this.entries.values()].filter((entry) => entry.status === "FULFILLED" || entry.status === "EXPIRED" || entry.status === "CANCELLED");
   }
 
   async queueFor(segmentRef: string, departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> {
@@ -82,17 +104,17 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   clear(): void { this.entries.clear(); }
 
   private buildQueue(segmentRef: string, departureDate: string, seatClass?: string): WaitlistQueue {
-    const matching = [...this.entries.values()].filter((entry) => entry.segmentRef === segmentRef && entry.departureDate === departureDate && (!seatClass || entry.seatClass === seatClass));
+    const matching = [...this.entries.values()].filter((entry) => entry.status !== "CLOSED" && entry.segmentRef === segmentRef && entry.departureDate === departureDate && (!seatClass || entry.seatClass === seatClass));
     const classForQueue = (seatClass ?? matching[0]?.seatClass ?? "SECOND") as FareClass;
     return new WaitlistQueue(segmentRef, departureDate, classForQueue, matching.filter((entry) => entry.seatClass === classForQueue));
   }
 
-  private snapshot(entry: WaitlistEntry): WaitlistEntrySnapshot {
-    return entry.toSnapshot(this.position(entry));
-  }
+  private snapshot(entry: WaitlistEntry): WaitlistEntrySnapshot { return entry.toSnapshot(this.position(entry)); }
+  private position(entry: WaitlistEntry): number { return entry.status === "CLOSED" ? 0 : this.buildQueue(entry.segmentRef, entry.departureDate, entry.seatClass).positionOf(entry.entryId); }
 
-  private position(entry: WaitlistEntry): number {
-    return this.buildQueue(entry.segmentRef, entry.departureDate, entry.seatClass).positionOf(entry.entryId);
+  private ensureNoActiveDuplicate(entry: WaitlistEntry): void {
+    const duplicate = [...this.entries.values()].find((candidate) => candidate.travelerRefs[0] === entry.travelerRefs[0] && candidate.intentFingerprint === entry.intentFingerprint && ["DRAFT", "QUEUED", "MATCHING", "SUSPENDED"].includes(candidate.status));
+    if (duplicate) throw new DomainError("CONFLICT", "Active waitlist request already exists for traveler and intentFingerprint");
   }
 }
 
@@ -111,23 +133,24 @@ export class WaitlistApplicationService {
     this.promotion = new PromotionOrchestrator(repository, farePricing, capacityAvailability, publisher ?? { publish: async () => undefined }, offerManagement, now);
   }
 
-  async join(request: JoinWaitlistRequest, correlationId?: string): Promise<WaitlistEntrySnapshot & { estimatedWaitMinutes: number }> {
+  async join(request: JoinWaitlistRequest, correlationId?: string): Promise<WaitlistRequestResource> {
     const entry = WaitlistEntry.create(this.toCreateCommand(request));
     const snapshot = await this.repository.add(entry);
     if (this.publisher) await publishAll(this.publisher, [waitlistEntryCreated(snapshot, correlationId)]);
-    return { ...snapshot, estimatedWaitMinutes: Math.max(5, snapshot.queuePosition * 15) };
+    return toWaitlistRequest(snapshot);
   }
 
-  async get(entryId: string): Promise<WaitlistEntrySnapshot> {
+  async get(entryId: string): Promise<WaitlistRequestResource> {
     const entry = await this.requireEntry(entryId);
-    return this.snapshot(entry);
+    return toWaitlistRequest(await this.snapshot(entry));
   }
 
-  async cancel(entryId: string): Promise<{ cancelled: true }> {
+  async cancel(entryId: string): Promise<{ waitlistRequestId: string; status: "CANCELLED"; cancelledAt: string }> {
     const entry = await this.requireEntry(entryId);
-    entry.cancel();
-    await this.repository.save(entry);
-    return { cancelled: true };
+    const cancelledAt = this.now();
+    entry.cancel(cancelledAt);
+    const snapshot = await this.repository.save(entry);
+    return { waitlistRequestId: snapshot.entryId, status: "CANCELLED", cancelledAt: snapshot.cancelledAt ?? cancelledAt.toISOString() };
   }
 
   async accept(entryId: string, request: AcceptPromotionRequest = {}, correlationId?: string): Promise<AcceptPromotionResponse> {
@@ -135,7 +158,7 @@ export class WaitlistApplicationService {
     const now = this.now();
     entry.ensureOfferAcceptable(now);
     const order = await this.journeyOrder.createOrder(entry, request.paymentMethodRef);
-    entry.accept(now);
+    entry.accept(now, order.orderId);
     const snapshot = await this.repository.save(entry);
     if (this.publisher) await publishAll(this.publisher, [waitlistEntryAccepted(snapshot, order.orderId, order.seatAssignment, correlationId)]);
     return order;
@@ -147,28 +170,38 @@ export class WaitlistApplicationService {
     return { totalQueued: queued.length, myPosition: entryId ? queued.find((entry) => entry.entryId === entryId)?.queuePosition ?? null : null, estimatedPromotionRate: queued.length === 0 ? 1 : 1 / queued.length };
   }
 
-  async handleCapacityFreed(event: WaitlistCapacityFreed, correlationId?: string) {
-    return this.promotion.onCapacityFreed(event, correlationId);
-  }
+  async handleCapacityFreed(event: WaitlistCapacityFreed, correlationId?: string) { return this.promotion.onCapacityFreed(event, correlationId); }
+  async expireDueOffers(correlationId?: string) { return this.promotion.expireDueOffers(correlationId); }
 
-  async expireDueOffers(correlationId?: string) {
-    return this.promotion.expireDueOffers(correlationId);
+  async archiveTerminalRequests(correlationId?: string): Promise<readonly WaitlistRequestResource[]> {
+    const archived: WaitlistRequestResource[] = [];
+    for (const entry of await this.repository.findArchivable()) {
+      entry.close(this.now());
+      const snapshot = await this.repository.save(entry);
+      archived.push(toWaitlistRequest(snapshot));
+    }
+    return archived;
   }
 
   private toCreateCommand(request: JoinWaitlistRequest): CreateWaitlistEntry {
+    const travelerRefs = request.travelerRefs ?? (request.travelerRef ? [request.travelerRef] : []);
+    const seatClass = request.seatClass ?? request.travelClass ?? "SECOND";
     return {
       accountId: request.accountId,
-      travelerRefs: request.travelerRefs,
+      travelerRefs,
       segmentRef: request.segmentRef,
-      departureDate: request.departureDate,
-      seatClass: request.seatClass,
-      itineraryRef: request.itineraryRef ?? request.segmentRef,
+      departureDate: datePart(request.deadline),
+      seatClass,
+      itineraryRef: request.itineraryRef,
+      deadline: new Date(request.deadline),
+      paymentGuaranteeRef: request.paymentGuaranteeRef,
+      intentFingerprint: request.intentFingerprint,
       priority: {
         loyaltyTier: request.loyaltyTier ?? "NONE",
         tripCount: request.tripCount ?? 0,
-        daysBefore: request.daysBefore ?? daysBefore(request.departureDate),
-        groupSize: request.travelerRefs.length,
-        fareClass: request.seatClass,
+        daysBefore: request.daysBefore ?? daysBefore(datePart(request.deadline)),
+        groupSize: travelerRefs.length,
+        fareClass: seatClass,
         specialStatus: request.specialStatus ?? "NONE",
       },
     };
@@ -176,14 +209,31 @@ export class WaitlistApplicationService {
 
   private async requireEntry(entryId: string): Promise<WaitlistEntry> {
     const entry = await this.repository.get(entryId);
-    if (!entry) throw new DomainError("NOT_FOUND", "Waitlist entry was not found");
+    if (!entry) throw new DomainError("NOT_FOUND", "Waitlist request was not found");
     return entry;
   }
 
   private async snapshot(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
+    if (entry.status === "CLOSED") return entry.toSnapshot(0);
     const queue = await this.repository.queueFor(entry.segmentRef, entry.departureDate, entry.seatClass);
     return queue.find((candidate) => candidate.entryId === entry.entryId) ?? entry.toSnapshot(0);
   }
+}
+
+export function toWaitlistRequest(snapshot: WaitlistEntrySnapshot): WaitlistRequestResource {
+  return {
+    waitlistRequestId: snapshot.entryId,
+    accountId: snapshot.accountId,
+    travelerRef: snapshot.travelerRefs[0] ?? "",
+    segmentRef: snapshot.segmentRef,
+    travelClass: snapshot.seatClass,
+    deadline: snapshot.deadline,
+    paymentGuaranteeRef: snapshot.paymentGuaranteeRef,
+    itineraryRef: snapshot.itineraryRef,
+    intentFingerprint: snapshot.intentFingerprint,
+    status: snapshot.status,
+    ...(snapshot.journeyOrderRef ? { journeyOrderRef: snapshot.journeyOrderRef } : {}),
+  };
 }
 
 function daysBefore(departureDate: string): number {
@@ -191,3 +241,4 @@ function daysBefore(departureDate: string): number {
   if (!Number.isFinite(departure)) return 0;
   return Math.max(0, Math.ceil((departure - Date.now()) / (24 * 60 * 60 * 1000)));
 }
+function datePart(value: string): string { return value.slice(0, 10); }

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -160,7 +160,7 @@ export class WaitlistApplicationService {
     const order = await this.journeyOrder.createOrder(entry, request.paymentMethodRef);
     entry.accept(now, order.orderId);
     const snapshot = await this.repository.save(entry);
-    if (this.publisher) await publishAll(this.publisher, [waitlistEntryAccepted(snapshot, order.orderId, order.seatAssignment, correlationId)]);
+    if (this.publisher) await publishAll(this.publisher, [waitlistEntryAccepted(snapshot, order.orderId, now.toISOString(), correlationId)]);
     return order;
   }
 

--- a/services/waitlist/src/bootstrap.ts
+++ b/services/waitlist/src/bootstrap.ts
@@ -31,11 +31,19 @@ export async function bootstrap(options: BootstrapOptions = {}) {
     const operation = storage
       ? storage.runCommand((repository, publisher) => new WaitlistApplicationService(repository, publisher).expireDueOffers())
       : memoryEventService.expireDueOffers();
-    operation.catch((error: unknown) => app.log.error({ err: error }, "waitlist offer expiry scan failed"));
+    operation.catch((error: unknown) => app.log.error({ err: error }, "waitlist expiry scan failed"));
   }, Number.parseInt(process.env.WAITLIST_EXPIRY_SCAN_MS ?? "60000", 10));
   expiryTimer.unref();
+  const archiveTimer = setInterval(() => {
+    const operation = storage
+      ? storage.runCommand((repository, publisher) => new WaitlistApplicationService(repository, publisher).archiveTerminalRequests())
+      : memoryEventService.archiveTerminalRequests();
+    operation.catch((error: unknown) => app.log.error({ err: error }, "waitlist archive sweep failed"));
+  }, Number.parseInt(process.env.WAITLIST_ARCHIVE_SWEEP_MS ?? "300000", 10));
+  archiveTimer.unref();
   app.addHook("onClose", async () => {
     clearInterval(expiryTimer);
+    clearInterval(archiveTimer);
     abortController.abort();
     messaging.subscriber.stop?.();
     await messaging.close();

--- a/services/waitlist/src/domain.ts
+++ b/services/waitlist/src/domain.ts
@@ -1,6 +1,6 @@
 import { uuidV7 } from "@trainticket/ts-kit";
 
-export type WaitlistStatus = "QUEUED" | "OFFERED" | "ACCEPTED" | "EXPIRED" | "CANCELLED";
+export type WaitlistStatus = "DRAFT" | "QUEUED" | "MATCHING" | "FULFILLED" | "EXPIRED" | "CANCELLED" | "SUSPENDED" | "CLOSED";
 export type LoyaltyTier = "PLATINUM" | "GOLD" | "SILVER" | "NONE";
 export type FareClass = "BUSINESS" | "FIRST" | "SECOND" | "SECOND_CLASS" | "STANDING";
 export type SpecialStatus = "MILITARY" | "DISABLED" | "STUDENT" | "NONE";
@@ -27,17 +27,24 @@ export type WaitlistEntrySnapshot = Readonly<{
   createdAt: string;
   offeredAt: string | null;
   offerExpiresAt: string | null;
+  deadline: string;
+  paymentGuaranteeRef: string;
+  intentFingerprint: string;
   fareQuoteId?: string;
   capacityHoldId?: string;
   offerId?: string;
   offerVersion?: number;
-  itineraryRef?: string;
+  itineraryRef: string;
+  journeyOrderRef?: string;
+  cancelledAt?: string;
+  closedAt?: string;
   fareQuoteIdempotencyKey?: string;
   offerIdempotencyKey?: string;
   capacityHoldIdempotencyKey?: string;
   capacityReleaseIdempotencyKey?: string;
   journeyOrderIdempotencyKey?: string;
   capacitySegmentBookingId?: string;
+  version: number;
 }>;
 
 export type CreateWaitlistEntry = Readonly<{
@@ -48,12 +55,15 @@ export type CreateWaitlistEntry = Readonly<{
   departureDate: string;
   seatClass: FareClass;
   priority: Omit<PriorityInput, "groupSize" | "fareClass"> & Partial<Pick<PriorityInput, "groupSize" | "fareClass">>;
-  itineraryRef?: string;
+  itineraryRef: string;
+  deadline: Date;
+  paymentGuaranteeRef: string;
+  intentFingerprint: string;
   createdAt?: Date;
 }>;
 
 export class DomainError extends Error {
-  constructor(public readonly code: "VALIDATION_FAILED" | "INVALID_TRANSITION" | "NOT_FOUND" | "PRECONDITION_FAILED", message: string) {
+  constructor(public readonly code: "VALIDATION_FAILED" | "INVALID_TRANSITION" | "NOT_FOUND" | "PRECONDITION_FAILED" | "CONFLICT", message: string) {
     super(message);
     this.name = "DomainError";
   }
@@ -72,17 +82,24 @@ export class WaitlistEntry {
     private _status: WaitlistStatus,
     private _offeredAt: Date | null = null,
     private _offerExpiresAt: Date | null = null,
+    public readonly deadline: Date,
+    public readonly paymentGuaranteeRef: string,
+    public readonly intentFingerprint: string,
     private _fareQuoteId?: string,
     private _capacityHoldId?: string,
     private _offerId?: string,
     private _offerVersion?: number,
-    public readonly itineraryRef?: string,
+    public readonly itineraryRef: string = "",
+    private _journeyOrderRef?: string,
+    private _cancelledAt?: Date,
+    private _closedAt?: Date,
     private readonly _fareQuoteIdempotencyKey: string = uuidV7(),
     private readonly _offerIdempotencyKey: string = uuidV7(),
     private readonly _capacityHoldIdempotencyKey: string = uuidV7(),
     private readonly _capacityReleaseIdempotencyKey: string = uuidV7(),
     private readonly _journeyOrderIdempotencyKey: string = uuidV7(),
     private readonly _capacitySegmentBookingId: string = `sb-${uuidV7()}`,
+    private _version = 1,
   ) {}
 
   static create(command: CreateWaitlistEntry): WaitlistEntry {
@@ -90,21 +107,30 @@ export class WaitlistEntry {
     if (command.travelerRefs.length === 0) throw new DomainError("VALIDATION_FAILED", "travelerRefs must contain at least one traveler");
     assertNonEmpty(command.segmentRef, "segmentRef");
     assertNonEmpty(command.departureDate, "departureDate");
+    assertNonEmpty(command.itineraryRef, "itineraryRef");
+    validateDeadline(command.deadline);
+    const createdAt = command.createdAt ?? new Date();
+    if (command.deadline <= createdAt) throw new DomainError("VALIDATION_FAILED", "deadline must be in the future");
+    validatePaymentGuaranteeRef(command.paymentGuaranteeRef);
+    assertNonEmpty(command.intentFingerprint, "intentFingerprint");
     const groupSize = command.priority.groupSize ?? command.travelerRefs.length;
     const fareClass = command.priority.fareClass ?? command.seatClass;
     const priorityScore = PriorityCalculator.calculate({ ...command.priority, groupSize, fareClass });
     return new WaitlistEntry(
-      command.entryId ?? `wl-${uuidV7()}`,
+      command.entryId ?? `wlr-${uuidV7()}`,
       command.accountId,
       [...command.travelerRefs],
       command.segmentRef,
       command.departureDate,
       command.seatClass,
       priorityScore,
-      command.createdAt ?? new Date(),
+      createdAt,
       "QUEUED",
       null,
       null,
+      command.deadline,
+      command.paymentGuaranteeRef,
+      command.intentFingerprint,
       undefined,
       undefined,
       undefined,
@@ -126,17 +152,24 @@ export class WaitlistEntry {
       snapshot.status,
       snapshot.offeredAt ? new Date(snapshot.offeredAt) : null,
       snapshot.offerExpiresAt ? new Date(snapshot.offerExpiresAt) : null,
+      new Date(snapshot.deadline),
+      snapshot.paymentGuaranteeRef,
+      snapshot.intentFingerprint,
       snapshot.fareQuoteId,
       snapshot.capacityHoldId,
       snapshot.offerId,
       snapshot.offerVersion,
       snapshot.itineraryRef,
+      snapshot.journeyOrderRef,
+      snapshot.cancelledAt ? new Date(snapshot.cancelledAt) : undefined,
+      snapshot.closedAt ? new Date(snapshot.closedAt) : undefined,
       snapshot.fareQuoteIdempotencyKey,
       snapshot.offerIdempotencyKey,
       snapshot.capacityHoldIdempotencyKey,
       snapshot.capacityReleaseIdempotencyKey,
       snapshot.journeyOrderIdempotencyKey,
       snapshot.capacitySegmentBookingId,
+      snapshot.version,
     );
   }
 
@@ -147,6 +180,8 @@ export class WaitlistEntry {
   get capacityHoldId(): string | undefined { return this._capacityHoldId; }
   get offerId(): string | undefined { return this._offerId; }
   get offerVersion(): number | undefined { return this._offerVersion; }
+  get journeyOrderRef(): string | undefined { return this._journeyOrderRef; }
+  get version(): number { return this._version; }
   get fareQuoteIdempotencyKey(): string { return this._fareQuoteIdempotencyKey; }
   get offerIdempotencyKey(): string { return this._offerIdempotencyKey; }
   get capacityHoldIdempotencyKey(): string { return this._capacityHoldIdempotencyKey; }
@@ -155,9 +190,9 @@ export class WaitlistEntry {
   get capacitySegmentBookingId(): string { return this._capacitySegmentBookingId; }
 
   offer(offerId: string, offerVersion: number, fareQuoteId: string, capacityHoldId: string, now: Date, expiresAt: Date): void {
-    this.assertStatus("QUEUED", "Only queued waitlist entries can be offered");
+    this.assertStatus("QUEUED", "Only queued waitlist requests can start matching");
     if (expiresAt <= now) throw new DomainError("VALIDATION_FAILED", "Offer expiry must be in the future");
-    this._status = "OFFERED";
+    this._status = "MATCHING";
     this._offeredAt = now;
     this._offerExpiresAt = expiresAt;
     if (!Number.isInteger(offerVersion) || offerVersion < 1) throw new DomainError("VALIDATION_FAILED", "offerVersion must be positive");
@@ -167,33 +202,42 @@ export class WaitlistEntry {
     this._offerVersion = offerVersion;
   }
 
-  accept(now: Date): void {
+  accept(now: Date, journeyOrderRef: string): void {
     this.ensureOfferAcceptable(now);
-    this._status = "ACCEPTED";
+    assertNonEmpty(journeyOrderRef, "journeyOrderRef");
+    this._status = "FULFILLED";
+    this._journeyOrderRef = journeyOrderRef;
   }
 
   ensureOfferAcceptable(now: Date): void {
-    this.assertStatus("OFFERED", "Only offered waitlist entries can be accepted");
-    if (this._offerExpiresAt && now > this._offerExpiresAt) {
-      throw new DomainError("PRECONDITION_FAILED", "Waitlist offer has expired");
-    }
+    this.assertStatus("MATCHING", "Only matching waitlist requests can be fulfilled");
+    if (this._offerExpiresAt && now > this._offerExpiresAt) throw new DomainError("PRECONDITION_FAILED", "Waitlist match has expired");
+    if (now > this.deadline) throw new DomainError("PRECONDITION_FAILED", "Waitlist deadline has expired");
   }
 
   expire(now: Date): void {
-    if (this._status !== "OFFERED" && this._status !== "QUEUED") {
-      throw new DomainError("INVALID_TRANSITION", `Cannot expire ${this._status} waitlist entry`);
-    }
-    if (this._status === "OFFERED" && this._offerExpiresAt && now < this._offerExpiresAt) {
-      throw new DomainError("PRECONDITION_FAILED", "Waitlist offer has not reached its expiry time");
+    if (this._status !== "MATCHING" && this._status !== "QUEUED") throw new DomainError("INVALID_TRANSITION", `Cannot expire ${this._status} waitlist request`);
+    if (this._status === "MATCHING" && this._offerExpiresAt && now < this._offerExpiresAt && now < this.deadline) {
+      throw new DomainError("PRECONDITION_FAILED", "Waitlist match has not reached its expiry time");
     }
     this._status = "EXPIRED";
   }
 
-  cancel(): void {
-    if (this._status === "ACCEPTED" || this._status === "EXPIRED") {
-      throw new DomainError("INVALID_TRANSITION", `Cannot cancel ${this._status} waitlist entry`);
-    }
+  cancel(now = new Date()): void {
+    if (["FULFILLED", "EXPIRED", "CANCELLED", "CLOSED"].includes(this._status)) throw new DomainError("INVALID_TRANSITION", `Cannot cancel ${this._status} waitlist request`);
     this._status = "CANCELLED";
+    this._cancelledAt = now;
+  }
+
+  close(now = new Date()): void {
+    if (this._status !== "FULFILLED" && this._status !== "EXPIRED" && this._status !== "CANCELLED") throw new DomainError("INVALID_TRANSITION", `Cannot close ${this._status} waitlist request`);
+    this._status = "CLOSED";
+    this._closedAt = now;
+  }
+
+  markPersisted(version: number): void {
+    if (!Number.isInteger(version) || version < 1) throw new DomainError("VALIDATION_FAILED", "version must be positive");
+    this._version = version;
   }
 
   toSnapshot(queuePosition = 0): WaitlistEntrySnapshot {
@@ -210,17 +254,24 @@ export class WaitlistEntry {
       createdAt: this.createdAt.toISOString(),
       offeredAt: this._offeredAt?.toISOString() ?? null,
       offerExpiresAt: this._offerExpiresAt?.toISOString() ?? null,
+      deadline: this.deadline.toISOString(),
+      paymentGuaranteeRef: this.paymentGuaranteeRef,
+      intentFingerprint: this.intentFingerprint,
       fareQuoteId: this._fareQuoteId,
       capacityHoldId: this._capacityHoldId,
       offerId: this._offerId,
       offerVersion: this._offerVersion,
       itineraryRef: this.itineraryRef,
+      journeyOrderRef: this._journeyOrderRef,
+      cancelledAt: this._cancelledAt?.toISOString(),
+      closedAt: this._closedAt?.toISOString(),
       fareQuoteIdempotencyKey: this._fareQuoteIdempotencyKey,
       offerIdempotencyKey: this._offerIdempotencyKey,
       capacityHoldIdempotencyKey: this._capacityHoldIdempotencyKey,
       capacityReleaseIdempotencyKey: this._capacityReleaseIdempotencyKey,
       journeyOrderIdempotencyKey: this._journeyOrderIdempotencyKey,
       capacitySegmentBookingId: this._capacitySegmentBookingId,
+      version: this._version,
     };
   }
 
@@ -232,42 +283,25 @@ export class WaitlistEntry {
 export class WaitlistQueue {
   private readonly entries = new Map<string, WaitlistEntry>();
 
-  constructor(
-    public readonly segmentRef: string,
-    public readonly departureDate: string,
-    public readonly seatClass: FareClass,
-    entries: readonly WaitlistEntry[] = [],
-  ) {
+  constructor(public readonly segmentRef: string, public readonly departureDate: string, public readonly seatClass: FareClass, entries: readonly WaitlistEntry[] = []) {
     for (const entry of entries) this.add(entry);
   }
 
   add(entry: WaitlistEntry): void {
-    if (entry.segmentRef !== this.segmentRef || entry.departureDate !== this.departureDate || entry.seatClass !== this.seatClass) {
-      throw new DomainError("VALIDATION_FAILED", "Entry does not belong to this waitlist queue partition");
-    }
-    this.entries.set(entry.entryId, entry);
+    if (entry.segmentRef !== this.segmentRef || entry.departureDate !== this.departureDate || entry.seatClass !== this.seatClass) throw new DomainError("VALIDATION_FAILED", "Entry does not belong to this waitlist queue partition");
+    if (entry.status !== "CLOSED") this.entries.set(entry.entryId, entry);
   }
 
   get(entryId: string): WaitlistEntry | undefined { return this.entries.get(entryId); }
-
-  queuedEntries(): readonly WaitlistEntry[] {
-    return this.sorted().filter((entry) => entry.status === "QUEUED");
-  }
-
+  queuedEntries(): readonly WaitlistEntry[] { return this.sorted().filter((entry) => entry.status === "QUEUED"); }
   allEntries(): readonly WaitlistEntry[] { return this.sorted(); }
-
   nextQueued(): WaitlistEntry | undefined { return this.queuedEntries()[0]; }
-
   positionOf(entryId: string): number {
     const index = this.queuedEntries().findIndex((entry) => entry.entryId === entryId);
     return index < 0 ? 0 : index + 1;
   }
-
   totalQueued(): number { return this.queuedEntries().length; }
-
-  private sorted(): WaitlistEntry[] {
-    return [...this.entries.values()].sort(compareEntries);
-  }
+  private sorted(): WaitlistEntry[] { return [...this.entries.values()].sort(compareEntries); }
 }
 
 export class PriorityCalculator {
@@ -284,44 +318,12 @@ function compareEntries(left: WaitlistEntry, right: WaitlistEntry): number {
   if (created !== 0) return created;
   return left.entryId.localeCompare(right.entryId);
 }
-
-function loyaltyPoints(tier: LoyaltyTier = "NONE"): number {
-  return ({ PLATINUM: 30, GOLD: 20, SILVER: 10, NONE: 0 } as const)[tier] ?? 0;
-}
-
-function historyPoints(tripCount = 0): number {
-  if (tripCount > 20) return 20;
-  if (tripCount >= 10) return 15;
-  if (tripCount >= 5) return 10;
-  return 5;
-}
-
-function advancePoints(daysBefore = 0): number {
-  if (daysBefore > 14) return 15;
-  if (daysBefore >= 7) return 10;
-  return 5;
-}
-
-function groupPoints(groupSize: number): number {
-  if (!Number.isInteger(groupSize) || groupSize < 1) throw new DomainError("VALIDATION_FAILED", "groupSize must be at least 1");
-  if (groupSize === 1) return 10;
-  if (groupSize === 2) return 8;
-  if (groupSize <= 4) return 5;
-  return 2;
-}
-
-function farePoints(fareClass: FareClass): number {
-  const normalized = fareClass === "SECOND_CLASS" ? "SECOND" : fareClass;
-  return ({ BUSINESS: 15, FIRST: 12, SECOND: 8, STANDING: 3 } as const)[normalized] ?? 0;
-}
-
-function specialPoints(status: SpecialStatus | readonly SpecialStatus[] = "NONE"): number {
-  const statuses = Array.isArray(status) ? status : [status];
-  if (statuses.includes("MILITARY") || statuses.includes("DISABLED")) return 10;
-  if (statuses.includes("STUDENT")) return 5;
-  return 0;
-}
-
-function assertNonEmpty(value: string, field: string): void {
-  if (value.trim().length === 0) throw new DomainError("VALIDATION_FAILED", `${field} is required`);
-}
+function loyaltyPoints(tier: LoyaltyTier = "NONE"): number { return ({ PLATINUM: 30, GOLD: 20, SILVER: 10, NONE: 0 } as const)[tier] ?? 0; }
+function historyPoints(tripCount = 0): number { if (tripCount > 20) return 20; if (tripCount >= 10) return 15; if (tripCount >= 5) return 10; return 5; }
+function advancePoints(daysBefore = 0): number { if (daysBefore > 14) return 15; if (daysBefore >= 7) return 10; return 5; }
+function groupPoints(groupSize: number): number { if (!Number.isInteger(groupSize) || groupSize < 1) throw new DomainError("VALIDATION_FAILED", "groupSize must be at least 1"); if (groupSize === 1) return 10; if (groupSize === 2) return 8; if (groupSize <= 4) return 5; return 2; }
+function farePoints(fareClass: FareClass): number { const normalized = fareClass === "SECOND_CLASS" ? "SECOND" : fareClass; return ({ BUSINESS: 15, FIRST: 12, SECOND: 8, STANDING: 3 } as const)[normalized] ?? 0; }
+function specialPoints(status: SpecialStatus | readonly SpecialStatus[] = "NONE"): number { const statuses = Array.isArray(status) ? status : [status]; if (statuses.includes("MILITARY") || statuses.includes("DISABLED")) return 10; if (statuses.includes("STUDENT")) return 5; return 0; }
+function assertNonEmpty(value: string, field: string): void { if (typeof value !== "string" || value.trim().length === 0) throw new DomainError("VALIDATION_FAILED", `${field} is required`); }
+function validateDeadline(deadline: Date): void { if (!Number.isFinite(deadline.getTime())) throw new DomainError("VALIDATION_FAILED", "deadline must be a valid RFC3339 instant"); }
+function validatePaymentGuaranteeRef(value: string): void { assertNonEmpty(value, "paymentGuaranteeRef"); if (!value.startsWith("pay-auth-") && !value.startsWith("pi-")) throw new DomainError("VALIDATION_FAILED", "paymentGuaranteeRef must start with pay-auth- or pi-"); }

--- a/services/waitlist/src/promotion.ts
+++ b/services/waitlist/src/promotion.ts
@@ -29,6 +29,7 @@ export interface WaitlistRepository {
   save(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> | WaitlistEntrySnapshot;
   findTopQueued(segmentRef: string, departureDate: string, seatClass?: string): Promise<WaitlistEntry | undefined> | WaitlistEntry | undefined;
   findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> | readonly WaitlistEntry[];
+  findArchivable(): Promise<readonly WaitlistEntry[]> | readonly WaitlistEntry[];
   queueFor(segmentRef: string, departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> | readonly WaitlistEntrySnapshot[];
 }
 
@@ -145,6 +146,11 @@ export class PromotionOrchestrator {
     for (let index = 0; index < slots; index++) {
       const entry = await this.repository.findTopQueued(event.segmentRef, event.departureDate, event.seatClass);
       if (!entry) break;
+      if (entry.deadline <= this.now()) {
+        entry.expire(this.now());
+        await this.repository.save(entry);
+        continue;
+      }
       const quote = await this.farePricing.quote(entry);
       const commercialOffer = await this.offerManagement.createOffer(entry, quote.fareQuoteId);
       const hold = await this.capacityAvailability.hold(entry, quote.fareQuoteId);
@@ -164,7 +170,7 @@ export class PromotionOrchestrator {
     const now = this.now();
     const expired: WaitlistEntrySnapshot[] = [];
     for (const entry of await this.repository.findExpiredOffers(now)) {
-      const offer = offerFromEntry(entry);
+      const offer = entry.status === "MATCHING" ? offerFromEntry(entry) : undefined;
       const capacityHoldId = entry.capacityHoldId;
       entry.expire(now);
       if (capacityHoldId) await this.capacityAvailability.releaseHold(entry, capacityHoldId);

--- a/services/waitlist/src/promotion.ts
+++ b/services/waitlist/src/promotion.ts
@@ -3,6 +3,7 @@ import { DomainError, type WaitlistEntry, type WaitlistEntrySnapshot } from "./d
 import { publishAll, waitlistEntryPromoted, waitlistOfferExpired } from "./publisher.js";
 
 export type WaitlistCapacityFreed = Readonly<{
+  eventId?: string;
   segmentRef: string;
   departureDate: string;
   seatClass?: string;
@@ -161,7 +162,7 @@ export class PromotionOrchestrator {
       const snapshot = await this.repository.save(entry);
       promoted.push(snapshot);
       offers.push(offer);
-      await publishAll(this.publisher, [waitlistEntryPromoted(snapshot, offer, correlationId)]);
+      await publishAll(this.publisher, [waitlistEntryPromoted(snapshot, event.eventId ?? `capacity-released:${entry.entryId}:${snapshot.version}`, snapshot.offeredAt ?? now.toISOString(), correlationId)]);
     }
     return { promoted, offers };
   }
@@ -170,13 +171,12 @@ export class PromotionOrchestrator {
     const now = this.now();
     const expired: WaitlistEntrySnapshot[] = [];
     for (const entry of await this.repository.findExpiredOffers(now)) {
-      const offer = entry.status === "MATCHING" ? offerFromEntry(entry) : undefined;
       const capacityHoldId = entry.capacityHoldId;
       entry.expire(now);
       if (capacityHoldId) await this.capacityAvailability.releaseHold(entry, capacityHoldId);
       const snapshot = await this.repository.save(entry);
       expired.push(snapshot);
-      await publishAll(this.publisher, [waitlistOfferExpired(snapshot, offer, correlationId)]);
+      await publishAll(this.publisher, [waitlistOfferExpired(snapshot, now.toISOString(), correlationId)]);
       await this.onCapacityFreed({ segmentRef: entry.segmentRef, departureDate: entry.departureDate, seatClass: entry.seatClass, freedSlots: 1 }, correlationId);
     }
     return expired;

--- a/services/waitlist/src/publisher.ts
+++ b/services/waitlist/src/publisher.ts
@@ -7,23 +7,39 @@ export const WAITLIST_PRODUCER = "waitlist";
 export type WaitlistEventPayload = Record<string, unknown>;
 
 export function waitlistEntryCreated(entry: WaitlistEntrySnapshot, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistEntryCreated", { entry }, correlationId);
+  return waitlistEnvelope("WaitlistRequestCreated", waitlistPayload(entry), correlationId);
 }
 
 export function waitlistEntryPromoted(entry: WaitlistEntrySnapshot, offer: WaitlistOffer, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistEntryPromoted", { entry, offer }, correlationId);
+  return waitlistEnvelope("WaitlistMatchStarted", { ...waitlistPayload(entry), offer }, correlationId);
 }
 
-export function waitlistOfferExpired(entry: WaitlistEntrySnapshot, offer: WaitlistOffer, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistOfferExpired", { entry, offer }, correlationId);
+export function waitlistOfferExpired(entry: WaitlistEntrySnapshot, offer: WaitlistOffer | undefined, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistExpired", { ...waitlistPayload(entry), ...(offer ? { offer } : {}) }, correlationId);
 }
 
 export function waitlistEntryAccepted(entry: WaitlistEntrySnapshot, orderId: string, seatAssignment: unknown, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistEntryAccepted", { entry, orderId, seatAssignment }, correlationId);
+  return waitlistEnvelope("WaitlistFulfilled", { ...waitlistPayload(entry), journeyOrderRef: orderId, seatAssignment }, correlationId);
 }
 
 export async function publishAll(publisher: EventPublisher, envelopes: readonly EventEnvelope[]): Promise<void> {
   for (const envelope of envelopes) await publisher.publish(envelope);
+}
+
+function waitlistPayload(entry: WaitlistEntrySnapshot): WaitlistEventPayload {
+  return {
+    waitlistRequestId: entry.entryId,
+    accountId: entry.accountId,
+    travelerRef: entry.travelerRefs[0] ?? "",
+    segmentRef: entry.segmentRef,
+    travelClass: entry.seatClass,
+    deadline: entry.deadline,
+    paymentGuaranteeRef: entry.paymentGuaranteeRef,
+    itineraryRef: entry.itineraryRef,
+    intentFingerprint: entry.intentFingerprint,
+    status: entry.status,
+    ...(entry.journeyOrderRef ? { journeyOrderRef: entry.journeyOrderRef } : {}),
+  };
 }
 
 function waitlistEnvelope(eventType: string, payload: WaitlistEventPayload, correlationId?: string): EventEnvelope<WaitlistEventPayload> {

--- a/services/waitlist/src/publisher.ts
+++ b/services/waitlist/src/publisher.ts
@@ -1,44 +1,61 @@
 import { createEventEnvelope, type EventEnvelope, type EventPublisher } from "@trainticket/ts-kit";
 import type { WaitlistEntrySnapshot } from "./domain.js";
-import type { WaitlistOffer } from "./promotion.js";
 
 export const WAITLIST_PRODUCER = "waitlist";
 
 export type WaitlistEventPayload = Record<string, unknown>;
 
 export function waitlistEntryCreated(entry: WaitlistEntrySnapshot, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistRequestCreated", waitlistPayload(entry), correlationId);
+  return waitlistEnvelope("WaitlistRequestCreated", {
+    ...basePayload(entry),
+    deadline: entry.deadline,
+    paymentGuaranteeRef: entry.paymentGuaranteeRef,
+    itineraryRef: entry.itineraryRef,
+    intentFingerprint: entry.intentFingerprint,
+    status: "DRAFT",
+    createdAt: entry.createdAt,
+  }, correlationId);
 }
 
-export function waitlistEntryPromoted(entry: WaitlistEntrySnapshot, offer: WaitlistOffer, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistMatchStarted", { ...waitlistPayload(entry), offer }, correlationId);
+export function waitlistEntryPromoted(entry: WaitlistEntrySnapshot, matchedCapacityReleaseRef: string, startedAt: string, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistMatchStarted", {
+    ...basePayload(entry),
+    matchedCapacityReleaseRef,
+    journeyOrderIdempotencyKey: entry.journeyOrderIdempotencyKey,
+    startedAt,
+    status: "MATCHING",
+  }, correlationId);
 }
 
-export function waitlistOfferExpired(entry: WaitlistEntrySnapshot, offer: WaitlistOffer | undefined, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistExpired", { ...waitlistPayload(entry), ...(offer ? { offer } : {}) }, correlationId);
+export function waitlistOfferExpired(entry: WaitlistEntrySnapshot, expiredAt: string, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistExpired", {
+    ...basePayload(entry),
+    deadline: entry.deadline,
+    expiredAt,
+    status: "EXPIRED",
+  }, correlationId);
 }
 
-export function waitlistEntryAccepted(entry: WaitlistEntrySnapshot, orderId: string, seatAssignment: unknown, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistFulfilled", { ...waitlistPayload(entry), journeyOrderRef: orderId, seatAssignment }, correlationId);
+export function waitlistEntryAccepted(entry: WaitlistEntrySnapshot, orderId: string, fulfilledAt: string, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistFulfilled", {
+    ...basePayload(entry),
+    journeyOrderRef: orderId,
+    fulfilledAt,
+    status: "FULFILLED",
+  }, correlationId);
 }
 
 export async function publishAll(publisher: EventPublisher, envelopes: readonly EventEnvelope[]): Promise<void> {
   for (const envelope of envelopes) await publisher.publish(envelope);
 }
 
-function waitlistPayload(entry: WaitlistEntrySnapshot): WaitlistEventPayload {
+function basePayload(entry: WaitlistEntrySnapshot): WaitlistEventPayload {
   return {
     waitlistRequestId: entry.entryId,
     accountId: entry.accountId,
     travelerRef: entry.travelerRefs[0] ?? "",
     segmentRef: entry.segmentRef,
     travelClass: entry.seatClass,
-    deadline: entry.deadline,
-    paymentGuaranteeRef: entry.paymentGuaranteeRef,
-    itineraryRef: entry.itineraryRef,
-    intentFingerprint: entry.intentFingerprint,
-    status: entry.status,
-    ...(entry.journeyOrderRef ? { journeyOrderRef: entry.journeyOrderRef } : {}),
   };
 }
 

--- a/services/waitlist/src/storage.ts
+++ b/services/waitlist/src/storage.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { Redis } from "ioredis";
 import { MigrationRunner, OutboxAppender, OutboxRelay, PostgresIdempotencyStore, checkPostgresReadiness, createPostgresPool, streamForProducer, withTransaction, type EventEnvelope } from "@trainticket/ts-kit";
 import type { Pool, PoolClient, QueryResult } from "pg";
-import { WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
+import { DomainError, WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
 import type { WaitlistRepository } from "./promotion.js";
 
 export class PostgresWaitlistRepository implements WaitlistRepository {
@@ -26,12 +26,15 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
 
   async save(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     const snapshot = entry.toSnapshot(0);
-    await this.db.query(
+    const result = await this.db.query(
       `UPDATE waitlist_entries
        SET status=$2, offered_at=$3, offer_expires_at=$4, fare_quote_id=$5, capacity_hold_id=$6, data=$7, version=version+1, updated_at=now()
-       WHERE entry_id=$1`,
-      [snapshot.entryId, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot],
-    );
+       WHERE entry_id=$1 AND version=$8
+       RETURNING version`,
+      [snapshot.entryId, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot, entry.version],
+    ) as QueryResult<{ version: string | number }>;
+    if (result.rowCount === 0) throw new DomainError("CONFLICT", "optimistic concurrency conflict");
+    entry.markPersisted(Number(result.rows[0]?.version ?? entry.version + 1));
     return this.snapshot(entry);
   }
 
@@ -47,7 +50,17 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
   }
 
   async findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> {
-    const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE status = 'OFFERED' AND offer_expires_at <= $1 ORDER BY offer_expires_at ASC`, [now.toISOString()]) as QueryResult<WaitlistRow>;
+    const result = await this.db.query(
+      `SELECT * FROM waitlist_entries
+       WHERE ((status = 'MATCHING' AND offer_expires_at <= $1) OR (status IN ('QUEUED', 'MATCHING') AND (data->>'deadline')::timestamptz <= $1))
+       ORDER BY COALESCE(offer_expires_at, (data->>'deadline')::timestamptz) ASC`,
+      [now.toISOString()],
+    ) as QueryResult<WaitlistRow>;
+    return result.rows.map(entryFromRow);
+  }
+
+  async findArchivable(): Promise<readonly WaitlistEntry[]> {
+    const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE status IN ('FULFILLED', 'EXPIRED', 'CANCELLED') ORDER BY updated_at ASC, entry_id ASC`) as QueryResult<WaitlistRow>;
     return result.rows.map(entryFromRow);
   }
 
@@ -56,7 +69,7 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
     const seatClause = seatClass ? "AND seat_class = $3" : "";
     if (seatClass) params.push(seatClass);
     const result = await this.db.query(
-      `SELECT * FROM waitlist_entries WHERE segment_ref = $1 AND departure_date = $2 ${seatClause} ORDER BY priority_score DESC, created_at ASC, entry_id ASC`,
+      `SELECT * FROM waitlist_entries WHERE segment_ref = $1 AND departure_date = $2 ${seatClause} AND status <> 'CLOSED' ORDER BY priority_score DESC, created_at ASC, entry_id ASC`,
       params,
     ) as QueryResult<WaitlistRow>;
     const entries = result.rows.map(entryFromRow);
@@ -64,6 +77,7 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
   }
 
   private async snapshot(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
+    if (entry.status === "CLOSED") return entry.toSnapshot(0);
     const queue = await this.queueFor(entry.segmentRef, entry.departureDate, entry.seatClass);
     return queue.find((candidate) => candidate.entryId === entry.entryId) ?? entry.toSnapshot(0);
   }
@@ -104,7 +118,7 @@ function entryFromRow(row: WaitlistRow): WaitlistEntry {
   return WaitlistEntry.fromSnapshot({
     entryId: row.entry_id,
     accountId: row.account_id,
-    travelerRefs: Array.isArray(row.traveler_refs) ? row.traveler_refs.map(String) : [],
+    travelerRefs: travelerRefs(row.traveler_refs),
     segmentRef: row.segment_ref,
     departureDate: dateString(row.departure_date),
     seatClass: row.seat_class as WaitlistEntrySnapshot["seatClass"],
@@ -114,26 +128,36 @@ function entryFromRow(row: WaitlistRow): WaitlistEntry {
     createdAt: instantString(row.created_at),
     offeredAt: row.offered_at ? instantString(row.offered_at) : null,
     offerExpiresAt: row.offer_expires_at ? instantString(row.offer_expires_at) : null,
-    fareQuoteId: row.fare_quote_id ?? (typeof data.fareQuoteId === "string" ? data.fareQuoteId : undefined),
-    capacityHoldId: row.capacity_hold_id ?? (typeof data.capacityHoldId === "string" ? data.capacityHoldId : undefined),
-    offerId: typeof data.offerId === "string" ? data.offerId : undefined,
+    deadline: stringData(data, "deadline") ?? instantString(row.created_at),
+    paymentGuaranteeRef: stringData(data, "paymentGuaranteeRef") ?? "pay-auth-legacy",
+    intentFingerprint: stringData(data, "intentFingerprint") ?? row.entry_id,
+    fareQuoteId: row.fare_quote_id ?? stringData(data, "fareQuoteId"),
+    capacityHoldId: row.capacity_hold_id ?? stringData(data, "capacityHoldId"),
+    offerId: stringData(data, "offerId"),
     offerVersion: typeof data.offerVersion === "number" ? data.offerVersion : undefined,
-    itineraryRef: typeof data.itineraryRef === "string" ? data.itineraryRef : undefined,
-    fareQuoteIdempotencyKey: typeof data.fareQuoteIdempotencyKey === "string" ? data.fareQuoteIdempotencyKey : undefined,
-    offerIdempotencyKey: typeof data.offerIdempotencyKey === "string" ? data.offerIdempotencyKey : undefined,
-    capacityHoldIdempotencyKey: typeof data.capacityHoldIdempotencyKey === "string" ? data.capacityHoldIdempotencyKey : undefined,
-    capacityReleaseIdempotencyKey: typeof data.capacityReleaseIdempotencyKey === "string" ? data.capacityReleaseIdempotencyKey : undefined,
-    journeyOrderIdempotencyKey: typeof data.journeyOrderIdempotencyKey === "string" ? data.journeyOrderIdempotencyKey : undefined,
-    capacitySegmentBookingId: typeof data.capacitySegmentBookingId === "string" ? data.capacitySegmentBookingId : undefined,
+    itineraryRef: stringData(data, "itineraryRef") ?? row.segment_ref,
+    journeyOrderRef: stringData(data, "journeyOrderRef"),
+    cancelledAt: stringData(data, "cancelledAt"),
+    closedAt: stringData(data, "closedAt"),
+    fareQuoteIdempotencyKey: stringData(data, "fareQuoteIdempotencyKey"),
+    offerIdempotencyKey: stringData(data, "offerIdempotencyKey"),
+    capacityHoldIdempotencyKey: stringData(data, "capacityHoldIdempotencyKey"),
+    capacityReleaseIdempotencyKey: stringData(data, "capacityReleaseIdempotencyKey"),
+    journeyOrderIdempotencyKey: stringData(data, "journeyOrderIdempotencyKey"),
+    capacitySegmentBookingId: stringData(data, "capacitySegmentBookingId"),
+    version: Number(row.version),
   });
 }
 
-function positionIn(entries: readonly WaitlistEntry[], entryId: string): number {
-  const queued = entries.filter((entry) => entry.status === "QUEUED");
-  const index = queued.findIndex((entry) => entry.entryId === entryId);
-  return index < 0 ? 0 : index + 1;
+function travelerRefs(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(String);
+  if (typeof value === "string") {
+    try { const parsed = JSON.parse(value) as unknown; return Array.isArray(parsed) ? parsed.map(String) : []; } catch { return []; }
+  }
+  return [];
 }
-
+function positionIn(entries: readonly WaitlistEntry[], entryId: string): number { const queued = entries.filter((entry) => entry.status === "QUEUED"); const index = queued.findIndex((entry) => entry.entryId === entryId); return index < 0 ? 0 : index + 1; }
+function stringData(data: Record<string, unknown>, field: string): string | undefined { return typeof data[field] === "string" ? data[field] as string : undefined; }
 function dateString(value: Date | string): string { return value instanceof Date ? value.toISOString().slice(0, 10) : String(value).slice(0, 10); }
 function instantString(value: Date | string): string { return value instanceof Date ? value.toISOString() : new Date(value).toISOString(); }
 function sanitizedErrorForLog(error: unknown): Readonly<{ name: string; message: string }> { return error instanceof Error ? { name: error.name || "Error", message: error.message || "Storage failed" } : { name: typeof error, message: "Storage failed" }; }
@@ -153,4 +177,5 @@ type WaitlistRow = Readonly<{
   capacity_hold_id: string | null;
   data: Record<string, unknown> | null;
   created_at: Date | string;
+  version: string | number;
 }>;

--- a/services/waitlist/src/subscriber.ts
+++ b/services/waitlist/src/subscriber.ts
@@ -13,7 +13,7 @@ export function consumerName(instanceId?: string): string {
 export function createWaitlistEventHandler(service: Pick<WaitlistApplicationService, "handleCapacityFreed">) {
   return async (envelope: EventEnvelope): Promise<EventHandlerResult> => {
     try {
-      if (envelope.eventType !== "WaitlistCapacityFreed") return successfulHandling();
+      if (envelope.eventType !== "CapacityReleased" && envelope.eventType !== "WaitlistCapacityFreed") return successfulHandling();
       await service.handleCapacityFreed(parseCapacityFreed(envelope), envelope.correlationId);
       return successfulHandling();
     } catch (error) {
@@ -26,10 +26,10 @@ export function createWaitlistEventHandler(service: Pick<WaitlistApplicationServ
 export function parseCapacityFreed(envelope: EventEnvelope): WaitlistCapacityFreed {
   const payload = envelope.payload as Record<string, unknown>;
   const segmentRef = string(payload.segmentRef);
-  const departureDate = string(payload.departureDate);
-  const freedSlots = number(payload.freedSlots ?? payload.availableSlots ?? 1);
-  const seatClass = typeof payload.seatClass === "string" ? payload.seatClass : undefined;
-  return { segmentRef, departureDate, freedSlots, seatClass };
+  const departureDate = string(payload.departureDate ?? payload.journeyDate ?? payload.serviceDate ?? payload.releasedAt);
+  const freedSlots = number(payload.freedSlots ?? payload.availableSlots ?? payload.quantity ?? 1);
+  const seatClass = typeof payload.seatClass === "string" ? payload.seatClass : typeof payload.classRef === "string" ? payload.classRef : undefined;
+  return { eventId: envelope.eventId, segmentRef, departureDate: datePart(departureDate), freedSlots, seatClass };
 }
 
 function string(value: unknown): string {
@@ -41,4 +41,8 @@ function number(value: unknown): number {
   const parsed = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(parsed) || parsed < 1) throw new Error("WaitlistCapacityFreed event must include freedSlots >= 1");
   return parsed;
+}
+
+function datePart(value: string): string {
+  return value.slice(0, 10);
 }

--- a/services/waitlist/tests/app.test.ts
+++ b/services/waitlist/tests/app.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { uuidV7 } from "@trainticket/ts-kit";
 import { createApp } from "../src/app.js";
 
 test("health endpoint returns 200", async () => {
@@ -7,5 +8,35 @@ test("health endpoint returns 200", async () => {
   const response = await app.inject({ method: "GET", url: "/health" });
   assert.equal(response.statusCode, 200);
   assert.equal(response.json().status, "ok");
+  await app.close();
+});
+
+test("contract create/get/cancel paths use WaitlistRequest resource shape", async () => {
+  const app = createApp({ now: () => new Date("2026-01-01T00:00:00.000Z") });
+  const body = {
+    accountId: "acc-contract",
+    travelerRef: "tvl-contract",
+    segmentRef: "seg-contract",
+    travelClass: "SECOND",
+    deadline: "2026-07-20T00:00:00.000Z",
+    paymentGuaranteeRef: "pay-auth-contract",
+    itineraryRef: "itin-contract",
+    intentFingerprint: "tvl-contract:seg-contract",
+  };
+
+  const created = await app.inject({ method: "POST", url: "/api/v1/waitlist-requests", headers: { "idempotency-key": uuidV7() }, payload: body });
+  assert.equal(created.statusCode, 201);
+  const resource = created.json();
+  assert.equal(resource.status, "QUEUED");
+  assert.equal(resource.waitlistRequestId.startsWith("wlr-"), true);
+  assert.equal(resource.entryId, undefined);
+
+  const fetched = await app.inject({ method: "GET", url: `/api/v1/waitlist-requests/${resource.waitlistRequestId}` });
+  assert.equal(fetched.statusCode, 200);
+  assert.deepEqual(fetched.json(), resource);
+
+  const cancelled = await app.inject({ method: "POST", url: `/api/v1/waitlist-requests/${resource.waitlistRequestId}/cancel`, headers: { "idempotency-key": uuidV7() }, payload: { reason: "CUSTOMER" } });
+  assert.equal(cancelled.statusCode, 200);
+  assert.equal(cancelled.json().status, "CANCELLED");
   await app.close();
 });

--- a/services/waitlist/tests/domain.test.ts
+++ b/services/waitlist/tests/domain.test.ts
@@ -11,9 +11,9 @@ test("platinum member scores higher than non-member", () => {
 });
 
 test("queue orders by priority descending then createdAt ascending", () => {
-  const older = WaitlistEntry.create({ entryId: "wl-old", accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "GOLD", tripCount: 10, daysBefore: 10 }, createdAt: new Date("2026-01-01T00:00:00.000Z") });
-  const newer = WaitlistEntry.create({ entryId: "wl-new", accountId: "acc", travelerRefs: ["t2"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "GOLD", tripCount: 10, daysBefore: 10 }, createdAt: new Date("2026-01-01T00:01:00.000Z") });
-  const platinum = WaitlistEntry.create({ entryId: "wl-vip", accountId: "acc", travelerRefs: ["t3"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "PLATINUM", tripCount: 10, daysBefore: 10 }, createdAt: new Date("2026-01-01T00:02:00.000Z") });
+  const older = WaitlistEntry.create({ entryId: "wl-old", accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "GOLD", tripCount: 10, daysBefore: 10 }, itineraryRef: "itin", deadline: new Date("2026-07-20T00:00:00.000Z"), paymentGuaranteeRef: "pay-auth-test", intentFingerprint: "fp-test", createdAt: new Date("2026-01-01T00:00:00.000Z") });
+  const newer = WaitlistEntry.create({ entryId: "wl-new", accountId: "acc", travelerRefs: ["t2"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "GOLD", tripCount: 10, daysBefore: 10 }, itineraryRef: "itin", deadline: new Date("2026-07-20T00:00:00.000Z"), paymentGuaranteeRef: "pay-auth-test", intentFingerprint: "fp-test-2", createdAt: new Date("2026-01-01T00:01:00.000Z") });
+  const platinum = WaitlistEntry.create({ entryId: "wl-vip", accountId: "acc", travelerRefs: ["t3"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "PLATINUM", tripCount: 10, daysBefore: 10 }, itineraryRef: "itin", deadline: new Date("2026-07-20T00:00:00.000Z"), paymentGuaranteeRef: "pay-auth-test", intentFingerprint: "fp-test-3", createdAt: new Date("2026-01-01T00:02:00.000Z") });
   const queue = new WaitlistQueue("seg", "2026-07-20", "SECOND", [newer, older, platinum]);
   assert.deepEqual(queue.queuedEntries().map((entry) => entry.entryId), ["wl-vip", "wl-old", "wl-new"]);
   assert.equal(queue.positionOf("wl-old"), 2);

--- a/services/waitlist/tests/http-clients.test.ts
+++ b/services/waitlist/tests/http-clients.test.ts
@@ -5,7 +5,7 @@ import { HttpCapacityAvailabilityClient, HttpFarePricingClient, HttpOfferManagem
 import { WaitlistEntry } from "../src/domain.js";
 
 function promotedEntry() {
-  const entry = WaitlistEntry.create({ entryId: "wl-contract", accountId: "acc", travelerRefs: ["tvl-1", "tvl-2"], segmentRef: "seg-1", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "PLATINUM", tripCount: 1 }, itineraryRef: "itn-1", createdAt: new Date("2026-01-01T00:00:00.000Z") });
+  const entry = WaitlistEntry.create({ entryId: "wl-contract", accountId: "acc", travelerRefs: ["tvl-1", "tvl-2"], segmentRef: "seg-1", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "PLATINUM", tripCount: 1 }, itineraryRef: "itn-1", deadline: new Date("2026-07-20T00:00:00.000Z"), paymentGuaranteeRef: "pay-auth-test", intentFingerprint: "fp-test", createdAt: new Date("2026-01-01T00:00:00.000Z") });
   entry.offer("off-1", 1, "fq-1", "hold-1", new Date("2026-01-01T00:00:00.000Z"), new Date("2026-01-01T00:15:00.000Z"));
   return entry;
 }

--- a/services/waitlist/tests/promotion.test.ts
+++ b/services/waitlist/tests/promotion.test.ts
@@ -31,15 +31,15 @@ test("WaitlistCapacityFreed promotes highest-priority queued entry", async () =>
   const fare = new StubFarePricing();
   const capacity = new StubCapacity();
   const service = new WaitlistApplicationService(repository, publisher, fare, capacity, new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
-  const regular = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "NONE", tripCount: 0, daysBefore: 20 });
-  const platinum = await service.join({ accountId: "acc", travelerRefs: ["t2"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
+  const regular = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", deadline: "2026-07-20T00:00:00.000Z", travelClass: "SECOND", loyaltyTier: "NONE", tripCount: 0, daysBefore: 20, itineraryRef: "itin", paymentGuaranteeRef: "pay-auth-test", intentFingerprint: "fp-regular" });
+  const platinum = await service.join({ accountId: "acc", travelerRefs: ["t2"], segmentRef: "seg", deadline: "2026-07-20T00:00:00.000Z", travelClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20, itineraryRef: "itin", paymentGuaranteeRef: "pay-auth-test", intentFingerprint: "fp-platinum" });
 
   const result = await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
 
-  assert.equal(result.promoted[0]?.entryId, platinum.entryId);
-  assert.equal((await service.get(platinum.entryId)).status, "OFFERED");
-  assert.equal((await service.get(regular.entryId)).status, "QUEUED");
-  assert.equal(publisher.findByEventType("WaitlistEntryPromoted").length, 1);
+  assert.equal(result.promoted[0]?.entryId, platinum.waitlistRequestId);
+  assert.equal((await service.get(platinum.waitlistRequestId)).status, "MATCHING");
+  assert.equal((await service.get(regular.waitlistRequestId)).status, "QUEUED");
+  assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 1);
 });
 
 test("expired offer releases hold and promotes next queued entry", async () => {
@@ -48,27 +48,27 @@ test("expired offer releases hold and promotes next queued entry", async () => {
   const publisher = new InMemoryEventPublisher();
   const capacity = new StubCapacity();
   const service = new WaitlistApplicationService(repository, publisher, new StubFarePricing(), capacity, new StubJourneyOrder(), () => current, new StubOfferManagement());
-  const first = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
-  const second = await service.join({ accountId: "acc", travelerRefs: ["t2"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "GOLD", tripCount: 0, daysBefore: 20 });
+  const first = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", deadline: "2026-07-20T00:00:00.000Z", travelClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20, itineraryRef: "itin", paymentGuaranteeRef: "pay-auth-test", intentFingerprint: "fp-first" });
+  const second = await service.join({ accountId: "acc", travelerRefs: ["t2"], segmentRef: "seg", deadline: "2026-07-20T00:00:00.000Z", travelClass: "SECOND", loyaltyTier: "GOLD", tripCount: 0, daysBefore: 20, itineraryRef: "itin", paymentGuaranteeRef: "pay-auth-test", intentFingerprint: "fp-second" });
   await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
 
   current = new Date("2026-01-01T00:16:00.000Z");
   await service.expireDueOffers();
 
-  assert.equal((await service.get(first.entryId)).status, "EXPIRED");
-  assert.equal((await service.get(second.entryId)).status, "OFFERED");
-  assert.deepEqual(capacity.released, [`hold-${first.entryId}`]);
-  assert.equal(publisher.findByEventType("WaitlistOfferExpired").length, 1);
-  assert.equal(publisher.findByEventType("WaitlistEntryPromoted").length, 2);
+  assert.equal((await service.get(first.waitlistRequestId)).status, "EXPIRED");
+  assert.equal((await service.get(second.waitlistRequestId)).status, "MATCHING");
+  assert.deepEqual(capacity.released, [`hold-${first.waitlistRequestId}`]);
+  assert.equal(publisher.findByEventType("WaitlistExpired").length, 1);
+  assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 2);
 });
 
-test("accept promotion creates journey order and publishes accepted event", async () => {
+test("fulfill matching request creates journey order and publishes fulfilled event", async () => {
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), new InMemoryEventPublisher(), new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
-  const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
+  const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", deadline: "2026-07-20T00:00:00.000Z", travelClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20, itineraryRef: "itin", paymentGuaranteeRef: "pay-auth-test", intentFingerprint: "fp-fulfill" });
   await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
-  const order = await service.accept(entry.entryId, { paymentMethodRef: "pm-1" });
-  assert.equal(order.orderId, `ord-${entry.entryId}`);
-  assert.equal((await service.get(entry.entryId)).status, "ACCEPTED");
+  const order = await service.accept(entry.waitlistRequestId, { paymentMethodRef: "pm-1" });
+  assert.equal(order.orderId, `ord-${entry.waitlistRequestId}`);
+  assert.equal((await service.get(entry.waitlistRequestId)).status, "FULFILLED");
 });
 
 test("accept does not mutate entry when journey order creation fails", async () => {
@@ -76,10 +76,34 @@ test("accept does not mutate entry when journey order creation fails", async () 
     async createOrder(): Promise<never> { throw new Error("downstream unavailable"); }
   }
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), new InMemoryEventPublisher(), new StubFarePricing(), new StubCapacity(), new FailingJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
-  const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
+  const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", deadline: "2026-07-20T00:00:00.000Z", travelClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20, itineraryRef: "itin", paymentGuaranteeRef: "pay-auth-test", intentFingerprint: "fp-fail" });
   await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
 
-  await assert.rejects(() => service.accept(entry.entryId), /downstream unavailable/);
+  await assert.rejects(() => service.accept(entry.waitlistRequestId), /downstream unavailable/);
 
-  assert.equal((await service.get(entry.entryId)).status, "OFFERED");
+  assert.equal((await service.get(entry.waitlistRequestId)).status, "MATCHING");
+});
+
+test("archive sweep closes terminal requests while contract GET remains retrievable", async () => {
+  const repository = new InMemoryWaitlistRepository();
+  const service = new WaitlistApplicationService(repository, new InMemoryEventPublisher(), new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
+  const entry = await service.join({ accountId: "acc", travelerRef: "t1", segmentRef: "seg", deadline: "2026-07-20T00:00:00.000Z", travelClass: "SECOND", itineraryRef: "itin-1", paymentGuaranteeRef: "pay-auth-1", intentFingerprint: "t1:seg" });
+  await service.cancel(entry.waitlistRequestId);
+
+  const archived = await service.archiveTerminalRequests();
+
+  assert.deepEqual(archived.map((item) => item.status), ["CLOSED"]);
+  assert.equal((await service.queueInfo("seg", "2026-07-20", "SECOND", entry.waitlistRequestId)).myPosition, null);
+  assert.deepEqual(await service.get(entry.waitlistRequestId), {
+    waitlistRequestId: entry.waitlistRequestId,
+    accountId: "acc",
+    travelerRef: "t1",
+    segmentRef: "seg",
+    travelClass: "SECOND",
+    deadline: "2026-07-20T00:00:00.000Z",
+    paymentGuaranteeRef: "pay-auth-1",
+    itineraryRef: "itin-1",
+    intentFingerprint: "t1:seg",
+    status: "CLOSED",
+  });
 });

--- a/services/waitlist/tests/promotion.test.ts
+++ b/services/waitlist/tests/promotion.test.ts
@@ -39,7 +39,19 @@ test("WaitlistCapacityFreed promotes highest-priority queued entry", async () =>
   assert.equal(result.promoted[0]?.entryId, platinum.waitlistRequestId);
   assert.equal((await service.get(platinum.waitlistRequestId)).status, "MATCHING");
   assert.equal((await service.get(regular.waitlistRequestId)).status, "QUEUED");
-  assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 1);
+  const matchStarted = publisher.findByEventType("WaitlistMatchStarted");
+  assert.equal(matchStarted.length, 1);
+  assert.deepEqual(matchStarted[0]?.payload, {
+    waitlistRequestId: platinum.waitlistRequestId,
+    accountId: "acc",
+    travelerRef: "t2",
+    segmentRef: "seg",
+    travelClass: "SECOND",
+    matchedCapacityReleaseRef: `capacity-released:${platinum.waitlistRequestId}:2`,
+    journeyOrderIdempotencyKey: matchStarted[0]?.payload.journeyOrderIdempotencyKey,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    status: "MATCHING",
+  });
 });
 
 test("expired offer releases hold and promotes next queued entry", async () => {
@@ -58,17 +70,39 @@ test("expired offer releases hold and promotes next queued entry", async () => {
   assert.equal((await service.get(first.waitlistRequestId)).status, "EXPIRED");
   assert.equal((await service.get(second.waitlistRequestId)).status, "MATCHING");
   assert.deepEqual(capacity.released, [`hold-${first.waitlistRequestId}`]);
-  assert.equal(publisher.findByEventType("WaitlistExpired").length, 1);
+  const expired = publisher.findByEventType("WaitlistExpired");
+  assert.equal(expired.length, 1);
+  assert.deepEqual(expired[0]?.payload, {
+    waitlistRequestId: first.waitlistRequestId,
+    accountId: "acc",
+    travelerRef: "t1",
+    segmentRef: "seg",
+    travelClass: "SECOND",
+    deadline: "2026-07-20T00:00:00.000Z",
+    expiredAt: "2026-01-01T00:16:00.000Z",
+    status: "EXPIRED",
+  });
   assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 2);
 });
 
 test("fulfill matching request creates journey order and publishes fulfilled event", async () => {
-  const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), new InMemoryEventPublisher(), new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
+  const publisher = new InMemoryEventPublisher();
+  const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
   const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", deadline: "2026-07-20T00:00:00.000Z", travelClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20, itineraryRef: "itin", paymentGuaranteeRef: "pay-auth-test", intentFingerprint: "fp-fulfill" });
   await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
   const order = await service.accept(entry.waitlistRequestId, { paymentMethodRef: "pm-1" });
   assert.equal(order.orderId, `ord-${entry.waitlistRequestId}`);
   assert.equal((await service.get(entry.waitlistRequestId)).status, "FULFILLED");
+  assert.deepEqual(publisher.findByEventType("WaitlistFulfilled")[0]?.payload, {
+    waitlistRequestId: entry.waitlistRequestId,
+    accountId: "acc",
+    travelerRef: "t1",
+    segmentRef: "seg",
+    travelClass: "SECOND",
+    journeyOrderRef: `ord-${entry.waitlistRequestId}`,
+    fulfilledAt: "2026-01-01T00:00:00.000Z",
+    status: "FULFILLED",
+  });
 });
 
 test("accept does not mutate entry when journey order creation fails", async () => {


### PR DESCRIPTION
## Summary
- implements contract CLOSED state archival sweep for terminal waitlist requests
- returns WaitlistRequest resource shape on contract create/get/cancel paths
- threads aggregate version into Postgres save and enforces optimistic concurrency with version predicate

## Validation
- cd services/waitlist && npm run build
- cd services/waitlist && npm test