### PR TITLE
fix(payment): immutable expiry index (timestamp not timestamptz)

### DIFF
--- a/services/payment/migrations/003_payment_multichannel.sql
+++ b/services/payment/migrations/003_payment_multichannel.sql
@@ -1,6 +1,9 @@
 CREATE INDEX IF NOT EXISTS idx_payment_intent_snapshots_expiry_open
-  ON payment_intent_snapshots (((data->>'expiresAt')::timestamptz))
+  ON payment_intent_snapshots (((data->>'expiresAt')::timestamp))
   WHERE data->>'status' IN ('CREATED', 'AUTHORIZED');
 
 -- Snapshots are JSONB; REQ-307 fields are stored in payment_intent_snapshots.data:
 -- channelRef, refundHistory[], channel-specific expiresAt, and PaymentTimedOut domain events.
+-- expiresAt is an RFC3339 UTC (Z) Instant string, so the timestamp cast (without
+-- time zone) is IMMUTABLE and valid in an index expression; a timestamptz cast is
+-- only STABLE and Postgres rejects it. findExpiredOpenIntents casts identically.

--- a/services/payment/src/main/java/com/trainticket/payment/infrastructure/persistence/PostgresPaymentIntentRepository.java
+++ b/services/payment/src/main/java/com/trainticket/payment/infrastructure/persistence/PostgresPaymentIntentRepository.java
@@ -57,10 +57,10 @@ public class PostgresPaymentIntentRepository implements PaymentIntentRepository 
     public List<PaymentIntent> findExpiredOpenIntents(Instant now, int limit) {
         return jdbc.query(
             "SELECT data->>'paymentIntentId' AS id FROM payment_intent_snapshots "
-                + "WHERE (data->>'expiresAt')::timestamptz <= ? AND data->>'status' IN ('CREATED','AUTHORIZED') "
-                + "ORDER BY (data->>'expiresAt')::timestamptz ASC LIMIT ?",
+                + "WHERE (data->>'expiresAt')::timestamp <= ?::timestamp AND data->>'status' IN ('CREATED','AUTHORIZED') "
+                + "ORDER BY (data->>'expiresAt')::timestamp ASC LIMIT ?",
             (rs, rowNum) -> findById(rs.getString("id")).orElseThrow(),
-            java.sql.Timestamp.from(now),
+            now.toString(),
             limit
         );
     }


### PR DESCRIPTION
payment crashed on startup: migration 003 indexed (data->>'expiresAt')::timestamptz, which is non-IMMUTABLE (Postgres rejects it in an index). Cast to ::timestamp (expiresAt is always RFC3339 UTC); align the findExpiredOpenIntents query to match and bind timezone-independently. Verified the migration applies and payment starts on kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)