### PR TITLE
REQ-343 waitlist API error conformance

### DIFF
--- a/services/waitlist/migrations/003_active_request_unique.sql
+++ b/services/waitlist/migrations/003_active_request_unique.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX IF NOT EXISTS waitlist_active_request_unique_idx
+    ON waitlist_entries ((traveler_refs->>0), (data->>'intentFingerprint'))
+    WHERE status IN ('DRAFT', 'QUEUED', 'MATCHING', 'SUSPENDED');

--- a/services/waitlist/src/app.ts
+++ b/services/waitlist/src/app.ts
@@ -101,8 +101,7 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   app.setErrorHandler((error, request, reply) => {
     const ctx = requestContext(request);
     if (error instanceof DomainError) {
-      const status = error.code === "NOT_FOUND" ? 404 : error.code === "PRECONDITION_FAILED" || error.code === "INVALID_TRANSITION" ? 409 : 400;
-      sendError(reply, status, error.code, error.message, ctx, { domainCode: error.code });
+      sendError(reply, statusForDomainError(error), error.code, error.message, ctx, { domainCode: error.code });
       return;
     }
     sendError(reply, 500, "INTERNAL_ERROR", errorMessage(error), ctx);
@@ -133,10 +132,17 @@ async function handleRead(reply: FastifyReply, request: FastifyRequest, operatio
   try { return reply.status(200).send(await operation()); }
   catch (error) {
     const ctx = requestContext(request);
-    if (error instanceof DomainError) sendError(reply, error.code === "NOT_FOUND" ? 404 : 409, error.code, error.message, ctx, { domainCode: error.code });
+    if (error instanceof DomainError) sendError(reply, statusForDomainError(error), error.code, error.message, ctx, { domainCode: error.code });
     else throw error;
     return reply;
   }
+}
+
+function statusForDomainError(error: DomainError): number {
+  if (error.code === "NOT_FOUND") return 404;
+  if (error.code === "PRECONDITION_FAILED") return 412;
+  if (error.code === "INVALID_TRANSITION" || error.code === "CONFLICT") return 409;
+  return 400;
 }
 
 function requestContext(request: FastifyRequest): RequestContext { return kitRequestContext({ headers: request.headers, id: request.id }); }

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -4,10 +4,10 @@ import { HttpCapacityAvailabilityClient, HttpFarePricingClient, HttpOfferManagem
 import { publishAll, waitlistCancelled, waitlistFulfilled, waitlistPaymentAuthorizationRequested, waitlistQueued, waitlistRequestCreated } from "./publisher.js";
 
 export type JoinWaitlistRequest = Readonly<{
-  accountId: string;
+  accountId?: string;
   travelerRefs?: readonly string[];
   travelerRef?: string;
-  segmentRef: string;
+  segmentRef?: string;
   departureDate?: string;
   seatClass?: FareClass;
   travelClass?: FareClass;
@@ -80,6 +80,9 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   private readonly entries = new Map<string, WaitlistEntry>();
 
   async add(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
+    if (this.hasActiveDuplicate(entry)) {
+      throw new DomainError("CONFLICT", "An active waitlist request already exists for this traveler and intent");
+    }
     this.entries.set(entry.entryId, entry);
     entry.markPersisted(1);
     return this.snapshot(entry);
@@ -133,6 +136,14 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   private position(entry: WaitlistEntry): number {
     return this.buildQueue(entry.segmentRef, entry.departureDate, entry.seatClass).positionOf(entry.entryId);
   }
+
+  private hasActiveDuplicate(entry: WaitlistEntry): boolean {
+    const travelerRef = entry.travelerRefs[0] ?? "";
+    return [...this.entries.values()].some((candidate) => candidate.entryId !== entry.entryId
+      && activeStatuses.has(candidate.status)
+      && candidate.travelerRefs[0] === travelerRef
+      && candidate.intentFingerprint === entry.intentFingerprint);
+  }
 }
 
 export class WaitlistApplicationService {
@@ -150,7 +161,7 @@ export class WaitlistApplicationService {
     this.promotion = new PromotionOrchestrator(repository, farePricing, capacityAvailability, publisher ?? { publish: async () => undefined }, offerManagement, now);
   }
 
-  async join(request: JoinWaitlistRequest, correlationId?: string): Promise<WaitlistRequestResource> {
+  async join(request: JoinWaitlistRequest | null | undefined, correlationId?: string): Promise<WaitlistRequestResource> {
     const entry = WaitlistEntry.create(this.toCreateCommand(request));
     const snapshot = await this.repository.add(entry);
     const aggregateVersion = entry.loadedVersion;
@@ -170,17 +181,24 @@ export class WaitlistApplicationService {
   }
 
   async listByTraveler(travelerRef: string, status?: WaitlistEntrySnapshot["status"], limit = 20, offset = 0): Promise<WaitlistRequestList> {
+    assertRequiredString(travelerRef, "travelerRef");
     const snapshots = (await this.repository.listByTraveler(travelerRef)).filter((entry) => !status || entry.status === status);
     const page = snapshots.slice(offset, offset + limit);
     return { items: page.map(toWaitlistRequestResource), total: snapshots.length, limit, offset };
   }
 
   async cancel(entryId: string, request: CancelWaitlistRequest = {}, correlationId?: string): Promise<{ waitlistRequestId: string; status: "CANCELLED"; cancelledAt: string }> {
+    const reason = assertRequiredString(request.reason, "reason");
     const entry = await this.requireEntry(entryId);
     const cancelledAt = this.now().toISOString();
-    entry.cancel();
+    try {
+      entry.cancel();
+    } catch (error) {
+      if (error instanceof DomainError && error.code === "INVALID_TRANSITION") throw new DomainError("PRECONDITION_FAILED", error.message);
+      throw error;
+    }
     const snapshot = await this.repository.save(entry);
-    if (this.publisher) await publishAll(this.publisher, [waitlistCancelled(snapshot, entry.loadedVersion, request.reason ?? "", correlationId, cancelledAt)]);
+    if (this.publisher) await publishAll(this.publisher, [waitlistCancelled(snapshot, entry.loadedVersion, reason, correlationId, cancelledAt)]);
     return { waitlistRequestId: snapshot.entryId, status: "CANCELLED", cancelledAt };
   }
 
@@ -229,27 +247,29 @@ export class WaitlistApplicationService {
     return this.promotion.expireDueOffers(correlationId);
   }
 
-  private toCreateCommand(request: JoinWaitlistRequest): CreateWaitlistEntry {
-    const travelerRefs = request.travelerRefs ?? (request.travelerRef ? [request.travelerRef] : []);
-    const seatClass = request.seatClass ?? request.travelClass ?? "SECOND";
-    const departureDate = request.departureDate ?? dateFromDeadline(request.deadline);
+  private toCreateCommand(request: JoinWaitlistRequest | null | undefined): CreateWaitlistEntry {
+    const payload = request ?? {};
+    const travelerRef = assertRequiredString(payload.travelerRef, "travelerRef");
+    const deadline = assertRequiredString(payload.deadline, "deadline");
+    const departureDate = payload.departureDate ?? dateFromDeadline(deadline);
+    const seatClass = payload.seatClass ?? payload.travelClass ?? "SECOND";
     return {
-      accountId: request.accountId,
-      travelerRefs,
-      segmentRef: request.segmentRef,
+      accountId: assertRequiredString(payload.accountId, "accountId"),
+      travelerRefs: [travelerRef],
+      segmentRef: assertRequiredString(payload.segmentRef, "segmentRef"),
       departureDate,
       seatClass,
-      itineraryRef: request.itineraryRef ?? request.segmentRef,
-      deadline: request.deadline,
-      paymentGuaranteeRef: request.paymentGuaranteeRef,
-      intentFingerprint: request.intentFingerprint,
+      itineraryRef: assertRequiredString(payload.itineraryRef, "itineraryRef"),
+      deadline,
+      paymentGuaranteeRef: assertRequiredString(payload.paymentGuaranteeRef, "paymentGuaranteeRef"),
+      intentFingerprint: assertRequiredString(payload.intentFingerprint, "intentFingerprint"),
       priority: {
-        loyaltyTier: request.loyaltyTier ?? "NONE",
-        tripCount: request.tripCount ?? 0,
-        daysBefore: request.daysBefore ?? daysBefore(departureDate),
-        groupSize: travelerRefs.length,
+        loyaltyTier: payload.loyaltyTier ?? "NONE",
+        tripCount: payload.tripCount ?? 0,
+        daysBefore: payload.daysBefore ?? daysBefore(departureDate),
+        groupSize: 1,
         fareClass: seatClass,
-        specialStatus: request.specialStatus ?? "NONE",
+        specialStatus: payload.specialStatus ?? "NONE",
       },
     };
   }
@@ -265,6 +285,8 @@ export class WaitlistApplicationService {
     return queue.find((candidate) => candidate.entryId === entry.entryId) ?? entry.toSnapshot(0);
   }
 }
+
+const activeStatuses = new Set<WaitlistEntrySnapshot["status"]>(["DRAFT", "QUEUED", "MATCHING", "SUSPENDED"]);
 
 function toWaitlistRequestResource(snapshot: WaitlistEntrySnapshot): WaitlistRequestResource {
   return {
@@ -288,7 +310,11 @@ function daysBefore(departureDate: string): number {
   return Math.max(0, Math.ceil((departure - Date.now()) / (24 * 60 * 60 * 1000)));
 }
 
-function dateFromDeadline(deadline?: string): string {
-  if (!deadline) return new Date().toISOString().slice(0, 10);
+function dateFromDeadline(deadline: string): string {
   return deadline.slice(0, 10);
+}
+
+function assertRequiredString(value: string | undefined, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) throw new DomainError("VALIDATION_FAILED", `${field} is required`);
+  return value;
 }

--- a/services/waitlist/src/domain.ts
+++ b/services/waitlist/src/domain.ts
@@ -52,15 +52,15 @@ export type CreateWaitlistEntry = Readonly<{
   departureDate: string;
   seatClass: FareClass;
   priority: Omit<PriorityInput, "groupSize" | "fareClass"> & Partial<Pick<PriorityInput, "groupSize" | "fareClass">>;
-  itineraryRef?: string;
-  deadline?: string;
-  paymentGuaranteeRef?: string;
-  intentFingerprint?: string;
+  itineraryRef: string;
+  deadline: string;
+  paymentGuaranteeRef: string;
+  intentFingerprint: string;
   createdAt?: Date;
 }>;
 
 export class DomainError extends Error {
-  constructor(public readonly code: "VALIDATION_FAILED" | "INVALID_TRANSITION" | "NOT_FOUND" | "PRECONDITION_FAILED", message: string) {
+  constructor(public readonly code: "VALIDATION_FAILED" | "INVALID_TRANSITION" | "NOT_FOUND" | "PRECONDITION_FAILED" | "CONFLICT", message: string) {
     super(message);
     this.name = "DomainError";
   }
@@ -99,9 +99,14 @@ export class WaitlistEntry {
 
   static create(command: CreateWaitlistEntry): WaitlistEntry {
     assertNonEmpty(command.accountId, "accountId");
-    if (command.travelerRefs.length === 0) throw new DomainError("VALIDATION_FAILED", "travelerRefs must contain at least one traveler");
+    if (command.travelerRefs.length === 0) throw new DomainError("VALIDATION_FAILED", "travelerRef is required");
+    assertNonEmpty(command.travelerRefs[0] ?? "", "travelerRef");
     assertNonEmpty(command.segmentRef, "segmentRef");
     assertNonEmpty(command.departureDate, "departureDate");
+    assertNonEmpty(command.itineraryRef, "itineraryRef");
+    assertNonEmpty(command.deadline, "deadline");
+    assertNonEmpty(command.paymentGuaranteeRef, "paymentGuaranteeRef");
+    assertNonEmpty(command.intentFingerprint, "intentFingerprint");
     const groupSize = command.priority.groupSize ?? command.travelerRefs.length;
     const fareClass = command.priority.fareClass ?? command.seatClass;
     const priorityScore = PriorityCalculator.calculate({ ...command.priority, groupSize, fareClass });
@@ -121,10 +126,10 @@ export class WaitlistEntry {
       undefined,
       undefined,
       undefined,
-      command.itineraryRef ?? command.segmentRef,
-      command.deadline ?? deadlineFromDepartureDate(command.departureDate),
-      command.paymentGuaranteeRef ?? `pay-auth-${uuidV7()}`,
-      command.intentFingerprint ?? defaultIntentFingerprint(command.travelerRefs[0] ?? "unknown", command.segmentRef, command.departureDate, command.seatClass),
+      command.itineraryRef,
+      command.deadline,
+      command.paymentGuaranteeRef,
+      command.intentFingerprint,
     );
   }
 

--- a/services/waitlist/src/storage.ts
+++ b/services/waitlist/src/storage.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { Redis } from "ioredis";
 import { MigrationRunner, OptimisticConcurrencyConflict, OutboxAppender, OutboxRelay, PostgresIdempotencyStore, checkPostgresReadiness, createPostgresPool, streamForProducer, withTransaction, type EventEnvelope } from "@trainticket/ts-kit";
 import type { Pool, PoolClient, QueryResult } from "pg";
-import { WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
+import { DomainError, WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
 import type { WaitlistRepository } from "./promotion.js";
 
 export class PostgresWaitlistRepository implements WaitlistRepository {
@@ -11,11 +11,16 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
 
   async add(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     const snapshot = entry.toSnapshot(0);
-    await this.db.query(
-      `INSERT INTO waitlist_entries (entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, priority_score, status, offered_at, offer_expires_at, fare_quote_id, capacity_hold_id, data, created_at)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
-      [snapshot.entryId, snapshot.accountId, JSON.stringify(snapshot.travelerRefs), snapshot.segmentRef, snapshot.departureDate, snapshot.seatClass, snapshot.priorityScore, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot, snapshot.createdAt],
-    );
+    try {
+      await this.db.query(
+        `INSERT INTO waitlist_entries (entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, priority_score, status, offered_at, offer_expires_at, fare_quote_id, capacity_hold_id, data, created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+        [snapshot.entryId, snapshot.accountId, JSON.stringify(snapshot.travelerRefs), snapshot.segmentRef, snapshot.departureDate, snapshot.seatClass, snapshot.priorityScore, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot, snapshot.createdAt],
+      );
+    } catch (error) {
+      if (isActiveRequestUniqueViolation(error)) throw activeDuplicateConflict();
+      throw error;
+    }
     entry.markPersisted(1);
     return this.snapshot(entry);
   }
@@ -186,6 +191,12 @@ function defaultIntentFingerprint(travelerRefs: unknown, segmentRef: string, dep
   const travelerRef = Array.isArray(travelerRefs) ? String(travelerRefs[0] ?? "unknown") : "unknown";
   return `${travelerRef}:${segmentRef}:${departureDate}:${seatClass}`;
 }
+function isActiveRequestUniqueViolation(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const pgError = error as { code?: unknown; constraint?: unknown };
+  return pgError.code === "23505" && pgError.constraint === "waitlist_active_request_unique_idx";
+}
+function activeDuplicateConflict(): DomainError { return new DomainError("CONFLICT", "An active waitlist request already exists for this traveler and intent"); }
 function sanitizedErrorForLog(error: unknown): Readonly<{ name: string; message: string }> { return error instanceof Error ? { name: error.name || "Error", message: error.message || "Storage failed" } : { name: typeof error, message: "Storage failed" }; }
 
 type WaitlistRow = Readonly<{

--- a/services/waitlist/tests/app.test.ts
+++ b/services/waitlist/tests/app.test.ts
@@ -2,6 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createApp, resetWaitlistStore } from "../src/app.js";
 
+const IDEMPOTENCY_KEY_ONE = "0194f2e0-7b3e-7610-8284-5c26e8b0c123";
+const IDEMPOTENCY_KEY_TWO = "0194f2e0-7b3e-7610-8284-5c26e8b0c124";
+const IDEMPOTENCY_KEY_THREE = "0194f2e0-7b3e-7610-8284-5c26e8b0c125";
+const IDEMPOTENCY_KEY_FOUR = "0194f2e0-7b3e-7610-8284-5c26e8b0c126";
+
 test("health endpoint returns 200", async () => {
   const app = createApp();
   const response = await app.inject({ method: "GET", url: "/health" });
@@ -16,7 +21,7 @@ test("waitlist request endpoints return contract resource shape", async () => {
   const create = await app.inject({
     method: "POST",
     url: "/api/v1/waitlist-requests",
-    headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c123" },
+    headers: { "Idempotency-Key": IDEMPOTENCY_KEY_ONE },
     payload: {
       accountId: "acc-1",
       travelerRef: "tvl-1",
@@ -52,6 +57,150 @@ test("waitlist request endpoints return contract resource shape", async () => {
   const list = await app.inject({ method: "GET", url: "/api/v1/waitlist-requests?travelerRef=tvl-1" });
   assert.equal(list.statusCode, 200);
   assert.equal(list.json().items[0].waitlistRequestId, resource.waitlistRequestId);
+
+  await app.close();
+});
+
+test("create rejects a missing request body", async () => {
+  resetWaitlistStore();
+  const app = createApp();
+  const response = await app.inject({
+    method: "POST",
+    url: "/api/v1/waitlist-requests",
+    headers: { "Idempotency-Key": IDEMPOTENCY_KEY_ONE },
+  });
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.json().code, "VALIDATION_FAILED");
+  assert.equal(response.json().details.domainCode, "VALIDATION_FAILED");
+  assert.match(response.json().message, /travelerRef is required/u);
+
+  await app.close();
+});
+
+test("create rejects missing singular travelerRef even when legacy travelerRefs is present", async () => {
+  resetWaitlistStore();
+  const app = createApp();
+  const response = await app.inject({
+    method: "POST",
+    url: "/api/v1/waitlist-requests",
+    headers: { "Idempotency-Key": IDEMPOTENCY_KEY_ONE },
+    payload: {
+      accountId: "acc-1",
+      travelerRefs: ["tvl-legacy"],
+      segmentRef: "seg-1",
+      deadline: "2026-07-20T00:00:00.000Z",
+      paymentGuaranteeRef: "pay-auth-1",
+      itineraryRef: "itn-1",
+      intentFingerprint: "intent-1",
+    },
+  });
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.json().code, "VALIDATION_FAILED");
+  assert.equal(response.json().details.domainCode, "VALIDATION_FAILED");
+  assert.match(response.json().message, /travelerRef is required/u);
+
+  await app.close();
+});
+
+test("create rejects other missing contract-required fields", async () => {
+  resetWaitlistStore();
+  const app = createApp();
+  const requiredFields = ["deadline", "paymentGuaranteeRef", "itineraryRef", "intentFingerprint"] as const;
+
+  for (const [index, field] of requiredFields.entries()) {
+    const payload = {
+      accountId: "acc-1",
+      travelerRef: "tvl-1",
+      segmentRef: "seg-1",
+      deadline: "2026-07-20T00:00:00.000Z",
+      paymentGuaranteeRef: "pay-auth-1",
+      itineraryRef: "itn-1",
+      intentFingerprint: "intent-1",
+    };
+    delete payload[field];
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/waitlist-requests",
+      headers: { "Idempotency-Key": `0194f2e0-7b3e-7610-8284-5c26e8b0c13${index}` },
+      payload,
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.json().code, "VALIDATION_FAILED");
+    assert.match(response.json().message, new RegExp(`${field} is required`, "u"));
+  }
+
+  await app.close();
+});
+
+test("duplicate active traveler intent returns conflict", async () => {
+  resetWaitlistStore();
+  const app = createApp();
+  const payload = {
+    accountId: "acc-1",
+    travelerRef: "tvl-1",
+    segmentRef: "seg-1",
+    travelClass: "SECOND",
+    deadline: "2026-07-20T00:00:00.000Z",
+    paymentGuaranteeRef: "pay-auth-1",
+    itineraryRef: "itn-1",
+    intentFingerprint: "intent-1",
+  };
+
+  const create = await app.inject({ method: "POST", url: "/api/v1/waitlist-requests", headers: { "Idempotency-Key": IDEMPOTENCY_KEY_ONE }, payload });
+  assert.equal(create.statusCode, 201);
+  const duplicate = await app.inject({ method: "POST", url: "/api/v1/waitlist-requests", headers: { "Idempotency-Key": IDEMPOTENCY_KEY_TWO }, payload: { ...payload, paymentGuaranteeRef: "pay-auth-2" } });
+
+  assert.equal(duplicate.statusCode, 409);
+  assert.equal(duplicate.json().code, "CONFLICT");
+  assert.equal(duplicate.json().details.domainCode, "CONFLICT");
+
+  await app.close();
+});
+
+test("cancel rejects missing or empty reason", async () => {
+  resetWaitlistStore();
+  const app = createApp();
+  const create = await app.inject({
+    method: "POST",
+    url: "/api/v1/waitlist-requests",
+    headers: { "Idempotency-Key": IDEMPOTENCY_KEY_ONE },
+    payload: {
+      accountId: "acc-1",
+      travelerRef: "tvl-1",
+      segmentRef: "seg-1",
+      travelClass: "SECOND",
+      deadline: "2026-07-20T00:00:00.000Z",
+      paymentGuaranteeRef: "pay-auth-1",
+      itineraryRef: "itn-1",
+      intentFingerprint: "intent-1",
+    },
+  });
+  const waitlistRequestId = create.json().waitlistRequestId;
+
+  for (const [index, payload] of [{}, { reason: "   " }].entries()) {
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/waitlist-requests/${waitlistRequestId}/cancel`,
+      headers: { "Idempotency-Key": index === 0 ? IDEMPOTENCY_KEY_THREE : IDEMPOTENCY_KEY_FOUR },
+      payload,
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.json().code, "VALIDATION_FAILED");
+    assert.match(response.json().message, /reason is required/u);
+  }
+
+  const cancelled = await app.inject({
+    method: "POST",
+    url: `/api/v1/waitlist-requests/${waitlistRequestId}/cancel`,
+    headers: { "Idempotency-Key": IDEMPOTENCY_KEY_TWO },
+    payload: { reason: "USER_REQUESTED" },
+  });
+  assert.equal(cancelled.statusCode, 200);
+  assert.equal(cancelled.json().status, "CANCELLED");
 
   await app.close();
 });

--- a/services/waitlist/tests/domain.test.ts
+++ b/services/waitlist/tests/domain.test.ts
@@ -11,16 +11,16 @@ test("platinum member scores higher than non-member", () => {
 });
 
 test("queue orders by priority descending then createdAt ascending", () => {
-  const older = WaitlistEntry.create({ entryId: "wl-old", accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "GOLD", tripCount: 10, daysBefore: 10 }, createdAt: new Date("2026-01-01T00:00:00.000Z") });
-  const newer = WaitlistEntry.create({ entryId: "wl-new", accountId: "acc", travelerRefs: ["t2"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "GOLD", tripCount: 10, daysBefore: 10 }, createdAt: new Date("2026-01-01T00:01:00.000Z") });
-  const platinum = WaitlistEntry.create({ entryId: "wl-vip", accountId: "acc", travelerRefs: ["t3"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "PLATINUM", tripCount: 10, daysBefore: 10 }, createdAt: new Date("2026-01-01T00:02:00.000Z") });
+  const older = WaitlistEntry.create({ entryId: "wl-old", accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "GOLD", tripCount: 10, daysBefore: 10 }, itineraryRef: "itn-1", deadline: "2026-07-20T00:00:00.000Z", paymentGuaranteeRef: "pay-auth-1", intentFingerprint: "intent-1", createdAt: new Date("2026-01-01T00:00:00.000Z") });
+  const newer = WaitlistEntry.create({ entryId: "wl-new", accountId: "acc", travelerRefs: ["t2"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "GOLD", tripCount: 10, daysBefore: 10 }, itineraryRef: "itn-2", deadline: "2026-07-20T00:00:00.000Z", paymentGuaranteeRef: "pay-auth-2", intentFingerprint: "intent-2", createdAt: new Date("2026-01-01T00:01:00.000Z") });
+  const platinum = WaitlistEntry.create({ entryId: "wl-vip", accountId: "acc", travelerRefs: ["t3"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "PLATINUM", tripCount: 10, daysBefore: 10 }, itineraryRef: "itn-3", deadline: "2026-07-20T00:00:00.000Z", paymentGuaranteeRef: "pay-auth-3", intentFingerprint: "intent-3", createdAt: new Date("2026-01-01T00:02:00.000Z") });
   const queue = new WaitlistQueue("seg", "2026-07-20", "SECOND", [newer, older, platinum]);
   assert.deepEqual(queue.queuedEntries().map((entry) => entry.entryId), ["wl-vip", "wl-old", "wl-new"]);
   assert.equal(queue.positionOf("wl-old"), 2);
 });
 
 test("matching entries return to queue instead of cancelling directly", () => {
-  const entry = WaitlistEntry.create({ entryId: "wl-match", accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "GOLD", tripCount: 10, daysBefore: 10 }, createdAt: new Date("2026-01-01T00:00:00.000Z") });
+  const entry = WaitlistEntry.create({ entryId: "wl-match", accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "GOLD", tripCount: 10, daysBefore: 10 }, itineraryRef: "itn-1", deadline: "2026-07-20T00:00:00.000Z", paymentGuaranteeRef: "pay-auth-1", intentFingerprint: "intent-1", createdAt: new Date("2026-01-01T00:00:00.000Z") });
   entry.offer("offer-1", 1, "fare-1", "hold-1", new Date("2026-01-01T00:00:00.000Z"), new Date("2026-01-01T00:15:00.000Z"));
 
   assert.throws(() => entry.cancel(), DomainError);

--- a/services/waitlist/tests/http-clients.test.ts
+++ b/services/waitlist/tests/http-clients.test.ts
@@ -5,7 +5,7 @@ import { HttpCapacityAvailabilityClient, HttpFarePricingClient, HttpOfferManagem
 import { WaitlistEntry } from "../src/domain.js";
 
 function promotedEntry() {
-  const entry = WaitlistEntry.create({ entryId: "wl-contract", accountId: "acc", travelerRefs: ["tvl-1", "tvl-2"], segmentRef: "seg-1", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "PLATINUM", tripCount: 1 }, itineraryRef: "itn-1", createdAt: new Date("2026-01-01T00:00:00.000Z") });
+  const entry = WaitlistEntry.create({ entryId: "wl-contract", accountId: "acc", travelerRefs: ["tvl-1", "tvl-2"], segmentRef: "seg-1", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "PLATINUM", tripCount: 1 }, itineraryRef: "itn-1", deadline: "2026-07-20T00:00:00.000Z", paymentGuaranteeRef: "pay-auth-1", intentFingerprint: "intent-1", createdAt: new Date("2026-01-01T00:00:00.000Z") });
   entry.offer("off-1", 1, "fq-1", "hold-1", new Date("2026-01-01T00:00:00.000Z"), new Date("2026-01-01T00:15:00.000Z"));
   return entry;
 }

--- a/services/waitlist/tests/promotion.test.ts
+++ b/services/waitlist/tests/promotion.test.ts
@@ -33,8 +33,8 @@ test("WaitlistCapacityFreed promotes highest-priority queued entry", async () =>
   const fare = new StubFarePricing();
   const capacity = new StubCapacity();
   const service = new WaitlistApplicationService(repository, publisher, fare, capacity, new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
-  const regular = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "NONE", tripCount: 0, daysBefore: 20 });
-  const platinum = await service.join({ accountId: "acc", travelerRefs: ["t2"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
+  const regular = await service.join({ accountId: "acc", travelerRef: "t1", segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", deadline: "2026-07-20T00:00:00.000Z", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn-1", intentFingerprint: "intent-1", loyaltyTier: "NONE", tripCount: 0, daysBefore: 20 });
+  const platinum = await service.join({ accountId: "acc", travelerRef: "t2", segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", deadline: "2026-07-20T00:00:00.000Z", paymentGuaranteeRef: "pay-auth-2", itineraryRef: "itn-2", intentFingerprint: "intent-2", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
 
   const result = await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
 
@@ -53,7 +53,7 @@ test("expired matching attempt expires and waits for CapacityReleased before pro
   const publisher = new InMemoryEventPublisher();
   const capacity = new StubCapacity();
   const service = new WaitlistApplicationService(repository, publisher, new StubFarePricing(), capacity, new StubJourneyOrder(), () => current, new StubOfferManagement());
-  const first = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
+  const first = await service.join({ accountId: "acc", travelerRef: "t1", segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", deadline: "2026-07-20T00:00:00.000Z", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn-1", intentFingerprint: "intent-1", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
   await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
 
   current = new Date("2026-01-01T00:16:00.000Z");
@@ -69,7 +69,7 @@ test("expired matching attempt expires and waits for CapacityReleased before pro
 test("capacity freed without a CapacityReleased eventId is rejected before publishing a match fact", async () => {
   const publisher = new InMemoryEventPublisher();
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
-  await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
+  await service.join({ accountId: "acc", travelerRef: "t1", segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", deadline: "2026-07-20T00:00:00.000Z", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn-1", intentFingerprint: "intent-1", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
 
   await assert.rejects(
     () => service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: "" }),
@@ -82,7 +82,7 @@ test("capacity freed without a CapacityReleased eventId is rejected before publi
 test("accept promotion creates journey order and records order ref", async () => {
   const publisher = new InMemoryEventPublisher();
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
-  const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
+  const entry = await service.join({ accountId: "acc", travelerRef: "t1", segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", deadline: "2026-07-20T00:00:00.000Z", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn-1", intentFingerprint: "intent-1", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
   await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
   const order = await service.accept(entry.waitlistRequestId, { paymentMethodRef: "pm-1" });
   assert.equal(order.orderId, `ord-${entry.waitlistRequestId}`);
@@ -95,7 +95,7 @@ test("accept does not mutate entry when journey order creation fails", async () 
     async createOrder(): Promise<never> { throw new Error("downstream unavailable"); }
   }
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), new InMemoryEventPublisher(), new StubFarePricing(), new StubCapacity(), new FailingJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
-  const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
+  const entry = await service.join({ accountId: "acc", travelerRef: "t1", segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", deadline: "2026-07-20T00:00:00.000Z", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn-1", intentFingerprint: "intent-1", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
   await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
 
   await assert.rejects(() => service.accept(entry.waitlistRequestId), /downstream unavailable/);

--- a/services/waitlist/tests/publisher.test.ts
+++ b/services/waitlist/tests/publisher.test.ts
@@ -84,7 +84,7 @@ test("join publishes waitlist contract facts with deterministic ids and fields",
 test("cancel publishes WaitlistCancelled with supplied reason without defaulting API input", async () => {
   const publisher = new InMemoryEventPublisher();
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, undefined, undefined, undefined, () => new Date("2026-01-01T00:00:00.000Z"));
-  const resource = await service.join({ accountId: "acc", travelerRef: "tvl", segmentRef: "seg", departureDate: "2026-07-20", travelClass: "SECOND", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn", intentFingerprint: "intent" });
+  const resource = await service.join({ accountId: "acc", travelerRef: "tvl", segmentRef: "seg", departureDate: "2026-07-20", travelClass: "SECOND", deadline: "2026-07-20T00:00:00.000Z", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn", intentFingerprint: "intent" });
 
   await service.cancel(resource.waitlistRequestId, { reason: "USER_REQUESTED" });
 
@@ -97,7 +97,7 @@ test("cancel publishes WaitlistCancelled with supplied reason without defaulting
 test("journey order cancellation requeue publishes WaitlistQueued with journeyOrderRef", async () => {
   const publisher = new InMemoryEventPublisher();
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
-  const entry = await service.join({ accountId: "acc", travelerRef: "tvl", segmentRef: "seg", departureDate: "2026-07-20", travelClass: "SECOND", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn", intentFingerprint: "intent" });
+  const entry = await service.join({ accountId: "acc", travelerRef: "tvl", segmentRef: "seg", departureDate: "2026-07-20", travelClass: "SECOND", deadline: "2026-07-20T00:00:00.000Z", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn", intentFingerprint: "intent" });
   await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c123" });
   await service.accept(entry.waitlistRequestId);
   const matching = await service.get(entry.waitlistRequestId);

--- a/services/waitlist/tests/storage.test.ts
+++ b/services/waitlist/tests/storage.test.ts
@@ -3,17 +3,19 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
 import { OptimisticConcurrencyConflict } from "@trainticket/ts-kit";
-import { WaitlistEntry } from "../src/domain.js";
+import { DomainError, WaitlistEntry } from "../src/domain.js";
 import { PostgresWaitlistRepository, ProcessedEventRepository } from "../src/storage.js";
 
 class FakeDb {
   public readonly calls: Array<{ sql: string; params: readonly unknown[] }> = [];
 
-  constructor(private readonly rowCounts: readonly number[] = []) {}
+  constructor(private readonly rowCounts: readonly number[] = [], private readonly errors: Readonly<Record<number, unknown>> = {}) {}
 
   async query(sql: string, params: readonly unknown[] = []) {
     this.calls.push({ sql, params });
-    return { rows: [], rowCount: this.rowCounts[this.calls.length - 1] ?? 0 };
+    const callNumber = this.calls.length;
+    if (this.errors[callNumber]) throw this.errors[callNumber];
+    return { rows: [], rowCount: this.rowCounts[callNumber - 1] ?? 0 };
   }
 }
 
@@ -25,6 +27,10 @@ function persistedEntry(version: number): WaitlistEntry {
     departureDate: "2026-07-20",
     seatClass: "SECOND",
     priority: { groupSize: 1, fareClass: "SECOND" },
+    itineraryRef: "itn-1",
+    deadline: "2026-07-20T00:00:00.000Z",
+    paymentGuaranteeRef: "pay-auth-1",
+    intentFingerprint: "intent-1",
     createdAt: new Date("2026-01-01T00:00:00.000Z"),
   });
   entry.markPersisted(version);
@@ -50,6 +56,24 @@ test("PostgresWaitlistRepository.save rejects stale loaded version", async () =>
   const repository = new PostgresWaitlistRepository(db as never);
 
   await assert.rejects(() => repository.save(persistedEntry(2)), OptimisticConcurrencyConflict);
+});
+
+test("PostgresWaitlistRepository.add translates duplicate active unique violations to conflict", async () => {
+  const db = new FakeDb([], { 1: { code: "23505", constraint: "waitlist_active_request_unique_idx" } });
+  const repository = new PostgresWaitlistRepository(db as never);
+
+  await assert.rejects(() => repository.add(WaitlistEntry.create({
+    accountId: "acc-1",
+    travelerRefs: ["tvl-1"],
+    segmentRef: "seg-1",
+    departureDate: "2026-07-20",
+    seatClass: "SECOND",
+    priority: { groupSize: 1, fareClass: "SECOND" },
+    itineraryRef: "itn-1",
+    deadline: "2026-07-20T00:00:00.000Z",
+    paymentGuaranteeRef: "pay-auth-1",
+    intentFingerprint: "intent-1",
+  })), (error: unknown) => error instanceof DomainError && error.code === "CONFLICT");
 });
 
 test("ProcessedEventRepository records by event_id primary key only", async () => {


### PR DESCRIPTION
## Summary
- enforce waitlist create/cancel contract-required fields and reject legacy plural traveler fallback for create
- translate active duplicate traveler/intent unique violations into CONFLICT responses
- add active-request unique migration and API/storage tests for error conformance

## Validation
- npm --prefix services/waitlist test
- npm --prefix services/waitlist run build