### PR TITLE
fix(wallet-promotion): reconcile stale ::numeric expiry index (migration 002)

### DIFF
--- a/services/wallet-promotion/migrations/002_fix_promotion_expiry_index.sql
+++ b/services/wallet-promotion/migrations/002_fix_promotion_expiry_index.sql
@@ -1,0 +1,10 @@
+-- Reconcile existing deployments that still have the pre-REQ-081A expiry index
+-- defined as ((data->>'validUntil')::numeric). validUntil is an RFC3339 UTC
+-- timestamp string, so the ::numeric cast makes every insert fail with
+-- "invalid input syntax for type numeric". Drop and recreate as the text index
+-- (RFC3339 UTC strings sort chronologically; the timestamptz cast is not
+-- IMMUTABLE in an index expression).
+DROP INDEX IF EXISTS idx_promotion_expiry;
+CREATE INDEX IF NOT EXISTS idx_promotion_expiry
+  ON promotion_instrument_snapshots ((data->>'validUntil'))
+  WHERE data->>'status' IN ('ISSUED', 'RESERVED', 'RELEASED');


### PR DESCRIPTION
Existing DBs have a stale ::numeric expiry index that rejects timestamp validUntil, breaking all benefit issuance (15-wallet 0/21). Migration 002 drops+recreates it as text. Verified 0->18/21 on kind. 🤖 Generated with Claude Code