### PR TITLE
REQ-364 activate fulfillment deferred consumers

### DIFF
--- a/services/fulfillment/internal/adapters/messaging/redis.go
+++ b/services/fulfillment/internal/adapters/messaging/redis.go
@@ -40,7 +40,7 @@ func (s *RedisSubscriber) Subscribe(ctx context.Context, streams []string, group
 }
 
 func FulfillmentSubscriptions() []string {
-	return []string{streamPrefix + "entitlement-ticketing", streamPrefix + "booking-orchestration"}
+	return []string{streamPrefix + "entitlement-ticketing", streamPrefix + "booking-orchestration", streamPrefix + "ancillary-service", streamPrefix + "dispatch"}
 }
 func FulfillmentGroup() string { return consumerGroup }
 

--- a/services/fulfillment/internal/adapters/postgres/repository.go
+++ b/services/fulfillment/internal/adapters/postgres/repository.go
@@ -149,6 +149,35 @@ func (p *ProcessedEvents) Claim(ctx context.Context, eventID string) (bool, erro
 	return storage.NewProcessedEvents(p.db.DBFor(ctx)).TryRecord(ctx, eventID, "")
 }
 
+func (r *FulfillmentRepository) SaveExternalFulfillmentHandoff(ctx context.Context, handoff *domain.ExternalFulfillmentHandoff) error {
+	data, err := json.Marshal(handoff)
+	if err != nil {
+		return err
+	}
+	_, err = r.db.DBFor(ctx).Exec(ctx, `INSERT INTO external_fulfillment_handoffs(producer, source_ref, data, updated_at) VALUES ($1, $2, $3, now()) ON CONFLICT (producer, source_ref) DO UPDATE SET data = EXCLUDED.data, updated_at = now()`, handoff.Producer, handoff.SourceRef, data)
+	return err
+}
+
+func (r *FulfillmentRepository) FindExternalFulfillmentHandoff(ctx context.Context, producer string, sourceRef string) (*domain.ExternalFulfillmentHandoff, error) {
+	rows, err := r.db.DBFor(ctx).Query(ctx, `SELECT data FROM external_fulfillment_handoffs WHERE producer = $1 AND source_ref = $2 LIMIT 1`, producer, sourceRef)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil, application.ErrNotFound
+	}
+	var raw json.RawMessage
+	if err := rows.Scan(&raw); err != nil {
+		return nil, err
+	}
+	var handoff domain.ExternalFulfillmentHandoff
+	if err := json.Unmarshal(raw, &handoff); err != nil {
+		return nil, err
+	}
+	return &handoff, nil
+}
+
 type recordSnapshot struct {
 	FulfillmentRecordID string                   `json:"fulfillmentRecordId"`
 	EntitlementID       string                   `json:"entitlementId"`

--- a/services/fulfillment/internal/application/ports.go
+++ b/services/fulfillment/internal/application/ports.go
@@ -50,6 +50,11 @@ type FulfillmentRepository interface {
 	FindByEntitlementSegment(ctx context.Context, entitlementID domain.EntitlementRef, segmentBookingID domain.SegmentBookingRef, segmentRef domain.SegmentRef) (*domain.FulfillmentRecord, error)
 }
 
+type ExternalFulfillmentRepository interface {
+	SaveExternalFulfillmentHandoff(ctx context.Context, handoff *domain.ExternalFulfillmentHandoff) error
+	FindExternalFulfillmentHandoff(ctx context.Context, producer string, sourceRef string) (*domain.ExternalFulfillmentHandoff, error)
+}
+
 type SegmentStatusRepository interface {
 	SaveSegmentStatus(ctx context.Context, record *domain.SegmentStatusRecord) (bool, error)
 	FindSegmentStatusByCommandID(ctx context.Context, commandID string) (*domain.SegmentStatusRecord, error)
@@ -66,15 +71,17 @@ type IDGenerator func(prefix string) string
 type Clock func() time.Time
 
 type Service struct {
-	repo     FulfillmentRepository
-	segments SegmentStatusRepository
-	pub      EventPublisher
-	consumed ConsumedEventLog
-	idGen    IDGenerator
-	clock    Clock
-	uow      UnitOfWork
-	mu       sync.Mutex
-	tickets  map[string]TicketProjection
+	repo        FulfillmentRepository
+	external    ExternalFulfillmentRepository
+	segments    SegmentStatusRepository
+	pub         EventPublisher
+	consumed    ConsumedEventLog
+	idGen       IDGenerator
+	clock       Clock
+	uow         UnitOfWork
+	mu          sync.Mutex
+	tickets     map[string]TicketProjection
+	externalMem map[string]*domain.ExternalFulfillmentHandoff
 }
 
 type TicketProjection struct {
@@ -94,7 +101,8 @@ func NewService(repo FulfillmentRepository, publisher EventPublisher, consumed C
 		clock = func() time.Time { return time.Now().UTC() }
 	}
 	segments, _ := repo.(SegmentStatusRepository)
-	return &Service{repo: repo, segments: segments, pub: publisher, consumed: consumed, idGen: idGen, clock: clock, tickets: map[string]TicketProjection{}}
+	external, _ := repo.(ExternalFulfillmentRepository)
+	return &Service{repo: repo, external: external, segments: segments, pub: publisher, consumed: consumed, idGen: idGen, clock: clock, tickets: map[string]TicketProjection{}, externalMem: map[string]*domain.ExternalFulfillmentHandoff{}}
 }
 
 func (s *Service) WithUnitOfWork(uow UnitOfWork) *Service {
@@ -107,6 +115,13 @@ func (s *Service) WithUnitOfWork(uow UnitOfWork) *Service {
 func (s *Service) WithSegmentStatusRepository(repo SegmentStatusRepository) *Service {
 	if s != nil {
 		s.segments = repo
+	}
+	return s
+}
+
+func (s *Service) WithExternalFulfillmentRepository(repo ExternalFulfillmentRepository) *Service {
+	if s != nil {
+		s.external = repo
 	}
 	return s
 }
@@ -361,6 +376,12 @@ func (s *Service) applySubscribedEvent(ctx context.Context, envelope EventEnvelo
 		return s.applyEntitlementVoided(envelope.Payload)
 	case "SegmentTicketed":
 		return s.applySegmentTicketed(ctx, envelope.Payload)
+	case "AncillaryOrderItemFulfillmentReady":
+		return s.applyAncillaryFulfillmentReady(ctx, envelope)
+	case "AncillaryFulfillmentFactRecorded":
+		return s.applyAncillaryFulfillmentFactRecorded(ctx, envelope)
+	case "DriverArrived", "RideStarted", "RideEnded":
+		return s.applyDispatchFulfillmentMilestone(ctx, envelope)
 	default:
 		return nil
 	}
@@ -842,10 +863,11 @@ type InMemoryRepository struct {
 	byTuple          map[string]domain.FulfillmentRecordID
 	segmentByID      map[domain.SegmentStatusRecordID]*domain.SegmentStatusRecord
 	segmentByCommand map[string]domain.SegmentStatusRecordID
+	external         map[string]*domain.ExternalFulfillmentHandoff
 }
 
 func NewInMemoryRepository() *InMemoryRepository {
-	return &InMemoryRepository{byID: map[domain.FulfillmentRecordID]*domain.FulfillmentRecord{}, byTuple: map[string]domain.FulfillmentRecordID{}, segmentByID: map[domain.SegmentStatusRecordID]*domain.SegmentStatusRecord{}, segmentByCommand: map[string]domain.SegmentStatusRecordID{}}
+	return &InMemoryRepository{byID: map[domain.FulfillmentRecordID]*domain.FulfillmentRecord{}, byTuple: map[string]domain.FulfillmentRecordID{}, segmentByID: map[domain.SegmentStatusRecordID]*domain.SegmentStatusRecord{}, segmentByCommand: map[string]domain.SegmentStatusRecordID{}, external: map[string]*domain.ExternalFulfillmentHandoff{}}
 }
 
 func (r *InMemoryRepository) Save(_ context.Context, record *domain.FulfillmentRecord) error {
@@ -896,6 +918,23 @@ func (r *InMemoryRepository) FindSegmentStatusByCommandID(_ context.Context, com
 		return nil, ErrNotFound
 	}
 	return cloneSegmentStatus(r.segmentByID[id]), nil
+}
+
+func (r *InMemoryRepository) SaveExternalFulfillmentHandoff(_ context.Context, handoff *domain.ExternalFulfillmentHandoff) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.external[externalHandoffKey(handoff.Producer, handoff.SourceRef)] = cloneExternalHandoff(handoff)
+	return nil
+}
+
+func (r *InMemoryRepository) FindExternalFulfillmentHandoff(_ context.Context, producer string, sourceRef string) (*domain.ExternalFulfillmentHandoff, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	handoff, ok := r.external[externalHandoffKey(producer, sourceRef)]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return cloneExternalHandoff(handoff), nil
 }
 
 func cloneSegmentStatus(record *domain.SegmentStatusRecord) *domain.SegmentStatusRecord {

--- a/services/fulfillment/internal/application/subscribed_external.go
+++ b/services/fulfillment/internal/application/subscribed_external.go
@@ -1,0 +1,188 @@
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/trainticket/greenfield/services/fulfillment/internal/domain"
+)
+
+func (s *Service) applyAncillaryFulfillmentReady(ctx context.Context, envelope EventEnvelope) error {
+	var event struct {
+		AncillaryOrderItemID string    `json:"ancillaryOrderItemId"`
+		JourneyOrderID       string    `json:"journeyOrderId"`
+		TravelerRef          string    `json:"travelerRef"`
+		SegmentRef           string    `json:"segmentRef"`
+		EntitlementRef       string    `json:"entitlementRef"`
+		ProviderRef          string    `json:"providerRef"`
+		Status               string    `json:"status"`
+		ReadyAt              time.Time `json:"readyAt"`
+	}
+	if err := json.Unmarshal(envelope.Payload, &event); err != nil {
+		return fmt.Errorf("%w: invalid AncillaryOrderItemFulfillmentReady payload: %v", ErrDomainRuleViolation, err)
+	}
+	if strings.TrimSpace(event.AncillaryOrderItemID) == "" || event.ReadyAt.IsZero() {
+		return fmt.Errorf("%w: invalid AncillaryOrderItemFulfillmentReady payload", ErrDomainRuleViolation)
+	}
+	handoff, err := s.externalHandoff(ctx, envelope.Producer, event.AncillaryOrderItemID, envelope.EventID)
+	if err != nil {
+		return err
+	}
+	if err := handoff.ApplyAncillaryReady(envelope.EventID, event.JourneyOrderID, event.TravelerRef, event.SegmentRef, event.EntitlementRef, event.ProviderRef, event.Status, event.ReadyAt); err != nil {
+		if errors.Is(err, domain.ErrUnknownExternalStatus) {
+			return nil
+		}
+		return fmt.Errorf("%w: %v", ErrDomainRuleViolation, err)
+	}
+	return s.saveExternalHandoff(ctx, handoff)
+}
+
+func (s *Service) applyAncillaryFulfillmentFactRecorded(ctx context.Context, envelope EventEnvelope) error {
+	var event struct {
+		AncillaryOrderItemID string `json:"ancillaryOrderItemId"`
+		JourneyOrderID       string `json:"journeyOrderId"`
+		TravelerRef          string `json:"travelerRef"`
+		SegmentRef           string `json:"segmentRef"`
+		ServiceType          string `json:"serviceType"`
+		Status               string `json:"status"`
+		FulfillmentFact      struct {
+			FulfillmentFactID string    `json:"fulfillmentFactId"`
+			FactType          string    `json:"factType"`
+			ProviderRef       string    `json:"providerRef"`
+			PlaceRef          string    `json:"placeRef"`
+			OccurredAt        time.Time `json:"occurredAt"`
+			RecordedAt        time.Time `json:"recordedAt"`
+			PerformedBy       string    `json:"performedBy"`
+			IdempotencyRef    string    `json:"idempotencyRef"`
+			Compensable       bool      `json:"compensable"`
+		} `json:"fulfillmentFact"`
+	}
+	if err := json.Unmarshal(envelope.Payload, &event); err != nil {
+		return fmt.Errorf("%w: invalid AncillaryFulfillmentFactRecorded payload: %v", ErrDomainRuleViolation, err)
+	}
+	if strings.TrimSpace(event.AncillaryOrderItemID) == "" {
+		return fmt.Errorf("%w: invalid AncillaryFulfillmentFactRecorded payload", ErrDomainRuleViolation)
+	}
+	handoff, err := s.externalHandoff(ctx, envelope.Producer, event.AncillaryOrderItemID, envelope.EventID)
+	if err != nil {
+		return err
+	}
+	fact := domain.ExternalFulfillmentFact{
+		FactID:         event.FulfillmentFact.FulfillmentFactID,
+		FactType:       event.FulfillmentFact.FactType,
+		ProviderRef:    event.FulfillmentFact.ProviderRef,
+		PlaceRef:       event.FulfillmentFact.PlaceRef,
+		IdempotencyRef: event.FulfillmentFact.IdempotencyRef,
+		OccurredAt:     event.FulfillmentFact.OccurredAt,
+		RecordedAt:     event.FulfillmentFact.RecordedAt,
+		PerformedBy:    event.FulfillmentFact.PerformedBy,
+		Compensable:    event.FulfillmentFact.Compensable,
+	}
+	if err := handoff.ApplyAncillaryFact(envelope.EventID, event.JourneyOrderID, event.TravelerRef, event.SegmentRef, event.ServiceType, event.Status, fact); err != nil {
+		return fmt.Errorf("%w: %v", ErrDomainRuleViolation, err)
+	}
+	return s.saveExternalHandoff(ctx, handoff)
+}
+
+func (s *Service) applyDispatchFulfillmentMilestone(ctx context.Context, envelope EventEnvelope) error {
+	var event struct {
+		RideRequestID    string    `json:"rideRequestId"`
+		RideAssignmentID string    `json:"rideAssignmentId"`
+		TravelerRef      string    `json:"travelerRef"`
+		ArrivedAt        time.Time `json:"arrivedAt"`
+		StartedAt        time.Time `json:"startedAt"`
+		EndedAt          time.Time `json:"endedAt"`
+		Status           string    `json:"status"`
+	}
+	if err := json.Unmarshal(envelope.Payload, &event); err != nil {
+		return fmt.Errorf("%w: invalid %s payload: %v", ErrDomainRuleViolation, envelope.EventType, err)
+	}
+	if strings.TrimSpace(event.RideRequestID) == "" {
+		return fmt.Errorf("%w: invalid %s payload", ErrDomainRuleViolation, envelope.EventType)
+	}
+	occurredAt := event.ArrivedAt
+	if envelope.EventType == "RideStarted" {
+		occurredAt = event.StartedAt
+	} else if envelope.EventType == "RideEnded" {
+		occurredAt = event.EndedAt
+	}
+	handoff, err := s.externalHandoff(ctx, envelope.Producer, event.RideRequestID, envelope.EventID)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(event.RideAssignmentID) != "" {
+		handoff.ProviderRef = strings.TrimSpace(event.RideAssignmentID)
+	}
+	if err := handoff.ApplyDispatchMilestone(envelope.EventType, envelope.EventID, event.TravelerRef, event.Status, occurredAt); err != nil {
+		if errors.Is(err, domain.ErrUnknownExternalStatus) {
+			return nil
+		}
+		return fmt.Errorf("%w: %v", ErrDomainRuleViolation, err)
+	}
+	return s.saveExternalHandoff(ctx, handoff)
+}
+
+func (s *Service) externalHandoff(ctx context.Context, producer string, sourceRef string, eventID string) (*domain.ExternalFulfillmentHandoff, error) {
+	producer = strings.TrimSpace(producer)
+	sourceRef = strings.TrimSpace(sourceRef)
+	if s.external != nil {
+		handoff, err := s.external.FindExternalFulfillmentHandoff(ctx, producer, sourceRef)
+		if err == nil {
+			return handoff, nil
+		}
+		if !errors.Is(err, ErrNotFound) {
+			return nil, err
+		}
+		return domain.NewExternalFulfillmentHandoff(producer, sourceRef, eventID)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := externalHandoffKey(producer, sourceRef)
+	if existing, ok := s.externalMem[key]; ok {
+		return cloneExternalHandoff(existing), nil
+	}
+	return domain.NewExternalFulfillmentHandoff(producer, sourceRef, eventID)
+}
+
+func (s *Service) saveExternalHandoff(ctx context.Context, handoff *domain.ExternalFulfillmentHandoff) error {
+	if s.external != nil {
+		return s.external.SaveExternalFulfillmentHandoff(ctx, handoff)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.externalMem[externalHandoffKey(handoff.Producer, handoff.SourceRef)] = cloneExternalHandoff(handoff)
+	return nil
+}
+
+func externalHandoffKey(producer, sourceRef string) string {
+	return strings.TrimSpace(producer) + "|" + strings.TrimSpace(sourceRef)
+}
+
+func cloneExternalHandoff(handoff *domain.ExternalFulfillmentHandoff) *domain.ExternalFulfillmentHandoff {
+	if handoff == nil {
+		return nil
+	}
+	copy := *handoff
+	if handoff.ReadyAt != nil {
+		t := *handoff.ReadyAt
+		copy.ReadyAt = &t
+	}
+	if handoff.ArrivedAt != nil {
+		t := *handoff.ArrivedAt
+		copy.ArrivedAt = &t
+	}
+	if handoff.StartedAt != nil {
+		t := *handoff.StartedAt
+		copy.StartedAt = &t
+	}
+	if handoff.CompletedAt != nil {
+		t := *handoff.CompletedAt
+		copy.CompletedAt = &t
+	}
+	copy.Facts = append([]domain.ExternalFulfillmentFact(nil), handoff.Facts...)
+	return &copy
+}

--- a/services/fulfillment/internal/application/subscribed_external_test.go
+++ b/services/fulfillment/internal/application/subscribed_external_test.go
@@ -1,0 +1,83 @@
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestConsumesAncillaryFulfillmentReadyWithDedup(t *testing.T) {
+	repo := NewInMemoryRepository()
+	log := NewInMemoryConsumedEventLog()
+	service := NewService(repo, NoopPublisher{}, log, nil, nil)
+	envelope := EventEnvelope{
+		EventID:       "evt-anc-ready-1",
+		EventType:     "AncillaryOrderItemFulfillmentReady",
+		Producer:      "ancillary-service",
+		SchemaVersion: 1,
+		Payload: json.RawMessage(`{
+			"ancillaryOrderItemId":"aoi-123",
+			"journeyOrderId":"ord-123",
+			"travelerRef":"tvl-123",
+			"segmentRef":"seg-123",
+			"entitlementRef":"ent-123",
+			"providerRef":"voucher-123",
+			"status":"FULFILLMENT_READY",
+			"readyAt":"2026-07-09T10:00:00Z"
+		}`),
+	}
+	if err := service.HandleSubscribedEvent(context.Background(), envelope); err != nil {
+		t.Fatalf("first ready event failed: %v", err)
+	}
+	if err := service.HandleSubscribedEvent(context.Background(), envelope); err != nil {
+		t.Fatalf("duplicate ready event should be ack-safe: %v", err)
+	}
+	handoff, err := repo.FindExternalFulfillmentHandoff(context.Background(), "ancillary-service", "aoi-123")
+	if err != nil {
+		t.Fatalf("handoff not stored: %v", err)
+	}
+	if handoff.Status != "FULFILLMENT_READY" || handoff.ProviderRef != "voucher-123" || handoff.ReadyAt == nil {
+		t.Fatalf("unexpected handoff: %#v", handoff)
+	}
+	if got := handoff.LastEventID; got != envelope.EventID {
+		t.Fatalf("last event not tracked: %s", got)
+	}
+}
+
+func TestConsumesDispatchRideLifecycleFacts(t *testing.T) {
+	repo := NewInMemoryRepository()
+	service := NewService(repo, NoopPublisher{}, NewInMemoryConsumedEventLog(), nil, nil)
+	events := []EventEnvelope{
+		{EventID: "evt-driver-arrived", EventType: "DriverArrived", Producer: "dispatch", SchemaVersion: 1, Payload: json.RawMessage(`{"rideRequestId":"rrq-123","rideAssignmentId":"ras-123","travelerRef":"tvl-123","arrivedAt":"2026-07-09T10:00:00Z","status":"DRIVER_ARRIVED"}`)},
+		{EventID: "evt-ride-started", EventType: "RideStarted", Producer: "dispatch", SchemaVersion: 1, Payload: json.RawMessage(`{"rideRequestId":"rrq-123","rideAssignmentId":"ras-123","travelerRef":"tvl-123","startedAt":"2026-07-09T10:05:00Z","status":"PICKED_UP"}`)},
+		{EventID: "evt-ride-ended", EventType: "RideEnded", Producer: "dispatch", SchemaVersion: 1, Payload: json.RawMessage(`{"rideRequestId":"rrq-123","rideAssignmentId":"ras-123","travelerRef":"tvl-123","startedAt":"2026-07-09T10:05:00Z","endedAt":"2026-07-09T10:25:00Z","status":"COMPLETED"}`)},
+	}
+	for _, envelope := range events {
+		if err := service.HandleSubscribedEvent(context.Background(), envelope); err != nil {
+			t.Fatalf("%s failed: %v", envelope.EventType, err)
+		}
+	}
+	handoff, err := repo.FindExternalFulfillmentHandoff(context.Background(), "dispatch", "rrq-123")
+	if err != nil {
+		t.Fatalf("handoff not stored: %v", err)
+	}
+	if handoff.Status != "COMPLETED" || handoff.ArrivedAt == nil || handoff.StartedAt == nil || handoff.CompletedAt == nil {
+		t.Fatalf("unexpected dispatch lifecycle: %#v", handoff)
+	}
+	if !handoff.CompletedAt.Equal(time.Date(2026, 7, 9, 10, 25, 0, 0, time.UTC)) {
+		t.Fatalf("unexpected completion time: %s", handoff.CompletedAt)
+	}
+}
+
+func TestUnknownDispatchStatusAckSkips(t *testing.T) {
+	repo := NewInMemoryRepository()
+	service := NewService(repo, NoopPublisher{}, NewInMemoryConsumedEventLog(), nil, nil)
+	envelope := EventEnvelope{EventID: "evt-driver-arrived-unknown", EventType: "DriverArrived", Producer: "dispatch", SchemaVersion: 1, Payload: json.RawMessage(`{"rideRequestId":"rrq-unknown","arrivedAt":"2026-07-09T10:00:00Z","status":"ARRIVED"}`)}
+	if err := service.HandleSubscribedEvent(context.Background(), envelope); err != nil {
+		t.Fatalf("unknown but conformant status should ack-skip: %v", err)
+	}
+	if _, err := repo.FindExternalFulfillmentHandoff(context.Background(), "dispatch", "rrq-unknown"); err == nil {
+		t.Fatalf("unknown status should not store a handoff")
+	}
+}

--- a/services/fulfillment/internal/domain/external_handoff.go
+++ b/services/fulfillment/internal/domain/external_handoff.go
@@ -1,0 +1,210 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var ErrUnknownExternalStatus = errors.New("unknown external fulfillment status")
+
+type ExternalFulfillmentHandoff struct {
+	HandoffID      string                    `json:"handoffId"`
+	Producer       string                    `json:"producer"`
+	SourceRef      string                    `json:"sourceRef"`
+	TravelerRef    string                    `json:"travelerRef,omitempty"`
+	JourneyOrderID string                    `json:"journeyOrderId,omitempty"`
+	SegmentRef     string                    `json:"segmentRef,omitempty"`
+	EntitlementRef string                    `json:"entitlementRef,omitempty"`
+	ServiceType    string                    `json:"serviceType,omitempty"`
+	ProviderRef    string                    `json:"providerRef,omitempty"`
+	Status         string                    `json:"status,omitempty"`
+	FirstEventID   string                    `json:"firstEventId"`
+	LastEventID    string                    `json:"lastEventId"`
+	ReadyAt        *time.Time                `json:"readyAt,omitempty"`
+	ArrivedAt      *time.Time                `json:"arrivedAt,omitempty"`
+	StartedAt      *time.Time                `json:"startedAt,omitempty"`
+	CompletedAt    *time.Time                `json:"completedAt,omitempty"`
+	Facts          []ExternalFulfillmentFact `json:"facts"`
+	CreatedAt      time.Time                 `json:"createdAt"`
+	UpdatedAt      time.Time                 `json:"updatedAt"`
+}
+
+type ExternalFulfillmentFact struct {
+	EventID        string    `json:"eventId"`
+	FactID         string    `json:"factId"`
+	FactType       string    `json:"factType"`
+	ProviderRef    string    `json:"providerRef,omitempty"`
+	PlaceRef       string    `json:"placeRef,omitempty"`
+	IdempotencyRef string    `json:"idempotencyRef,omitempty"`
+	OccurredAt     time.Time `json:"occurredAt"`
+	RecordedAt     time.Time `json:"recordedAt"`
+	PerformedBy    string    `json:"performedBy,omitempty"`
+	Compensable    bool      `json:"compensable"`
+	Status         string    `json:"status,omitempty"`
+}
+
+func NewExternalFulfillmentHandoff(producer, sourceRef, firstEventID string) (*ExternalFulfillmentHandoff, error) {
+	producer = strings.TrimSpace(producer)
+	sourceRef = strings.TrimSpace(sourceRef)
+	firstEventID = strings.TrimSpace(firstEventID)
+	if producer == "" {
+		return nil, fmt.Errorf("external fulfillment handoff: producer is required")
+	}
+	if sourceRef == "" {
+		return nil, fmt.Errorf("external fulfillment handoff: sourceRef is required")
+	}
+	if firstEventID == "" {
+		return nil, fmt.Errorf("external fulfillment handoff: firstEventId is required")
+	}
+	now := timeNow().UTC()
+	return &ExternalFulfillmentHandoff{
+		HandoffID:    producer + ":" + sourceRef,
+		Producer:     producer,
+		SourceRef:    sourceRef,
+		FirstEventID: firstEventID,
+		LastEventID:  firstEventID,
+		Facts:        []ExternalFulfillmentFact{},
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}, nil
+}
+
+func (h *ExternalFulfillmentHandoff) ApplyAncillaryReady(eventID, journeyOrderID, travelerRef, segmentRef, entitlementRef, providerRef, status string, readyAt time.Time) error {
+	if err := h.validateExisting(eventID); err != nil {
+		return err
+	}
+	if status != "FULFILLMENT_READY" {
+		return fmt.Errorf("%w: ancillary fulfillment-ready status %q", ErrUnknownExternalStatus, status)
+	}
+	if readyAt.IsZero() {
+		return fmt.Errorf("external fulfillment handoff: readyAt is required")
+	}
+	h.JourneyOrderID = strings.TrimSpace(journeyOrderID)
+	h.TravelerRef = strings.TrimSpace(travelerRef)
+	h.SegmentRef = strings.TrimSpace(segmentRef)
+	h.EntitlementRef = strings.TrimSpace(entitlementRef)
+	h.ProviderRef = strings.TrimSpace(providerRef)
+	h.Status = status
+	ready := readyAt.UTC()
+	h.ReadyAt = &ready
+	h.markUpdated(eventID)
+	return nil
+}
+
+func (h *ExternalFulfillmentHandoff) ApplyAncillaryFact(eventID, journeyOrderID, travelerRef, segmentRef, serviceType, status string, fact ExternalFulfillmentFact) error {
+	if err := h.validateExisting(eventID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(status) == "" {
+		return fmt.Errorf("external fulfillment handoff: status is required")
+	}
+	if err := fact.validate(); err != nil {
+		return err
+	}
+	if h.hasFact(eventID, fact.FactID) {
+		return nil
+	}
+	h.JourneyOrderID = strings.TrimSpace(journeyOrderID)
+	h.TravelerRef = strings.TrimSpace(travelerRef)
+	h.SegmentRef = strings.TrimSpace(segmentRef)
+	h.ServiceType = strings.TrimSpace(serviceType)
+	h.Status = strings.TrimSpace(status)
+	if strings.TrimSpace(fact.ProviderRef) != "" {
+		h.ProviderRef = strings.TrimSpace(fact.ProviderRef)
+	}
+	fact.EventID = strings.TrimSpace(eventID)
+	fact.Status = h.Status
+	fact.OccurredAt = fact.OccurredAt.UTC()
+	fact.RecordedAt = fact.RecordedAt.UTC()
+	h.Facts = append(h.Facts, fact)
+	h.markUpdated(eventID)
+	return nil
+}
+
+func (h *ExternalFulfillmentHandoff) ApplyDispatchMilestone(eventType, eventID, travelerRef, status string, occurredAt time.Time) error {
+	if err := h.validateExisting(eventID); err != nil {
+		return err
+	}
+	if occurredAt.IsZero() {
+		return fmt.Errorf("external fulfillment handoff: milestone time is required")
+	}
+	status = strings.TrimSpace(status)
+	occurred := occurredAt.UTC()
+	switch eventType {
+	case "DriverArrived":
+		if status != "DRIVER_ARRIVED" {
+			return fmt.Errorf("%w: DriverArrived status %q", ErrUnknownExternalStatus, status)
+		}
+		h.ArrivedAt = &occurred
+	case "RideStarted":
+		if status != "PICKED_UP" {
+			return fmt.Errorf("%w: RideStarted status %q", ErrUnknownExternalStatus, status)
+		}
+		h.StartedAt = &occurred
+	case "RideEnded":
+		if status != "COMPLETED" {
+			return fmt.Errorf("%w: RideEnded status %q", ErrUnknownExternalStatus, status)
+		}
+		h.CompletedAt = &occurred
+	default:
+		return fmt.Errorf("%w: dispatch event type %q", ErrUnknownExternalStatus, eventType)
+	}
+	h.TravelerRef = strings.TrimSpace(travelerRef)
+	h.Status = status
+	h.markUpdated(eventID)
+	return nil
+}
+
+func (h *ExternalFulfillmentHandoff) validateExisting(eventID string) error {
+	if h == nil {
+		return fmt.Errorf("external fulfillment handoff is nil")
+	}
+	if strings.TrimSpace(h.Producer) == "" || strings.TrimSpace(h.SourceRef) == "" {
+		return fmt.Errorf("external fulfillment handoff identity is incomplete")
+	}
+	if strings.TrimSpace(eventID) == "" {
+		return fmt.Errorf("external fulfillment handoff: eventId is required")
+	}
+	return nil
+}
+
+func (h *ExternalFulfillmentHandoff) hasFact(eventID, factID string) bool {
+	eventID = strings.TrimSpace(eventID)
+	factID = strings.TrimSpace(factID)
+	for _, existing := range h.Facts {
+		if existing.EventID == eventID || (factID != "" && existing.FactID == factID) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *ExternalFulfillmentHandoff) markUpdated(eventID string) {
+	now := timeNow().UTC()
+	if h.CreatedAt.IsZero() {
+		h.CreatedAt = now
+	}
+	if h.FirstEventID == "" {
+		h.FirstEventID = strings.TrimSpace(eventID)
+	}
+	h.LastEventID = strings.TrimSpace(eventID)
+	h.UpdatedAt = now
+}
+
+func (f ExternalFulfillmentFact) validate() error {
+	if strings.TrimSpace(f.FactID) == "" {
+		return fmt.Errorf("external fulfillment fact: fulfillmentFactId is required")
+	}
+	if strings.TrimSpace(f.FactType) == "" {
+		return fmt.Errorf("external fulfillment fact: factType is required")
+	}
+	if f.OccurredAt.IsZero() {
+		return fmt.Errorf("external fulfillment fact: occurredAt is required")
+	}
+	if f.RecordedAt.IsZero() {
+		return fmt.Errorf("external fulfillment fact: recordedAt is required")
+	}
+	return nil
+}

--- a/services/fulfillment/migrations/003_external_fulfillment_handoffs.sql
+++ b/services/fulfillment/migrations/003_external_fulfillment_handoffs.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS external_fulfillment_handoffs (
+  producer   text NOT NULL,
+  source_ref text NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (producer, source_ref)
+);
+
+CREATE INDEX IF NOT EXISTS idx_external_fulfillment_handoffs_status ON external_fulfillment_handoffs ((data->>'status'));


### PR DESCRIPTION
## Summary
- subscribe fulfillment to ancillary-service and dispatch streams
- consume AncillaryOrderItemFulfillmentReady, AncillaryFulfillmentFactRecorded, DriverArrived, RideStarted, and RideEnded with eventId dedup
- persist external fulfillment handoff read model for ancillary/dispatch evidence and lifecycle facts

## Validation
- go test ./services/fulfillment/...
