### PR TITLE
docs: reconcile active consumer metadata

### DIFF
--- a/docs/00-current-status.md
+++ b/docs/00-current-status.md
@@ -1,8 +1,8 @@
 # Current Project Status
 
-Last updated: 2026-07-12
+Last updated: 2026-07-15
 
-## Status: Phase 3 domain enrichment complete (22 services enriched with real-world business logic)
+## Status: Phase 3 domain enrichment complete; consumer activation batch reconciled
 
 The greenfield DDD rewrite is a working, end-to-end-verified system. All
 Phase-1 work packages (WP-01..WP-23 of the accepted roadmap) are merged to
@@ -10,9 +10,10 @@ Phase-1 work packages (WP-01..WP-23 of the accepted roadmap) are merged to
 and certified by the e2e suite.
 
 Wave 11 completed the persistence baseline from
-`docs/08-contracts/persistence.md`: all 23 deployed business services use
-PostgreSQL aggregate snapshot rows with optimistic concurrency, transactional
-outbox publishing, and durable `processed_events` consumer dedup/idempotency.
+`docs/08-contracts/persistence.md` for the original deployed business-service
+set: PostgreSQL aggregate snapshot rows with optimistic concurrency,
+transactional outbox publishing, and durable `processed_events` consumer
+dedup/idempotency. The deployed business-service set has since grown to 38.
 Redis Streams remain the event bus; Redis is transport only, not a system of
 record. It runs without a persistent volume — a Redis pod deletion wipes
 streams and consumer groups by design, and services recover from PostgreSQL
@@ -21,16 +22,19 @@ are recreated on demand). `deploy/e2e/12-restart.sh` certifies exactly this.
 
 ## What runs today
 
-23 deployed business services + Redis Streams + PostgreSQL, all under
-`deploy/k8s/`, with service images built by `deploy/build-images.sh`:
+38 deployed business services + Redis Streams + PostgreSQL, all under
+`deploy/k8s/`, with service images built by `deploy/build-images.sh`.
+`service-catalog.json` currently catalogs 33 of these contexts; the deployed set
+also includes corporate-travel, group-booking, loyalty-membership,
+marketing-campaign, and travel-insurance:
 
 | Language | Services |
 |---|---|
-| Java (Boot 4) | admin-audit, booking-orchestration, finance-settlement, journey-order, payment, post-sales, traveler-profile, wallet-promotion |
-| Python (FastAPI) | disruption-recovery, fare-pricing, legacy-acl, reporting, risk-compliance, transfer-management, trip-planning |
-| Node (TS) | account, ancillary-service, customer-service, notification, offer-management |
-| Go | dispatch, fulfillment, place-network, provider-integration, service-plan, supplier-catalog |
-| Rust | capacity-availability, entitlement-ticketing, waitlist |
+| Java (Boot 4) | admin-audit, booking-orchestration, finance-settlement, group-booking, journey-order, marketing-campaign, payment, post-sales, traveler-profile, wallet-promotion |
+| Python (FastAPI) | corporate-travel, disruption-recovery, fare-pricing, identity-verification, legacy-acl, reporting, risk-compliance, transfer-management, trip-planning |
+| Node (TS) | account, ancillary-service, customer-service, loyalty-membership, notification, offer-management, waitlist |
+| Go | dispatch, fulfillment, payment-channel, place-network, provider-integration, seat-assignment, service-plan, supplier-catalog, travel-insurance |
+| Rust | capacity-availability, entitlement-ticketing, invoicing |
 
 Wave 15 activated **waitlist** (ADR-0002): sold-out demand now queues with
 deadline, payment guarantee and fairness invariants, matches released
@@ -94,6 +98,20 @@ real-world business logic while maintaining backward API compatibility:
 - **reporting**: real-time metrics, anomaly detection
 - **finance-settlement**: daily reconciliation, supplier settlement
 
+## Consumer activation and waitlist conformance (REQ-320..344, REQ-350..370)
+
+The post-enrichment WorkGraph batch activated the remaining event consumers and
+closed the waitlist conformance tail. Reporting now subscribes to every bounded
+context stream for operational rollups. Notification, Customer Service, Journey
+Order, Offer Management, Post Sales, Fulfillment, Finance Settlement, Fare
+Pricing, Traveler Profile, Trip Planning, Payment, and Risk Compliance consume
+the event subsets implemented in their stream configs and handlers. Waitlist
+conformance work tightened the queue/payment-guarantee lifecycle and the
+consumer activation docs have been reconciled so producer event rows distinguish
+active subscribers from still-deferred touchpoints. No remaining deferred
+consumer label should describe a service that is already subscribed and handling
+the event.
+
 Total WorkGraph tasks: done/=187. PRs #307..#329 merged.
 
 ## Verification baseline
@@ -138,7 +156,7 @@ ack-skipped with a WARN; true transients retry. Every DLQ entry now carries
 consumerGroup / failureReason / deadLetteredAt / attempts for attribution.
 
 Wave 13 delivered the observability baseline: an OTel collector runs in
-the integration cluster and all 23 services export OTLP traces through the
+the integration cluster and all deployed services export OTLP traces through the
 five language kits (HTTP server spans plus event-consumer spans carrying
 stream/consumerGroup/eventId/eventType/correlationId; W3C traceparent on
 outbound HTTP; env-driven and zero-overhead when OTEL_* is absent). The DLQ
@@ -161,16 +179,10 @@ e2e smoke (13-observability.sh, receiver-counter based).
 
 ## Current backlog
 
-Nothing queued. Next per ADR-0002: disruption-recovery + ancillary-service,
-then transfer-management. Known small debts: ~~loadgen's ConfigMap is created imperatively by
-deploy/loadgen/run.sh (a stale copy masked new journeys for a day — should move
-under kustomize)~~ — resolved: `loadgen-config-*` is generated from
-`deploy/loadgen/config.yaml` and config changes roll the Deployment;
-Wallet/Promotion's finance/notification consumers remain documented-deferred.
-
-Known accepted gaps after Phase 2: payment remains a simulated provider
-boundary; legacy-acl rebook books the first leg only (caller follows up) — both
-by explicit ruling.
+Nothing queued. ADR-0002 activation and the subsequent consumer-activation /
+waitlist-conformance batch are complete. Known accepted gaps after Phase 2:
+payment remains a simulated provider boundary; legacy-acl rebook books the
+first leg only (caller follows up) — both by explicit ruling.
 
 ## Historical note
 

--- a/docs/00-current-status.md
+++ b/docs/00-current-status.md
@@ -23,7 +23,11 @@ are recreated on demand). `deploy/e2e/12-restart.sh` certifies exactly this.
 ## What runs today
 
 38 deployed business services + Redis Streams + PostgreSQL, all under
-`deploy/k8s/`, with service images built by `deploy/build-images.sh`.
+`deploy/k8s/`, each with a Dockerfile at `deploy/docker/<service>/Dockerfile`.
+`deploy/build-images.sh` currently builds 34 of them; four deployed services —
+group-booking, invoicing, loyalty-membership, and travel-insurance — have
+Dockerfiles under `deploy/docker/` but are not yet in the script's `services`
+array, so their images are built separately (a known build-script gap).
 `service-catalog.json` currently catalogs 33 of these contexts; the deployed set
 also includes corporate-travel, group-booking, loyalty-membership,
 marketing-campaign, and travel-insurance:
@@ -31,10 +35,14 @@ marketing-campaign, and travel-insurance:
 | Language | Services |
 |---|---|
 | Java (Boot 4) | admin-audit, booking-orchestration, finance-settlement, group-booking, journey-order, marketing-campaign, payment, post-sales, traveler-profile, wallet-promotion |
-| Python (FastAPI) | corporate-travel, disruption-recovery, fare-pricing, identity-verification, legacy-acl, reporting, risk-compliance, transfer-management, trip-planning |
+| Python (FastAPI) | corporate-travel, disruption-recovery, fare-pricing, identity-verification, legacy-acl, reporting, risk-compliance, transfer-management |
 | Node (TS) | account, ancillary-service, customer-service, loyalty-membership, notification, offer-management, waitlist |
 | Go | dispatch, fulfillment, payment-channel, place-network, provider-integration, seat-assignment, service-plan, supplier-catalog, travel-insurance |
-| Rust | capacity-availability, entitlement-ticketing, invoicing |
+| Rust | capacity-availability, entitlement-ticketing, invoicing, trip-planning |
+
+The deployed `trip-planning` image builds the Rust `services/trip-planning-rs`
+(its Dockerfile compiles that crate; a legacy Python `services/trip-planning`
+tree remains in the repo but is not what ships).
 
 Wave 15 activated **waitlist** (ADR-0002): sold-out demand now queues with
 deadline, payment guarantee and fairness invariants, matches released

--- a/docs/08-contracts/events/ancillary-service.md
+++ b/docs/08-contracts/events/ancillary-service.md
@@ -1,6 +1,6 @@
 # Ancillary Service — Events & Commands
 
-Last updated: 2026-07-09
+Last updated: 2026-07-15
 
 ## Scope and activation-wave rulings
 
@@ -29,9 +29,10 @@ Activation-wave rulings:
 - Ancillary Service subscribes only to `JourneyOrderCancelled` from
   `events:journey-order` in this wave. It cancels associated non-terminal order
   items idempotently and emits normal cancellation lifecycle facts.
-- Finance Settlement, Notification, and Post Sales are intended consumers for the
-  published event surface, but concrete consumer implementations are deferred to
-  later waves. Reporting may consume events for read models and metrics.
+- Finance Settlement, Notification, Post Sales, Journey Order, Offer Management,
+  Fulfillment, Payment, and Reporting now consume the event subsets listed below.
+  Catalog-item notifications remain a documented future touchpoint until the
+  notification service maps those event types.
 
 All payload fields are camelCase, all enum values are SCREAMING_SNAKE_CASE, and
 all timestamps are RFC3339 UTC. Envelope fields, including optional trace context
@@ -122,7 +123,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | deferred: offer-management, notification, reporting |
+| **Consumers** | offer-management, reporting; deferred: notification |
 | **Trigger** | `PublishCatalogItem` command publishes a configured catalog item. |
 
 **Payload:**
@@ -153,7 +154,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | deferred: offer-management, notification, reporting |
+| **Consumers** | offer-management, reporting; deferred: notification |
 | **Trigger** | `SuspendCatalogItem` command pauses sale of a published or suspended item. |
 
 **Payload:**
@@ -174,7 +175,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | deferred: offer-management, notification, reporting |
+| **Consumers** | offer-management, reporting; deferred: notification |
 | **Trigger** | `SupersedeCatalogItem` command replaces a catalog version. |
 
 **Payload:**
@@ -196,7 +197,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | deferred: offer-management, journey-order, notification, reporting |
+| **Consumers** | offer-management, journey-order, notification, reporting |
 | **Trigger** | `QuoteAncillaryOffer` command succeeds after minimum eligibility and Fare & Pricing dynamic-rule pricing or catalog fallback pricing. |
 
 **Payload:**
@@ -229,7 +230,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | deferred: offer-management, journey-order, notification, reporting |
+| **Consumers** | offer-management, journey-order, notification, reporting |
 | **Trigger** | Quote validity window elapsed or explicit scheduler/domain expiry. |
 
 **Payload:**
@@ -252,7 +253,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | deferred: journey-order, notification, reporting |
+| **Consumers** | journey-order, notification, reporting |
 | **Trigger** | `SelectAncillaryOffer` creates an ancillary order item from a valid quote. |
 
 **Payload:**
@@ -282,7 +283,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | deferred: journey-order, notification, reporting |
+| **Consumers** | journey-order, notification, reporting |
 | **Trigger** | `ConfirmAncillaryItem` begins supplier/voucher/entitlement confirmation but is not final. |
 
 **Payload fields:** same identity, reference, `payableAmount`, and
@@ -295,7 +296,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | deferred: journey-order, notification, reporting |
+| **Consumers** | journey-order, notification, reporting |
 | **Trigger** | `ConfirmAncillaryItem` confirms the service after required prerequisites. |
 
 **Payload fields:** same identity, reference, `payableAmount`, and
@@ -308,7 +309,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | deferred: fulfillment, journey-order, notification, reporting |
+| **Consumers** | fulfillment, journey-order, notification, reporting |
 | **Trigger** | `MarkFulfillmentReady` records voucher, seat, consign, or service-window readiness. |
 
 **Payload fields:** same identity/reference fields as
@@ -321,7 +322,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | deferred: journey-order, finance-settlement, notification, post-sales, reporting |
+| **Consumers** | journey-order, finance-settlement, notification, post-sales, reporting |
 | **Trigger** | A fulfillment fact completes the service, such as meal issued, lounge redeemed, fast track used, pickup completed, baggage/consign completed, or insurance activated. |
 
 **Payload fields:** same identity/reference fields as
@@ -333,7 +334,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | deferred: journey-order, notification, post-sales, reporting |
+| **Consumers** | journey-order, notification, post-sales, reporting |
 | **Trigger** | Confirmation or fulfillment fails, including provider fulfillment failure facts. |
 
 **Payload fields:** same identity/reference fields as
@@ -346,7 +347,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | deferred: journey-order, finance-settlement, notification, post-sales, reporting |
+| **Consumers** | journey-order, finance-settlement, notification, post-sales, reporting |
 | **Trigger** | Explicit cancel command or `JourneyOrderCancelled` consumed from Journey Order. |
 
 **Payload:**
@@ -374,7 +375,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | deferred: payment, finance-settlement, notification, post-sales, reporting |
+| **Consumers** | payment, finance-settlement, notification, post-sales, reporting |
 | **Trigger** | `SuggestAncillaryRefund` determines a refund is due; Payment execution is deferred. |
 
 **Payload:**
@@ -401,7 +402,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | deferred: journey-order, finance-settlement, notification, post-sales, reporting |
+| **Consumers** | journey-order, finance-settlement, notification, post-sales, reporting |
 | **Trigger** | `RecordAncillaryRefunded` records external Payment or operations refund completion. |
 
 **Payload:**
@@ -425,7 +426,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | deferred: fulfillment, finance-settlement, notification, post-sales, reporting |
+| **Consumers** | fulfillment, finance-settlement, notification, post-sales, reporting |
 | **Trigger** | `RecordFulfillmentFact` appends an idempotent fulfillment fact to an order item. |
 
 **Payload:**
@@ -489,9 +490,4 @@ No Journey Order contract shape is changed by this subscription.
 
 | Downstream context | Deferred events | Purpose when activated |
 |---|---|---|
-| Finance Settlement | `AncillaryOrderItemFulfilled`, `AncillaryOrderItemCancelled`, `AncillaryOrderItemRefundPending`, `AncillaryOrderItemRefunded`, `AncillaryFulfillmentFactRecorded` | Revenue recognition, refund/retention facts, supplier-cost read models. |
-| Notification | quoted/expired, order-item lifecycle, refund, and fulfillment-fact events | User-facing ancillary confirmations, failures, voucher/redeem, and refund progress. |
-| Post Sales | order-item cancellation, failure, fulfillment, refund-pending/refunded, fulfillment facts | Main-ticket after-sales impact evaluation and future compensation workflows. |
-| Journey Order | order-item selected/confirmed/ready/fulfilled/cancelled/refunded lifecycle | Future order-detail projection only; this wave does not modify Journey Order contracts. |
-| Fulfillment | `AncillaryOrderItemFulfillmentReady`, `AncillaryFulfillmentFactRecorded`, selected completion lifecycle facts | Future service voucher and evidence handoff. |
-| Reporting | all Ancillary Service events | Attach rate, refund rate, fulfillment failure, and supplier-performance read models. |
+| Notification | catalog item publish/suspend/supersede events | Optional traveler/ops catalog availability messages; notification currently handles offer/order/refund/fulfillment triggers only. |

--- a/docs/08-contracts/events/dispatch.md
+++ b/docs/08-contracts/events/dispatch.md
@@ -1,6 +1,6 @@
 # Dispatch — Events & Commands
 
-Last updated: 2026-07-08
+Last updated: 2026-07-15
 
 ## Scope and activation-wave rulings
 
@@ -20,10 +20,10 @@ Activation-wave rulings:
   this wave. Future external platform integration may replace the ops driver
   without changing these event payloads.
 - Dispatch produces `DriverArrived`, `RideStarted`, and `RideEnded` as
-  Fulfillment handoff facts. Fulfillment consumption is deferred in this wave.
-- Post Sales and Notification consumption is also deferred. The events below
-  identify intended touchpoints, but `docs/08-contracts/messaging.md` registers
-  no active Dispatch subscribers for this activation wave.
+  Fulfillment handoff facts; Fulfillment now consumes those events.
+- Notification consumes the full Dispatch lifecycle listed below, and Post Sales
+  consumes the cancellation/no-show/completion/failure subset for after-sales
+  evaluation.
 - Mutual exclusion is enforced by Dispatch: the same
   `(riderAccountId, intentFingerprint)` may have at most one active dispatch in
   `REQUESTED`, `MATCHING`, `ASSIGNED`, `DRIVER_ARRIVING`, `DRIVER_ARRIVED`,
@@ -66,7 +66,7 @@ request as `FAILED`.
 | Field | Description |
 |---|---|
 | **Producer** | dispatch |
-| **Consumers** | deferred: notification, reporting |
+| **Consumers** | notification, reporting |
 | **Trigger** | `RequestDispatch` command accepted from `POST /api/v1/ride-requests`. |
 
 **Payload:**
@@ -89,7 +89,7 @@ request as `FAILED`.
 | Field | Description |
 |---|---|
 | **Producer** | dispatch |
-| **Consumers** | deferred: notification, reporting |
+| **Consumers** | notification, reporting |
 | **Trigger** | `AssignDriver` ops command binds a driver/vehicle assignment. |
 
 **Payload:**
@@ -113,7 +113,7 @@ request as `FAILED`.
 | Field | Description |
 |---|---|
 | **Producer** | dispatch |
-| **Consumers** | deferred: notification, reporting |
+| **Consumers** | notification, reporting |
 | **Trigger** | `UpdateEta` ops command updates the active assignment ETA. |
 
 **Payload:**
@@ -135,7 +135,7 @@ request as `FAILED`.
 | Field | Description |
 |---|---|
 | **Producer** | dispatch |
-| **Consumers** | deferred: fulfillment, notification, reporting |
+| **Consumers** | fulfillment, notification, reporting |
 | **Trigger** | `MarkDriverArrived` ops command records driver arrival at pickup. |
 
 **Payload:**
@@ -153,15 +153,14 @@ request as `FAILED`.
 | `arrivedAt` | RFC3339 UTC | yes | Driver arrival timestamp. |
 | `status` | enum | yes | `DRIVER_ARRIVED`. |
 
-This event is the first Fulfillment handoff fact, but Fulfillment consumption is
-deferred in this wave.
+This event is the first Fulfillment handoff fact and is consumed by Fulfillment.
 
 ### RideStarted
 
 | Field | Description |
 |---|---|
 | **Producer** | dispatch |
-| **Consumers** | deferred: fulfillment, notification, reporting |
+| **Consumers** | fulfillment, notification, reporting |
 | **Trigger** | `StartRide` ops command records rider pickup / ride start. |
 
 **Payload:**
@@ -179,15 +178,14 @@ deferred in this wave.
 | `startedAt` | RFC3339 UTC | yes | Ride start timestamp. |
 | `status` | enum | yes | `PICKED_UP`. |
 
-This event is a Fulfillment handoff fact, but Fulfillment consumption is deferred
-in this wave.
+This event is a Fulfillment handoff fact and is consumed by Fulfillment.
 
 ### RideEnded
 
 | Field | Description |
 |---|---|
 | **Producer** | dispatch |
-| **Consumers** | deferred: fulfillment, post-sales, notification, reporting |
+| **Consumers** | fulfillment, post-sales, notification, reporting |
 | **Trigger** | `CompleteDispatch` ops command records ride completion. This is the wire event for the domain `DispatchCompleted` fact. |
 
 **Payload:**
@@ -207,15 +205,14 @@ in this wave.
 | `finalFareRef` | string | no | Optional final fare or adjustment reference recorded by Dispatch. |
 | `status` | enum | yes | `COMPLETED`. |
 
-This event is the final Fulfillment handoff fact. Fulfillment and Post Sales
-consumption is deferred in this wave.
+This event is the final Fulfillment handoff fact and is consumed by Fulfillment and Post Sales.
 
 ### DriverCancelled
 
 | Field | Description |
 |---|---|
 | **Producer** | dispatch |
-| **Consumers** | deferred: notification, reporting |
+| **Consumers** | notification, reporting |
 | **Trigger** | `CancelByDriver` ops command records driver/provider cancellation of the active assignment. |
 
 **Payload:**
@@ -241,7 +238,7 @@ publishing this fact unless a future failure policy closes the request.
 | Field | Description |
 |---|---|
 | **Producer** | dispatch |
-| **Consumers** | deferred: post-sales, notification, reporting |
+| **Consumers** | post-sales, notification, reporting |
 | **Trigger** | `CancelByUser` command cancels an active dispatch. |
 
 **Payload:**
@@ -263,7 +260,7 @@ publishing this fact unless a future failure policy closes the request.
 | Field | Description |
 |---|---|
 | **Producer** | dispatch |
-| **Consumers** | deferred: post-sales, notification, reporting |
+| **Consumers** | post-sales, notification, reporting |
 | **Trigger** | `RecordNoShow` ops command records that the rider did not appear after driver arrival. |
 
 **Payload:**
@@ -287,7 +284,7 @@ publishing this fact unless a future failure policy closes the request.
 | Field | Description |
 |---|---|
 | **Producer** | dispatch |
-| **Consumers** | deferred: post-sales, notification, reporting |
+| **Consumers** | post-sales, notification, reporting |
 | **Trigger** | Timeout scan closes a `REQUESTED`/`MATCHING` request whose window elapsed (activation-wave increment 2026-07-09). |
 
 **Payload:**
@@ -326,12 +323,3 @@ the wire event name used for the domain `DispatchCompleted` completion fact.
 
 Dispatch registers no upstream event subscriptions in this activation wave.
 External provider-platform events are deferred by the simulation-boundary ruling.
-
-## Deferred downstream touchpoints
-
-| Downstream context | Deferred events | Purpose when activated |
-|---|---|---|
-| Fulfillment | `DriverArrived`, `RideStarted`, `RideEnded` | Ride arrival/start/end facts for fulfillment evidence and lifecycle. |
-| Notification | `DispatchRequested`, `DriverAssigned`, `DriverEtaUpdated`, `DriverArrived`, `DriverCancelled`, `DispatchUserCancelled`, `DispatchNoShowRecorded`, `RideEnded` | User-facing dispatch lifecycle notifications. |
-| Post Sales | `DispatchUserCancelled`, `DispatchNoShowRecorded`, `RideEnded` | Cancellation, waiting-fee, no-show, and final-charge dispute handling. |
-| Reporting | all Dispatch events | Dispatch lifecycle metrics and operational read models. |

--- a/docs/08-contracts/events/disruption-recovery.md
+++ b/docs/08-contracts/events/disruption-recovery.md
@@ -1,6 +1,6 @@
 # Disruption Recovery — Events & Commands
 
-Last updated: 2026-07-09
+Last updated: 2026-07-15
 
 ## Scope and activation-wave rulings
 
@@ -45,11 +45,12 @@ Activation-wave rulings:
   `REACCOMMODATION` calls Transfer Management
   `POST /api/v1/connections/{connectionId}/reaccommodate` with a folded UUID-v7
   idempotency key. `MANUAL` moves the case to manual review.
-- Reporting consumption of Disruption Recovery events remains deferred in this
-  wave. Notification is active for traveler-facing recovery lifecycle and alert
-  facts. Active inbound subscriptions are `events:post-sales` `PostSalesApplied`,
-  `events:journey-order` `JourneyOrderCreated`, and Provider Integration /
-  Fulfillment segment delay/cancellation facts.
+- Reporting consumption of Disruption Recovery events is active for analytics
+  projection handling. Notification is active for traveler-facing recovery
+  lifecycle and alert facts. Active inbound subscriptions are
+  `events:post-sales` `PostSalesApplied`, `events:journey-order`
+  `JourneyOrderCreated`, and Provider Integration / Fulfillment segment
+  delay/cancellation facts.
 
 All payload fields are camelCase, all enum values are SCREAMING_SNAKE_CASE, and
 all timestamps are RFC3339 UTC. Envelope fields, including optional trace context
@@ -148,7 +149,7 @@ are part of this normative enum.
 | Field | Description |
 |---|---|
 | **Producer** | disruption-recovery |
-| **Consumers** | deferred: reporting |
+| **Consumers** | reporting |
 | **Trigger** | Operations report accepted from `POST /api/v1/disruptions`. |
 
 **Payload:**
@@ -170,7 +171,7 @@ are part of this normative enum.
 | Field | Description |
 |---|---|
 | **Producer** | disruption-recovery |
-| **Consumers** | deferred: notification, reporting |
+| **Consumers** | reporting; deferred: notification |
 | **Trigger** | Accepted report opens a new incident instead of merging into an existing one. |
 
 **Payload:**
@@ -193,7 +194,7 @@ are part of this normative enum.
 | Field | Description |
 |---|---|
 | **Producer** | disruption-recovery |
-| **Consumers** | notification; deferred: reporting |
+| **Consumers** | notification, reporting |
 | **Trigger** | A report opens a recovery case for one explicit `affectedOrderId`. |
 
 **Payload:**
@@ -213,7 +214,7 @@ are part of this normative enum.
 | Field | Description |
 |---|---|
 | **Producer** | disruption-recovery |
-| **Consumers** | notification; deferred: reporting |
+| **Consumers** | notification, reporting |
 | **Trigger** | `GenerateRecoveryOptions` creates this wave's option set for a case. |
 
 **Payload:**
@@ -235,7 +236,7 @@ are part of this normative enum.
 | Field | Description |
 |---|---|
 | **Producer** | disruption-recovery |
-| **Consumers** | notification; deferred: reporting |
+| **Consumers** | notification, reporting |
 | **Trigger** | Automatic `WAIT` selection or user/customer-service `select-option` command. |
 
 **Payload:**
@@ -257,7 +258,7 @@ are part of this normative enum.
 | Field | Description |
 |---|---|
 | **Producer** | disruption-recovery |
-| **Consumers** | notification; deferred: reporting |
+| **Consumers** | notification, reporting |
 | **Trigger** | Selected option starts local execution or a downstream HTTP command. |
 
 **Payload:**
@@ -281,7 +282,7 @@ are part of this normative enum.
 | Field | Description |
 |---|---|
 | **Producer** | disruption-recovery |
-| **Consumers** | notification, transfer-management; deferred: reporting |
+| **Consumers** | notification, transfer-management, reporting |
 | **Trigger** | `WAIT` completes locally, Wallet / Promotion benefit issuance succeeds, consumed `PostSalesApplied` converges a REFUND execution, or Transfer Management reaccommodation returns `200`. |
 
 **Payload:**
@@ -303,7 +304,7 @@ are part of this normative enum.
 | Field | Description |
 |---|---|
 | **Producer** | disruption-recovery |
-| **Consumers** | notification, transfer-management; deferred: reporting |
+| **Consumers** | notification, transfer-management, reporting |
 | **Trigger** | A selected option fails and cannot automatically converge. |
 
 **Payload:**
@@ -324,7 +325,7 @@ are part of this normative enum.
 | Field | Description |
 |---|---|
 | **Producer** | disruption-recovery |
-| **Consumers** | deferred: reporting |
+| **Consumers** | reporting |
 | **Trigger** | `CloseRecoveryCase` archives a terminal or manually resolved case. |
 
 **Payload:**
@@ -345,7 +346,7 @@ are part of this normative enum.
 | Field | Description |
 |---|---|
 | **Producer** | disruption-recovery |
-| **Consumers** | notification; deferred: reporting |
+| **Consumers** | notification, reporting |
 | **Trigger** | Incident alert fact is published for affected users, customer service, or operations. |
 
 **Payload:**

--- a/docs/08-contracts/events/identity-verification.md
+++ b/docs/08-contracts/events/identity-verification.md
@@ -1,6 +1,6 @@
 # Identity Verification — Events & Commands
 
-Last updated: 2026-07-10
+Last updated: 2026-07-15
 
 ## Scope and activation-wave rulings
 
@@ -9,9 +9,9 @@ This contract enumerates the Identity Verification events for ADR-0003 wave A. I
 Activation-wave rulings:
 
 - **RULING (ADR-0003 wave A):** SIM 公安网关 is a deterministic, seedable in-process simulator. The default policy maps the normalized document number tail digit as `0`-`5` -> pass, `6`-`8` -> reject, and `9` -> manual review. No real公安/学信/民政/军残/铁路 endpoint, credential, token, or raw payload is used or emitted.
-- Journey Order uses the synchronous pre-order hook documented in the HTTP API before accepting order creation; Identity Verification events do not create Journey Order state transitions.
-- Fare & Pricing uses only the read-only certificate query for discount-rule eligibility. This event surface publishes certificate facts but does not compute fare amounts or Money.
-- Purchase-limit fact events are published for future Risk & Compliance consumption. Risk & Compliance is not an active consumer in this wave and no `AssessRisk` command is emitted by this context.
+- Journey Order uses the synchronous pre-order hook documented in the HTTP API before accepting order creation; Identity Verification events do not create Journey Order state transitions, but Journey Order now consumes identity and eligibility facts for projections and idempotent convergence.
+- Fare & Pricing uses the read-only certificate query for discount-rule eligibility and now consumes certificate/usage facts to maintain its eligibility read model. This event surface does not compute fare amounts or Money.
+- Purchase-limit fact events are now active Risk & Compliance inputs for duplicate-ticket/risk tracking. Customer Service consumes the failed/missed exception subset for support context.
 
 All payload fields are camelCase, all enum values are SCREAMING_SNAKE_CASE, and all timestamps are RFC3339 UTC. Envelope fields, including optional trace context propagation, follow `docs/08-contracts/messaging.md` and `docs/08-contracts/shared-primitives.md`. Event payloads MUST NOT carry unmasked document numbers, full names, birth dates, SIM raw request/response, or external credentials.
 
@@ -92,7 +92,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | none in this wave (deferred: traveler-profile, journey-order, customer-service) |
+| **Consumers** | traveler-profile, journey-order; deferred: customer-service |
 | **Trigger** | `RegisterCredential` accepts hashed/masked credential material. |
 
 **Payload:**
@@ -116,7 +116,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | none in this wave (deferred: journey-order, customer-service, reporting) |
+| **Consumers** | journey-order, reporting; deferred: customer-service |
 | **Trigger** | `StartVerificationCase` creates a new case for a credential and purpose. |
 
 **Payload:**
@@ -138,7 +138,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | none in this wave (deferred: reporting) |
+| **Consumers** | reporting |
 | **Trigger** | Case material is submitted to the deterministic SIM adapter. |
 
 **Payload:**
@@ -160,7 +160,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | none in this wave (deferred: journey-order, traveler-profile, customer-service, reporting) |
+| **Consumers** | journey-order, traveler-profile, reporting; deferred: customer-service |
 | **Trigger** | Deterministic SIM result is `MATCH` or an audited override produces a passed conclusion. |
 
 **Payload:**
@@ -184,7 +184,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | none in this wave (deferred: journey-order, traveler-profile, customer-service, reporting) |
+| **Consumers** | journey-order, traveler-profile, customer-service, reporting |
 | **Trigger** | Deterministic SIM result is rejected, manual review is required, or audited conclusion fails. |
 
 **Payload:**
@@ -207,7 +207,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | none in this wave (deferred: fare-pricing, journey-order, customer-service) |
+| **Consumers** | fare-pricing, journey-order; deferred: customer-service |
 | **Trigger** | `RegisterEligibilityCertificate` stores certificate material hash and policy scope. |
 
 **Payload:**
@@ -238,7 +238,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | none in this wave (deferred: fare-pricing, journey-order, customer-service) |
+| **Consumers** | fare-pricing, journey-order; deferred: customer-service |
 | **Trigger** | Certificate material passes the deterministic eligibility simulator or audit. |
 
 **Payload:**
@@ -268,7 +268,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | none in this wave (deferred: journey-order, fare-pricing; future: risk-compliance) |
+| **Consumers** | journey-order, fare-pricing |
 | **Trigger** | Order intent reserves one annual certificate usage. |
 
 **Payload:**
@@ -291,7 +291,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | none in this wave (deferred: journey-order, fare-pricing; future: risk-compliance) |
+| **Consumers** | journey-order, fare-pricing |
 | **Trigger** | A protected Journey Order was accepted and consumes the reserved usage. |
 
 **Payload:**
@@ -313,7 +313,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | none in this wave (deferred: journey-order, fare-pricing; future: risk-compliance) |
+| **Consumers** | journey-order, fare-pricing |
 | **Trigger** | A reservation is released because order creation is abandoned, cancelled before protection, or precondition fails. |
 
 **Payload:**
@@ -335,7 +335,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | none in this wave (future: risk-compliance; deferred: reporting) |
+| **Consumers** | risk-compliance, reporting |
 | **Trigger** | Pre-order check records an idempotent fact for a protected identity scope. |
 
 **Payload:**
@@ -361,7 +361,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | none in this wave (future: risk-compliance; deferred: reporting) |
+| **Consumers** | risk-compliance, reporting |
 | **Trigger** | Journey Order acceptance confirms a recorded purchase-limit fact. |
 
 **Payload:**
@@ -381,7 +381,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | none in this wave (future: risk-compliance; deferred: reporting) |
+| **Consumers** | risk-compliance, reporting |
 | **Trigger** | Order intent is abandoned or cancelled before the protection point. |
 
 **Payload:**
@@ -402,7 +402,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | none in this wave (future: risk-compliance; deferred: reporting) |
+| **Consumers** | risk-compliance, customer-service, reporting |
 | **Trigger** | A monitor detects no confirm/release before the fact TTL bucket. |
 
 **Payload:**
@@ -422,7 +422,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | none in this wave (future: risk-compliance; deferred: reporting) |
+| **Consumers** | risk-compliance, customer-service, reporting |
 | **Trigger** | Ledger detects a conflict or invariant violation while recording or reconciling a limit fact. |
 
 **Payload:**
@@ -457,4 +457,4 @@ Identity Verification may consume `RiskBlockApplied` and `RiskBlockLifted` from 
 | `journey-order` | Event/command mapping | Do not add new order lifecycle events for identity results in this wave; existing create rejection uses existing validation/domain error paths. |
 | `fare-pricing` | Quote eligibility adapter | Query active `EligibilityCertificate` summaries read-only before discount evaluation. |
 | `fare-pricing` | Discount enum mapping | Map `STUDENT`, `CHILD`, `MILITARY_DISABLED` without changing Money fields. |
-| `risk-compliance` | Future subscription placeholder | No active consumer in this wave; future consumer will deduplicate purchase-limit facts by envelope `eventId` and fact ID. |
+| `risk-compliance` | Purchase-limit fact projection | Actively consumes `PurchaseLimitFactRecorded`, `PurchaseLimitFactConfirmed`, `PurchaseLimitFactReleased`, `PurchaseLimitFactMissed`, and `PurchaseLimitFactFailed` from `events:identity-verification`; deduplicate by envelope `eventId` and fact ID. |

--- a/docs/08-contracts/events/payment-channel.md
+++ b/docs/08-contracts/events/payment-channel.md
@@ -1,6 +1,6 @@
 # Payment Channel — Events & Commands
 
-Last updated: 2026-07-10
+Last updated: 2026-07-15
 
 ## Scope and activation-wave rulings
 
@@ -90,7 +90,7 @@ stored directly; internal commands fold canonical material as documented in
 | Field | Description |
 |---|---|
 | **Producer** | payment-channel |
-| **Consumers** | none in this wave (payment ack-skips operational attempt/query facts per messaging.md row 20a; deferred: reporting) |
+| **Consumers** | reporting (payment ack-skips operational attempt/query facts per messaging.md row 20a) |
 | **Trigger** | `CreateChannelOrder` command accepted from Payment handoff. |
 
 **Payload:**
@@ -116,7 +116,7 @@ stored directly; internal commands fold canonical material as documented in
 | Field | Description |
 |---|---|
 | **Producer** | payment-channel |
-| **Consumers** | none in this wave (payment ack-skips operational attempt/query facts per messaging.md row 20a; deferred: reporting) |
+| **Consumers** | reporting (payment ack-skips operational attempt/query facts per messaging.md row 20a) |
 | **Trigger** | `SubmitChannelOrder` records an outbound SIM submit attempt. |
 
 **Payload:**
@@ -139,7 +139,7 @@ stored directly; internal commands fold canonical material as documented in
 | Field | Description |
 |---|---|
 | **Producer** | payment-channel |
-| **Consumers** | none in this wave (payment ack-skips operational attempt/query facts per messaging.md row 20a; deferred: reporting) |
+| **Consumers** | reporting (payment ack-skips operational attempt/query facts per messaging.md row 20a) |
 | **Trigger** | SIM deterministically accepts the order but finality is not yet known. |
 
 **Payload:**
@@ -234,7 +234,7 @@ stored directly; internal commands fold canonical material as documented in
 | Field | Description |
 |---|---|
 | **Producer** | payment-channel |
-| **Consumers** | none in this wave (payment ack-skips operational attempt/query facts per messaging.md row 20a; deferred: reporting) |
+| **Consumers** | reporting (payment ack-skips operational attempt/query facts per messaging.md row 20a) |
 | **Trigger** | `QueryChannelOrder` records deterministic status query evidence. |
 
 **Payload:**
@@ -277,7 +277,7 @@ stored directly; internal commands fold canonical material as documented in
 | Field | Description |
 |---|---|
 | **Producer** | payment-channel |
-| **Consumers** | none in this wave (payment ack-skips operational attempt/query facts per messaging.md row 20a; deferred: reporting) |
+| **Consumers** | reporting (payment ack-skips operational attempt/query facts per messaging.md row 20a) |
 | **Trigger** | `CreateChannelRefund` command accepted from Payment handoff. |
 
 **Payload:**
@@ -311,7 +311,7 @@ out of `ACCEPTED`.
 | Field | Description |
 |---|---|
 | **Producer** | payment-channel |
-| **Consumers** | none in this wave (payment ack-skips operational attempt/query facts per messaging.md row 20a; deferred: reporting) |
+| **Consumers** | reporting (payment ack-skips operational attempt/query facts per messaging.md row 20a) |
 | **Trigger** | `SubmitChannelRefund` records an outbound SIM refund attempt. |
 
 **Payload:**
@@ -409,7 +409,7 @@ out of `ACCEPTED`.
 | Field | Description |
 |---|---|
 | **Producer** | payment-channel |
-| **Consumers** | none in this wave (payment ack-skips operational attempt/query facts per messaging.md row 20a; deferred: reporting) |
+| **Consumers** | reporting (payment ack-skips operational attempt/query facts per messaging.md row 20a) |
 | **Trigger** | `QueryChannelRefund` records deterministic refund query evidence. |
 
 **Payload:**
@@ -505,7 +505,7 @@ out of `ACCEPTED`.
 | Field | Description |
 |---|---|
 | **Producer** | payment-channel |
-| **Consumers** | finance-settlement ack-skip if it owns the match; none in this wave (deferred: reporting). |
+| **Consumers** | reporting; finance-settlement ack-skip if it owns the match. |
 | **Trigger** | Statement matching links a line to platform/channel facts. |
 
 **Payload:**
@@ -557,7 +557,7 @@ out of `ACCEPTED`.
 | Field | Description |
 |---|---|
 | **Producer** | payment-channel |
-| **Consumers** | finance-settlement ack-skip; none in this wave (deferred: reporting). |
+| **Consumers** | reporting; finance-settlement ack-skip. |
 | **Trigger** | A discrepancy is linked to an existing Finance reconciliation case. |
 
 **Payload:**

--- a/docs/08-contracts/events/transfer-management.md
+++ b/docs/08-contracts/events/transfer-management.md
@@ -1,6 +1,6 @@
 # Transfer Management — Events & Commands
 
-Last updated: 2026-07-09
+Last updated: 2026-07-15
 
 ## Scope and activation-wave rulings
 
@@ -37,11 +37,12 @@ Activation-wave rulings:
   replacement fields; when it later consumes the resulting `RecoveryCompleted`
   for the same `caseId`, it idempotently skips because the original connection is
   already `RECOVERED`. `SELF_TRANSFER` misses publish facts only.
-- Notification now actively consumes traveler-facing connection-state events
-  (`TransferAtRisk`, `ConnectionMissed`, and `ConnectionRecovered`). Reporting,
-  Offer Management, Journey Order, and Customer Service downstream consumers
-  remain deferred except Transfer Management's inbound subscription to Disruption
-  Recovery.
+- Notification actively consumes traveler-facing connection-state events
+  (`TransferAtRisk`, `ConnectionMissed`, and `ConnectionRecovered`). Reporting
+  consumes the full Transfer Management stream. Offer Management, Journey Order,
+  Trip Planning, and Customer Service consume the event subsets called out in the
+  per-event consumer rows; other intended touchpoints remain deferred until their
+  handlers map those event types.
 
 All payload fields are camelCase, all enum values are SCREAMING_SNAKE_CASE, and
 all timestamps are RFC3339 UTC. Envelope fields, including optional trace context
@@ -132,7 +133,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: offer-management, journey-order, reporting |
+| **Consumers** | reporting; deferred: offer-management, journey-order |
 | **Trigger** | `CreateTransferPlan` accepted from `POST /api/v1/transfer-plans`. |
 
 **Payload:**
@@ -154,7 +155,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: offer-management, journey-order, reporting |
+| **Consumers** | offer-management, reporting; deferred: journey-order |
 | **Trigger** | Plan evaluation completed or refreshed. |
 
 **Payload:**
@@ -177,7 +178,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: offer-management, reporting |
+| **Consumers** | reporting; deferred: offer-management |
 | **Trigger** | Planning/offer window expires. |
 
 **Payload:**
@@ -196,7 +197,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: journey-order, customer-service, reporting |
+| **Consumers** | reporting; deferred: journey-order, customer-service |
 | **Trigger** | `RegisterConnection` command creates a connection. |
 
 **Payload:**
@@ -227,7 +228,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: offer-management, journey-order, customer-service, reporting |
+| **Consumers** | reporting; deferred: offer-management, journey-order, customer-service |
 | **Trigger** | Initial, scheduled, or segment-report-driven risk evaluation completes. |
 
 **Payload:**
@@ -246,7 +247,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | notification; deferred: customer-service, reporting |
+| **Consumers** | notification, reporting; deferred: customer-service |
 | **Trigger** | A connection transitions to `AT_RISK`. |
 
 **Payload:**
@@ -267,7 +268,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | notification; deferred: customer-service, reporting |
+| **Consumers** | notification, journey-order, customer-service, reporting |
 | **Trigger** | A connection transitions to `MISSED`. Protected contracts also start the outbound Disruption Recovery HTTP command. |
 
 **Payload:**
@@ -290,7 +291,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | notification; deferred: customer-service, reporting |
+| **Consumers** | notification, journey-order, customer-service, reporting |
 | **Trigger** | Consumed Disruption Recovery `RecoveryCompleted` matches a stored `caseId`, an explicit controlled recovery command restores the connection, or Disruption Recovery calls `POST /api/v1/connections/{connectionId}/reaccommodate`. |
 
 **Payload:**
@@ -321,7 +322,7 @@ a normal transition to `RECOVERED`.
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: customer-service, reporting |
+| **Consumers** | customer-service, reporting |
 | **Trigger** | Consumed Disruption Recovery `RecoveryFailed` matches a stored `caseId`, or the outbound recovery report failed permanently. |
 
 **Payload:**
@@ -340,7 +341,7 @@ a normal transition to `RECOVERED`.
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: offer-management, journey-order, reporting |
+| **Consumers** | offer-management, reporting; deferred: journey-order |
 | **Trigger** | Contract option proposed for a connection. |
 
 **Payload:**
@@ -362,7 +363,7 @@ a normal transition to `RECOVERED`.
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: journey-order, customer-service, reporting |
+| **Consumers** | journey-order, reporting; deferred: customer-service |
 | **Trigger** | Offer/order accepts the contract snapshot. |
 
 **Payload:**
@@ -383,7 +384,7 @@ a normal transition to `RECOVERED`.
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: journey-order, customer-service, reporting |
+| **Consumers** | reporting; deferred: journey-order, customer-service |
 | **Trigger** | Contract is withdrawn, voided, or rejected by controlled command. |
 
 **Payload:**
@@ -405,7 +406,7 @@ a normal transition to `RECOVERED`.
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: reporting, operations audit |
+| **Consumers** | reporting; deferred: operations audit |
 | **Trigger** | Operations activates a `TransferRiskPolicy`; any previous active policy is retired. |
 
 **Payload:**
@@ -426,7 +427,7 @@ a normal transition to `RECOVERED`.
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: reporting |
+| **Consumers** | reporting |
 | **Trigger** | Operations creates a draft MCT rule. |
 
 **Payload:**
@@ -450,7 +451,7 @@ a normal transition to `RECOVERED`.
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: trip-planning, offer-management, reporting |
+| **Consumers** | trip-planning, offer-management, reporting |
 | **Trigger** | Operations publishes a validated MCT rule version. |
 
 **Payload:**
@@ -476,7 +477,7 @@ a normal transition to `RECOVERED`.
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: trip-planning, offer-management, reporting |
+| **Consumers** | trip-planning, reporting; deferred: offer-management |
 | **Trigger** | Operations retires a published MCT rule version. |
 
 **Payload:**
@@ -524,10 +525,9 @@ remains the active fallback adapter.
 
 ## Deferred downstream touchpoints
 
-| Downstream context | Events | Purpose |
+| Downstream context | Deferred events | Purpose when activated |
 |---|---|---|
-| Notification | `TransferAtRisk`, `ConnectionMissed`, `ConnectionRecovered` | Active user-facing transfer risk and recovery notifications. |
-| Reporting | all Transfer Management events | Connection success rate, MCT quality, protected exposure, and supplier quality metrics. |
-| Journey Order | `ConnectionContractConfirmed`, `ConnectionMissed`, `ConnectionRecovered` | Order-detail responsibility and recovery display. |
-| Offer Management | `TransferPlanEvaluated`, `ConnectionContractProposed`, `MctRulePublished` | Quote-time feasibility and contract display. |
-| Customer Service | `TransferAtRisk`, `ConnectionMissed`, `ConnectionRecovered`, `ConnectionRecoveryFailed` | Support timeline and responsibility explanation. |
+| Journey Order | `TransferPlanCreated`, `TransferPlanEvaluated`, `TransferRiskEvaluated`, `ConnectionRegistered`, `ConnectionContractProposed`, `ConnectionContractWithdrawn` | Broader order-detail projection beyond confirmed contract and missed/recovered connection facts. |
+| Offer Management | `TransferPlanCreated`, `TransferPlanExpired`, `TransferRiskEvaluated`, `MctRuleRetired` | Additional quote-time feasibility and catalog maintenance beyond the active evaluated/proposed/published subset. |
+| Customer Service | non-exception transfer-planning/contract events | Support context beyond missed/recovered/recovery-failed exception handling. |
+| Operations audit | `RiskPolicyActivated` | Operator audit projection if/when admin-audit subscribes to transfer-management. |


### PR DESCRIPTION
## Summary
- Move verified active event consumers out of deferred labels across producer contract docs
- Remove/update deferred touchpoint tables for activated downstream consumers
- Refresh current status with deployed service count and consumer-activation/waitlist conformance summary

## Validation
- git diff --check
- subscription spot-check script across reporting, notification, customer-service, journey-order, offer-management, post-sales, fulfillment, finance-settlement, payment, fare-pricing, traveler-profile, trip-planning, and risk-compliance stream configs/handlers
- docs-only diff check