### PR TITLE
fix(payment): IMMUTABLE fn wrapper for expiry index (supersedes #383)

### DIFF
--- a/services/payment/migrations/003_payment_multichannel.sql
+++ b/services/payment/migrations/003_payment_multichannel.sql
@@ -1,9 +1,18 @@
+-- text::timestamp / ::timestamptz casts are only STABLE (they depend on the
+-- DateStyle / TimeZone GUCs), so Postgres refuses them in an index expression
+-- (ERROR: functions in index expression must be marked IMMUTABLE). expiresAt is
+-- always an RFC3339 UTC Instant string (T...Z), which parses deterministically
+-- regardless of those GUCs, so an IMMUTABLE wrapper is safe here.
+CREATE OR REPLACE FUNCTION payment_expires_at_immutable(snapshot_data jsonb)
+  RETURNS timestamp
+  LANGUAGE sql
+  IMMUTABLE
+  PARALLEL SAFE
+AS $$ SELECT (snapshot_data->>'expiresAt')::timestamp $$;
+
 CREATE INDEX IF NOT EXISTS idx_payment_intent_snapshots_expiry_open
-  ON payment_intent_snapshots (((data->>'expiresAt')::timestamp))
+  ON payment_intent_snapshots (payment_expires_at_immutable(data))
   WHERE data->>'status' IN ('CREATED', 'AUTHORIZED');
 
 -- Snapshots are JSONB; REQ-307 fields are stored in payment_intent_snapshots.data:
 -- channelRef, refundHistory[], channel-specific expiresAt, and PaymentTimedOut domain events.
--- expiresAt is an RFC3339 UTC (Z) Instant string, so the timestamp cast (without
--- time zone) is IMMUTABLE and valid in an index expression; a timestamptz cast is
--- only STABLE and Postgres rejects it. findExpiredOpenIntents casts identically.

--- a/services/payment/src/main/java/com/trainticket/payment/infrastructure/persistence/PostgresPaymentIntentRepository.java
+++ b/services/payment/src/main/java/com/trainticket/payment/infrastructure/persistence/PostgresPaymentIntentRepository.java
@@ -57,8 +57,8 @@ public class PostgresPaymentIntentRepository implements PaymentIntentRepository 
     public List<PaymentIntent> findExpiredOpenIntents(Instant now, int limit) {
         return jdbc.query(
             "SELECT data->>'paymentIntentId' AS id FROM payment_intent_snapshots "
-                + "WHERE (data->>'expiresAt')::timestamp <= ?::timestamp AND data->>'status' IN ('CREATED','AUTHORIZED') "
-                + "ORDER BY (data->>'expiresAt')::timestamp ASC LIMIT ?",
+                + "WHERE payment_expires_at_immutable(data) <= ?::timestamp AND data->>'status' IN ('CREATED','AUTHORIZED') "
+                + "ORDER BY payment_expires_at_immutable(data) ASC LIMIT ?",
             (rs, rowNum) -> findById(rs.getString("id")).orElseThrow(),
             now.toString(),
             limit


### PR DESCRIPTION
PR #383's ::timestamp cast was still non-IMMUTABLE (text->timestamp depends on DateStyle), so payment still crashed. Wrap the parse in an IMMUTABLE SQL function used by both the index and the query. Verified on kind: migration applies, payment 1/1 Running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)