### PR TITLE
fix(waitlist): set tsc --rootDir src in Docker build (TS5011)

### DIFF
--- a/deploy/docker/waitlist/Dockerfile
+++ b/deploy/docker/waitlist/Dockerfile
@@ -8,7 +8,7 @@ COPY services/waitlist/package.json services/waitlist/package-lock.json services
 RUN --mount=type=cache,target=/root/.npm cd services/waitlist && npm ci --install-links
 COPY services/waitlist/src ./services/waitlist/src
 COPY services/waitlist/migrations ./services/waitlist/migrations
-RUN cd services/waitlist && npx tsc --noEmit false --outDir dist
+RUN cd services/waitlist && npx tsc --noEmit false --rootDir src --outDir dist
 
 FROM node:26-alpine
 WORKDIR /app


### PR DESCRIPTION
The waitlist prod image failed to build (TS5011) after REQ-340..344 added a tests/ dir + tsconfig include without rootDir. Pass --rootDir src in the Dockerfile build step; verified the image builds with flat dist/main.js. Local npm test unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)