### PR TITLE
REQ-351 preserve optional walking edge weights

### DIFF
--- a/docs/08-contracts/api/place-network.md
+++ b/docs/08-contracts/api/place-network.md
@@ -56,7 +56,7 @@ Registers a new geographic place.
 | `code` | string | Short code, if set. |
 | `timezone` | string | IANA timezone, if set. |
 | `status` | enum | Current status. |
-| `nodes` | array | List of associated transport nodes using the TransportNode shape below, including optional access-time weights when configured. |
+| `nodes` | array | List of associated transport nodes using a summary shape (`nodeId`, `displayName`, `servingModes`, and optional access-time weights when configured); use Get Transport Node for full TransportNode details. |
 
 **Error codes:** `NOT_FOUND`
 

--- a/services/place-network/internal/adapters/postgres/snapshots.go
+++ b/services/place-network/internal/adapters/postgres/snapshots.go
@@ -25,7 +25,7 @@ type placeSnapshot struct {
 
 type walkingEdgeSnapshot struct {
 	ToNodeID           string `json:"toNodeId"`
-	WalkingTimeMinutes int    `json:"walkingTimeMinutes"`
+	WalkingTimeMinutes *int   `json:"walkingTimeMinutes,omitempty"`
 }
 
 type nodeSnapshot struct {

--- a/services/place-network/internal/adapters/postgres/snapshots_test.go
+++ b/services/place-network/internal/adapters/postgres/snapshots_test.go
@@ -1,0 +1,52 @@
+package postgres
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/trainticket/greenfield/services/place-network/internal/domain"
+)
+
+func TestNodeSnapshotPreservesOmittedAndZeroWalkingTimeMinutes(t *testing.T) {
+	zero := 0
+	node, err := domain.NewTransportNode("node-sha-hongqiao", "place-sha-hongqiao", "Shanghai Hongqiao Railway Station", []domain.TransportMode{domain.TransportModeTrain})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	node.SetAccessWeights(nil, []domain.WalkingEdge{{ToNodeID: "node-fallback"}, {ToNodeID: "node-zero", WalkingTimeMinutes: &zero}})
+	node.MarkCreatedAt(time.Date(2026, 7, 5, 10, 30, 0, 0, time.UTC))
+
+	data, err := json.Marshal(nodeSnapshotFromDomain(node))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSnapshotWalkingTimePresence(t, data, []bool{false, true})
+
+	decoded, err := decodeNode(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.WalkingEdges) != 2 || decoded.WalkingEdges[0].WalkingTimeMinutes != nil || decoded.WalkingEdges[1].WalkingTimeMinutes == nil || *decoded.WalkingEdges[1].WalkingTimeMinutes != 0 {
+		t.Fatalf("unexpected decoded walking edges: %#v", decoded.WalkingEdges)
+	}
+}
+
+func assertSnapshotWalkingTimePresence(t *testing.T, data []byte, want []bool) {
+	t.Helper()
+	var snap struct {
+		WalkingEdges []map[string]json.RawMessage `json:"walkingEdges"`
+	}
+	if err := json.Unmarshal(data, &snap); err != nil {
+		t.Fatal(err)
+	}
+	if len(snap.WalkingEdges) != len(want) {
+		t.Fatalf("walking edge count mismatch: got %d want %d data=%s", len(snap.WalkingEdges), len(want), data)
+	}
+	for i, edge := range snap.WalkingEdges {
+		_, ok := edge["walkingTimeMinutes"]
+		if ok != want[i] {
+			t.Fatalf("walking edge %d walkingTimeMinutes presence mismatch: got %t want %t data=%s", i, ok, want[i], data)
+		}
+	}
+}

--- a/services/place-network/internal/application/service.go
+++ b/services/place-network/internal/application/service.go
@@ -105,7 +105,7 @@ func (s *Service) CreatePlace(ctx context.Context, req CreatePlaceRequest) (*Cre
 
 type WalkingEdgeResponse struct {
 	ToNodeID           string `json:"toNodeId"`
-	WalkingTimeMinutes int    `json:"walkingTimeMinutes"`
+	WalkingTimeMinutes *int   `json:"walkingTimeMinutes,omitempty"`
 }
 
 type NodeSummary struct {
@@ -194,7 +194,7 @@ func (s *Service) ListPlaces(ctx context.Context, req ListPlacesRequest) (*ListP
 
 type WalkingEdgeRequest struct {
 	ToNodeID           string
-	WalkingTimeMinutes int
+	WalkingTimeMinutes *int
 }
 
 type CreateTransportNodeRequest struct {

--- a/services/place-network/internal/domain/events.go
+++ b/services/place-network/internal/domain/events.go
@@ -25,7 +25,7 @@ type PlaceUpdatedEvent struct {
 
 type WalkingEdgePayload struct {
 	ToNodeID           TransportNodeID `json:"toNodeId"`
-	WalkingTimeMinutes int             `json:"walkingTimeMinutes"`
+	WalkingTimeMinutes *int            `json:"walkingTimeMinutes,omitempty"`
 }
 
 type TransportNodeUpdatedEvent struct {

--- a/services/place-network/internal/domain/master_data.go
+++ b/services/place-network/internal/domain/master_data.go
@@ -127,7 +127,7 @@ func (p Place) Validate() error {
 
 type WalkingEdge struct {
 	ToNodeID           TransportNodeID
-	WalkingTimeMinutes int
+	WalkingTimeMinutes *int
 }
 
 // TransportNode binds a transport-meaningful node to a canonical Place. Service
@@ -167,12 +167,20 @@ func (n *TransportNode) SetAccessWeights(accessTimeMinutes *int, walkingEdges []
 	}
 	n.WalkingEdges = make([]WalkingEdge, len(walkingEdges))
 	for i, edge := range walkingEdges {
-		n.WalkingEdges[i] = WalkingEdge{ToNodeID: TransportNodeID(strings.TrimSpace(string(edge.ToNodeID))), WalkingTimeMinutes: edge.WalkingTimeMinutes}
+		n.WalkingEdges[i] = WalkingEdge{ToNodeID: TransportNodeID(strings.TrimSpace(string(edge.ToNodeID))), WalkingTimeMinutes: copyOptionalInt(edge.WalkingTimeMinutes)}
 	}
 }
 
 func (n *TransportNode) MarkCreatedAt(createdAt time.Time) {
 	n.CreatedAt = createdAt.UTC()
+}
+
+func copyOptionalInt(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	copied := *value
+	return &copied
 }
 
 func (n TransportNode) Validate() error {
@@ -207,7 +215,7 @@ func (n TransportNode) Validate() error {
 		if toNodeID == "" {
 			return fmt.Errorf("walking edge toNodeId is required")
 		}
-		if edge.WalkingTimeMinutes < 0 {
+		if edge.WalkingTimeMinutes != nil && *edge.WalkingTimeMinutes < 0 {
 			return fmt.Errorf("walkingTimeMinutes must be non-negative")
 		}
 		if _, exists := seenEdges[toNodeID]; exists {

--- a/services/place-network/internal/domain/master_data_test.go
+++ b/services/place-network/internal/domain/master_data_test.go
@@ -31,6 +31,27 @@ func TestNewTransportNodeRequiresServingMode(t *testing.T) {
 	}
 }
 
+func TestTransportNodeWalkingTimeMinutesIsOptionalButNonNegative(t *testing.T) {
+	node, err := NewTransportNode("node-sha-hongqiao", "place-sha-hongqiao", "Shanghai Hongqiao Railway Station", []TransportMode{TransportModeTrain})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	zero := 0
+	node.SetAccessWeights(nil, []WalkingEdge{{ToNodeID: "node-fallback"}, {ToNodeID: "node-zero", WalkingTimeMinutes: &zero}})
+	if err := node.Validate(); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+	if node.WalkingEdges[0].WalkingTimeMinutes != nil || node.WalkingEdges[1].WalkingTimeMinutes == nil || *node.WalkingEdges[1].WalkingTimeMinutes != 0 {
+		t.Fatalf("unexpected walking edges: %#v", node.WalkingEdges)
+	}
+
+	negative := -1
+	node.SetAccessWeights(nil, []WalkingEdge{{ToNodeID: "node-negative", WalkingTimeMinutes: &negative}})
+	if err := node.Validate(); err == nil || !strings.Contains(err.Error(), "walkingTimeMinutes") {
+		t.Fatalf("expected walkingTimeMinutes validation error, got %v", err)
+	}
+}
+
 func TestProviderPlaceMappingStandardRequiresTargetAndConfidence(t *testing.T) {
 	validFrom := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
 	_, err := NewProviderPlaceMapping("cr", "rail-import", "AOH", "Shanghai Hongqiao", nil, ProviderMappingStandard, 0.95, validFrom, nil, "")

--- a/services/place-network/internal/http/handler.go
+++ b/services/place-network/internal/http/handler.go
@@ -94,7 +94,7 @@ func (h *Handler) CreateTransportNode(ctx *gin.Context) {
 		AccessTimeMinutes *int     `json:"accessTimeMinutes"`
 		WalkingEdges      []struct {
 			ToNodeID           string `json:"toNodeId" binding:"required"`
-			WalkingTimeMinutes int    `json:"walkingTimeMinutes"`
+			WalkingTimeMinutes *int   `json:"walkingTimeMinutes"`
 		} `json:"walkingEdges"`
 	}
 	if err := ctx.ShouldBindJSON(&req); err != nil {

--- a/services/place-network/internal/http/handler_test.go
+++ b/services/place-network/internal/http/handler_test.go
@@ -123,9 +123,51 @@ func TestGetTransportNodeHappyPath(t *testing.T) {
 	}
 	var resp application.GetTransportNodeResponse
 	decode(t, rec, &resp)
-	if resp.NodeID != created.NodeID || resp.PlaceID != place.PlaceID || resp.CreatedAt != "2026-07-05T10:30:00Z" || resp.AccessTimeMinutes == nil || *resp.AccessTimeMinutes != 7 || len(resp.WalkingEdges) != 1 || resp.WalkingEdges[0].ToNodeID != "tnd-next" || resp.WalkingEdges[0].WalkingTimeMinutes != 5 {
+	if resp.NodeID != created.NodeID || resp.PlaceID != place.PlaceID || resp.CreatedAt != "2026-07-05T10:30:00Z" || resp.AccessTimeMinutes == nil || *resp.AccessTimeMinutes != 7 || len(resp.WalkingEdges) != 1 || resp.WalkingEdges[0].ToNodeID != "tnd-next" || resp.WalkingEdges[0].WalkingTimeMinutes == nil || *resp.WalkingEdges[0].WalkingTimeMinutes != 5 {
 		t.Fatalf("unexpected response: %#v", resp)
 	}
+}
+
+func TestCreateTransportNodeDistinguishesOmittedAndZeroWalkingTime(t *testing.T) {
+	publisher := &recordingPublisher{}
+	router := setupTestRouter(publisher)
+	place := createPlace(t, router, "Beijing South", "STATION", "0194f2e0-7b3e-700d-8284-5c26e8b0000d")
+	createdRec := performJSON(router, http.MethodPost, "/api/v1/transport-nodes", map[string]any{"placeId": place.PlaceID, "displayName": "Transfer hall", "servingModes": []string{"TRAIN"}, "walkingEdges": []map[string]any{{"toNodeId": "tnd-fallback"}, {"toNodeId": "tnd-zero", "walkingTimeMinutes": 0}}}, "0194f2e0-7b3e-700e-8284-5c26e8b0000e")
+	if createdRec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", createdRec.Code, createdRec.Body.String())
+	}
+	assertWalkingTimePresence(t, createdRec, []bool{false, true})
+
+	var created application.CreateTransportNodeResponse
+	decode(t, createdRec, &created)
+	if len(created.WalkingEdges) != 2 || created.WalkingEdges[0].WalkingTimeMinutes != nil || created.WalkingEdges[1].WalkingTimeMinutes == nil || *created.WalkingEdges[1].WalkingTimeMinutes != 0 {
+		t.Fatalf("unexpected create response: %#v", created.WalkingEdges)
+	}
+
+	getRec := perform(router, http.MethodGet, "/api/v1/transport-nodes/"+created.NodeID, nil)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", getRec.Code, getRec.Body.String())
+	}
+	assertWalkingTimePresence(t, getRec, []bool{false, true})
+
+	var got application.GetTransportNodeResponse
+	decode(t, getRec, &got)
+	if len(got.WalkingEdges) != 2 || got.WalkingEdges[0].WalkingTimeMinutes != nil || got.WalkingEdges[1].WalkingTimeMinutes == nil || *got.WalkingEdges[1].WalkingTimeMinutes != 0 {
+		t.Fatalf("unexpected get response: %#v", got.WalkingEdges)
+	}
+
+	payload, ok := publisher.last().Payload.(domain.TransportNodeUpdatedEvent)
+	if !ok {
+		t.Fatalf("unexpected event payload: %#v", publisher.last().Payload)
+	}
+	if len(payload.WalkingEdges) != 2 || payload.WalkingEdges[0].WalkingTimeMinutes != nil || payload.WalkingEdges[1].WalkingTimeMinutes == nil || *payload.WalkingEdges[1].WalkingTimeMinutes != 0 {
+		t.Fatalf("unexpected event walking edges: %#v", payload.WalkingEdges)
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertRawWalkingTimePresence(t, body, []bool{false, true})
 }
 
 func TestValidationFailureErrorBody(t *testing.T) {
@@ -266,6 +308,30 @@ func decode(t *testing.T, rec *httptest.ResponseRecorder, out any) {
 	t.Helper()
 	if err := json.Unmarshal(rec.Body.Bytes(), out); err != nil {
 		t.Fatalf("decode failed: %v; body=%s", err, rec.Body.String())
+	}
+}
+
+func assertWalkingTimePresence(t *testing.T, rec *httptest.ResponseRecorder, want []bool) {
+	t.Helper()
+	assertRawWalkingTimePresence(t, rec.Body.Bytes(), want)
+}
+
+func assertRawWalkingTimePresence(t *testing.T, data []byte, want []bool) {
+	t.Helper()
+	var body struct {
+		WalkingEdges []map[string]json.RawMessage `json:"walkingEdges"`
+	}
+	if err := json.Unmarshal(data, &body); err != nil {
+		t.Fatalf("decode failed: %v; body=%s", err, data)
+	}
+	if len(body.WalkingEdges) != len(want) {
+		t.Fatalf("walking edge count mismatch: got %d want %d body=%s", len(body.WalkingEdges), len(want), data)
+	}
+	for i, edge := range body.WalkingEdges {
+		_, ok := edge["walkingTimeMinutes"]
+		if ok != want[i] {
+			t.Fatalf("walking edge %d walkingTimeMinutes presence mismatch: got %t want %t body=%s", i, ok, want[i], data)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Decode walkingEdges[].walkingTimeMinutes as optional so omitted weights remain omitted while explicit 0 is preserved.
- Persist and publish optional walking edge weights with omitempty at boundaries.
- Correct Get Place API docs to describe the nodes summary shape.

## Validation
- go test ./services/place-network/...