### PR TITLE
fix(wallet-promotion): expiry sweep text-compares RFC3339 validUntil

### DIFF
--- a/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/infrastructure/persistence/PostgresPromotionRepository.java
+++ b/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/infrastructure/persistence/PostgresPromotionRepository.java
@@ -113,16 +113,18 @@ public class PostgresPromotionRepository implements PromotionRepository {
             SELECT data::text
               FROM promotion_instrument_snapshots
              WHERE data->>'status' IN ('ISSUED', 'RESERVED', 'RELEASED')
-               AND (data->>'validUntil')::numeric <= ?
-             ORDER BY (data->>'validUntil')::numeric
+               AND data->>'validUntil' <= ?
+             ORDER BY data->>'validUntil'
              LIMIT ?
             """;
-        // Snapshots store Instants as epoch decimals (internal convention);
-        // numeric comparison matches the numeric-expression index.
+        // validUntil is serialized as an RFC3339 UTC (Z) Instant string, which sorts
+        // chronologically as text (matching idx_promotion_expiry). The previous
+        // ::numeric cast assumed epoch decimals and silently matched nothing, so the
+        // scheduled expiry sweep never expired any benefit.
         return jdbc.query(
             sql,
             (rs, rowNumber) -> read(rs.getString(1), PromotionInstrument.class),
-            java.math.BigDecimal.valueOf(now.getEpochSecond()),
+            now.toString(),
             limit
         );
     }


### PR DESCRIPTION
The scheduled expiry sweep's findExpirable used ::numeric on an RFC3339 timestamp string, matching nothing, so benefits never expired. Text-compare instead. Verified 15-wallet 18/3->21/0. 🤖 Generated with Claude Code