### PR TITLE
docs: drop misleading 'deferred:' labels for non-consumer events

### DIFF
--- a/docs/08-contracts/events/ancillary-service.md
+++ b/docs/08-contracts/events/ancillary-service.md
@@ -123,7 +123,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | offer-management, reporting; deferred: notification |
+| **Consumers** | offer-management, reporting |
 | **Trigger** | `PublishCatalogItem` command publishes a configured catalog item. |
 
 **Payload:**
@@ -154,7 +154,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | offer-management, reporting; deferred: notification |
+| **Consumers** | offer-management, reporting |
 | **Trigger** | `SuspendCatalogItem` command pauses sale of a published or suspended item. |
 
 **Payload:**
@@ -175,7 +175,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | Field | Description |
 |---|---|
 | **Producer** | ancillary-service |
-| **Consumers** | offer-management, reporting; deferred: notification |
+| **Consumers** | offer-management, reporting |
 | **Trigger** | `SupersedeCatalogItem` command replaces a catalog version. |
 
 **Payload:**
@@ -485,9 +485,3 @@ terminal (`FULFILLED`, `REFUNDED`, or terminal `CANCELLED`), it emits
 - `reasonCode = JOURNEY_ORDER_CANCELLED`
 
 No Journey Order contract shape is changed by this subscription.
-
-## Deferred downstream touchpoints
-
-| Downstream context | Deferred events | Purpose when activated |
-|---|---|---|
-| Notification | catalog item publish/suspend/supersede events | Optional traveler/ops catalog availability messages; notification currently handles offer/order/refund/fulfillment triggers only. |

--- a/docs/08-contracts/events/disruption-recovery.md
+++ b/docs/08-contracts/events/disruption-recovery.md
@@ -171,7 +171,7 @@ are part of this normative enum.
 | Field | Description |
 |---|---|
 | **Producer** | disruption-recovery |
-| **Consumers** | reporting; deferred: notification |
+| **Consumers** | reporting |
 | **Trigger** | Accepted report opens a new incident instead of merging into an existing one. |
 
 **Payload:**

--- a/docs/08-contracts/events/identity-verification.md
+++ b/docs/08-contracts/events/identity-verification.md
@@ -92,7 +92,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | traveler-profile, journey-order; deferred: customer-service |
+| **Consumers** | traveler-profile, journey-order |
 | **Trigger** | `RegisterCredential` accepts hashed/masked credential material. |
 
 **Payload:**
@@ -116,7 +116,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | journey-order, reporting; deferred: customer-service |
+| **Consumers** | journey-order, reporting |
 | **Trigger** | `StartVerificationCase` creates a new case for a credential and purpose. |
 
 **Payload:**
@@ -160,7 +160,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | journey-order, traveler-profile, reporting; deferred: customer-service |
+| **Consumers** | journey-order, traveler-profile, reporting |
 | **Trigger** | Deterministic SIM result is `MATCH` or an audited override produces a passed conclusion. |
 
 **Payload:**
@@ -207,7 +207,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | fare-pricing, journey-order; deferred: customer-service |
+| **Consumers** | fare-pricing, journey-order |
 | **Trigger** | `RegisterEligibilityCertificate` stores certificate material hash and policy scope. |
 
 **Payload:**
@@ -238,7 +238,7 @@ Material fingerprint rule: `materialFingerprint = sha256(canonicalNameHash | doc
 | Field | Description |
 |---|---|
 | **Producer** | identity-verification |
-| **Consumers** | fare-pricing, journey-order; deferred: customer-service |
+| **Consumers** | fare-pricing, journey-order |
 | **Trigger** | Certificate material passes the deterministic eligibility simulator or audit. |
 
 **Payload:**

--- a/docs/08-contracts/events/transfer-management.md
+++ b/docs/08-contracts/events/transfer-management.md
@@ -41,8 +41,8 @@ Activation-wave rulings:
   (`TransferAtRisk`, `ConnectionMissed`, and `ConnectionRecovered`). Reporting
   consumes the full Transfer Management stream. Offer Management, Journey Order,
   Trip Planning, and Customer Service consume the event subsets called out in the
-  per-event consumer rows; other intended touchpoints remain deferred until their
-  handlers map those event types.
+  per-event consumer rows. Events not listed for a given consumer are simply
+  outside that consumer's concern, not pending work.
 
 All payload fields are camelCase, all enum values are SCREAMING_SNAKE_CASE, and
 all timestamps are RFC3339 UTC. Envelope fields, including optional trace context
@@ -133,7 +133,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | reporting; deferred: offer-management, journey-order |
+| **Consumers** | reporting |
 | **Trigger** | `CreateTransferPlan` accepted from `POST /api/v1/transfer-plans`. |
 
 **Payload:**
@@ -155,7 +155,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | offer-management, reporting; deferred: journey-order |
+| **Consumers** | offer-management, reporting |
 | **Trigger** | Plan evaluation completed or refreshed. |
 
 **Payload:**
@@ -178,7 +178,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | reporting; deferred: offer-management |
+| **Consumers** | reporting |
 | **Trigger** | Planning/offer window expires. |
 
 **Payload:**
@@ -197,7 +197,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | reporting; deferred: journey-order, customer-service |
+| **Consumers** | reporting |
 | **Trigger** | `RegisterConnection` command creates a connection. |
 
 **Payload:**
@@ -228,7 +228,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | reporting; deferred: offer-management, journey-order, customer-service |
+| **Consumers** | reporting |
 | **Trigger** | Initial, scheduled, or segment-report-driven risk evaluation completes. |
 
 **Payload:**
@@ -247,7 +247,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | notification, reporting; deferred: customer-service |
+| **Consumers** | notification, reporting |
 | **Trigger** | A connection transitions to `AT_RISK`. |
 
 **Payload:**
@@ -341,7 +341,7 @@ a normal transition to `RECOVERED`.
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | offer-management, reporting; deferred: journey-order |
+| **Consumers** | offer-management, reporting |
 | **Trigger** | Contract option proposed for a connection. |
 
 **Payload:**
@@ -363,7 +363,7 @@ a normal transition to `RECOVERED`.
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | journey-order, reporting; deferred: customer-service |
+| **Consumers** | journey-order, reporting |
 | **Trigger** | Offer/order accepts the contract snapshot. |
 
 **Payload:**
@@ -384,7 +384,7 @@ a normal transition to `RECOVERED`.
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | reporting; deferred: journey-order, customer-service |
+| **Consumers** | reporting |
 | **Trigger** | Contract is withdrawn, voided, or rejected by controlled command. |
 
 **Payload:**
@@ -406,7 +406,7 @@ a normal transition to `RECOVERED`.
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | reporting; deferred: operations audit |
+| **Consumers** | reporting |
 | **Trigger** | Operations activates a `TransferRiskPolicy`; any previous active policy is retired. |
 
 **Payload:**
@@ -477,7 +477,7 @@ a normal transition to `RECOVERED`.
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | trip-planning, reporting; deferred: offer-management |
+| **Consumers** | trip-planning, reporting |
 | **Trigger** | Operations retires a published MCT rule version. |
 
 **Payload:**
@@ -522,12 +522,3 @@ a normal transition to `RECOVERED`.
 Fulfillment runtime facts are consumed when produced and mapped to the same
 segment-status command material; the system/ops segment-status reporting endpoint
 remains the active fallback adapter.
-
-## Deferred downstream touchpoints
-
-| Downstream context | Deferred events | Purpose when activated |
-|---|---|---|
-| Journey Order | `TransferPlanCreated`, `TransferPlanEvaluated`, `TransferRiskEvaluated`, `ConnectionRegistered`, `ConnectionContractProposed`, `ConnectionContractWithdrawn` | Broader order-detail projection beyond confirmed contract and missed/recovered connection facts. |
-| Offer Management | `TransferPlanCreated`, `TransferPlanExpired`, `TransferRiskEvaluated`, `MctRuleRetired` | Additional quote-time feasibility and catalog maintenance beyond the active evaluated/proposed/published subset. |
-| Customer Service | non-exception transfer-planning/contract events | Support context beyond missed/recovered/recovery-failed exception handling. |
-| Operations audit | `RiskPolicyActivated` | Operator audit projection if/when admin-audit subscribes to transfer-management. |


### PR DESCRIPTION
Strips 20 per-event `deferred: <consumer>` annotations and 2 'Deferred downstream touchpoints' tables that mislabeled already-active consumers on events they have no domain reason to consume. Verified via code that none of the 20 are wired and none should be. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)