### PR TITLE
REQ-343 conform waitlist API errors

### DIFF
--- a/services/waitlist/migrations/001_waitlist.sql
+++ b/services/waitlist/migrations/001_waitlist.sql
@@ -26,6 +26,10 @@ CREATE INDEX IF NOT EXISTS waitlist_offer_expiry_idx
     ON waitlist_entries (offer_expires_at)
     WHERE status = 'MATCHING';
 
+CREATE UNIQUE INDEX IF NOT EXISTS waitlist_active_traveler_intent_unique
+    ON waitlist_entries ((traveler_refs->>0), (data->>'intentFingerprint'))
+    WHERE status IN ('DRAFT', 'QUEUED', 'MATCHING', 'SUSPENDED');
+
 CREATE TABLE IF NOT EXISTS waitlist_offers (
     offer_id text PRIMARY KEY,
     entry_id text NOT NULL REFERENCES waitlist_entries(entry_id),

--- a/services/waitlist/migrations/003_active_traveler_intent_unique.sql
+++ b/services/waitlist/migrations/003_active_traveler_intent_unique.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX IF NOT EXISTS waitlist_active_traveler_intent_unique
+    ON waitlist_entries ((traveler_refs->>0), (data->>'intentFingerprint'))
+    WHERE status IN ('DRAFT', 'QUEUED', 'MATCHING', 'SUSPENDED');

--- a/services/waitlist/src/app.ts
+++ b/services/waitlist/src/app.ts
@@ -1,7 +1,7 @@
 import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from "fastify";
 import { InMemoryEventPublisher, InMemoryIdempotencyStore, errorMessage, handleIdempotency, headerValue, requestContext as kitRequestContext, requestFingerprint, sendError, type EventPublisher, type IdempotencyStore, type RequestContext } from "@trainticket/ts-kit";
 import { DomainError } from "./domain.js";
-import { InMemoryWaitlistRepository, WaitlistApplicationService, type JourneyOrderClient } from "./application.js";
+import { InMemoryWaitlistRepository, WaitlistApplicationService, type JoinWaitlistRequest, type JourneyOrderClient } from "./application.js";
 import type { CapacityAvailabilityClient, FarePricingClient, OfferManagementClient, WaitlistRepository } from "./promotion.js";
 import { serviceProfile } from "./profile.js";
 
@@ -58,10 +58,13 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   app.get("/readyz", async (_request, reply) => readyBody(reply, dependencies.storage));
   app.get("/metadata", async () => metadata());
 
-  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests", async (request, ctx) => ({
-    statusCode: 201,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).join(request.body as any, ctx.correlationId)),
-  }));
+  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests", async (request, ctx) => {
+    validateCreateWaitlistRequest(request.body);
+    return {
+      statusCode: 201,
+      body: await runCommand((repository, publisher) => commandService(repository, publisher).join(request.body as any, ctx.correlationId)),
+    };
+  });
   stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist/entries", async (request, ctx) => ({
     statusCode: 201,
     body: await runCommand((repository, publisher) => commandService(repository, publisher).join(request.body as any, ctx.correlationId)),
@@ -69,7 +72,7 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   app.get("/api/v1/waitlist-requests", async (request, reply) => handleRead(reply, request, () => {
     const params = query(request);
     return runCommand((repository, publisher) => commandService(repository, publisher).listByTraveler(
-      params.travelerRef ?? "",
+      requiredString(params.travelerRef, "travelerRef"),
       params.status as any,
       parsePageNumber(params.limit, 20, 100),
       parsePageNumber(params.offset, 0, Number.MAX_SAFE_INTEGER),
@@ -101,8 +104,7 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   app.setErrorHandler((error, request, reply) => {
     const ctx = requestContext(request);
     if (error instanceof DomainError) {
-      const status = error.code === "NOT_FOUND" ? 404 : error.code === "PRECONDITION_FAILED" || error.code === "INVALID_TRANSITION" ? 409 : 400;
-      sendError(reply, status, error.code, error.message, ctx, { domainCode: error.code });
+      sendError(reply, statusForDomainError(error), error.code, error.message, ctx, { domainCode: error.code });
       return;
     }
     sendError(reply, 500, "INTERNAL_ERROR", errorMessage(error), ctx);
@@ -133,10 +135,37 @@ async function handleRead(reply: FastifyReply, request: FastifyRequest, operatio
   try { return reply.status(200).send(await operation()); }
   catch (error) {
     const ctx = requestContext(request);
-    if (error instanceof DomainError) sendError(reply, error.code === "NOT_FOUND" ? 404 : 409, error.code, error.message, ctx, { domainCode: error.code });
+    if (error instanceof DomainError) sendError(reply, statusForDomainError(error), error.code, error.message, ctx, { domainCode: error.code });
     else throw error;
     return reply;
   }
+}
+
+function validateCreateWaitlistRequest(body: unknown): void {
+  const request = asCreateRequest(body);
+  requiredString(request.accountId, "accountId");
+  requiredString(request.travelerRef ?? request.travelerRefs?.[0], "travelerRef");
+  requiredString(request.segmentRef, "segmentRef");
+  requiredString(request.deadline, "deadline");
+  requiredString(request.paymentGuaranteeRef, "paymentGuaranteeRef");
+  requiredString(request.itineraryRef, "itineraryRef");
+  requiredString(request.intentFingerprint, "intentFingerprint");
+}
+
+function asCreateRequest(body: unknown): Partial<JoinWaitlistRequest> {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) throw new DomainError("VALIDATION_FAILED", "request body is required");
+  return body as Partial<JoinWaitlistRequest>;
+}
+
+function requiredString(value: string | undefined, field: string): string {
+  if (!value || value.trim().length === 0) throw new DomainError("VALIDATION_FAILED", `${field} is required`);
+  return value;
+}
+
+function statusForDomainError(error: DomainError): number {
+  if (error.code === "NOT_FOUND") return 404;
+  if (error.code === "CONFLICT" || error.code === "PRECONDITION_FAILED" || error.code === "INVALID_TRANSITION") return 409;
+  return 400;
 }
 
 function requestContext(request: FastifyRequest): RequestContext { return kitRequestContext({ headers: request.headers, id: request.id }); }

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -80,6 +80,9 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   private readonly entries = new Map<string, WaitlistEntry>();
 
   async add(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
+    if (this.hasActiveRequestFor(entry.travelerRefs[0] ?? "", entry.intentFingerprint)) {
+      throw new DomainError("CONFLICT", "An active waitlist request already exists for this traveler and intent");
+    }
     this.entries.set(entry.entryId, entry);
     entry.markPersisted(1);
     return this.snapshot(entry);
@@ -119,6 +122,10 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   }
 
   clear(): void { this.entries.clear(); }
+
+  private hasActiveRequestFor(travelerRef: string, intentFingerprint: string): boolean {
+    return [...this.entries.values()].some((entry) => entry.travelerRefs[0] === travelerRef && entry.intentFingerprint === intentFingerprint && isActiveStatus(entry.status));
+  }
 
   private buildQueue(segmentRef: string, departureDate: string, seatClass?: string): WaitlistQueue {
     const matching = [...this.entries.values()].filter((entry) => entry.segmentRef === segmentRef && entry.departureDate === departureDate && (!seatClass || entry.seatClass === seatClass));
@@ -176,11 +183,12 @@ export class WaitlistApplicationService {
   }
 
   async cancel(entryId: string, request: CancelWaitlistRequest = {}, correlationId?: string): Promise<{ waitlistRequestId: string; status: "CANCELLED"; cancelledAt: string }> {
+    const reason = requiredString(asCancelRequest(request).reason, "reason");
     const entry = await this.requireEntry(entryId);
     const cancelledAt = this.now().toISOString();
     entry.cancel();
     const snapshot = await this.repository.save(entry);
-    if (this.publisher) await publishAll(this.publisher, [waitlistCancelled(snapshot, entry.loadedVersion, request.reason ?? "", correlationId, cancelledAt)]);
+    if (this.publisher) await publishAll(this.publisher, [waitlistCancelled(snapshot, entry.loadedVersion, reason, correlationId, cancelledAt)]);
     return { waitlistRequestId: snapshot.entryId, status: "CANCELLED", cancelledAt };
   }
 
@@ -280,6 +288,20 @@ function toWaitlistRequestResource(snapshot: WaitlistEntrySnapshot): WaitlistReq
     status: snapshot.status,
     journeyOrderRef: snapshot.journeyOrderRef,
   };
+}
+
+function isActiveStatus(status: WaitlistEntrySnapshot["status"]): boolean {
+  return status === "DRAFT" || status === "QUEUED" || status === "MATCHING" || status === "SUSPENDED";
+}
+
+function asCancelRequest(request: unknown): Partial<CancelWaitlistRequest> {
+  if (typeof request !== "object" || request === null || Array.isArray(request)) throw new DomainError("VALIDATION_FAILED", "request body is required");
+  return request as Partial<CancelWaitlistRequest>;
+}
+
+function requiredString(value: string | undefined, field: string): string {
+  if (!value || value.trim().length === 0) throw new DomainError("VALIDATION_FAILED", `${field} is required`);
+  return value;
 }
 
 function daysBefore(departureDate: string): number {

--- a/services/waitlist/src/domain.ts
+++ b/services/waitlist/src/domain.ts
@@ -60,7 +60,7 @@ export type CreateWaitlistEntry = Readonly<{
 }>;
 
 export class DomainError extends Error {
-  constructor(public readonly code: "VALIDATION_FAILED" | "INVALID_TRANSITION" | "NOT_FOUND" | "PRECONDITION_FAILED", message: string) {
+  constructor(public readonly code: "VALIDATION_FAILED" | "DOMAIN_RULE_VIOLATION" | "CONFLICT" | "INVALID_TRANSITION" | "NOT_FOUND" | "PRECONDITION_FAILED", message: string) {
     super(message);
     this.name = "DomainError";
   }

--- a/services/waitlist/src/storage.ts
+++ b/services/waitlist/src/storage.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { Redis } from "ioredis";
 import { MigrationRunner, OptimisticConcurrencyConflict, OutboxAppender, OutboxRelay, PostgresIdempotencyStore, checkPostgresReadiness, createPostgresPool, streamForProducer, withTransaction, type EventEnvelope } from "@trainticket/ts-kit";
 import type { Pool, PoolClient, QueryResult } from "pg";
-import { WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
+import { DomainError, WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
 import type { WaitlistRepository } from "./promotion.js";
 
 export class PostgresWaitlistRepository implements WaitlistRepository {
@@ -11,11 +11,18 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
 
   async add(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     const snapshot = entry.toSnapshot(0);
-    await this.db.query(
-      `INSERT INTO waitlist_entries (entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, priority_score, status, offered_at, offer_expires_at, fare_quote_id, capacity_hold_id, data, created_at)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
-      [snapshot.entryId, snapshot.accountId, JSON.stringify(snapshot.travelerRefs), snapshot.segmentRef, snapshot.departureDate, snapshot.seatClass, snapshot.priorityScore, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot, snapshot.createdAt],
-    );
+    try {
+      await this.db.query(
+        `INSERT INTO waitlist_entries (entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, priority_score, status, offered_at, offer_expires_at, fare_quote_id, capacity_hold_id, data, created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+        [snapshot.entryId, snapshot.accountId, JSON.stringify(snapshot.travelerRefs), snapshot.segmentRef, snapshot.departureDate, snapshot.seatClass, snapshot.priorityScore, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot, snapshot.createdAt],
+      );
+    } catch (error) {
+      if (isActiveRequestUniqueViolation(error)) {
+        throw new DomainError("CONFLICT", "An active waitlist request already exists for this traveler and intent");
+      }
+      throw error;
+    }
     entry.markPersisted(1);
     return this.snapshot(entry);
   }
@@ -177,6 +184,10 @@ function positionIn(entries: readonly WaitlistEntry[], entryId: string): number 
   const queued = entries.filter((entry) => entry.status === "QUEUED");
   const index = queued.findIndex((entry) => entry.entryId === entryId);
   return index < 0 ? 0 : index + 1;
+}
+
+function isActiveRequestUniqueViolation(error: unknown): boolean {
+  return typeof error === "object" && error !== null && (error as { code?: unknown; constraint?: unknown }).code === "23505" && (error as { constraint?: unknown }).constraint === "waitlist_active_traveler_intent_unique";
 }
 
 function dateString(value: Date | string): string { return value instanceof Date ? value.toISOString().slice(0, 10) : String(value).slice(0, 10); }

--- a/services/waitlist/tests/app.test.ts
+++ b/services/waitlist/tests/app.test.ts
@@ -55,3 +55,98 @@ test("waitlist request endpoints return contract resource shape", async () => {
 
   await app.close();
 });
+
+test("duplicate active waitlist request returns documented conflict", async () => {
+  resetWaitlistStore();
+  const app = createApp();
+  const payload = {
+    accountId: "acc-1",
+    travelerRef: "tvl-1",
+    segmentRef: "seg-1",
+    travelClass: "SECOND",
+    deadline: "2026-07-20T00:00:00.000Z",
+    paymentGuaranteeRef: "pay-auth-1",
+    itineraryRef: "itn-1",
+    intentFingerprint: "intent-1",
+  };
+
+  await app.inject({ method: "POST", url: "/api/v1/waitlist-requests", headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c124" }, payload });
+  const duplicate = await app.inject({ method: "POST", url: "/api/v1/waitlist-requests", headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c125" }, payload });
+
+  assert.equal(duplicate.statusCode, 409);
+  assert.equal(duplicate.json().code, "CONFLICT");
+  await app.close();
+});
+
+test("cancel requires a non-empty reason", async () => {
+  resetWaitlistStore();
+  const app = createApp();
+  const create = await app.inject({
+    method: "POST",
+    url: "/api/v1/waitlist-requests",
+    headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c126" },
+    payload: {
+      accountId: "acc-1",
+      travelerRef: "tvl-1",
+      segmentRef: "seg-1",
+      travelClass: "SECOND",
+      deadline: "2026-07-20T00:00:00.000Z",
+      paymentGuaranteeRef: "pay-auth-1",
+      itineraryRef: "itn-1",
+      intentFingerprint: "intent-1",
+    },
+  });
+
+  const blankReason = await app.inject({
+    method: "POST",
+    url: `/api/v1/waitlist-requests/${create.json().waitlistRequestId}/cancel`,
+    headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c127" },
+    payload: { reason: " " },
+  });
+
+  assert.equal(blankReason.statusCode, 400);
+  assert.equal(blankReason.json().code, "VALIDATION_FAILED");
+  assert.equal(blankReason.json().details.domainCode, "VALIDATION_FAILED");
+
+  const nullBody = await app.inject({
+    method: "POST",
+    url: `/api/v1/waitlist-requests/${create.json().waitlistRequestId}/cancel`,
+    headers: { "content-type": "application/json", "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c129" },
+    payload: "null",
+  });
+
+  assert.equal(nullBody.statusCode, 400);
+  assert.equal(nullBody.json().code, "VALIDATION_FAILED");
+  assert.equal(nullBody.json().details.domainCode, "VALIDATION_FAILED");
+  await app.close();
+});
+
+test("create and list reject contract-required fields instead of defaulting", async () => {
+  resetWaitlistStore();
+  const app = createApp();
+  const create = await app.inject({
+    method: "POST",
+    url: "/api/v1/waitlist-requests",
+    headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c128" },
+    payload: {
+      accountId: "acc-1",
+      travelerRef: "tvl-1",
+      segmentRef: "seg-1",
+      travelClass: "SECOND",
+      paymentGuaranteeRef: "pay-auth-1",
+      itineraryRef: "itn-1",
+      intentFingerprint: "intent-1",
+    },
+  });
+
+  assert.equal(create.statusCode, 400);
+  assert.equal(create.json().code, "VALIDATION_FAILED");
+  assert.equal(create.json().details.domainCode, "VALIDATION_FAILED");
+
+  const list = await app.inject({ method: "GET", url: "/api/v1/waitlist-requests" });
+
+  assert.equal(list.statusCode, 400);
+  assert.equal(list.json().code, "VALIDATION_FAILED");
+  assert.equal(list.json().details.domainCode, "VALIDATION_FAILED");
+  await app.close();
+});

--- a/services/waitlist/tests/storage.test.ts
+++ b/services/waitlist/tests/storage.test.ts
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
 import { OptimisticConcurrencyConflict } from "@trainticket/ts-kit";
-import { WaitlistEntry } from "../src/domain.js";
+import { DomainError, WaitlistEntry } from "../src/domain.js";
 import { PostgresWaitlistRepository, ProcessedEventRepository } from "../src/storage.js";
 
 class FakeDb {
@@ -14,6 +14,13 @@ class FakeDb {
   async query(sql: string, params: readonly unknown[] = []) {
     this.calls.push({ sql, params });
     return { rows: [], rowCount: this.rowCounts[this.calls.length - 1] ?? 0 };
+  }
+}
+
+class FailingDb extends FakeDb {
+  async query(sql: string, params: readonly unknown[] = []): Promise<{ rows: never[]; rowCount: number }> {
+    this.calls.push({ sql, params });
+    throw { code: "23505", constraint: "waitlist_active_traveler_intent_unique" };
   }
 }
 
@@ -31,6 +38,23 @@ function persistedEntry(version: number): WaitlistEntry {
   entry.cancel();
   return entry;
 }
+
+test("PostgresWaitlistRepository.add translates active duplicate unique violation to conflict", async () => {
+  const repository = new PostgresWaitlistRepository(new FailingDb() as never);
+  const entry = WaitlistEntry.create({
+    accountId: "acc-1",
+    travelerRefs: ["tvl-1"],
+    segmentRef: "seg-1",
+    departureDate: "2026-07-20",
+    seatClass: "SECOND",
+    intentFingerprint: "intent-1",
+    paymentGuaranteeRef: "pay-auth-1",
+    itineraryRef: "itn-1",
+    priority: { groupSize: 1, fareClass: "SECOND" },
+  });
+
+  await assert.rejects(repository.add(entry), (error) => error instanceof DomainError && error.code === "CONFLICT");
+});
 
 test("PostgresWaitlistRepository.save uses loaded version in OCC predicate", async () => {
   const db = new FakeDb([1, 0]);
@@ -70,4 +94,14 @@ test("processed_events primary key change is applied by a follow-up migration", 
   assert.match(migration, /DROP CONSTRAINT IF EXISTS processed_events_pkey/u);
   assert.match(migration, /DROP NOT NULL/u);
   assert.match(migration, /ADD PRIMARY KEY \(event_id\)/u);
+});
+
+test("active traveler-intent uniqueness is enforced by migration", async () => {
+  const migrationsDir = join(process.cwd(), "migrations");
+  const migration = await readFile(join(migrationsDir, "003_active_traveler_intent_unique.sql"), "utf8");
+
+  assert.match(migration, /CREATE UNIQUE INDEX IF NOT EXISTS waitlist_active_traveler_intent_unique/u);
+  assert.match(migration, /traveler_refs->>0/u);
+  assert.match(migration, /data->>'intentFingerprint'/u);
+  assert.match(migration, /status IN \('DRAFT', 'QUEUED', 'MATCHING', 'SUSPENDED'\)/u);
 });


### PR DESCRIPTION
## Summary
- translate duplicate active waitlist requests into documented CONFLICT responses
- require HTTP create fields and cancel.reason per waitlist contract
- add active traveler/intent unique index migration and focused tests

## Validation
- cd services/waitlist && npm run build
- cd services/waitlist && npm test