### PR TITLE
Fix post-sales refund apply convergence

### DIFF
--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
@@ -90,7 +90,11 @@ public class PostSalesApplicationService {
         if (isTerminalNonRefundable(postSalesCase)) {
             throw new OrderNotRefundableException();
         }
-        if (postSalesCase.status().name().equals("APPROVED")) {
+        if (postSalesCase.status() == PostSalesCaseStatus.EXECUTING || postSalesCase.status() == PostSalesCaseStatus.APPLIED) {
+            return postSalesCase;
+        }
+        if (postSalesCase.status() == PostSalesCaseStatus.APPROVED) {
+            startApprovedExecution(postSalesCase, sourceCommandId, correlationId);
             return postSalesCase;
         }
         if (postSalesCase.decision() == null) {
@@ -103,8 +107,7 @@ public class PostSalesApplicationService {
                 .map(PostSalesPolicyContext::incrementAppliedChangeCount)
                 .ifPresent(policyContextStore::save);
         }
-        repository.save(postSalesCase);
-        publishNewEvents(postSalesCase);
+        startApprovedExecution(postSalesCase, sourceCommandId, correlationId);
         return postSalesCase;
     }
 
@@ -113,6 +116,12 @@ public class PostSalesApplicationService {
             .orElseThrow(() -> new CaseNotFoundException(caseId));
     }
 
+
+    private void startApprovedExecution(PostSalesCase postSalesCase, String sourceCommandId, String correlationId) {
+        postSalesCase.startExecution(clock.instant(), sourceCommandId, sourceCommandId, correlationId);
+        repository.save(postSalesCase);
+        publishNewEvents(postSalesCase);
+    }
 
     private PostSalesCase openNewCase(OpenCaseCommand command) {
         if (requiresExclusiveRefundSlot(command.caseType())) {
@@ -222,8 +231,35 @@ public class PostSalesApplicationService {
             return PostSalesDecision.change(postSalesCase.caseId(), true, "ELIGIBLE", ruleSnapshot, amount, changeFlowSnapshot, assessment, now, now.plusSeconds(900));
         }
 
-        Money penaltyBase = policyContext.originalFareOr(refundable.isZero() ? zero : refundable);
-        RefundAssessment assessment = refundPolicyEngine.evaluateRefund(
+        RefundAssessment assessment = refundAssessmentFor(postSalesCase, now, policyContext, refundable, zero);
+        AmountDecisionSnapshot amount = AmountDecisionSnapshot.refund(assessment.penaltyAmount(), assessment.refundableAmount(), assessment.explanation(), assessment.componentDecisions());
+        return PostSalesDecision.refund(postSalesCase.caseId(), true, "ELIGIBLE", ruleSnapshot, amount, assessment, now, now.plusSeconds(900));
+    }
+
+    private RefundAssessment refundAssessmentFor(
+        PostSalesCase postSalesCase,
+        Instant now,
+        PostSalesPolicyContext policyContext,
+        Money quotedRefundable,
+        Money zero
+    ) {
+        if (!quotedRefundable.isZero()) {
+            Money originalFare = policyContext.originalFareOr(quotedRefundable);
+            Money retainedAmount = originalFare.compareTo(quotedRefundable) > 0
+                ? Money.fromMinorUnits(originalFare.toMinorUnits() - quotedRefundable.toMinorUnits(), originalFare.currency().getCurrencyCode())
+                : zeroFor(quotedRefundable);
+            return new RefundAssessment(
+                quotedRefundable,
+                retainedAmount,
+                java.math.BigDecimal.ZERO,
+                "FARE_RULE_QUOTE",
+                "fare-pricing refundable amount applied to paid fare",
+                classify(postSalesCase.reasonCode()),
+                List.of()
+            );
+        }
+        Money penaltyBase = policyContext.originalFareOr(zero);
+        return refundPolicyEngine.evaluateRefund(
             policyContext.waterfallFor(penaltyBase),
             penaltyBase,
             now,
@@ -232,8 +268,10 @@ public class PostSalesApplicationService {
             policyContext.travelerType(postSalesCase.scope().travelerRefs()),
             policyContext.groupSize()
         );
-        AmountDecisionSnapshot amount = AmountDecisionSnapshot.refund(assessment.penaltyAmount(), assessment.refundableAmount(), assessment.explanation(), assessment.componentDecisions());
-        return PostSalesDecision.refund(postSalesCase.caseId(), true, "ELIGIBLE", ruleSnapshot, amount, assessment, now, now.plusSeconds(900));
+    }
+
+    private static Money zeroFor(Money money) {
+        return Money.zero(money.currency());
     }
 
     private PostSalesPolicyContext policyContextFor(PostSalesCase postSalesCase, Instant now, Money fallbackAmount) {

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesMapper.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesMapper.java
@@ -167,7 +167,10 @@ public final class PostSalesMapper {
             payload.put("reason", rejected.reasonCode());
         } else if (event instanceof PostSalesApplied applied) {
             payload.put("orderId", applied.journeyOrderId());
-            payload.put("resultSummary", resultSummary(applied));
+            if (sourceCase != null) {
+                payload.put("scope", sourceCase.scope());
+            }
+            payload.put("resultSummary", resultSummary(applied, sourceCase));
         } else if (event instanceof PostSalesExecutionStarted executionStarted) {
             payload.put("orderedSteps", executionStarted.orderedSteps().stream().map(Enum::name).toList());
             payload.put("approvalRef", executionStarted.approvalRef());
@@ -231,6 +234,14 @@ public final class PostSalesMapper {
     private static Map<String, Object> resultSummary(PostSalesApplied applied) {
         Map<String, Object> summary = new LinkedHashMap<>();
         summary.put("description", applied.resultSummary());
+        return summary;
+    }
+
+    private static Map<String, Object> resultSummary(PostSalesApplied applied, PostSalesCase sourceCase) {
+        Map<String, Object> summary = resultSummary(applied);
+        if (sourceCase != null && sourceCase.decision() != null) {
+            summary.put("refundableAmount", money(sourceCase.decision().amountSnapshot().refundAmount()));
+        }
         return summary;
     }
 

--- a/services/post-sales/src/test/java/com/trainticket/postsales/application/PostSalesApplicationServicePolicyIntegrationTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/application/PostSalesApplicationServicePolicyIntegrationTest.java
@@ -1,8 +1,11 @@
 package com.trainticket.postsales.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.trainticket.platformkit.messaging.EventEnvelope;
 import com.trainticket.postsales.domain.Money;
+import com.trainticket.postsales.domain.PostSalesCaseStatus;
 import com.trainticket.postsales.domain.PostSalesCase;
 import com.trainticket.postsales.domain.PostSalesCaseType;
 import com.trainticket.postsales.domain.PostSalesScope;
@@ -18,38 +21,60 @@ class PostSalesApplicationServicePolicyIntegrationTest {
     private static final Instant NOW = Instant.parse("2026-07-03T10:00:00Z");
 
     @Test
-    void refundQuoteUsesStoredThreeDayDepartureContext() {
+    void refundQuoteUsesFarePricingRefundableAmount() {
         InMemoryPostSalesPolicyContextStore contextStore = new InMemoryPostSalesPolicyContextStore();
-        PostSalesApplicationService service = service(contextStore, quote("adjq-refund", 10_000, "CNY", 0, "CNY"));
-        service.recordPolicyContext(PostSalesPolicyContext.fallback("ord-policy-1", NOW.plusSeconds(3 * 86_400), 1, Money.of("100.00", "CNY")));
+        PostSalesApplicationService service = service(contextStore, quote("adjq-refund", 8_750, "CNY", 0, "CNY"));
+        service.recordPolicyContext(PostSalesPolicyContext.fallback("ord-policy-1", NOW.plusSeconds(3 * 86_400), 1, Money.of("107.50", "CNY")));
         PostSalesCase postSalesCase = service.open(command("ord-policy-1", PostSalesCaseType.REFUND, "idem-refund-policy"));
 
         PostSalesCase evaluated = service.evaluate("psc-" + postSalesCase.caseId(), "cmd-evaluate", "corr-policy");
 
-        assertEquals("TIER_2_TO_7_DAYS", evaluated.decision().refundAssessment().tierApplied());
+        assertEquals("FARE_RULE_QUOTE", evaluated.decision().refundAssessment().tierApplied());
+        assertEquals(8_750, evaluated.decision().amountSnapshot().refundAmount().toMinorUnits());
         assertEquals(2_000, evaluated.decision().refundAssessment().penaltyAmount().toMinorUnits());
     }
 
     @Test
-    void refundQuoteUsesInvoluntaryClassificationWithStoredDepartureContext() {
+    void zeroQuoteFallsBackToStoredPolicyContext() {
         InMemoryPostSalesPolicyContextStore contextStore = new InMemoryPostSalesPolicyContextStore();
-        PostSalesApplicationService service = service(contextStore, quote("adjq-carrier", 10_000, "CNY", 0, "CNY"));
+        PostSalesApplicationService service = service(contextStore, quote("adjq-zero", 0, "CNY", 0, "CNY"));
         service.recordPolicyContext(PostSalesPolicyContext.fallback("ord-policy-2", NOW.plusSeconds(3 * 86_400), 1, Money.of("100.00", "CNY")));
-        PostSalesCase postSalesCase = service.open(new PostSalesApplicationService.OpenCaseCommand(
-            "ord-policy-2",
-            PostSalesCaseType.REFUND,
-            scope(),
-            "CARRIER_CANCELLED",
-            "acct-1",
-            "idem-carrier-policy",
-            "cmd-open",
-            "corr-policy"
-        ));
+        PostSalesCase postSalesCase = service.open(command("ord-policy-2", PostSalesCaseType.REFUND, "idem-zero-policy"));
 
         PostSalesCase evaluated = service.evaluate("psc-" + postSalesCase.caseId(), "cmd-evaluate", "corr-policy");
 
-        assertEquals("INVOLUNTARY_OVERRIDE", evaluated.decision().refundAssessment().tierApplied());
-        assertEquals(0, evaluated.decision().refundAssessment().penaltyAmount().toMinorUnits());
+        assertEquals("TIER_2_TO_7_DAYS", evaluated.decision().refundAssessment().tierApplied());
+        assertEquals(8_000, evaluated.decision().amountSnapshot().refundAmount().toMinorUnits());
+        assertEquals(2_000, evaluated.decision().refundAssessment().penaltyAmount().toMinorUnits());
+    }
+
+    @Test
+    void approveStartsExecutionAndCapacityReleaseAppliesCase() {
+        InMemoryPostSalesPolicyContextStore contextStore = new InMemoryPostSalesPolicyContextStore();
+        InMemoryPostSalesRepository repository = new InMemoryPostSalesRepository();
+        List<EventEnvelope> events = new java.util.ArrayList<>();
+        PostSalesApplicationService service = service(repository, contextStore, quote("adjq-apply", 8_750, "CNY", 0, "CNY"), events);
+        service.recordPolicyContext(PostSalesPolicyContext.fallback("ord-apply", NOW.plusSeconds(3 * 86_400), 1, Money.of("107.50", "CNY")));
+        PostSalesCase postSalesCase = service.open(command("ord-apply", PostSalesCaseType.REFUND, "idem-apply"));
+        service.evaluate("psc-" + postSalesCase.caseId(), "cmd-evaluate", "corr-policy");
+
+        PostSalesCase approved = service.approve("psc-" + postSalesCase.caseId(), "cmd-approve", "corr-policy");
+
+        assertEquals(PostSalesCaseStatus.EXECUTING, approved.status());
+
+        service.applyForSegmentBooking("oi-1", "evt-capacity", "corr-policy");
+        PostSalesCase applied = service.get("psc-" + postSalesCase.caseId());
+
+        assertEquals(PostSalesCaseStatus.APPLIED, applied.status());
+        assertTrue(events.stream().anyMatch(event -> "PostSalesExecutionStarted".equals(event.eventType())));
+        EventEnvelope appliedEvent = events.stream()
+            .filter(event -> "PostSalesApplied".equals(event.eventType()))
+            .reduce((first, second) -> second)
+            .orElseThrow();
+        assertTrue(((Map<?, ?>) appliedEvent.payload()).containsKey("scope"));
+        Map<?, ?> appliedRefund = (Map<?, ?>) ((Map<?, ?>) ((Map<?, ?>) appliedEvent.payload()).get("resultSummary")).get("refundableAmount");
+        assertEquals("CNY", appliedRefund.get("currency"));
+        assertEquals(8_750L, ((Number) appliedRefund.get("minorUnits")).longValue());
     }
 
     @Test
@@ -77,10 +102,19 @@ class PostSalesApplicationServicePolicyIntegrationTest {
         PostSalesPolicyContextStore contextStore,
         AdjustmentQuotePort.AdjustmentQuoteResult quote
     ) {
+        return service(new InMemoryPostSalesRepository(), contextStore, quote, new java.util.ArrayList<>());
+    }
+
+    private static PostSalesApplicationService service(
+        InMemoryPostSalesRepository repository,
+        PostSalesPolicyContextStore contextStore,
+        AdjustmentQuotePort.AdjustmentQuoteResult quote,
+        List<EventEnvelope> events
+    ) {
         AdjustmentQuotePort quotePort = ignored -> Optional.of(quote);
         return new PostSalesApplicationService(
-            new InMemoryPostSalesRepository(),
-            ignored -> { },
+            repository,
+            events::add,
             quotePort,
             contextStore,
             Clock.fixed(NOW, ZoneOffset.UTC)


### PR DESCRIPTION
## Summary
- use fare-pricing adjustment quote refundable amount directly for positive refund quotes
- start post-sales execution as part of approval convergence and keep idempotent approved/executing handling
- include scoped context/refundable amount on PostSalesApplied for downstream application/timeline consumers

## Validation
- cd platform/java-kit && mvn -q install -DskipTests
- cd services/post-sales && mvn -q test -Dtest=PostSalesApplicationServicePolicyIntegrationTest,PostSalesCaseDomainTest