### PR TITLE
fix(entitlement-ticketing): accept seg- slug segmentRef (shared funnel blocker)

### DIFF
--- a/services/entitlement-ticketing/src/adapters/storage/mod.rs
+++ b/services/entitlement-ticketing/src/adapters/storage/mod.rs
@@ -1209,7 +1209,7 @@ fn validate_issue_request(c: &IssueEntitlementRequest) -> PgResult<()> {
     validate_prefixed_uuid(&c.segment_booking_id, "segmentBookingId", "sb-")?;
     validate_prefixed_uuid(&c.journey_order_id, "journeyOrderId", "ord-")?;
     validate_prefixed_uuid(&c.traveler_ref, "travelerRef", "tvl-")?;
-    validate_prefixed_uuid(&c.segment_ref, "segmentRef", "seg-")?;
+    validate_prefixed(&c.segment_ref, "segmentRef", "seg-")?;
     if let Some(prefs) = &c.seat_preferences {
         if prefs.preference_version.trim().is_empty() {
             return Err(ApiErrorKind::ValidationFailed(

--- a/services/entitlement-ticketing/src/lib.rs
+++ b/services/entitlement-ticketing/src/lib.rs
@@ -2968,7 +2968,7 @@ impl EntitlementApi for InMemoryEntitlementService {
         validate_prefixed_uuid(&command.segment_booking_id, "segmentBookingId", "sb-")?;
         validate_prefixed_uuid(&command.journey_order_id, "journeyOrderId", "ord-")?;
         validate_prefixed_uuid(&command.traveler_ref, "travelerRef", "tvl-")?;
-        validate_prefixed_uuid(&command.segment_ref, "segmentRef", "seg-")?;
+        validate_prefixed(&command.segment_ref, "segmentRef", "seg-")?;
         let fingerprint = serde_json::to_string(&command).unwrap_or_default();
         if let Some(replayed) = self.replayed_response(&key, &fingerprint)? {
             if let IdempotentResponse::Issue(response) = replayed {
@@ -3436,6 +3436,21 @@ fn validate_prefixed_uuid(value: &str, field: &'static str, prefix: &'static str
     uuid::Uuid::parse_str(uuid_part).map_err(|_| {
         ApiErrorKind::ValidationFailed(format!("{field} must use {prefix}<uuid> format"))
     })?;
+    Ok(())
+}
+
+// Prefix-only validation for refs that are NOT uuids. segmentRef is the canonical
+// trip-planning service segment ref (e.g. `seg-web-2026-08-01-<hash>`), which the
+// rest of the system (fare-pricing, journey-order, booking-orchestration) accepts
+// as an opaque `seg-`-prefixed slug. Requiring `seg-<uuid>` here wrongly rejected
+// real refs and blocked every entitlement issue in the purchase funnel.
+fn validate_prefixed(value: &str, field: &'static str, prefix: &'static str) -> ApiResult<()> {
+    validate_non_empty(value, field)?;
+    if !value.starts_with(prefix) {
+        return Err(ApiErrorKind::ValidationFailed(format!(
+            "{field} must be {prefix}-prefixed"
+        )));
+    }
     Ok(())
 }
 


### PR DESCRIPTION
entitlement-ticketing required segmentRef=seg-<uuid>, but trip-planning produces seg-web-<date>-<hash> which the rest of the system accepts. Every real entitlement issue 400'd, cascading through order/refund/change/paychan. Relax to prefix-only. Verified: 07-fare-rules 25/4->29/0. 🤖 Generated with Claude Code