### PR TITLE
fix(fare-pricing,payment): Decimal round-trip + payment-channel channel-id

### DIFF
--- a/services/fare-pricing/src/fare_pricing/adapters/storage/postgres.py
+++ b/services/fare-pricing/src/fare_pricing/adapters/storage/postgres.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
+from decimal import Decimal
 import json
 from typing import Any
 
@@ -154,9 +155,13 @@ def _rule_from_json(data: Mapping[str, Any]) -> FareRule:
         explanation=_explanation_from_json(data["explanation"]),
         refundable=bool(data["refundable"]),
         seat_class_multipliers={str(key): value for key, value in (data.get("seatClassMultipliers") or DEFAULT_SEAT_CLASS_MULTIPLIERS).items()},
-        per_km_rate=data.get("perKmRate"),
+        per_km_rate=Decimal(str(data["perKmRate"])) if data.get("perKmRate") is not None else None,
         minimum_fare=_money_from_json(data["minimumFare"]) if data.get("minimumFare") else None,
-        distance_discount_threshold_km=data.get("distanceDiscountThresholdKm"),
+        distance_discount_threshold_km=(
+            Decimal(str(data["distanceDiscountThresholdKm"]))
+            if data.get("distanceDiscountThresholdKm") is not None
+            else None
+        ),
         distance_discount_pct=int(data.get("distanceDiscountPct") or 0),
     )
 

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/paymentchannel/HttpPaymentChannelClient.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/paymentchannel/HttpPaymentChannelClient.java
@@ -2,6 +2,7 @@ package com.trainticket.payment.adapters.paymentchannel;
 
 import com.trainticket.payment.application.PaymentChannelClient;
 import com.trainticket.payment.domain.ChannelRef;
+import com.trainticket.payment.domain.ChannelRouter;
 import com.trainticket.payment.domain.Money;
 import com.trainticket.payment.domain.PaymentIntent;
 import com.trainticket.payment.domain.Refund;
@@ -41,7 +42,7 @@ public final class HttpPaymentChannelClient implements PaymentChannelClient {
             "paymentIntentId", intent.paymentIntentId(),
             "businessRef", intent.businessRef(),
             "purpose", intent.purpose(),
-            "channel", ref.channel(),
+            "channel", ChannelRouter.channelFacingId(ref.channel()),
             "amount", money(intent.amount()),
             "sourceCommandId", commandId(orderIdempotencyKey),
             "correlationId", correlationId
@@ -62,7 +63,7 @@ public final class HttpPaymentChannelClient implements PaymentChannelClient {
             "paymentIntentId", intent.paymentIntentId(),
             "channelOrderId", ref.channelOrderId(),
             "originalChannelTransactionId", ref.channelTransactionId(),
-            "channel", ref.channel(),
+            "channel", ChannelRouter.channelFacingId(ref.channel()),
             "amount", money(refund.amount()),
             "refundReasonCode", refund.reasonCode(),
             "sourceCommandId", commandId(refundIdempotencyKey),

--- a/services/payment/src/main/java/com/trainticket/payment/domain/ChannelRouter.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/ChannelRouter.java
@@ -126,4 +126,20 @@ public final class ChannelRouter {
             default -> value;
         };
     }
+
+    /**
+     * Inverse of {@link #normalize}: maps an internal channel id to the
+     * payment-channel-facing (simulated provider) channel id used on the
+     * payment-channel handoff contract. Channels without a provider mapping
+     * pass through unchanged.
+     */
+    public static String channelFacingId(String channelId) {
+        String value = Objects.requireNonNull(channelId, "channelId is required").trim();
+        return switch (value) {
+            case "ALIPAY" -> "ALIPAY_SIM";
+            case "WECHAT_PAY" -> "WECHAT_SIM";
+            case "UNIONPAY" -> "UNIONPAY_SIM";
+            default -> value;
+        };
+    }
 }


### PR DESCRIPTION
Two bugs surfaced deploying HEAD to kind + e2e: fare-pricing per_km_rate str-vs-Decimal crash on reload; payment sending its internal channel id (ALIPAY) to payment-channel which expects ALIPAY_SIM. Both verified fixed on kind (capture now 200, purchase saga COMPLETED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)