### PR TITLE
fix(observability): raise otel-collector memory to stop backpressure crashes

### DIFF
--- a/deploy/k8s/otel-collector.yaml
+++ b/deploy/k8s/otel-collector.yaml
@@ -24,7 +24,7 @@ data:
     processors:
       memory_limiter:
         check_interval: 5s
-        limit_mib: 96
+        limit_mib: 768
       batch:
         timeout: 2s
         send_batch_size: 1024
@@ -116,10 +116,10 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 64Mi
+              memory: 256Mi
             limits:
-              cpu: 250m
-              memory: 128Mi
+              cpu: 500m
+              memory: 1Gi
           readinessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
The 96MiB collector limiter tripped under load and refused spans; Go services treat OTLP export failure as fatal and crash-loop, causing flaky e2e failures. Raise limiter to 768MiB / container 1Gi. Verified: no backpressure post-bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)