### PR TITLE
REQ-342 conform waitlist event publishing

### DIFF
--- a/services/waitlist/src/app.ts
+++ b/services/waitlist/src/app.ts
@@ -81,13 +81,13 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   app.get("/api/v1/waitlist/entries/:entryId", async (request, reply) => handleRead(reply, request, () => (
     runCommand((repository, publisher) => commandService(repository, publisher).get(param(request, "entryId")))
   )));
-  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests/:waitlistRequestId/cancel", async (request) => ({
+  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests/:waitlistRequestId/cancel", async (request, ctx) => ({
     statusCode: 200,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "waitlistRequestId"))),
+    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "waitlistRequestId"), cancellationReason(request.body), ctx.correlationId)),
   }));
-  stateChanging(app, idempotencyStore, "DELETE", "/api/v1/waitlist/entries/:entryId", async (request) => ({
+  stateChanging(app, idempotencyStore, "DELETE", "/api/v1/waitlist/entries/:entryId", async (request, ctx) => ({
     statusCode: 200,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "entryId"))),
+    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "entryId"), cancellationReason(request.body), ctx.correlationId)),
   }));
   stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist/entries/:entryId/accept", async (request, ctx) => ({
     statusCode: 200,
@@ -142,6 +142,9 @@ async function handleRead(reply: FastifyReply, request: FastifyRequest, operatio
 function requestContext(request: FastifyRequest): RequestContext { return kitRequestContext({ headers: request.headers, id: request.id }); }
 function param(request: FastifyRequest, name: string): string { return (request.params as Record<string, string>)[name] ?? ""; }
 function query(request: FastifyRequest): Record<string, string | undefined> { return request.query as Record<string, string | undefined>; }
+function cancellationReason(body: unknown): string {
+  return typeof body === "object" && body !== null && typeof (body as Record<string, unknown>).reason === "string" ? (body as Record<string, string>).reason : "USER_REQUESTED";
+}
 function parsePageNumber(value: string | undefined, fallback: number, max: number): number {
   const parsed = Number.parseInt(value ?? "", 10);
   if (!Number.isFinite(parsed) || parsed < 0) return fallback;

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -1,7 +1,7 @@
 import { type EventPublisher } from "@trainticket/ts-kit";
 import { DomainError, WaitlistEntry, WaitlistQueue, type CreateWaitlistEntry, type FareClass, type PriorityInput, type WaitlistEntrySnapshot } from "./domain.js";
 import { HttpCapacityAvailabilityClient, HttpFarePricingClient, HttpOfferManagementClient, PromotionOrchestrator, type CapacityAvailabilityClient, type FarePricingClient, type OfferManagementClient, type WaitlistCapacityFreed, type WaitlistRepository } from "./promotion.js";
-import { publishAll, waitlistCancelled, waitlistFulfilled, waitlistPaymentAuthorizationRequested, waitlistQueued, waitlistRequestCreated } from "./publisher.js";
+import { publishAll, waitlistCancelled, waitlistExpired, waitlistFulfilled, waitlistPaymentAuthorizationRequested, waitlistQueued, waitlistRequestCreated } from "./publisher.js";
 
 export type JoinWaitlistRequest = Readonly<{
   accountId: string;
@@ -99,6 +99,10 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
 
   async findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> {
     return [...this.entries.values()].filter((entry) => entry.status === "MATCHING" && entry.offerExpiresAt !== null && entry.offerExpiresAt <= now);
+  }
+
+  async findExpired(now: Date): Promise<readonly WaitlistEntry[]> {
+    return [...this.entries.values()].filter((entry) => entry.status === "QUEUED" && new Date(entry.deadline) <= now);
   }
 
   async findByJourneyOrderRef(journeyOrderRef: string): Promise<WaitlistEntry | undefined> {
@@ -224,7 +228,20 @@ export class WaitlistApplicationService {
   }
 
   async expireDueOffers(correlationId?: string) {
+    await this.expireDueWaitlistRequests(correlationId);
     return this.promotion.expireDueOffers(correlationId);
+  }
+
+  async expireDueWaitlistRequests(correlationId?: string): Promise<readonly WaitlistEntrySnapshot[]> {
+    const expiredAt = this.now().toISOString();
+    const expired: WaitlistEntrySnapshot[] = [];
+    for (const entry of await this.repository.findExpired(new Date(expiredAt))) {
+      entry.expire();
+      const snapshot = await this.repository.save(entry);
+      expired.push(snapshot);
+      if (this.publisher) await publishAll(this.publisher, [waitlistExpired(snapshot, expiredAt, entry.loadedVersion, correlationId)]);
+    }
+    return expired;
   }
 
   private toCreateCommand(request: JoinWaitlistRequest): CreateWaitlistEntry {

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -1,7 +1,7 @@
 import { type EventPublisher } from "@trainticket/ts-kit";
 import { DomainError, WaitlistEntry, WaitlistQueue, type CreateWaitlistEntry, type FareClass, type PriorityInput, type WaitlistEntrySnapshot } from "./domain.js";
 import { HttpCapacityAvailabilityClient, HttpFarePricingClient, HttpOfferManagementClient, PromotionOrchestrator, type CapacityAvailabilityClient, type FarePricingClient, type OfferManagementClient, type WaitlistCapacityFreed, type WaitlistRepository } from "./promotion.js";
-import { publishAll, waitlistEntryAccepted, waitlistEntryCreated } from "./publisher.js";
+import { publishAll, waitlistCancelled, waitlistFulfilled, waitlistPaymentAuthorizationRequested, waitlistQueued, waitlistRequestCreated } from "./publisher.js";
 
 export type JoinWaitlistRequest = Readonly<{
   accountId: string;
@@ -80,6 +80,7 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
 
   async add(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     this.entries.set(entry.entryId, entry);
+    entry.markPersisted(3);
     return this.snapshot(entry);
   }
 
@@ -87,6 +88,7 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
 
   async save(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     this.entries.set(entry.entryId, entry);
+    entry.markPersisted(entry.loadedVersion + 1);
     return this.snapshot(entry);
   }
 
@@ -150,7 +152,13 @@ export class WaitlistApplicationService {
   async join(request: JoinWaitlistRequest, correlationId?: string): Promise<WaitlistRequestResource> {
     const entry = WaitlistEntry.create(this.toCreateCommand(request));
     const snapshot = await this.repository.add(entry);
-    if (this.publisher) await publishAll(this.publisher, [waitlistEntryCreated(snapshot, correlationId)]);
+    if (this.publisher) {
+      await publishAll(this.publisher, [
+        waitlistRequestCreated(snapshot, 1, correlationId),
+        waitlistPaymentAuthorizationRequested(snapshot, snapshot.createdAt, 2, correlationId),
+        waitlistQueued(snapshot, snapshot.createdAt, 3, correlationId),
+      ]);
+    }
     return toWaitlistRequestResource(snapshot);
   }
 
@@ -165,21 +173,22 @@ export class WaitlistApplicationService {
     return { items: page.map(toWaitlistRequestResource), total: snapshots.length, limit, offset };
   }
 
-  async cancel(entryId: string): Promise<{ waitlistRequestId: string; status: "CANCELLED"; cancelledAt: string }> {
+  async cancel(entryId: string, reason = "USER_REQUESTED", correlationId?: string): Promise<{ waitlistRequestId: string; status: "CANCELLED"; cancelledAt: string }> {
     const entry = await this.requireEntry(entryId);
+    const cancelledAt = this.now().toISOString();
     entry.cancel();
     const snapshot = await this.repository.save(entry);
-    return { waitlistRequestId: snapshot.entryId, status: "CANCELLED", cancelledAt: this.now().toISOString() };
+    if (this.publisher) await publishAll(this.publisher, [waitlistCancelled(snapshot, cancelledAt, reason, entry.loadedVersion, correlationId)]);
+    return { waitlistRequestId: snapshot.entryId, status: "CANCELLED", cancelledAt };
   }
 
-  async accept(entryId: string, request: AcceptPromotionRequest = {}, correlationId?: string): Promise<AcceptPromotionResponse> {
+  async accept(entryId: string, request: AcceptPromotionRequest = {}, _correlationId?: string): Promise<AcceptPromotionResponse> {
     const entry = await this.requireEntry(entryId);
     const now = this.now();
     entry.ensureOfferAcceptable(now);
     const order = await this.journeyOrder.createOrder(entry, request.paymentMethodRef);
-    entry.accept(now, order.orderId);
-    const snapshot = await this.repository.save(entry);
-    if (this.publisher) await publishAll(this.publisher, [waitlistEntryAccepted(snapshot, order.orderId, order.seatAssignment, correlationId)]);
+    entry.startMatch(order.orderId);
+    await this.repository.save(entry);
     return order;
   }
 
@@ -197,18 +206,21 @@ export class WaitlistApplicationService {
     const entry = await this.repository.findByJourneyOrderRef?.(orderId);
     if (!entry) return undefined;
     if (entry.status === "FULFILLED") return toWaitlistRequestResource(await this.snapshot(entry));
-    const now = this.now();
-    entry.accept(now, orderId);
+    const fulfilledAt = this.now().toISOString();
+    entry.accept(new Date(fulfilledAt), orderId);
     const snapshot = await this.repository.save(entry);
-    if (this.publisher) await publishAll(this.publisher, [waitlistEntryAccepted(snapshot, orderId, null, correlationId)]);
+    if (this.publisher) await publishAll(this.publisher, [waitlistFulfilled(snapshot, fulfilledAt, entry.loadedVersion, correlationId, orderId)]);
     return toWaitlistRequestResource(snapshot);
   }
 
-  async handleJourneyOrderCancelled(orderId: string): Promise<WaitlistRequestResource | undefined> {
+  async handleJourneyOrderCancelled(orderId: string, correlationId?: string): Promise<WaitlistRequestResource | undefined> {
     const entry = await this.repository.findByJourneyOrderRef?.(orderId);
     if (!entry || entry.status !== "MATCHING") return undefined;
+    const queuedAt = this.now().toISOString();
     entry.returnToQueue();
-    return toWaitlistRequestResource(await this.repository.save(entry));
+    const snapshot = await this.repository.save(entry);
+    if (this.publisher) await publishAll(this.publisher, [waitlistQueued(snapshot, queuedAt, entry.loadedVersion, correlationId, { journeyOrderRef: orderId })]);
+    return toWaitlistRequestResource(snapshot);
   }
 
   async expireDueOffers(correlationId?: string) {

--- a/services/waitlist/src/domain.ts
+++ b/services/waitlist/src/domain.ts
@@ -193,9 +193,19 @@ export class WaitlistEntry {
     this._offerVersion = offerVersion;
   }
 
-  accept(now: Date, journeyOrderRef: string): void {
-    this.ensureOfferAcceptable(now);
+  authorizeHold(offerId: string, offerVersion: number, fareQuoteId: string, capacityHoldId: string, now: Date, expiresAt: Date): void {
+    this.offer(offerId, offerVersion, fareQuoteId, capacityHoldId, now, expiresAt);
+  }
+
+  startMatch(journeyOrderRef: string): void {
+    this.assertStatus("MATCHING", "Only matching waitlist entries can record a journey order reference");
     this.recordJourneyOrderRef(journeyOrderRef);
+  }
+
+  accept(now: Date, journeyOrderRef?: string): void {
+    this.ensureOfferAcceptable(now);
+    if (journeyOrderRef) this.recordJourneyOrderRef(journeyOrderRef);
+    if (!this._journeyOrderRef) throw new DomainError("PRECONDITION_FAILED", "Waitlist fulfillment requires a journeyOrderRef");
     this._status = "FULFILLED";
   }
 

--- a/services/waitlist/src/promotion.ts
+++ b/services/waitlist/src/promotion.ts
@@ -33,6 +33,7 @@ export interface WaitlistRepository {
   findTopQueued(segmentRef: string, departureDate: string, seatClass?: string): Promise<WaitlistEntry | undefined> | WaitlistEntry | undefined;
   findByJourneyOrderRef?(journeyOrderRef: string): Promise<WaitlistEntry | undefined> | WaitlistEntry | undefined;
   findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> | readonly WaitlistEntry[];
+  findExpired(now: Date): Promise<readonly WaitlistEntry[]> | readonly WaitlistEntry[];
   queueFor(segmentRef: string, departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> | readonly WaitlistEntrySnapshot[];
   listByTraveler(travelerRef: string): Promise<readonly WaitlistEntrySnapshot[]> | readonly WaitlistEntrySnapshot[];
 }
@@ -144,6 +145,25 @@ export class PromotionOrchestrator {
   ) {}
 
   async onCapacityFreed(event: WaitlistCapacityFreed, correlationId?: string): Promise<PromotionResult> {
+    if (!event.eventId) throw new DomainError("PRECONDITION_FAILED", "CapacityReleased eventId is required to publish WaitlistMatchStarted");
+    return this.promoteQueuedEntries(event, event.eventId, correlationId);
+  }
+
+  async expireDueOffers(correlationId?: string): Promise<readonly WaitlistEntrySnapshot[]> {
+    const now = this.now();
+    const expired: WaitlistEntrySnapshot[] = [];
+    for (const entry of await this.repository.findExpiredOffers(now)) {
+      const capacityHoldId = entry.capacityHoldId;
+      entry.returnToQueue();
+      if (capacityHoldId) await this.capacityAvailability.releaseHold(entry, capacityHoldId);
+      const snapshot = await this.repository.save(entry);
+      expired.push(snapshot);
+      await publishAll(this.publisher, [waitlistQueued(snapshot, now.toISOString(), entry.loadedVersion, correlationId, { requeueReason: "MATCH_EXPIRED" })]);
+    }
+    return expired;
+  }
+
+  private async promoteQueuedEntries(event: WaitlistCapacityFreed, matchedCapacityReleaseRef: string, correlationId?: string): Promise<PromotionResult> {
     const promoted: PromotedWaitlistRequest[] = [];
     const offers: WaitlistOffer[] = [];
     const slots = Math.max(0, Math.floor(event.freedSlots));
@@ -162,25 +182,10 @@ export class PromotionOrchestrator {
       offers.push(offer);
       await publishAll(this.publisher, [
         waitlistHoldAuthorized(snapshot, now.toISOString(), entry.loadedVersion, correlationId),
-        waitlistMatchStarted(snapshot, event.eventId ?? "capacity-release:unknown", now.toISOString(), entry.loadedVersion, correlationId),
+        waitlistMatchStarted(snapshot, matchedCapacityReleaseRef, now.toISOString(), entry.loadedVersion, correlationId),
       ]);
     }
     return { promoted, offers };
-  }
-
-  async expireDueOffers(correlationId?: string): Promise<readonly WaitlistEntrySnapshot[]> {
-    const now = this.now();
-    const expired: WaitlistEntrySnapshot[] = [];
-    for (const entry of await this.repository.findExpiredOffers(now)) {
-      const capacityHoldId = entry.capacityHoldId;
-      entry.returnToQueue();
-      if (capacityHoldId) await this.capacityAvailability.releaseHold(entry, capacityHoldId);
-      const snapshot = await this.repository.save(entry);
-      expired.push(snapshot);
-      await publishAll(this.publisher, [waitlistQueued(snapshot, now.toISOString(), entry.loadedVersion, correlationId, { requeueReason: "MATCH_EXPIRED" })]);
-      await this.onCapacityFreed({ segmentRef: entry.segmentRef, departureDate: entry.departureDate, seatClass: entry.seatClass, freedSlots: 1 }, correlationId);
-    }
-    return expired;
   }
 }
 

--- a/services/waitlist/src/promotion.ts
+++ b/services/waitlist/src/promotion.ts
@@ -1,12 +1,13 @@
 import { type EventPublisher } from "@trainticket/ts-kit";
 import { DomainError, type WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
-import { publishAll, waitlistEntryPromoted, waitlistOfferExpired } from "./publisher.js";
+import { publishAll, waitlistHoldAuthorized, waitlistMatchStarted, waitlistQueued } from "./publisher.js";
 
 export type WaitlistCapacityFreed = Readonly<{
   segmentRef: string;
   departureDate: string;
   seatClass?: string;
   freedSlots: number;
+  eventId?: string;
 }>;
 
 export type WaitlistOffer = Readonly<{
@@ -155,11 +156,14 @@ export class PromotionOrchestrator {
       const now = this.now();
       const expiresAt = new Date(now.getTime() + 15 * 60 * 1000);
       const offer = { offerId: commercialOffer.offerId, offerVersion: commercialOffer.offerVersion, entryId: entry.entryId, fareQuoteId: quote.fareQuoteId, capacityHoldId: hold.capacityHoldId, expiresAt: expiresAt.toISOString() };
-      entry.offer(offer.offerId, offer.offerVersion, quote.fareQuoteId, hold.capacityHoldId, now, expiresAt);
+      entry.authorizeHold(offer.offerId, offer.offerVersion, quote.fareQuoteId, hold.capacityHoldId, now, expiresAt);
       const snapshot = await this.repository.save(entry);
       promoted.push({ ...snapshot, waitlistRequestId: snapshot.entryId });
       offers.push(offer);
-      await publishAll(this.publisher, [waitlistEntryPromoted(snapshot, offer, correlationId)]);
+      await publishAll(this.publisher, [
+        waitlistHoldAuthorized(snapshot, now.toISOString(), entry.loadedVersion, correlationId),
+        waitlistMatchStarted(snapshot, event.eventId ?? "capacity-release:unknown", now.toISOString(), entry.loadedVersion, correlationId),
+      ]);
     }
     return { promoted, offers };
   }
@@ -168,13 +172,12 @@ export class PromotionOrchestrator {
     const now = this.now();
     const expired: WaitlistEntrySnapshot[] = [];
     for (const entry of await this.repository.findExpiredOffers(now)) {
-      const offer = offerFromEntry(entry);
       const capacityHoldId = entry.capacityHoldId;
       entry.returnToQueue();
       if (capacityHoldId) await this.capacityAvailability.releaseHold(entry, capacityHoldId);
       const snapshot = await this.repository.save(entry);
       expired.push(snapshot);
-      await publishAll(this.publisher, [waitlistOfferExpired(snapshot, offer, correlationId)]);
+      await publishAll(this.publisher, [waitlistQueued(snapshot, now.toISOString(), entry.loadedVersion, correlationId, { requeueReason: "MATCH_EXPIRED" })]);
       await this.onCapacityFreed({ segmentRef: entry.segmentRef, departureDate: entry.departureDate, seatClass: entry.seatClass, freedSlots: 1 }, correlationId);
     }
     return expired;

--- a/services/waitlist/src/publisher.ts
+++ b/services/waitlist/src/publisher.ts
@@ -1,4 +1,5 @@
-import { newCommandId, newCorrelationId, type EventEnvelope, type EventPublisher } from "@trainticket/ts-kit";
+import { createHash } from "node:crypto";
+import { createEventEnvelope, type EventEnvelope, type EventPublisher } from "@trainticket/ts-kit";
 import type { WaitlistEntrySnapshot } from "./domain.js";
 
 export const WAITLIST_PRODUCER = "waitlist";
@@ -131,16 +132,26 @@ export function waitlistEventIdSeed(eventType: WaitlistEventType, waitlistReques
 }
 
 function waitlistEnvelope(eventType: WaitlistEventType, entry: WaitlistEntrySnapshot, aggregateVersion: number, payload: WaitlistEventPayload, correlationId?: string, occurredAt?: string): EventEnvelope<WaitlistEventPayload> {
-  return Object.freeze({
-    eventId: waitlistEventIdSeed(eventType, entry.entryId, aggregateVersion),
+  const envelope = createEventEnvelope({
+    eventId: deterministicEventId(waitlistEventIdSeed(eventType, entry.entryId, aggregateVersion)),
     eventType,
-    schemaVersion: 1,
     producer: WAITLIST_PRODUCER,
-    causationId: newCommandId(),
-    correlationId: correlationId ?? newCorrelationId(),
-    occurredAt: occurredAt ?? new Date().toISOString(),
-    payload: Object.freeze(omitUndefined(payload)),
+    correlationId,
+    occurredAt,
+    payload,
   });
+  return Object.freeze({
+    ...envelope,
+    eventId: waitlistEventIdSeed(eventType, entry.entryId, aggregateVersion),
+  });
+}
+
+function deterministicEventId(seed: string): string {
+  const hash = createHash("sha256").update(seed).digest();
+  hash[6] = (hash[6] & 0x0f) | 0x70;
+  hash[8] = (hash[8] & 0x3f) | 0x80;
+  const hex = hash.subarray(0, 16).toString("hex");
+  return `evt-${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
 }
 
 function travelerRef(entry: WaitlistEntrySnapshot): string {
@@ -149,8 +160,4 @@ function travelerRef(entry: WaitlistEntrySnapshot): string {
 
 function itineraryRef(entry: WaitlistEntrySnapshot): string {
   return entry.itineraryRef ?? entry.segmentRef;
-}
-
-function omitUndefined(payload: WaitlistEventPayload): WaitlistEventPayload {
-  return Object.fromEntries(Object.entries(payload).filter(([, value]) => value !== undefined));
 }

--- a/services/waitlist/src/publisher.ts
+++ b/services/waitlist/src/publisher.ts
@@ -1,31 +1,156 @@
-import { createEventEnvelope, type EventEnvelope, type EventPublisher } from "@trainticket/ts-kit";
+import { newCommandId, newCorrelationId, type EventEnvelope, type EventPublisher } from "@trainticket/ts-kit";
 import type { WaitlistEntrySnapshot } from "./domain.js";
-import type { WaitlistOffer } from "./promotion.js";
 
 export const WAITLIST_PRODUCER = "waitlist";
 
 export type WaitlistEventPayload = Record<string, unknown>;
+export type WaitlistEventType =
+  | "WaitlistRequestCreated"
+  | "WaitlistPaymentAuthorizationRequested"
+  | "WaitlistQueued"
+  | "WaitlistMatchStarted"
+  | "WaitlistHoldAuthorized"
+  | "WaitlistFulfilled"
+  | "WaitlistCancelled"
+  | "WaitlistExpired";
 
-export function waitlistEntryCreated(entry: WaitlistEntrySnapshot, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistEntryCreated", { entry }, correlationId);
+export function waitlistRequestCreated(entry: WaitlistEntrySnapshot, aggregateVersion: number, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistRequestCreated", entry, aggregateVersion, {
+    waitlistRequestId: entry.entryId,
+    accountId: entry.accountId,
+    travelerRef: travelerRef(entry),
+    segmentRef: entry.segmentRef,
+    travelClass: entry.seatClass,
+    deadline: entry.deadline,
+    paymentGuaranteeRef: entry.paymentGuaranteeRef,
+    itineraryRef: itineraryRef(entry),
+    intentFingerprint: entry.intentFingerprint,
+    status: "DRAFT",
+    createdAt: entry.createdAt,
+  }, correlationId, entry.createdAt);
 }
 
-export function waitlistEntryPromoted(entry: WaitlistEntrySnapshot, offer: WaitlistOffer, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistEntryPromoted", { entry, offer }, correlationId);
+export function waitlistPaymentAuthorizationRequested(entry: WaitlistEntrySnapshot, requestedAt: string, aggregateVersion: number, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistPaymentAuthorizationRequested", entry, aggregateVersion, {
+    waitlistRequestId: entry.entryId,
+    accountId: entry.accountId,
+    travelerRef: travelerRef(entry),
+    paymentGuaranteeRef: entry.paymentGuaranteeRef,
+    requestedAt,
+    status: "DRAFT",
+  }, correlationId, requestedAt);
 }
 
-export function waitlistOfferExpired(entry: WaitlistEntrySnapshot, offer: WaitlistOffer, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistOfferExpired", { entry, offer }, correlationId);
+export function waitlistQueued(entry: WaitlistEntrySnapshot, queuedAt: string, aggregateVersion: number, correlationId?: string, options: { journeyOrderRef?: string; requeueReason?: string } = {}): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistQueued", entry, aggregateVersion, {
+    waitlistRequestId: entry.entryId,
+    accountId: entry.accountId,
+    travelerRef: travelerRef(entry),
+    segmentRef: entry.segmentRef,
+    travelClass: entry.seatClass,
+    itineraryRef: itineraryRef(entry),
+    intentFingerprint: entry.intentFingerprint,
+    queuedAt,
+    status: "QUEUED",
+    journeyOrderRef: options.journeyOrderRef ?? entry.journeyOrderRef,
+    requeueReason: options.requeueReason,
+  }, correlationId, queuedAt);
 }
 
-export function waitlistEntryAccepted(entry: WaitlistEntrySnapshot, orderId: string, seatAssignment: unknown, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistEntryAccepted", { entry, orderId, seatAssignment }, correlationId);
+export function waitlistMatchStarted(entry: WaitlistEntrySnapshot, matchedCapacityReleaseRef: string, startedAt: string, aggregateVersion: number, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistMatchStarted", entry, aggregateVersion, {
+    waitlistRequestId: entry.entryId,
+    accountId: entry.accountId,
+    travelerRef: travelerRef(entry),
+    segmentRef: entry.segmentRef,
+    travelClass: entry.seatClass,
+    matchedCapacityReleaseRef,
+    journeyOrderIdempotencyKey: entry.journeyOrderIdempotencyKey,
+    startedAt,
+    status: "MATCHING",
+  }, correlationId, startedAt);
+}
+
+export function waitlistHoldAuthorized(entry: WaitlistEntrySnapshot, authorizedAt: string, aggregateVersion: number, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistHoldAuthorized", entry, aggregateVersion, {
+    waitlistRequestId: entry.entryId,
+    accountId: entry.accountId,
+    travelerRef: travelerRef(entry),
+    segmentRef: entry.segmentRef,
+    travelClass: entry.seatClass,
+    authorizedAt,
+    status: "MATCHING",
+  }, correlationId, authorizedAt);
+}
+
+export function waitlistFulfilled(entry: WaitlistEntrySnapshot, fulfilledAt: string, aggregateVersion: number, correlationId?: string, journeyOrderRef = entry.journeyOrderRef): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistFulfilled", entry, aggregateVersion, {
+    waitlistRequestId: entry.entryId,
+    accountId: entry.accountId,
+    travelerRef: travelerRef(entry),
+    segmentRef: entry.segmentRef,
+    travelClass: entry.seatClass,
+    journeyOrderRef,
+    fulfilledAt,
+    status: "FULFILLED",
+  }, correlationId, fulfilledAt);
+}
+
+export function waitlistCancelled(entry: WaitlistEntrySnapshot, cancelledAt: string, reason: string, aggregateVersion: number, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistCancelled", entry, aggregateVersion, {
+    waitlistRequestId: entry.entryId,
+    accountId: entry.accountId,
+    travelerRef: travelerRef(entry),
+    segmentRef: entry.segmentRef,
+    travelClass: entry.seatClass,
+    cancelledAt,
+    reason,
+    status: "CANCELLED",
+  }, correlationId, cancelledAt);
+}
+
+export function waitlistExpired(entry: WaitlistEntrySnapshot, expiredAt: string, aggregateVersion: number, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistExpired", entry, aggregateVersion, {
+    waitlistRequestId: entry.entryId,
+    accountId: entry.accountId,
+    travelerRef: travelerRef(entry),
+    segmentRef: entry.segmentRef,
+    travelClass: entry.seatClass,
+    deadline: entry.deadline,
+    expiredAt,
+    status: "EXPIRED",
+  }, correlationId, expiredAt);
 }
 
 export async function publishAll(publisher: EventPublisher, envelopes: readonly EventEnvelope[]): Promise<void> {
   for (const envelope of envelopes) await publisher.publish(envelope);
 }
 
-function waitlistEnvelope(eventType: string, payload: WaitlistEventPayload, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return createEventEnvelope({ eventType, producer: WAITLIST_PRODUCER, payload, correlationId });
+export function waitlistEventIdSeed(eventType: WaitlistEventType, waitlistRequestId: string, aggregateVersion: number): string {
+  return `waitlist:${eventType}:${waitlistRequestId}:${aggregateVersion}`;
+}
+
+function waitlistEnvelope(eventType: WaitlistEventType, entry: WaitlistEntrySnapshot, aggregateVersion: number, payload: WaitlistEventPayload, correlationId?: string, occurredAt?: string): EventEnvelope<WaitlistEventPayload> {
+  return Object.freeze({
+    eventId: waitlistEventIdSeed(eventType, entry.entryId, aggregateVersion),
+    eventType,
+    schemaVersion: 1,
+    producer: WAITLIST_PRODUCER,
+    causationId: newCommandId(),
+    correlationId: correlationId ?? newCorrelationId(),
+    occurredAt: occurredAt ?? new Date().toISOString(),
+    payload: Object.freeze(omitUndefined(payload)),
+  });
+}
+
+function travelerRef(entry: WaitlistEntrySnapshot): string {
+  return entry.travelerRefs[0] ?? "";
+}
+
+function itineraryRef(entry: WaitlistEntrySnapshot): string {
+  return entry.itineraryRef ?? entry.segmentRef;
+}
+
+function omitUndefined(payload: WaitlistEventPayload): WaitlistEventPayload {
+  return Object.fromEntries(Object.entries(payload).filter(([, value]) => value !== undefined));
 }

--- a/services/waitlist/src/storage.ts
+++ b/services/waitlist/src/storage.ts
@@ -12,11 +12,11 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
   async add(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     const snapshot = entry.toSnapshot(0);
     await this.db.query(
-      `INSERT INTO waitlist_entries (entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, priority_score, status, offered_at, offer_expires_at, fare_quote_id, capacity_hold_id, data, created_at)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
-      [snapshot.entryId, snapshot.accountId, JSON.stringify(snapshot.travelerRefs), snapshot.segmentRef, snapshot.departureDate, snapshot.seatClass, snapshot.priorityScore, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot, snapshot.createdAt],
+      `INSERT INTO waitlist_entries (entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, priority_score, status, offered_at, offer_expires_at, fare_quote_id, capacity_hold_id, data, created_at, version)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
+      [snapshot.entryId, snapshot.accountId, JSON.stringify(snapshot.travelerRefs), snapshot.segmentRef, snapshot.departureDate, snapshot.seatClass, snapshot.priorityScore, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot, snapshot.createdAt, 3],
     );
-    entry.markPersisted(1);
+    entry.markPersisted(3);
     return this.snapshot(entry);
   }
 
@@ -31,9 +31,9 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
     if (loadedVersion < 1) throw new OptimisticConcurrencyConflict(`Waitlist entry ${entry.entryId} has no loaded version`);
     const result = await this.db.query(
       `UPDATE waitlist_entries
-       SET status=$2, offered_at=$3, offer_expires_at=$4, fare_quote_id=$5, capacity_hold_id=$6, data=$7, version=version+1, updated_at=now()
+       SET status=$2, offered_at=$3, offer_expires_at=$4, fare_quote_id=$5, capacity_hold_id=$6, data=$7, offer_version=$9, version=version+1, updated_at=now()
        WHERE entry_id=$1 AND version=$8`,
-      [snapshot.entryId, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot, loadedVersion],
+      [snapshot.entryId, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot, loadedVersion, snapshot.offerVersion ?? null],
     );
     if (result.rowCount === 0) throw new OptimisticConcurrencyConflict(`Waitlist entry ${entry.entryId} was modified by another writer`);
     entry.markPersisted(loadedVersion + 1);
@@ -155,7 +155,7 @@ function entryFromRow(row: WaitlistRow): WaitlistEntry {
     fareQuoteId: row.fare_quote_id ?? (typeof data.fareQuoteId === "string" ? data.fareQuoteId : undefined),
     capacityHoldId: row.capacity_hold_id ?? (typeof data.capacityHoldId === "string" ? data.capacityHoldId : undefined),
     offerId: typeof data.offerId === "string" ? data.offerId : undefined,
-    offerVersion: typeof data.offerVersion === "number" ? data.offerVersion : undefined,
+    offerVersion: row.offer_version ?? (typeof data.offerVersion === "number" ? data.offerVersion : undefined),
     itineraryRef: typeof data.itineraryRef === "string" ? data.itineraryRef : undefined,
     deadline: typeof data.deadline === "string" ? data.deadline : deadlineFromDepartureDate(dateString(row.departure_date)),
     paymentGuaranteeRef: typeof data.paymentGuaranteeRef === "string" ? data.paymentGuaranteeRef : `pay-auth-${row.entry_id}`,
@@ -200,6 +200,7 @@ type WaitlistRow = Readonly<{
   offer_expires_at: Date | string | null;
   fare_quote_id: string | null;
   capacity_hold_id: string | null;
+  offer_version: number | null;
   data: Record<string, unknown> | null;
   version: string | number | bigint;
   created_at: Date | string;

--- a/services/waitlist/src/storage.ts
+++ b/services/waitlist/src/storage.ts
@@ -56,6 +56,11 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
     return result.rows.map(entryFromRow);
   }
 
+  async findExpired(now: Date): Promise<readonly WaitlistEntry[]> {
+    const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE status = 'QUEUED' AND data->>'deadline' <= $1 ORDER BY data->>'deadline' ASC, created_at ASC`, [now.toISOString()]) as QueryResult<WaitlistRow>;
+    return result.rows.map(entryFromRow);
+  }
+
   async findByJourneyOrderRef(journeyOrderRef: string): Promise<WaitlistEntry | undefined> {
     const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE data->>'journeyOrderRef' = $1 ORDER BY created_at ASC LIMIT 1`, [journeyOrderRef]) as QueryResult<WaitlistRow>;
     return result.rows[0] ? entryFromRow(result.rows[0]) : undefined;

--- a/services/waitlist/src/subscriber.ts
+++ b/services/waitlist/src/subscriber.ts
@@ -46,7 +46,7 @@ export function parseCapacityFreed(envelope: EventEnvelope): WaitlistCapacityFre
   const departureDate = string(payload.departureDate);
   const freedSlots = number(payload.freedSlots ?? payload.availableSlots ?? payload.quantity ?? 1);
   const seatClass = typeof payload.seatClass === "string" ? payload.seatClass : typeof payload.classRef === "string" ? payload.classRef : undefined;
-  return { segmentRef, departureDate, freedSlots, seatClass };
+  return { segmentRef, departureDate, freedSlots, seatClass, eventId: envelope.eventId };
 }
 
 export function parseJourneyOrderId(envelope: EventEnvelope): string {

--- a/services/waitlist/tests/events.test.ts
+++ b/services/waitlist/tests/events.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { InMemoryEventPublisher } from "@trainticket/ts-kit";
+import { InMemoryWaitlistRepository, WaitlistApplicationService, type JourneyOrderClient } from "../src/application.js";
+import type { CapacityAvailabilityClient, FarePricingClient, OfferManagementClient } from "../src/promotion.js";
+import type { WaitlistEntry } from "../src/domain.js";
+import { waitlistEventIdSeed } from "../src/publisher.js";
+
+class StubFarePricing implements FarePricingClient {
+  async quote(entry: WaitlistEntry) { return { fareQuoteId: `fq-${entry.entryId}` }; }
+}
+
+class StubOfferManagement implements OfferManagementClient {
+  async createOffer(entry: WaitlistEntry) { return { offerId: `off-${entry.entryId}`, offerVersion: 1 }; }
+}
+
+class StubCapacity implements CapacityAvailabilityClient {
+  async hold(entry: WaitlistEntry) { return { capacityHoldId: `hold-${entry.entryId}` }; }
+  async releaseHold() {}
+}
+
+class StubJourneyOrder implements JourneyOrderClient {
+  async createOrder(entry: WaitlistEntry) { return { orderId: `ord-${entry.entryId}`, seatAssignment: null }; }
+}
+
+test("join publishes deterministic created, payment authorization, and queued facts", async () => {
+  const publisher = new InMemoryEventPublisher();
+  const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
+
+  const request = await service.join({ accountId: "acc", travelerRef: "tvl", segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn", intentFingerprint: "intent" }, "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c123");
+
+  assert.deepEqual(publisher.envelopes.map((event) => event.eventType), ["WaitlistRequestCreated", "WaitlistPaymentAuthorizationRequested", "WaitlistQueued"]);
+  assert.deepEqual(publisher.envelopes.map((event) => event.eventId), [
+    waitlistEventIdSeed("WaitlistRequestCreated", request.waitlistRequestId, 1),
+    waitlistEventIdSeed("WaitlistPaymentAuthorizationRequested", request.waitlistRequestId, 2),
+    waitlistEventIdSeed("WaitlistQueued", request.waitlistRequestId, 3),
+  ]);
+  assert.deepEqual(publisher.findByEventType("WaitlistQueued")[0]?.payload, {
+    waitlistRequestId: request.waitlistRequestId,
+    accountId: "acc",
+    travelerRef: "tvl",
+    segmentRef: "seg",
+    travelClass: "SECOND",
+    itineraryRef: "itn",
+    intentFingerprint: "intent",
+    queuedAt: publisher.envelopes[2]?.occurredAt,
+    status: "QUEUED",
+  });
+});
+
+test("cancel publishes WaitlistCancelled with deterministic id", async () => {
+  const publisher = new InMemoryEventPublisher();
+  const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
+  const request = await service.join({ accountId: "acc", travelerRef: "tvl", segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn", intentFingerprint: "intent" });
+
+  await service.cancel(request.waitlistRequestId, "USER_CHANGED_PLANS");
+
+  const cancelled = publisher.findByEventType("WaitlistCancelled")[0];
+  assert.equal(cancelled?.eventId, waitlistEventIdSeed("WaitlistCancelled", request.waitlistRequestId, 4));
+  assert.equal(cancelled?.payload.reason, "USER_CHANGED_PLANS");
+  assert.equal(cancelled?.payload.status, "CANCELLED");
+});
+
+test("journey order cancellation requeues with journeyOrderRef still present in event", async () => {
+  const publisher = new InMemoryEventPublisher();
+  const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
+  const request = await service.join({ accountId: "acc", travelerRef: "tvl", segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn", intentFingerprint: "intent" });
+  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, eventId: "evt-capacity-1" });
+  const order = await service.accept(request.waitlistRequestId);
+
+  await service.handleJourneyOrderCancelled(order.orderId);
+
+  const requeued = publisher.findByEventType("WaitlistQueued").at(-1);
+  assert.equal(requeued?.payload.journeyOrderRef, order.orderId);
+  assert.equal(requeued?.payload.status, "QUEUED");
+});
+
+test("journey order confirmation publishes WaitlistFulfilled", async () => {
+  const publisher = new InMemoryEventPublisher();
+  const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
+  const request = await service.join({ accountId: "acc", travelerRef: "tvl", segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn", intentFingerprint: "intent" });
+  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, eventId: "evt-capacity-1" });
+  const order = await service.accept(request.waitlistRequestId);
+
+  await service.handleJourneyOrderConfirmed(order.orderId);
+
+  const fulfilled = publisher.findByEventType("WaitlistFulfilled")[0];
+  assert.equal(fulfilled?.payload.journeyOrderRef, order.orderId);
+  assert.equal(fulfilled?.payload.status, "FULFILLED");
+});

--- a/services/waitlist/tests/events.test.ts
+++ b/services/waitlist/tests/events.test.ts
@@ -88,3 +88,19 @@ test("journey order confirmation publishes WaitlistFulfilled", async () => {
   assert.equal(fulfilled?.payload.journeyOrderRef, order.orderId);
   assert.equal(fulfilled?.payload.status, "FULFILLED");
 });
+
+test("expired queued request publishes WaitlistExpired with deterministic id", async () => {
+  const publisher = new InMemoryEventPublisher();
+  const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-02T00:00:00.000Z"), new StubOfferManagement());
+  const request = await service.join({ accountId: "acc", travelerRef: "tvl", segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", deadline: "2026-01-01T00:00:00.000Z", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn", intentFingerprint: "intent" });
+
+  await service.expireDueWaitlistRequests();
+
+  const expired = publisher.findByEventType("WaitlistExpired")[0];
+  assert.equal(expired?.eventId, waitlistEventIdSeed("WaitlistExpired", request.waitlistRequestId, 4));
+  assert.equal(expired?.payload.waitlistRequestId, request.waitlistRequestId);
+  assert.equal(expired?.payload.deadline, "2026-01-01T00:00:00.000Z");
+  assert.equal(expired?.payload.expiredAt, "2026-01-02T00:00:00.000Z");
+  assert.equal(expired?.payload.status, "EXPIRED");
+  assert.equal((await service.get(request.waitlistRequestId)).status, "EXPIRED");
+});

--- a/services/waitlist/tests/promotion.test.ts
+++ b/services/waitlist/tests/promotion.test.ts
@@ -34,13 +34,14 @@ test("WaitlistCapacityFreed promotes highest-priority queued entry", async () =>
   const regular = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "NONE", tripCount: 0, daysBefore: 20 });
   const platinum = await service.join({ accountId: "acc", travelerRefs: ["t2"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
 
-  const result = await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
+  const result = await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, eventId: "evt-capacity-1" });
 
   assert.equal(result.promoted[0]?.waitlistRequestId, platinum.waitlistRequestId);
   assert.equal((await service.get(platinum.waitlistRequestId)).status, "MATCHING");
   assert.equal((await service.get(regular.waitlistRequestId)).status, "QUEUED");
   assert.equal(publisher.findByEventType("WaitlistHoldAuthorized").length, 1);
   assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 1);
+  assert.equal(publisher.findByEventType("WaitlistMatchStarted")[0]?.payload.matchedCapacityReleaseRef, "evt-capacity-1");
 });
 
 test("expired matching attempt returns to queue, releases hold, and frees capacity", async () => {
@@ -55,10 +56,10 @@ test("expired matching attempt returns to queue, releases hold, and frees capaci
   current = new Date("2026-01-01T00:16:00.000Z");
   await service.expireDueOffers();
 
-  assert.equal((await service.get(first.waitlistRequestId)).status, "MATCHING");
+  assert.equal((await service.get(first.waitlistRequestId)).status, "QUEUED");
   assert.deepEqual(capacity.released, [`hold-${first.waitlistRequestId}`]);
   assert.equal(publisher.findByEventType("WaitlistQueued").filter((event) => event.payload.requeueReason === "MATCH_EXPIRED").length, 1);
-  assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 2);
+  assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 1);
 });
 
 test("accept promotion records journey order and waits for confirmation", async () => {

--- a/services/waitlist/tests/promotion.test.ts
+++ b/services/waitlist/tests/promotion.test.ts
@@ -39,7 +39,8 @@ test("WaitlistCapacityFreed promotes highest-priority queued entry", async () =>
   assert.equal(result.promoted[0]?.waitlistRequestId, platinum.waitlistRequestId);
   assert.equal((await service.get(platinum.waitlistRequestId)).status, "MATCHING");
   assert.equal((await service.get(regular.waitlistRequestId)).status, "QUEUED");
-  assert.equal(publisher.findByEventType("WaitlistEntryPromoted").length, 1);
+  assert.equal(publisher.findByEventType("WaitlistHoldAuthorized").length, 1);
+  assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 1);
 });
 
 test("expired matching attempt returns to queue, releases hold, and frees capacity", async () => {
@@ -49,24 +50,25 @@ test("expired matching attempt returns to queue, releases hold, and frees capaci
   const capacity = new StubCapacity();
   const service = new WaitlistApplicationService(repository, publisher, new StubFarePricing(), capacity, new StubJourneyOrder(), () => current, new StubOfferManagement());
   const first = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
-  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
+  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, eventId: "evt-capacity-1" });
 
   current = new Date("2026-01-01T00:16:00.000Z");
   await service.expireDueOffers();
 
   assert.equal((await service.get(first.waitlistRequestId)).status, "MATCHING");
   assert.deepEqual(capacity.released, [`hold-${first.waitlistRequestId}`]);
-  assert.equal(publisher.findByEventType("WaitlistOfferExpired").length, 1);
-  assert.equal(publisher.findByEventType("WaitlistEntryPromoted").length, 2);
+  assert.equal(publisher.findByEventType("WaitlistQueued").filter((event) => event.payload.requeueReason === "MATCH_EXPIRED").length, 1);
+  assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 2);
 });
 
-test("accept promotion creates journey order and publishes accepted event", async () => {
+test("accept promotion records journey order and waits for confirmation", async () => {
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), new InMemoryEventPublisher(), new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
   const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
-  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
+  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, eventId: "evt-capacity-1" });
   const order = await service.accept(entry.waitlistRequestId, { paymentMethodRef: "pm-1" });
   assert.equal(order.orderId, `ord-${entry.waitlistRequestId}`);
-  assert.equal((await service.get(entry.waitlistRequestId)).status, "FULFILLED");
+  assert.equal((await service.get(entry.waitlistRequestId)).status, "MATCHING");
+  assert.equal((await service.get(entry.waitlistRequestId)).journeyOrderRef, `ord-${entry.waitlistRequestId}`);
 });
 
 test("accept does not mutate entry when journey order creation fails", async () => {
@@ -75,7 +77,7 @@ test("accept does not mutate entry when journey order creation fails", async () 
   }
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), new InMemoryEventPublisher(), new StubFarePricing(), new StubCapacity(), new FailingJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
   const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
-  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
+  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, eventId: "evt-capacity-1" });
 
   await assert.rejects(() => service.accept(entry.waitlistRequestId), /downstream unavailable/);
 


### PR DESCRIPTION
## Summary
- Repair waitlist event publishing contract blockers from verification.
- Require consumed CapacityReleased eventId for WaitlistMatchStarted and stop synthetic re-promotion with capacity-release:unknown.
- Wire queued request expiry to publish WaitlistExpired, and route waitlist envelopes through the repository factory while preserving deterministic waitlist event IDs.

## Validation
- cd services/waitlist && npm test
- cd services/waitlist && npm run build