### PR TITLE
REQ-391 implement seat map allocation contract

### DIFF
--- a/services/seat-assignment/internal/adapters/api/handlers.go
+++ b/services/seat-assignment/internal/adapters/api/handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -25,6 +26,16 @@ func (h *Handler) RegisterRoutes(r gin.IRouter) {
 	v.GET("/seat-assignments/:segmentRef/:departureDate/availability", h.availability)
 	v.DELETE("/seat-assignments/:assignmentId", h.release)
 	v.POST("/seat-assignments/:assignmentId/confirm", m, h.confirm)
+	v.POST("/seat-maps", m, h.createSeatMap)
+	v.GET("/seat-maps", h.listSeatMaps)
+	v.GET("/seat-maps/:seatMapId", h.getSeatMap)
+	v.POST("/seat-maps/:seatMapId/publish", m, h.publishSeatMap)
+	v.POST("/seat-maps/:seatMapId/retire", m, h.retireSeatMap)
+	v.POST("/seat-maps/:seatMapId/seat-units/:seatUnitRef/mark-unavailable", m, h.markSeatUnitUnavailable)
+	v.POST("/seat-maps/:seatMapId/seat-units/:seatUnitRef/reopen", m, h.reopenSeatUnit)
+	v.POST("/internal/seat-allocations", m, h.allocateSeat)
+	v.GET("/seat-allocations/:seatAllocationId", h.getSeatAllocation)
+	v.GET("/seat-allocations", h.listSeatAllocations)
 }
 func (h *Handler) assign(c *gin.Context) {
 	var req application.AssignSeatsRequest
@@ -56,6 +67,91 @@ func (h *Handler) confirm(c *gin.Context) {
 	}
 	h.write(c, http.StatusOK, gin.H{"confirmed": true, "seatId": resp.SeatId, "travelerRef": resp.TravelerRef}, nil)
 }
+
+func (h *Handler) createSeatMap(c *gin.Context) {
+	var req application.CreateSeatMapRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpkit.WriteError(c, http.StatusBadRequest, httpkit.ValidationFailed, "invalid request body: "+err.Error(), nil)
+		return
+	}
+	req.CorrelationID = goruntime.CorrelationID(c.Request.Context())
+	resp, err := h.svc.CreateSeatMap(c.Request.Context(), req)
+	h.write(c, http.StatusCreated, resp, err)
+}
+func (h *Handler) publishSeatMap(c *gin.Context) {
+	var req application.PublishSeatMapRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpkit.WriteError(c, http.StatusBadRequest, httpkit.ValidationFailed, "invalid request body: "+err.Error(), nil)
+		return
+	}
+	req.CorrelationID = goruntime.CorrelationID(c.Request.Context())
+	resp, err := h.svc.PublishSeatMap(c.Request.Context(), c.Param("seatMapId"), req)
+	h.write(c, http.StatusOK, resp, err)
+}
+func (h *Handler) retireSeatMap(c *gin.Context) {
+	var req application.RetireSeatMapRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpkit.WriteError(c, http.StatusBadRequest, httpkit.ValidationFailed, "invalid request body: "+err.Error(), nil)
+		return
+	}
+	req.CorrelationID = goruntime.CorrelationID(c.Request.Context())
+	resp, err := h.svc.RetireSeatMap(c.Request.Context(), c.Param("seatMapId"), req)
+	h.write(c, http.StatusOK, resp, err)
+}
+func (h *Handler) markSeatUnitUnavailable(c *gin.Context) {
+	var req application.MarkSeatUnitUnavailableRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpkit.WriteError(c, http.StatusBadRequest, httpkit.ValidationFailed, "invalid request body: "+err.Error(), nil)
+		return
+	}
+	req.CorrelationID = goruntime.CorrelationID(c.Request.Context())
+	resp, err := h.svc.MarkSeatUnitUnavailable(c.Request.Context(), c.Param("seatMapId"), c.Param("seatUnitRef"), req)
+	h.write(c, http.StatusOK, resp, err)
+}
+func (h *Handler) reopenSeatUnit(c *gin.Context) {
+	var req application.ReopenSeatUnitRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpkit.WriteError(c, http.StatusBadRequest, httpkit.ValidationFailed, "invalid request body: "+err.Error(), nil)
+		return
+	}
+	req.CorrelationID = goruntime.CorrelationID(c.Request.Context())
+	resp, err := h.svc.ReopenSeatUnit(c.Request.Context(), c.Param("seatMapId"), c.Param("seatUnitRef"), req)
+	h.write(c, http.StatusOK, resp, err)
+}
+func (h *Handler) getSeatMap(c *gin.Context) {
+	resp, err := h.svc.GetSeatMap(c.Request.Context(), c.Param("seatMapId"))
+	h.write(c, http.StatusOK, resp, err)
+}
+func (h *Handler) listSeatMaps(c *gin.Context) {
+	resp, err := h.svc.ListSeatMaps(c.Request.Context(), c.Query("scheduledServiceRef"), c.Query("serviceDate"), c.Query("status"), atoiDefault(c.Query("limit"), 20), atoiDefault(c.Query("offset"), 0))
+	h.write(c, http.StatusOK, resp, err)
+}
+func (h *Handler) allocateSeat(c *gin.Context) {
+	var req application.AllocateSeatRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpkit.WriteError(c, http.StatusBadRequest, httpkit.ValidationFailed, "invalid request body: "+err.Error(), nil)
+		return
+	}
+	req.CorrelationID = goruntime.CorrelationID(c.Request.Context())
+	resp, err := h.svc.AllocateSeat(c.Request.Context(), req)
+	h.write(c, http.StatusCreated, resp, err)
+}
+func (h *Handler) getSeatAllocation(c *gin.Context) {
+	resp, err := h.svc.GetSeatAllocation(c.Request.Context(), c.Param("seatAllocationId"))
+	h.write(c, http.StatusOK, resp, err)
+}
+func (h *Handler) listSeatAllocations(c *gin.Context) {
+	resp, err := h.svc.ListSeatAllocations(c.Request.Context(), c.Query("segmentBookingId"), c.Query("status"), atoiDefault(c.Query("limit"), 20), atoiDefault(c.Query("offset"), 0))
+	h.write(c, http.StatusOK, resp, err)
+}
+func atoiDefault(raw string, def int) int {
+	var v int
+	if _, err := fmt.Sscanf(raw, "%d", &v); err != nil {
+		return def
+	}
+	return v
+}
+
 func (h *Handler) write(c *gin.Context, status int, body any, err error) {
 	if err == nil {
 		c.JSON(status, body)
@@ -70,6 +166,8 @@ func (h *Handler) write(c *gin.Context, status int, body any, err error) {
 			code = http.StatusNotFound
 		case "CONFLICT":
 			code = http.StatusConflict
+		case "PRECONDITION_FAILED":
+			code = http.StatusPreconditionFailed
 		case "UNAVAILABLE":
 			code = http.StatusServiceUnavailable
 		}

--- a/services/seat-assignment/internal/adapters/messaging/subscriber.go
+++ b/services/seat-assignment/internal/adapters/messaging/subscriber.go
@@ -26,5 +26,5 @@ func (s *RedisSubscriber) Subscribe(ctx context.Context, consumerName string, ha
 	return s.bus.Subscribe(ctx, kitmsg.Subscription{Streams: SubscribedStreams(), Group: ConsumerGroup, ConsumerName: consumerName}, handler)
 }
 func SubscribedStreams() []string {
-	return []string{"events:booking-orchestration", "events:entitlement-ticketing", "events:post-sales"}
+	return []string{"events:booking-orchestration", "events:entitlement-ticketing", "events:post-sales", "events:capacity-availability"}
 }

--- a/services/seat-assignment/internal/adapters/storage/postgres.go
+++ b/services/seat-assignment/internal/adapters/storage/postgres.go
@@ -128,6 +128,170 @@ func (r *Repository) FindAssignments(ctx context.Context, segmentRef, departureD
 	}
 	return out, rows.Err()
 }
+
+func (r *Repository) SaveSeatMap(ctx context.Context, m *domain.ContractSeatMap) error {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	return conflict(kitstorage.NewSnapshotRepository(r.tx.DBFor(ctx), "seat_maps").Insert(ctx, m.SeatMapID, b))
+}
+func (r *Repository) UpdateSeatMap(ctx context.Context, m *domain.ContractSeatMap, expected int64) error {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	_, err = kitstorage.NewSnapshotRepository(r.tx.DBFor(ctx), "seat_maps").Save(ctx, m.SeatMapID, expected, b)
+	return conflict(err)
+}
+func (r *Repository) GetSeatMap(ctx context.Context, id string) (*domain.ContractSeatMap, int64, error) {
+	snap, ok, err := kitstorage.NewSnapshotRepository(r.tx.DBFor(ctx), "seat_maps").Get(ctx, id)
+	if err != nil {
+		return nil, 0, err
+	}
+	if !ok {
+		return nil, 0, fmt.Errorf("not found")
+	}
+	var m domain.ContractSeatMap
+	if err := json.Unmarshal(snap.Data, &m); err != nil {
+		return nil, 0, err
+	}
+	return &m, snap.Version, nil
+}
+func (r *Repository) FindSeatMaps(ctx context.Context, scheduledServiceRef, serviceDate, status string, limit, offset int) ([]domain.ContractSeatMap, int, error) {
+	parts := []string{"data->>'scheduledServiceRef'=$1", "data->>'serviceDate'=$2"}
+	args := []any{scheduledServiceRef, serviceDate}
+	if strings.TrimSpace(status) != "" {
+		args = append(args, status)
+		parts = append(parts, fmt.Sprintf("data->>'status'=$%d", len(args)))
+	}
+	where := strings.Join(parts, " AND ")
+	var total int
+	if err := r.tx.DBFor(ctx).QueryRow(ctx, "SELECT count(*) FROM seat_maps WHERE "+where, args...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+	args = append(args, limit, offset)
+	rows, err := r.tx.DBFor(ctx).Query(ctx, "SELECT data FROM seat_maps WHERE "+where+fmt.Sprintf(" ORDER BY updated_at DESC LIMIT $%d OFFSET $%d", len(args)-1, len(args)), args...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+	out := []domain.ContractSeatMap{}
+	for rows.Next() {
+		var raw json.RawMessage
+		if err := rows.Scan(&raw); err != nil {
+			return nil, 0, err
+		}
+		var m domain.ContractSeatMap
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return nil, 0, err
+		}
+		out = append(out, m)
+	}
+	return out, total, rows.Err()
+}
+func (r *Repository) SaveSeatAllocation(ctx context.Context, a *domain.ContractSeatAllocation) error {
+	b, err := json.Marshal(a)
+	if err != nil {
+		return err
+	}
+	return conflict(kitstorage.NewSnapshotRepository(r.tx.DBFor(ctx), "seat_allocations").Insert(ctx, a.SeatAllocationID, b))
+}
+func (r *Repository) UpdateSeatAllocation(ctx context.Context, a *domain.ContractSeatAllocation, expected int64) error {
+	b, err := json.Marshal(a)
+	if err != nil {
+		return err
+	}
+	_, err = kitstorage.NewSnapshotRepository(r.tx.DBFor(ctx), "seat_allocations").Save(ctx, a.SeatAllocationID, expected, b)
+	return conflict(err)
+}
+func (r *Repository) GetSeatAllocation(ctx context.Context, id string) (*domain.ContractSeatAllocation, int64, error) {
+	snap, ok, err := kitstorage.NewSnapshotRepository(r.tx.DBFor(ctx), "seat_allocations").Get(ctx, id)
+	if err != nil {
+		return nil, 0, err
+	}
+	if !ok {
+		return nil, 0, fmt.Errorf("not found")
+	}
+	var a domain.ContractSeatAllocation
+	if err := json.Unmarshal(snap.Data, &a); err != nil {
+		return nil, 0, err
+	}
+	return &a, snap.Version, nil
+}
+func (r *Repository) FindSeatAllocations(ctx context.Context, segmentBookingID, status string, limit, offset int) ([]domain.ContractSeatAllocation, int, error) {
+	parts := []string{"data->>'segmentBookingId'=$1"}
+	args := []any{segmentBookingID}
+	if strings.TrimSpace(status) != "" {
+		args = append(args, status)
+		parts = append(parts, fmt.Sprintf("data->>'status'=$%d", len(args)))
+	}
+	where := strings.Join(parts, " AND ")
+	var total int
+	if err := r.tx.DBFor(ctx).QueryRow(ctx, "SELECT count(*) FROM seat_allocations WHERE "+where, args...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+	args = append(args, limit, offset)
+	rows, err := r.tx.DBFor(ctx).Query(ctx, "SELECT data FROM seat_allocations WHERE "+where+fmt.Sprintf(" ORDER BY updated_at DESC LIMIT $%d OFFSET $%d", len(args)-1, len(args)), args...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+	out := []domain.ContractSeatAllocation{}
+	for rows.Next() {
+		var raw json.RawMessage
+		if err := rows.Scan(&raw); err != nil {
+			return nil, 0, err
+		}
+		var a domain.ContractSeatAllocation
+		if err := json.Unmarshal(raw, &a); err != nil {
+			return nil, 0, err
+		}
+		out = append(out, a)
+	}
+	return out, total, rows.Err()
+}
+func (r *Repository) FindActiveSeatAllocations(ctx context.Context, scheduledServiceRef, serviceDate string) ([]domain.ContractSeatAllocation, error) {
+	rows, err := r.tx.DBFor(ctx).Query(ctx, "SELECT data FROM seat_allocations WHERE data->>'scheduledServiceRef'=$1 AND data->>'serviceDate'=$2 AND data->>'status' IN ('ALLOCATED','STANDING','CONFIRMED') ORDER BY id", scheduledServiceRef, serviceDate)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []domain.ContractSeatAllocation{}
+	for rows.Next() {
+		var raw json.RawMessage
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		var a domain.ContractSeatAllocation
+		if err := json.Unmarshal(raw, &a); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+func (r *Repository) FindSeatAllocationsByCapacityRecovery(ctx context.Context, holdID, capacityUnitRef string, interval domain.StationInterval) ([]domain.ContractSeatAllocation, error) {
+	rows, err := r.tx.DBFor(ctx).Query(ctx, "SELECT data FROM seat_allocations WHERE data->>'capacityHoldId'=$1 AND data->>'capacityUnitRef'=$2 AND (data->'interval'->>'fromSeq')::int=$3 AND (data->'interval'->>'toSeq')::int=$4 ORDER BY id", holdID, capacityUnitRef, interval.FromSeq, interval.ToSeq)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []domain.ContractSeatAllocation{}
+	for rows.Next() {
+		var raw json.RawMessage
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		var a domain.ContractSeatAllocation
+		if err := json.Unmarshal(raw, &a); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
 func inventoryID(segmentRef, date string) string { return segmentRef + "|" + date }
 func conflict(err error) error {
 	if errors.Is(err, kitstorage.ErrConflict) {

--- a/services/seat-assignment/internal/application/seatmap_contract_respec_test.go
+++ b/services/seat-assignment/internal/application/seatmap_contract_respec_test.go
@@ -1,0 +1,181 @@
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/trainticket/greenfield/platform/go-kit/ids"
+	kitmsg "github.com/trainticket/greenfield/platform/go-kit/messaging"
+	"github.com/trainticket/greenfield/services/seat-assignment/internal/domain"
+)
+
+func TestSeatMapTopologyIsDeterministicForSameSeedMaterial(t *testing.T) {
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	first, err := domain.NewContractSeatMap("ss-1", "2026-08-02", "v1", "BASE", "sim-v1", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := domain.NewContractSeatMap("ss-1", "2026-08-02", "v1", "BASE", "sim-v1", "", now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.SeatMapID != second.SeatMapID {
+		t.Fatalf("seatMapId not deterministic: %s != %s", first.SeatMapID, second.SeatMapID)
+	}
+	if first.Coaches[0].CoachRef != second.Coaches[0].CoachRef {
+		t.Fatalf("coachRef not deterministic: %s != %s", first.Coaches[0].CoachRef, second.Coaches[0].CoachRef)
+	}
+	for i := range first.Coaches[0].SeatUnits {
+		if first.Coaches[0].SeatUnits[i].SeatUnitRef != second.Coaches[0].SeatUnits[i].SeatUnitRef {
+			t.Fatalf("seatUnitRef[%d] not deterministic: %s != %s", i, first.Coaches[0].SeatUnits[i].SeatUnitRef, second.Coaches[0].SeatUnits[i].SeatUnitRef)
+		}
+	}
+
+	changed, err := domain.NewContractSeatMap("ss-1", "2026-08-02", "v1", "DIFFERENT", "sim-v1", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.SeatMapID == changed.SeatMapID || first.Coaches[0].SeatUnits[0].SeatUnitRef == changed.Coaches[0].SeatUnits[0].SeatUnitRef {
+		t.Fatalf("different seed material should produce different topology refs")
+	}
+}
+
+func TestEntitlementIssuedConfirmsSeatAllocationAndEmitsContractEvent(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemRepo()
+	pub := &memPub{}
+	svc := New(repo, pub, nil)
+	m, err := svc.CreateSeatMap(ctx, CreateSeatMapRequest{ScheduledServiceRef: "ss-1", ServiceDate: "2026-08-02", CompositionVersion: "v1", CompositionSeed: "BASE", MappingVersion: "sim-v1", OperatorRef: "op"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = svc.PublishSeatMap(ctx, m.SeatMapID, PublishSeatMapRequest{ExpectedSeatMapVersion: m.SeatMapVersion, PublishReason: "READY", OperatorRef: "op"}); err != nil {
+		t.Fatal(err)
+	}
+	allocation, err := svc.AllocateSeat(ctx, allocReq("sb-confirm", "tvl-confirm", "hold-confirm", &domain.SeatPreferences{AcceptStanding: true, PreferenceVersion: "pv"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload, _ := json.Marshal(map[string]any{"entitlementId": "ent-1", "seatAllocationId": allocation.SeatAllocationID, "seatRef": allocation.SeatRef})
+	envelope := kitmsg.EventEnvelope{EventID: ids.NewEventID(), EventType: "EntitlementIssued", CorrelationID: ids.NewCorrelationID(), Payload: payload}
+	if err := svc.HandleSubscribedEvent(ctx, envelope); err != nil {
+		t.Fatal(err)
+	}
+	stored, _, err := repo.GetSeatAllocation(ctx, allocation.SeatAllocationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status != domain.AllocationStatusConfirmed || stored.ConfirmedAt == nil {
+		t.Fatalf("expected confirmed allocation, got %#v", stored)
+	}
+	if len(pub.payloads["SeatAllocationConfirmed"]) != 1 {
+		t.Fatalf("missing SeatAllocationConfirmed event in %#v", pub.types)
+	}
+	if got := pub.payloads["SeatAllocationConfirmed"][0]["entitlementId"]; got != "ent-1" {
+		t.Fatalf("expected entitlementId in confirmation event, got %#v", pub.payloads["SeatAllocationConfirmed"][0])
+	}
+	assertPublishedEventID(t, pub, "SeatAllocationConfirmed", deterministicSeatAssignmentEventID("SeatAllocationConfirmed", allocation.SeatAllocationID, 2))
+}
+
+func TestCapacityReleasedMatchesHoldCapacityUnitAndInterval(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemRepo()
+	pub := &memPub{}
+	svc := New(repo, pub, nil)
+	m, err := svc.CreateSeatMap(ctx, CreateSeatMapRequest{ScheduledServiceRef: "ss-1", ServiceDate: "2026-08-02", CompositionVersion: "v1", CompositionSeed: "BASE", MappingVersion: "sim-v1", OperatorRef: "op"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = svc.PublishSeatMap(ctx, m.SeatMapID, PublishSeatMapRequest{ExpectedSeatMapVersion: m.SeatMapVersion, PublishReason: "READY", OperatorRef: "op"}); err != nil {
+		t.Fatal(err)
+	}
+	matching, err := svc.AllocateSeat(ctx, allocReq("sb-match", "tvl-match", "hold-shared", &domain.SeatPreferences{AcceptStanding: true, PreferenceVersion: "pv"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	differentUnitReq := allocReq("sb-other-unit", "tvl-other-unit", "hold-shared", &domain.SeatPreferences{AcceptStanding: true, PreferenceVersion: "pv"})
+	differentUnitReq.CapacityUnitRef = "cap-other"
+	differentUnit, err := svc.AllocateSeat(ctx, differentUnitReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	differentIntervalReq := allocReq("sb-other-interval", "tvl-other-interval", "hold-shared", &domain.SeatPreferences{AcceptStanding: true, PreferenceVersion: "pv"})
+	differentIntervalReq.Interval = domain.StationInterval{FromSeq: 3, ToSeq: 5}
+	differentInterval, err := svc.AllocateSeat(ctx, differentIntervalReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload, _ := json.Marshal(map[string]any{"holdId": "hold-shared", "capacityUnitRef": "cap-standard", "interval": domain.StationInterval{FromSeq: 1, ToSeq: 3}, "releasedAt": time.Now().UTC().Format(time.RFC3339)})
+	if err := svc.HandleSubscribedEvent(ctx, kitmsg.EventEnvelope{EventID: ids.NewEventID(), EventType: "CapacityReleased", CorrelationID: ids.NewCorrelationID(), Payload: payload}); err != nil {
+		t.Fatal(err)
+	}
+
+	mustStatus := func(id, want string) {
+		t.Helper()
+		stored, _, err := repo.GetSeatAllocation(ctx, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if stored.Status != want {
+			t.Fatalf("allocation %s status=%s want %s", id, stored.Status, want)
+		}
+	}
+	mustStatus(matching.SeatAllocationID, domain.AllocationStatusReleased)
+	mustStatus(differentUnit.SeatAllocationID, domain.AllocationStatusAllocated)
+	mustStatus(differentInterval.SeatAllocationID, domain.AllocationStatusAllocated)
+	if len(pub.payloads["SeatAllocationReleased"]) != 1 {
+		t.Fatalf("expected one release event, got %#v", pub.payloads["SeatAllocationReleased"])
+	}
+	assertPublishedEventID(t, pub, "SeatAllocationReleased", deterministicSeatAssignmentEventID("SeatAllocationReleased", matching.SeatAllocationID, 2))
+}
+
+func TestEntitlementVoidedReleasesSeatAllocation(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemRepo()
+	pub := &memPub{}
+	svc := New(repo, pub, nil)
+	m, err := svc.CreateSeatMap(ctx, CreateSeatMapRequest{ScheduledServiceRef: "ss-1", ServiceDate: "2026-08-02", CompositionVersion: "v1", CompositionSeed: "BASE", MappingVersion: "sim-v1", OperatorRef: "op"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = svc.PublishSeatMap(ctx, m.SeatMapID, PublishSeatMapRequest{ExpectedSeatMapVersion: m.SeatMapVersion, PublishReason: "READY", OperatorRef: "op"}); err != nil {
+		t.Fatal(err)
+	}
+	allocation, err := svc.AllocateSeat(ctx, allocReq("sb-void", "tvl-void", "hold-void", &domain.SeatPreferences{AcceptStanding: true, PreferenceVersion: "pv"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	voidedAt := time.Date(2026, 8, 2, 12, 30, 0, 0, time.UTC)
+	payload, _ := json.Marshal(map[string]any{"entitlementId": "ent-void", "segmentBookingId": allocation.SeatAllocationID, "seatAllocationId": allocation.SeatAllocationID, "reason": "REFUND", "voidedAt": voidedAt.Format(time.RFC3339)})
+	if err := svc.HandleSubscribedEvent(ctx, kitmsg.EventEnvelope{EventID: ids.NewEventID(), EventType: "EntitlementVoided", CorrelationID: ids.NewCorrelationID(), Payload: payload}); err != nil {
+		t.Fatal(err)
+	}
+	stored, _, err := repo.GetSeatAllocation(ctx, allocation.SeatAllocationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status != domain.AllocationStatusReleased || stored.ReleasedAt == nil || !stored.ReleasedAt.Equal(voidedAt) {
+		t.Fatalf("expected released allocation at void time, got %#v", stored)
+	}
+	if got := pub.payloads["SeatAllocationReleased"][0]["releaseReason"]; got != "VOIDED" {
+		t.Fatalf("expected VOIDED release reason, got %#v", pub.payloads["SeatAllocationReleased"][0])
+	}
+	assertPublishedEventID(t, pub, "SeatAllocationReleased", deterministicSeatAssignmentEventID("SeatAllocationReleased", allocation.SeatAllocationID, 2))
+}
+
+func assertPublishedEventID(t *testing.T, pub *memPub, eventType, want string) {
+	t.Helper()
+	for _, event := range pub.events {
+		if event.EventType == eventType {
+			if event.EventID != want {
+				t.Fatalf("%s eventId=%s want %s", eventType, event.EventID, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing published event %s in %#v", eventType, pub.types)
+}

--- a/services/seat-assignment/internal/application/seatmap_repair_test.go
+++ b/services/seat-assignment/internal/application/seatmap_repair_test.go
@@ -88,6 +88,78 @@ func TestAdjacentAllocationRequiresSameGroupAndAdjacentKey(t *testing.T) {
 	}
 }
 
+func TestAllocateSeatValidatesContractRequiredEnums(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemRepo()
+	svc := New(repo, &memPub{}, nil)
+	m, err := svc.CreateSeatMap(ctx, CreateSeatMapRequest{ScheduledServiceRef: "ss-1", ServiceDate: "2026-08-02", CompositionVersion: "v1", CompositionSeed: "SMALL", MappingVersion: "sim-v1", ChangeScenario: "SMALL", OperatorRef: "op"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = svc.PublishSeatMap(ctx, m.SeatMapID, PublishSeatMapRequest{ExpectedSeatMapVersion: m.SeatMapVersion, PublishReason: "READY", OperatorRef: "op"}); err != nil {
+		t.Fatal(err)
+	}
+
+	missingPurpose := allocReq("sb-missing-purpose", "tvl", "hold", nil)
+	missingPurpose.IssuePurpose = ""
+	if _, err := svc.AllocateSeat(ctx, missingPurpose); err == nil {
+		t.Fatal("expected missing issuePurpose validation error")
+	}
+
+	missingPreferenceVersion := allocReq("sb-missing-pref", "tvl", "hold", &domain.SeatPreferences{AcceptStanding: true})
+	if _, err := svc.AllocateSeat(ctx, missingPreferenceVersion); err == nil {
+		t.Fatal("expected missing preferenceVersion validation error")
+	}
+
+	invalidPreference := allocReq("sb-invalid-pref", "tvl", "hold", &domain.SeatPreferences{AcceptStanding: true, PreferenceVersion: "pv", AdjacencyPreference: "SIDE_BY_SIDE"})
+	if _, err := svc.AllocateSeat(ctx, invalidPreference); err == nil {
+		t.Fatal("expected invalid adjacencyPreference validation error")
+	}
+
+	invalidSeatPosition := allocReq("sb-invalid-seat", "tvl", "hold", &domain.SeatPreferences{AcceptStanding: true, PreferenceVersion: "pv", PreferredSeatPositions: []string{"ROOF"}})
+	if _, err := svc.AllocateSeat(ctx, invalidSeatPosition); err == nil {
+		t.Fatal("expected invalid seatPosition validation error")
+	}
+
+	invalidBerthPosition := allocReq("sb-invalid-berth", "tvl", "hold", &domain.SeatPreferences{AcceptStanding: true, PreferenceVersion: "pv", PreferredBerthPositions: []string{"TOP"}})
+	if _, err := svc.AllocateSeat(ctx, invalidBerthPosition); err == nil {
+		t.Fatal("expected invalid berthPosition validation error")
+	}
+}
+
+func TestEntitlementReleaseBySegmentBookingReleasesSeatAllocation(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemRepo()
+	pub := &memPub{}
+	svc := New(repo, pub, nil)
+	m, err := svc.CreateSeatMap(ctx, CreateSeatMapRequest{ScheduledServiceRef: "ss-1", ServiceDate: "2026-08-02", CompositionVersion: "v1", CompositionSeed: "SMALL", MappingVersion: "sim-v1", ChangeScenario: "SMALL", OperatorRef: "op"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = svc.PublishSeatMap(ctx, m.SeatMapID, PublishSeatMapRequest{ExpectedSeatMapVersion: m.SeatMapVersion, PublishReason: "READY", OperatorRef: "op"}); err != nil {
+		t.Fatal(err)
+	}
+	alloc, err := svc.AllocateSeat(ctx, allocReq("sb-release", "tvl-release", "hold-release", &domain.SeatPreferences{AcceptStanding: true, PreferenceVersion: "pv"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	releasedAt := time.Now().UTC().Truncate(time.Second)
+	payload, _ := json.Marshal(map[string]any{"segmentBookingId": "sb-release", "reason": "CHANGE", "voidedAt": releasedAt.Format(time.RFC3339)})
+	if err := svc.HandleSubscribedEvent(ctx, kitmsg.EventEnvelope{EventID: ids.NewEventID(), EventType: "EntitlementVoided", CorrelationID: ids.NewCorrelationID(), Payload: payload}); err != nil {
+		t.Fatal(err)
+	}
+	stored, _, err := repo.GetSeatAllocation(ctx, alloc.SeatAllocationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status != domain.AllocationStatusReleased || stored.ReleasedAt == nil || !stored.ReleasedAt.Equal(releasedAt) {
+		t.Fatalf("expected released allocation at event time, got %#v", stored)
+	}
+	if len(pub.payloads["SeatAllocationReleased"]) == 0 || pub.payloads["SeatAllocationReleased"][0]["releaseReason"] != "CHANGED" {
+		t.Fatalf("missing SeatAllocationReleased CHANGED event: %#v", pub.payloads["SeatAllocationReleased"])
+	}
+}
+
 func TestCapacityHoldExpiredExpiresSeatAllocations(t *testing.T) {
 	ctx := context.Background()
 	repo := newMemRepo()

--- a/services/seat-assignment/internal/application/seatmap_repair_test.go
+++ b/services/seat-assignment/internal/application/seatmap_repair_test.go
@@ -1,0 +1,123 @@
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/trainticket/greenfield/platform/go-kit/ids"
+	kitmsg "github.com/trainticket/greenfield/platform/go-kit/messaging"
+	"github.com/trainticket/greenfield/services/seat-assignment/internal/domain"
+)
+
+func TestDraftSeatMapReopenAndRetireLifecycle(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemRepo()
+	pub := &memPub{}
+	svc := New(repo, pub, nil)
+
+	m, err := svc.CreateSeatMap(ctx, CreateSeatMapRequest{ScheduledServiceRef: "ss-1", ServiceDate: "2026-08-02", CompositionVersion: "v1", CompositionSeed: "BASE", MappingVersion: "sim-v1", OperatorRef: "op"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	unitRef := m.Coaches[0].SeatUnits[0].SeatUnitRef
+	m, err = svc.MarkSeatUnitUnavailable(ctx, m.SeatMapID, unitRef, MarkSeatUnitUnavailableRequest{ExpectedSeatMapVersion: m.SeatMapVersion, UnavailableReason: "MAINTENANCE", OperatorRef: "op"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Coaches[0].SeatUnits[0].Assignable {
+		t.Fatal("expected unit to be unavailable")
+	}
+	m, err = svc.ReopenSeatUnit(ctx, m.SeatMapID, unitRef, ReopenSeatUnitRequest{ExpectedSeatMapVersion: m.SeatMapVersion, ReopenReason: "MAINTENANCE_CLEARED", OperatorRef: "op"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.Coaches[0].SeatUnits[0].Assignable || m.Coaches[0].SeatUnits[0].UnavailableReason != "" {
+		t.Fatalf("expected reopened unit, got %#v", m.Coaches[0].SeatUnits[0])
+	}
+	m, err = svc.RetireSeatMap(ctx, m.SeatMapID, RetireSeatMapRequest{ExpectedSeatMapVersion: m.SeatMapVersion, RetireReason: "SERVICE_ENDED", OperatorRef: "op"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Status != domain.SeatMapStatusRetired || m.RetiredAt == nil {
+		t.Fatalf("expected retired seat map, got %#v", m)
+	}
+	for _, eventType := range []string{"SeatUnitUnavailableMarked", "SeatUnitReopened", "SeatMapVersionRetired"} {
+		if len(pub.payloads[eventType]) == 0 {
+			t.Fatalf("missing event %s in %#v", eventType, pub.types)
+		}
+	}
+}
+
+func TestAdjacentAllocationRequiresSameGroupAndAdjacentKey(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemRepo()
+	svc := New(repo, &memPub{}, nil)
+	m, err := svc.CreateSeatMap(ctx, CreateSeatMapRequest{ScheduledServiceRef: "ss-1", ServiceDate: "2026-08-02", CompositionVersion: "v1", CompositionSeed: "BASE", MappingVersion: "sim-v1", OperatorRef: "op"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err = svc.PublishSeatMap(ctx, m.SeatMapID, PublishSeatMapRequest{ExpectedSeatMapVersion: m.SeatMapVersion, PublishReason: "READY", OperatorRef: "op"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := svc.AllocateSeat(ctx, allocReq("sb-other", "tvl-other", "hold-other", &domain.SeatPreferences{AcceptStanding: false, AdjacencyPreference: domain.AdjacencyAdjacent, AdjacencyGroupRef: "other", PreferenceVersion: "pv-other"})); err != nil {
+		t.Fatal(err)
+	}
+	degradedResp, err := svc.AllocateSeat(ctx, allocReq("sb-degraded", "tvl-degraded", "hold-degraded", &domain.SeatPreferences{AcceptStanding: false, AdjacencyPreference: domain.AdjacencyAdjacent, AdjacencyGroupRef: "grp", PreferenceVersion: "pv1"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !degradedResp.SeatRef.Degraded || degradedResp.SeatRef.DegradationReason != domain.DegradationNoAdjacentBlock {
+		t.Fatalf("expected unrelated occupied seat not to satisfy adjacency, got %#v", degradedResp.SeatRef)
+	}
+
+	rowTwoUnit := m.Coaches[0].SeatUnits[4]
+	active := []domain.ContractSeatAllocation{{
+		Interval:    domain.StationInterval{FromSeq: 1, ToSeq: 3},
+		Status:      domain.AllocationStatusAllocated,
+		Preferences: &domain.SeatPreferences{AdjacencyPreference: domain.AdjacencyAdjacent, AdjacencyGroupRef: "row1", PreferenceVersion: "pv-row1"},
+		SeatRef:     domain.SeatRef{SeatUnitRef: rowTwoUnit.SeatUnitRef},
+	}}
+	pref := &domain.SeatPreferences{AdjacencyPreference: domain.AdjacencyAdjacent, AdjacencyGroupRef: "row1", PreferenceVersion: "pv-row1", AvoidSeatUnitRefs: []string{m.Coaches[0].SeatUnits[1].SeatUnitRef, m.Coaches[0].SeatUnits[2].SeatUnitRef, m.Coaches[0].SeatUnits[3].SeatUnitRef, m.Coaches[0].SeatUnits[5].SeatUnitRef, m.Coaches[0].SeatUnits[6].SeatUnitRef, m.Coaches[0].SeatUnits[7].SeatUnitRef}}
+	nonAdjacent, degraded, reason := chooseSeatUnit(*m, "standard", domain.StationInterval{FromSeq: 1, ToSeq: 3}, pref, active)
+	if nonAdjacent == nil || !degraded || reason != domain.DegradationNoAdjacentBlock {
+		t.Fatalf("expected different adjacencyGroupKey not to satisfy ADJACENT, got unit=%#v degraded=%v reason=%s", nonAdjacent, degraded, reason)
+	}
+}
+
+func TestCapacityHoldExpiredExpiresSeatAllocations(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemRepo()
+	pub := &memPub{}
+	svc := New(repo, pub, nil)
+	m, err := svc.CreateSeatMap(ctx, CreateSeatMapRequest{ScheduledServiceRef: "ss-1", ServiceDate: "2026-08-02", CompositionVersion: "v1", CompositionSeed: "SMALL", MappingVersion: "sim-v1", ChangeScenario: "SMALL", OperatorRef: "op"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = svc.PublishSeatMap(ctx, m.SeatMapID, PublishSeatMapRequest{ExpectedSeatMapVersion: m.SeatMapVersion, PublishReason: "READY", OperatorRef: "op"}); err != nil {
+		t.Fatal(err)
+	}
+	alloc, err := svc.AllocateSeat(ctx, allocReq("sb-expire", "tvl-expire", "hold-expire", &domain.SeatPreferences{AcceptStanding: true, PreferenceVersion: "pv"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expiredAt := time.Now().UTC().Truncate(time.Second)
+	payload, _ := json.Marshal(map[string]any{"holdId": "hold-expire", "capacityUnitRef": "cap-standard", "interval": domain.StationInterval{FromSeq: 1, ToSeq: 3}, "expiredAt": expiredAt.Format(time.RFC3339)})
+	err = svc.HandleSubscribedEvent(ctx, kitmsg.EventEnvelope{EventID: ids.NewEventID(), EventType: "CapacityHoldExpired", CorrelationID: ids.NewCorrelationID(), Payload: payload})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored, _, err := repo.GetSeatAllocation(ctx, alloc.SeatAllocationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status != domain.AllocationStatusExpired {
+		t.Fatalf("expected expired allocation, got %#v", stored)
+	}
+	if len(pub.payloads["SeatAllocationExpired"]) == 0 {
+		t.Fatalf("missing SeatAllocationExpired event in %#v", pub.types)
+	}
+}

--- a/services/seat-assignment/internal/application/seatmap_service.go
+++ b/services/seat-assignment/internal/application/seatmap_service.go
@@ -1,0 +1,583 @@
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	kitmsg "github.com/trainticket/greenfield/platform/go-kit/messaging"
+	"github.com/trainticket/greenfield/services/seat-assignment/internal/domain"
+)
+
+type CreateSeatMapRequest struct {
+	ScheduledServiceRef string `json:"scheduledServiceRef"`
+	ServiceDate         string `json:"serviceDate"`
+	CompositionVersion  string `json:"compositionVersion"`
+	CompositionSeed     string `json:"compositionSeed"`
+	MappingVersion      string `json:"mappingVersion"`
+	ChangeScenario      string `json:"changeScenario"`
+	OperatorRef         string `json:"operatorRef"`
+	CorrelationID       string `json:"-"`
+	CausationID         string `json:"-"`
+}
+
+type PublishSeatMapRequest struct {
+	ExpectedSeatMapVersion int    `json:"expectedSeatMapVersion"`
+	PublishReason          string `json:"publishReason"`
+	OperatorRef            string `json:"operatorRef"`
+	CorrelationID          string `json:"-"`
+	CausationID            string `json:"-"`
+}
+
+type RetireSeatMapRequest struct {
+	ExpectedSeatMapVersion int    `json:"expectedSeatMapVersion"`
+	RetireReason           string `json:"retireReason"`
+	OperatorRef            string `json:"operatorRef"`
+	CorrelationID          string `json:"-"`
+	CausationID            string `json:"-"`
+}
+
+type MarkSeatUnitUnavailableRequest struct {
+	ExpectedSeatMapVersion int    `json:"expectedSeatMapVersion"`
+	UnavailableReason      string `json:"unavailableReason"`
+	OperatorRef            string `json:"operatorRef"`
+	CorrelationID          string `json:"-"`
+	CausationID            string `json:"-"`
+}
+
+type ReopenSeatUnitRequest struct {
+	ExpectedSeatMapVersion int    `json:"expectedSeatMapVersion"`
+	ReopenReason           string `json:"reopenReason"`
+	OperatorRef            string `json:"operatorRef"`
+	CorrelationID          string `json:"-"`
+	CausationID            string `json:"-"`
+}
+
+type AllocateSeatRequest struct {
+	SegmentBookingID    string                  `json:"segmentBookingId"`
+	JourneyOrderID      string                  `json:"journeyOrderId"`
+	TravelerRef         string                  `json:"travelerRef"`
+	SegmentRef          string                  `json:"segmentRef"`
+	ScheduledServiceRef string                  `json:"scheduledServiceRef"`
+	ServiceDate         string                  `json:"serviceDate"`
+	CapacityHoldID      string                  `json:"capacityHoldId"`
+	CapacityUnitRef     string                  `json:"capacityUnitRef"`
+	Interval            domain.StationInterval  `json:"interval"`
+	ClassRef            string                  `json:"classRef"`
+	IssuePurpose        string                  `json:"issuePurpose"`
+	SeatPreferences     *domain.SeatPreferences `json:"seatPreferences"`
+	ExpiresAt           time.Time               `json:"expiresAt"`
+	CorrelationID       string                  `json:"-"`
+	CausationID         string                  `json:"-"`
+}
+
+type AllocateSeatResponse struct {
+	SeatAllocationID string         `json:"seatAllocationId"`
+	Status           string         `json:"status"`
+	SeatRef          domain.SeatRef `json:"seatRef"`
+	ExpiresAt        time.Time      `json:"expiresAt"`
+}
+
+type Page[T any] struct {
+	Items  []T `json:"items"`
+	Total  int `json:"total"`
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
+}
+
+func (s *Service) CreateSeatMap(ctx context.Context, req CreateSeatMapRequest) (*domain.ContractSeatMap, error) {
+	if strings.TrimSpace(req.OperatorRef) == "" {
+		return nil, derr("VALIDATION_FAILED", "operatorRef is required")
+	}
+	now := time.Now().UTC()
+	seatMap, err := domain.NewContractSeatMap(req.ScheduledServiceRef, req.ServiceDate, req.CompositionVersion, req.CompositionSeed, req.MappingVersion, req.ChangeScenario, now)
+	if err != nil {
+		return nil, derr("VALIDATION_FAILED", err.Error())
+	}
+	err = s.tx(ctx, func(tx context.Context) error {
+		if err := s.repo.SaveSeatMap(tx, seatMap); err != nil {
+			return derr("CONFLICT", err.Error())
+		}
+		return s.publish(tx, []domain.Event{{EventType: "SeatMapBuilt", AggregateID: seatMap.SeatMapID, Version: int64(seatMap.SeatMapVersion), OccurredAt: now, CorrelationID: req.CorrelationID, CausationID: req.CausationID, Payload: seatMapBuiltPayload(*seatMap, now)}})
+	})
+	if err != nil {
+		return nil, err
+	}
+	return seatMap, nil
+}
+
+func (s *Service) PublishSeatMap(ctx context.Context, id string, req PublishSeatMapRequest) (*domain.ContractSeatMap, error) {
+	if strings.TrimSpace(req.OperatorRef) == "" || strings.TrimSpace(req.PublishReason) == "" {
+		return nil, derr("VALIDATION_FAILED", "publishReason and operatorRef are required")
+	}
+	now := time.Now().UTC()
+	var out *domain.ContractSeatMap
+	err := s.tx(ctx, func(tx context.Context) error {
+		seatMap, exp, err := s.repo.GetSeatMap(tx, id)
+		if err != nil {
+			return derr("NOT_FOUND", "seat map not found")
+		}
+		if seatMap.SeatMapVersion != req.ExpectedSeatMapVersion {
+			return derr("PRECONDITION_FAILED", "seatMapVersion does not match")
+		}
+		if err := seatMap.Publish(req.ExpectedSeatMapVersion, now); err != nil {
+			return derr("DOMAIN_RULE_VIOLATION", "seat map cannot be published from its current state")
+		}
+		if err := s.repo.UpdateSeatMap(tx, seatMap, exp); err != nil {
+			return derr("CONFLICT", err.Error())
+		}
+		out = seatMap
+		return s.publish(tx, []domain.Event{{EventType: "SeatMapVersionPublished", AggregateID: seatMap.SeatMapID, Version: int64(seatMap.SeatMapVersion), OccurredAt: now, CorrelationID: req.CorrelationID, CausationID: req.CausationID, Payload: map[string]any{"seatMapId": seatMap.SeatMapID, "scheduledServiceRef": seatMap.ScheduledServiceRef, "serviceDate": seatMap.ServiceDate, "compositionVersion": seatMap.CompositionVersion, "seatMapVersion": seatMap.SeatMapVersion, "publishedAt": now, "operatorRef": req.OperatorRef, "status": seatMap.Status}}})
+	})
+	return out, err
+}
+
+func (s *Service) RetireSeatMap(ctx context.Context, id string, req RetireSeatMapRequest) (*domain.ContractSeatMap, error) {
+	if strings.TrimSpace(req.OperatorRef) == "" || strings.TrimSpace(req.RetireReason) == "" {
+		return nil, derr("VALIDATION_FAILED", "retireReason and operatorRef are required")
+	}
+	now := time.Now().UTC()
+	var out *domain.ContractSeatMap
+	err := s.tx(ctx, func(tx context.Context) error {
+		seatMap, exp, err := s.repo.GetSeatMap(tx, id)
+		if err != nil {
+			return derr("NOT_FOUND", "seat map not found")
+		}
+		if seatMap.SeatMapVersion != req.ExpectedSeatMapVersion {
+			return derr("PRECONDITION_FAILED", "seatMapVersion does not match")
+		}
+		if err := seatMap.Retire(req.ExpectedSeatMapVersion, req.RetireReason, now); err != nil {
+			return derr("DOMAIN_RULE_VIOLATION", "seat map cannot be retired from its current state")
+		}
+		if err := s.repo.UpdateSeatMap(tx, seatMap, exp); err != nil {
+			return derr("CONFLICT", err.Error())
+		}
+		out = seatMap
+		return s.publish(tx, []domain.Event{{EventType: "SeatMapVersionRetired", AggregateID: seatMap.SeatMapID, Version: int64(seatMap.SeatMapVersion), OccurredAt: now, CorrelationID: req.CorrelationID, CausationID: req.CausationID, Payload: map[string]any{"seatMapId": seatMap.SeatMapID, "scheduledServiceRef": seatMap.ScheduledServiceRef, "serviceDate": seatMap.ServiceDate, "seatMapVersion": seatMap.SeatMapVersion, "retireReason": req.RetireReason, "retiredAt": now, "operatorRef": req.OperatorRef, "status": seatMap.Status}}})
+	})
+	return out, err
+}
+
+func (s *Service) MarkSeatUnitUnavailable(ctx context.Context, id, seatUnitRef string, req MarkSeatUnitUnavailableRequest) (*domain.ContractSeatMap, error) {
+	if strings.TrimSpace(req.OperatorRef) == "" || strings.TrimSpace(req.UnavailableReason) == "" {
+		return nil, derr("VALIDATION_FAILED", "unavailableReason and operatorRef are required")
+	}
+	var out *domain.ContractSeatMap
+	now := time.Now().UTC()
+	err := s.tx(ctx, func(tx context.Context) error {
+		seatMap, exp, err := s.repo.GetSeatMap(tx, id)
+		if err != nil {
+			return derr("NOT_FOUND", "seat map not found")
+		}
+		if seatMap.Status == domain.SeatMapStatusPublished {
+			return derr("DOMAIN_RULE_VIOLATION", "published SeatMaps are immutable")
+		}
+		if seatMap.SeatMapVersion != req.ExpectedSeatMapVersion {
+			return derr("PRECONDITION_FAILED", "seatMapVersion does not match")
+		}
+		unit, ok := seatMap.FindUnit(seatUnitRef)
+		if !ok {
+			return derr("NOT_FOUND", "seat unit not found")
+		}
+		coachNo, seatNo := unit.CoachNo, unit.SeatNo
+		if err := seatMap.MarkSeatUnitUnavailable(seatUnitRef, req.UnavailableReason, req.ExpectedSeatMapVersion); err != nil {
+			return mapDomain(err)
+		}
+		if err := s.repo.UpdateSeatMap(tx, seatMap, exp); err != nil {
+			return derr("CONFLICT", err.Error())
+		}
+		out = seatMap
+		return s.publish(tx, []domain.Event{{EventType: "SeatUnitUnavailableMarked", AggregateID: seatMap.SeatMapID, Version: int64(seatMap.SeatMapVersion), OccurredAt: now, CorrelationID: req.CorrelationID, CausationID: req.CausationID, Payload: map[string]any{"seatMapId": seatMap.SeatMapID, "seatMapVersion": seatMap.SeatMapVersion, "seatUnitRef": seatUnitRef, "coachNo": coachNo, "seatNo": seatNo, "unavailableReason": req.UnavailableReason, "markedAt": now, "operatorRef": req.OperatorRef}}})
+	})
+	return out, err
+}
+
+func (s *Service) ReopenSeatUnit(ctx context.Context, id, seatUnitRef string, req ReopenSeatUnitRequest) (*domain.ContractSeatMap, error) {
+	if strings.TrimSpace(req.OperatorRef) == "" || strings.TrimSpace(req.ReopenReason) == "" {
+		return nil, derr("VALIDATION_FAILED", "reopenReason and operatorRef are required")
+	}
+	var out *domain.ContractSeatMap
+	now := time.Now().UTC()
+	err := s.tx(ctx, func(tx context.Context) error {
+		seatMap, exp, err := s.repo.GetSeatMap(tx, id)
+		if err != nil {
+			return derr("NOT_FOUND", "seat map not found")
+		}
+		if seatMap.Status == domain.SeatMapStatusPublished {
+			return derr("DOMAIN_RULE_VIOLATION", "published SeatMaps are immutable")
+		}
+		if seatMap.SeatMapVersion != req.ExpectedSeatMapVersion {
+			return derr("PRECONDITION_FAILED", "seatMapVersion does not match")
+		}
+		unit, ok := seatMap.FindUnit(seatUnitRef)
+		if !ok {
+			return derr("NOT_FOUND", "seat unit not found")
+		}
+		coachNo, seatNo := unit.CoachNo, unit.SeatNo
+		if err := seatMap.ReopenSeatUnit(seatUnitRef, req.ExpectedSeatMapVersion); err != nil {
+			return mapDomain(err)
+		}
+		if err := s.repo.UpdateSeatMap(tx, seatMap, exp); err != nil {
+			return derr("CONFLICT", err.Error())
+		}
+		out = seatMap
+		return s.publish(tx, []domain.Event{{EventType: "SeatUnitReopened", AggregateID: seatMap.SeatMapID, Version: int64(seatMap.SeatMapVersion), OccurredAt: now, CorrelationID: req.CorrelationID, CausationID: req.CausationID, Payload: map[string]any{"seatMapId": seatMap.SeatMapID, "seatMapVersion": seatMap.SeatMapVersion, "seatUnitRef": seatUnitRef, "coachNo": coachNo, "seatNo": seatNo, "reopenReason": req.ReopenReason, "reopenedAt": now, "operatorRef": req.OperatorRef}}})
+	})
+	return out, err
+}
+
+func (s *Service) GetSeatMap(ctx context.Context, id string) (*domain.ContractSeatMap, error) {
+	m, _, err := s.repo.GetSeatMap(ctx, id)
+	if err != nil {
+		return nil, derr("NOT_FOUND", "seat map not found")
+	}
+	return m, nil
+}
+func (s *Service) ListSeatMaps(ctx context.Context, ss, date, status string, limit, offset int) (*Page[domain.ContractSeatMap], error) {
+	if ss == "" || date == "" {
+		return nil, derr("VALIDATION_FAILED", "scheduledServiceRef and serviceDate are required")
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	items, total, err := s.repo.FindSeatMaps(ctx, ss, date, status, limit, offset)
+	if err != nil {
+		return nil, derr("UNAVAILABLE", err.Error())
+	}
+	return &Page[domain.ContractSeatMap]{Items: items, Total: total, Limit: limit, Offset: offset}, nil
+}
+
+func (s *Service) AllocateSeat(ctx context.Context, req AllocateSeatRequest) (*AllocateSeatResponse, error) {
+	if err := validateAllocate(req); err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	var resp *AllocateSeatResponse
+	err := s.tx(ctx, func(tx context.Context) error {
+		maps, _, err := s.repo.FindSeatMaps(tx, req.ScheduledServiceRef, req.ServiceDate, domain.SeatMapStatusPublished, 100, 0)
+		if err != nil {
+			return derr("UNAVAILABLE", err.Error())
+		}
+		var seatMap *domain.ContractSeatMap
+		for i := range maps {
+			if len(maps[i].AssignableUnits(req.ClassRef)) > 0 {
+				seatMap = &maps[i]
+				break
+			}
+		}
+		if seatMap == nil {
+			return derr("PRECONDITION_FAILED", "no published SeatMap matches scheduled service, date and class")
+		}
+		active, err := s.repo.FindActiveSeatAllocations(tx, req.ScheduledServiceRef, req.ServiceDate)
+		if err != nil {
+			return derr("UNAVAILABLE", err.Error())
+		}
+		unit, degraded, reason := chooseSeatUnit(*seatMap, req.ClassRef, req.Interval, req.SeatPreferences, active)
+		allocID := domain.NewID("salloc")
+		status := domain.AllocationStatusAllocated
+		seatRef := domain.SeatRef{SeatAllocationID: allocID, Degraded: degraded}
+		if reason != domain.DegradationNone {
+			seatRef.DegradationReason = reason
+		}
+		if unit == nil {
+			if req.SeatPreferences == nil || !req.SeatPreferences.AcceptStanding {
+				return derr("DOMAIN_RULE_VIOLATION", "no compatible seat exists and standing is not accepted")
+			}
+			status = domain.AllocationStatusStanding
+			seatRef.AllocationType = domain.AllocationTypeStanding
+			seatRef.DisplayLabel = "STANDING"
+			seatRef.Degraded = true
+			seatRef.DegradationReason = domain.DegradationStandingAssigned
+		} else {
+			seatRef.AllocationType = unit.AllocationType
+			seatRef.SeatMapID = seatMap.SeatMapID
+			seatRef.SeatMapVersion = seatMap.SeatMapVersion
+			seatRef.SeatUnitRef = unit.SeatUnitRef
+			seatRef.CoachNo = unit.CoachNo
+			seatRef.SeatNo = unit.SeatNo
+			seatRef.BerthPosition = unit.BerthPosition
+			seatRef.DisplayLabel = fmt.Sprintf("%s车 %s", unit.CoachNo, unit.SeatNo)
+		}
+		alloc := &domain.ContractSeatAllocation{SeatAllocationID: allocID, SegmentBookingID: req.SegmentBookingID, JourneyOrderID: req.JourneyOrderID, TravelerRef: req.TravelerRef, SegmentRef: req.SegmentRef, ScheduledServiceRef: req.ScheduledServiceRef, ServiceDate: req.ServiceDate, CapacityHoldID: req.CapacityHoldID, CapacityUnitRef: req.CapacityUnitRef, Interval: req.Interval, SeatRef: seatRef, Status: status, Preferences: req.SeatPreferences, CreatedAt: now, ExpiresAt: req.ExpiresAt}
+		if err := s.repo.SaveSeatAllocation(tx, alloc); err != nil {
+			return derr("CONFLICT", err.Error())
+		}
+		events := []domain.Event{}
+		if pref := normalizedPref(req.SeatPreferences); pref.AdjacencyGroupRef != "" || pref.AdjacencyPreference != domain.AdjacencyNone {
+			events = append(events, adjacencyEvents(req, *alloc, pref, reason, now)...)
+		}
+		eventType := "SeatAllocated"
+		payloadTimeKey := "allocatedAt"
+		if status == domain.AllocationStatusStanding {
+			eventType = "StandingAssigned"
+			payloadTimeKey = "assignedAt"
+		}
+		events = append(events, domain.Event{EventType: eventType, AggregateID: alloc.SeatAllocationID, Version: 1, OccurredAt: now, CorrelationID: req.CorrelationID, CausationID: req.CausationID, Payload: allocationPayload(*alloc, payloadTimeKey, now)})
+		resp = &AllocateSeatResponse{SeatAllocationID: alloc.SeatAllocationID, Status: alloc.Status, SeatRef: alloc.SeatRef, ExpiresAt: alloc.ExpiresAt}
+		return s.publish(tx, events)
+	})
+	return resp, err
+}
+
+func (s *Service) GetSeatAllocation(ctx context.Context, id string) (*domain.ContractSeatAllocation, error) {
+	a, _, err := s.repo.GetSeatAllocation(ctx, id)
+	if err != nil {
+		return nil, derr("NOT_FOUND", "seat allocation not found")
+	}
+	return a, nil
+}
+func (s *Service) ListSeatAllocations(ctx context.Context, sb, status string, limit, offset int) (*Page[domain.ContractSeatAllocation], error) {
+	if sb == "" {
+		return nil, derr("VALIDATION_FAILED", "segmentBookingId is required")
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	items, total, err := s.repo.FindSeatAllocations(ctx, sb, status, limit, offset)
+	if err != nil {
+		return nil, derr("UNAVAILABLE", err.Error())
+	}
+	return &Page[domain.ContractSeatAllocation]{Items: items, Total: total, Limit: limit, Offset: offset}, nil
+}
+
+func validateAllocate(req AllocateSeatRequest) error {
+	if strings.TrimSpace(req.SegmentBookingID) == "" || strings.TrimSpace(req.JourneyOrderID) == "" || strings.TrimSpace(req.TravelerRef) == "" || strings.TrimSpace(req.SegmentRef) == "" || strings.TrimSpace(req.ScheduledServiceRef) == "" || strings.TrimSpace(req.ServiceDate) == "" || strings.TrimSpace(req.CapacityHoldID) == "" || strings.TrimSpace(req.CapacityUnitRef) == "" || strings.TrimSpace(req.ClassRef) == "" || !req.Interval.Valid() || req.ExpiresAt.IsZero() {
+		return derr("VALIDATION_FAILED", "segmentBookingId, journeyOrderId, travelerRef, segmentRef, scheduledServiceRef, serviceDate, capacityHoldId, capacityUnitRef, valid interval, classRef and expiresAt are required")
+	}
+	return nil
+}
+func normalizedPref(p *domain.SeatPreferences) domain.SeatPreferences {
+	if p == nil {
+		return domain.SeatPreferences{AdjacencyPreference: domain.AdjacencyNone}
+	}
+	out := *p
+	if out.AdjacencyPreference == "" {
+		out.AdjacencyPreference = domain.AdjacencyNone
+	}
+	return out
+}
+func chooseSeatUnit(m domain.ContractSeatMap, classRef string, interval domain.StationInterval, pref *domain.SeatPreferences, active []domain.ContractSeatAllocation) (*domain.SeatUnit, bool, string) {
+	np := normalizedPref(pref)
+	occupied := occupiedSeatUnits(active, interval)
+	avoid := map[string]bool{}
+	for _, r := range np.AvoidSeatUnitRefs {
+		avoid[r] = true
+	}
+	candidates := availableUnits(m.AssignableUnits(classRef), occupied, avoid)
+	if len(candidates) == 0 {
+		return nil, false, domain.DegradationNone
+	}
+	if !requiresAdjacency(np) {
+		return &candidates[0], false, domain.DegradationNone
+	}
+	for i := range candidates {
+		if satisfiesAdjacency(candidates[i], np, m, active, interval) {
+			return &candidates[i], false, domain.DegradationNone
+		}
+	}
+	return &candidates[0], true, domain.DegradationNoAdjacentBlock
+}
+
+func occupiedSeatUnits(active []domain.ContractSeatAllocation, interval domain.StationInterval) map[string]bool {
+	occupied := map[string]bool{}
+	for _, a := range active {
+		if !isConcreteActive(a) || !a.Interval.Overlaps(interval) {
+			continue
+		}
+		occupied[a.SeatRef.SeatUnitRef] = true
+	}
+	return occupied
+}
+
+func availableUnits(units []domain.SeatUnit, occupied, avoid map[string]bool) []domain.SeatUnit {
+	out := make([]domain.SeatUnit, 0, len(units))
+	for _, unit := range units {
+		if !occupied[unit.SeatUnitRef] && !avoid[unit.SeatUnitRef] {
+			out = append(out, unit)
+		}
+	}
+	return out
+}
+
+func requiresAdjacency(pref domain.SeatPreferences) bool {
+	switch pref.AdjacencyPreference {
+	case domain.AdjacencySameCoach, domain.AdjacencySameRow, domain.AdjacencyAdjacent, domain.AdjacencySameCompartment:
+		return true
+	default:
+		return false
+	}
+}
+
+func satisfiesAdjacency(candidate domain.SeatUnit, pref domain.SeatPreferences, seatMap domain.ContractSeatMap, active []domain.ContractSeatAllocation, interval domain.StationInterval) bool {
+	if pref.AdjacencyGroupRef == "" {
+		return false
+	}
+	for _, allocation := range active {
+		if !isConcreteActive(allocation) || !allocation.Interval.Overlaps(interval) || allocation.Preferences == nil || allocation.Preferences.AdjacencyGroupRef != pref.AdjacencyGroupRef {
+			continue
+		}
+		other, ok := seatMap.UnitByRef(allocation.SeatRef.SeatUnitRef)
+		if !ok {
+			continue
+		}
+		if adjacencySatisfied(candidate, other, pref.AdjacencyPreference) {
+			return true
+		}
+	}
+	return false
+}
+
+func isConcreteActive(a domain.ContractSeatAllocation) bool {
+	switch a.Status {
+	case domain.AllocationStatusAllocated, domain.AllocationStatusConfirmed:
+		return a.SeatRef.SeatUnitRef != ""
+	default:
+		return false
+	}
+}
+
+func adjacencySatisfied(candidate, other domain.SeatUnit, preference string) bool {
+	switch preference {
+	case domain.AdjacencySameCoach:
+		return candidate.CoachNo == other.CoachNo
+	case domain.AdjacencySameRow:
+		return candidate.CoachNo == other.CoachNo && candidate.RowNo != "" && candidate.RowNo == other.RowNo
+	case domain.AdjacencyAdjacent, domain.AdjacencySameCompartment:
+		return candidate.CoachNo == other.CoachNo && candidate.AdjacencyGroupKey != "" && candidate.AdjacencyGroupKey == other.AdjacencyGroupKey
+	default:
+		return false
+	}
+}
+func seatMapBuiltPayload(m domain.ContractSeatMap, now time.Time) map[string]any {
+	count := 0
+	for _, c := range m.Coaches {
+		count += len(c.SeatUnits)
+	}
+	return map[string]any{"seatMapId": m.SeatMapID, "scheduledServiceRef": m.ScheduledServiceRef, "serviceDate": m.ServiceDate, "compositionVersion": m.CompositionVersion, "seatMapVersion": m.SeatMapVersion, "compositionSeed": m.CompositionSeed, "mappingVersion": m.MappingVersion, "coachCount": len(m.Coaches), "seatUnitCount": count, "status": m.Status, "builtAt": now}
+}
+func allocationPayload(a domain.ContractSeatAllocation, timeKey string, now time.Time) map[string]any {
+	p := map[string]any{"seatAllocationId": a.SeatAllocationID, "segmentBookingId": a.SegmentBookingID, "journeyOrderId": a.JourneyOrderID, "travelerRef": a.TravelerRef, "segmentRef": a.SegmentRef, "scheduledServiceRef": a.ScheduledServiceRef, "serviceDate": a.ServiceDate, "capacityHoldId": a.CapacityHoldID, "capacityUnitRef": a.CapacityUnitRef, "interval": a.Interval, "seatRef": a.SeatRef, "expiresAt": a.ExpiresAt, "status": a.Status, timeKey: now}
+	if a.Preferences != nil {
+		p["preferences"] = a.Preferences
+	}
+	return p
+}
+func adjacencyEvents(req AllocateSeatRequest, a domain.ContractSeatAllocation, pref domain.SeatPreferences, reason string, now time.Time) []domain.Event {
+	adjID := domain.NewID("adj")
+	result := "SATISFIED"
+	degraded := reason != "" && reason != domain.DegradationNone
+	if degraded {
+		result = "PARTIALLY_SATISFIED"
+	}
+	evs := []domain.Event{{EventType: "AdjacencyGroupCreated", AggregateID: adjID, Version: 1, OccurredAt: now, CorrelationID: req.CorrelationID, CausationID: req.CausationID, Payload: map[string]any{"adjacencyGroupId": adjID, "journeyOrderId": req.JourneyOrderID, "segmentRef": req.SegmentRef, "travelerRefs": []string{req.TravelerRef}, "preference": pref.AdjacencyPreference, "preferenceVersion": pref.PreferenceVersion, "status": "OPEN", "createdAt": now}}, {EventType: "AdjacentAllocationSolved", AggregateID: adjID, Version: 2, OccurredAt: now, CorrelationID: req.CorrelationID, CausationID: req.CausationID, Payload: map[string]any{"adjacencyGroupId": adjID, "journeyOrderId": req.JourneyOrderID, "segmentRef": req.SegmentRef, "seatAllocationIds": []string{a.SeatAllocationID}, "result": result, "degraded": degraded, "degradationReason": reason, "solvedAt": now, "status": result}}}
+	if degraded {
+		evs = append(evs, domain.Event{EventType: "AdjacencyDegradationAccepted", AggregateID: adjID, Version: 3, OccurredAt: now, CorrelationID: req.CorrelationID, CausationID: req.CausationID, Payload: map[string]any{"adjacencyGroupId": adjID, "journeyOrderId": req.JourneyOrderID, "seatAllocationIds": []string{a.SeatAllocationID}, "acceptedByRef": "POLICY", "degradationReason": reason, "acceptedAt": now}})
+	}
+	return evs
+}
+
+func (s *Service) handleCapacityReleased(ctx context.Context, e kitmsg.EventEnvelope) error {
+	var p map[string]any
+	_ = json.Unmarshal(e.Payload, &p)
+	releasedAt := time.Now().UTC()
+	if raw := str(p, "releasedAt"); raw != "" {
+		if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+			releasedAt = parsed.UTC()
+		}
+	}
+	return s.transitionAllocationsByCapacityRecovery(ctx, capacityRecoveryMatchFromPayload(p), e, func(a *domain.ContractSeatAllocation, at time.Time) { a.Release(at) }, "SeatAllocationReleased", "releasedAt", map[string]any{"releaseReason": "CAPACITY_RELEASED", "releasedAt": releasedAt})
+}
+
+func (s *Service) handleCapacityHoldExpired(ctx context.Context, e kitmsg.EventEnvelope) error {
+	var p map[string]any
+	_ = json.Unmarshal(e.Payload, &p)
+	expiredAt := time.Now().UTC()
+	if raw := str(p, "expiredAt"); raw != "" {
+		if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+			expiredAt = parsed.UTC()
+		}
+	}
+	return s.transitionAllocationsByCapacityRecovery(ctx, capacityRecoveryMatchFromPayload(p), e, func(a *domain.ContractSeatAllocation, at time.Time) { a.Expire(at) }, "SeatAllocationExpired", "expiredAt", map[string]any{"expiredAt": expiredAt})
+}
+
+type capacityRecoveryMatch struct {
+	HoldID          string
+	CapacityUnitRef string
+	Interval        domain.StationInterval
+}
+
+func capacityRecoveryMatchFromPayload(p map[string]any) capacityRecoveryMatch {
+	return capacityRecoveryMatch{HoldID: str(p, "holdId"), CapacityUnitRef: str(p, "capacityUnitRef"), Interval: intervalFromAny(p["interval"])}
+}
+
+func intervalFromAny(raw any) domain.StationInterval {
+	switch v := raw.(type) {
+	case domain.StationInterval:
+		return v
+	case map[string]any:
+		return domain.StationInterval{FromSeq: intFromAny(v["fromSeq"]), ToSeq: intFromAny(v["toSeq"])}
+	default:
+		return domain.StationInterval{}
+	}
+}
+
+func intFromAny(raw any) int {
+	switch v := raw.(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	case json.Number:
+		i, _ := v.Int64()
+		return int(i)
+	default:
+		return 0
+	}
+}
+
+func (s *Service) transitionAllocationsByCapacityRecovery(ctx context.Context, match capacityRecoveryMatch, e kitmsg.EventEnvelope, apply func(*domain.ContractSeatAllocation, time.Time), eventType, timeKey string, extra map[string]any) error {
+	if match.HoldID == "" || match.CapacityUnitRef == "" || !match.Interval.Valid() {
+		return nil
+	}
+	transitionedAt := time.Now().UTC()
+	if v, ok := extra[timeKey].(time.Time); ok {
+		transitionedAt = v
+	}
+	allocs, err := s.repo.FindSeatAllocationsByCapacityRecovery(ctx, match.HoldID, match.CapacityUnitRef, match.Interval)
+	if err != nil {
+		return err
+	}
+	for _, alloc := range allocs {
+		if alloc.Status == domain.AllocationStatusReleased || alloc.Status == domain.AllocationStatusExpired {
+			continue
+		}
+		current := alloc
+		_, exp, err := s.repo.GetSeatAllocation(ctx, current.SeatAllocationID)
+		if err != nil {
+			continue
+		}
+		apply(&current, transitionedAt)
+		if current.Status == alloc.Status {
+			continue
+		}
+		if err := s.repo.UpdateSeatAllocation(ctx, &current, exp); err != nil {
+			return err
+		}
+		payload := map[string]any{"seatAllocationId": current.SeatAllocationID, "segmentBookingId": current.SegmentBookingID, "journeyOrderId": current.JourneyOrderID, "travelerRef": current.TravelerRef, "capacityHoldId": current.CapacityHoldID, "capacityUnitRef": current.CapacityUnitRef, "interval": current.Interval, "seatRef": current.SeatRef, timeKey: transitionedAt, "sourceEventId": e.EventID, "status": current.Status}
+		for k, v := range extra {
+			payload[k] = v
+		}
+		if err := s.publish(ctx, []domain.Event{{EventType: eventType, AggregateID: current.SeatAllocationID, Version: 2, OccurredAt: transitionedAt, CorrelationID: e.CorrelationID, CausationID: e.EventID, Payload: payload}}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/services/seat-assignment/internal/application/seatmap_service.go
+++ b/services/seat-assignment/internal/application/seatmap_service.go
@@ -349,10 +349,74 @@ func (s *Service) ListSeatAllocations(ctx context.Context, sb, status string, li
 }
 
 func validateAllocate(req AllocateSeatRequest) error {
-	if strings.TrimSpace(req.SegmentBookingID) == "" || strings.TrimSpace(req.JourneyOrderID) == "" || strings.TrimSpace(req.TravelerRef) == "" || strings.TrimSpace(req.SegmentRef) == "" || strings.TrimSpace(req.ScheduledServiceRef) == "" || strings.TrimSpace(req.ServiceDate) == "" || strings.TrimSpace(req.CapacityHoldID) == "" || strings.TrimSpace(req.CapacityUnitRef) == "" || strings.TrimSpace(req.ClassRef) == "" || !req.Interval.Valid() || req.ExpiresAt.IsZero() {
-		return derr("VALIDATION_FAILED", "segmentBookingId, journeyOrderId, travelerRef, segmentRef, scheduledServiceRef, serviceDate, capacityHoldId, capacityUnitRef, valid interval, classRef and expiresAt are required")
+	if strings.TrimSpace(req.SegmentBookingID) == "" || strings.TrimSpace(req.JourneyOrderID) == "" || strings.TrimSpace(req.TravelerRef) == "" || strings.TrimSpace(req.SegmentRef) == "" || strings.TrimSpace(req.ScheduledServiceRef) == "" || strings.TrimSpace(req.ServiceDate) == "" || strings.TrimSpace(req.CapacityHoldID) == "" || strings.TrimSpace(req.CapacityUnitRef) == "" || strings.TrimSpace(req.ClassRef) == "" || strings.TrimSpace(req.IssuePurpose) == "" || !req.Interval.Valid() || req.ExpiresAt.IsZero() {
+		return derr("VALIDATION_FAILED", "segmentBookingId, journeyOrderId, travelerRef, segmentRef, scheduledServiceRef, serviceDate, capacityHoldId, capacityUnitRef, valid interval, classRef, issuePurpose and expiresAt are required")
+	}
+	if !validIssuePurpose(req.IssuePurpose) {
+		return derr("VALIDATION_FAILED", "issuePurpose must be INITIAL, REPLACEMENT, MANUAL_RECOVERY, PROVIDER_REBUILD or DISRUPTION_REPLACEMENT")
+	}
+	if req.SeatPreferences != nil {
+		if err := validateSeatPreferences(*req.SeatPreferences); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+func validIssuePurpose(v string) bool {
+	switch strings.TrimSpace(v) {
+	case "INITIAL", "REPLACEMENT", "MANUAL_RECOVERY", "PROVIDER_REBUILD", "DISRUPTION_REPLACEMENT":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateSeatPreferences(pref domain.SeatPreferences) error {
+	if strings.TrimSpace(pref.PreferenceVersion) == "" {
+		return derr("VALIDATION_FAILED", "seatPreferences.preferenceVersion is required")
+	}
+	if !validAdjacencyPreference(pref.AdjacencyPreference) {
+		return derr("VALIDATION_FAILED", "seatPreferences.adjacencyPreference must be NONE, SAME_COACH, SAME_ROW, ADJACENT or SAME_COMPARTMENT")
+	}
+	for _, position := range pref.PreferredSeatPositions {
+		if !validSeatPosition(position) {
+			return derr("VALIDATION_FAILED", "seatPreferences.preferredSeatPositions contains an invalid seatPosition")
+		}
+	}
+	for _, position := range pref.PreferredBerthPositions {
+		if !validBerthPosition(position) {
+			return derr("VALIDATION_FAILED", "seatPreferences.preferredBerthPositions contains an invalid berthPosition")
+		}
+	}
+	return nil
+}
+
+func validAdjacencyPreference(v string) bool {
+	switch strings.TrimSpace(v) {
+	case "", domain.AdjacencyNone, domain.AdjacencySameCoach, domain.AdjacencySameRow, domain.AdjacencyAdjacent, domain.AdjacencySameCompartment:
+		return true
+	default:
+		return false
+	}
+}
+
+func validSeatPosition(v string) bool {
+	switch strings.TrimSpace(v) {
+	case "WINDOW", "AISLE", "MIDDLE", "LOWER_DECK", "UPPER_DECK":
+		return true
+	default:
+		return false
+	}
+}
+
+func validBerthPosition(v string) bool {
+	switch strings.TrimSpace(v) {
+	case "UPPER", "MIDDLE", "LOWER", "SIDE_UPPER", "SIDE_LOWER":
+		return true
+	default:
+		return false
+	}
 }
 func normalizedPref(p *domain.SeatPreferences) domain.SeatPreferences {
 	if p == nil {

--- a/services/seat-assignment/internal/application/seatmap_service_test.go
+++ b/services/seat-assignment/internal/application/seatmap_service_test.go
@@ -1,0 +1,200 @@
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	kitmsg "github.com/trainticket/greenfield/platform/go-kit/messaging"
+	"github.com/trainticket/greenfield/services/seat-assignment/internal/domain"
+)
+
+type memRepo struct {
+	maps   map[string]*domain.ContractSeatMap
+	allocs map[string]*domain.ContractSeatAllocation
+}
+
+func newMemRepo() *memRepo {
+	return &memRepo{maps: map[string]*domain.ContractSeatMap{}, allocs: map[string]*domain.ContractSeatAllocation{}}
+}
+func (r *memRepo) GetInventory(context.Context, string, string) (*domain.SeatInventory, int64, error) {
+	return nil, 0, nil
+}
+func (r *memRepo) SaveInventory(context.Context, *domain.SeatInventory) error          { return nil }
+func (r *memRepo) UpdateInventory(context.Context, *domain.SeatInventory, int64) error { return nil }
+func (r *memRepo) GetAssignment(context.Context, string) (*domain.SeatAssignment, int64, error) {
+	return nil, 0, fmt.Errorf("not found")
+}
+func (r *memRepo) FindAssignments(context.Context, string, string, string) ([]domain.SeatAssignment, error) {
+	return nil, nil
+}
+func (r *memRepo) SaveAssignment(context.Context, *domain.SeatAssignment) error          { return nil }
+func (r *memRepo) UpdateAssignment(context.Context, *domain.SeatAssignment, int64) error { return nil }
+func (r *memRepo) SaveSeatMap(_ context.Context, m *domain.ContractSeatMap) error {
+	cp := *m
+	r.maps[m.SeatMapID] = &cp
+	return nil
+}
+func (r *memRepo) UpdateSeatMap(_ context.Context, m *domain.ContractSeatMap, _ int64) error {
+	cp := *m
+	r.maps[m.SeatMapID] = &cp
+	return nil
+}
+func (r *memRepo) GetSeatMap(_ context.Context, id string) (*domain.ContractSeatMap, int64, error) {
+	m := r.maps[id]
+	if m == nil {
+		return nil, 0, fmt.Errorf("not found")
+	}
+	cp := *m
+	return &cp, 1, nil
+}
+func (r *memRepo) FindSeatMaps(_ context.Context, ss, date, status string, limit, offset int) ([]domain.ContractSeatMap, int, error) {
+	out := []domain.ContractSeatMap{}
+	for _, m := range r.maps {
+		if m.ScheduledServiceRef == ss && m.ServiceDate == date && (status == "" || m.Status == status) {
+			out = append(out, *m)
+		}
+	}
+	return out, len(out), nil
+}
+func (r *memRepo) SaveSeatAllocation(_ context.Context, a *domain.ContractSeatAllocation) error {
+	cp := *a
+	r.allocs[a.SeatAllocationID] = &cp
+	return nil
+}
+func (r *memRepo) UpdateSeatAllocation(_ context.Context, a *domain.ContractSeatAllocation, _ int64) error {
+	cp := *a
+	r.allocs[a.SeatAllocationID] = &cp
+	return nil
+}
+func (r *memRepo) GetSeatAllocation(_ context.Context, id string) (*domain.ContractSeatAllocation, int64, error) {
+	a := r.allocs[id]
+	if a == nil {
+		return nil, 0, fmt.Errorf("not found")
+	}
+	cp := *a
+	return &cp, 1, nil
+}
+func (r *memRepo) FindSeatAllocations(_ context.Context, sb, status string, limit, offset int) ([]domain.ContractSeatAllocation, int, error) {
+	out := []domain.ContractSeatAllocation{}
+	for _, a := range r.allocs {
+		if a.SegmentBookingID == sb && (status == "" || a.Status == status) {
+			out = append(out, *a)
+		}
+	}
+	return out, len(out), nil
+}
+func (r *memRepo) FindActiveSeatAllocations(_ context.Context, ss, date string) ([]domain.ContractSeatAllocation, error) {
+	out := []domain.ContractSeatAllocation{}
+	for _, a := range r.allocs {
+		if a.ScheduledServiceRef == ss && a.ServiceDate == date && a.Status != domain.AllocationStatusReleased {
+			out = append(out, *a)
+		}
+	}
+	return out, nil
+}
+func (r *memRepo) FindSeatAllocationsByCapacityRecovery(_ context.Context, hold, capacityUnitRef string, interval domain.StationInterval) ([]domain.ContractSeatAllocation, error) {
+	out := []domain.ContractSeatAllocation{}
+	for _, a := range r.allocs {
+		if a.CapacityHoldID == hold && a.CapacityUnitRef == capacityUnitRef && a.Interval == interval {
+			out = append(out, *a)
+		}
+	}
+	return out, nil
+}
+
+type memPub struct {
+	types    []string
+	events   []kitmsg.EventEnvelope
+	payloads map[string][]map[string]any
+}
+
+func (p *memPub) Publish(_ context.Context, e kitmsg.EventEnvelope) error {
+	p.types = append(p.types, e.EventType)
+	p.events = append(p.events, e)
+	if p.payloads == nil {
+		p.payloads = map[string][]map[string]any{}
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(e.Payload, &payload); err == nil {
+		p.payloads[e.EventType] = append(p.payloads[e.EventType], payload)
+	}
+	return nil
+}
+
+func TestSeatMapPublishImmutabilityAllocateAdjacencyAndStanding(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemRepo()
+	pub := &memPub{}
+	svc := New(repo, pub, nil)
+	m, err := svc.CreateSeatMap(ctx, CreateSeatMapRequest{ScheduledServiceRef: "ss-1", ServiceDate: "2026-08-02", CompositionVersion: "v1", CompositionSeed: "SMALL", MappingVersion: "sim-v1", ChangeScenario: "SMALL", OperatorRef: "op"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Status != domain.SeatMapStatusDraft || len(m.Coaches[0].SeatUnits) != 2 {
+		t.Fatalf("unexpected map %#v", m)
+	}
+	m, err = svc.PublishSeatMap(ctx, m.SeatMapID, PublishSeatMapRequest{ExpectedSeatMapVersion: m.SeatMapVersion, PublishReason: "READY", OperatorRef: "op"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Status != domain.SeatMapStatusPublished {
+		t.Fatalf("not published: %s", m.Status)
+	}
+	_, err = svc.MarkSeatUnitUnavailable(ctx, m.SeatMapID, m.Coaches[0].SeatUnits[0].SeatUnitRef, MarkSeatUnitUnavailableRequest{ExpectedSeatMapVersion: m.SeatMapVersion, UnavailableReason: "MAINTENANCE", OperatorRef: "op"})
+	if err == nil {
+		t.Fatal("expected immutable published map error")
+	}
+	_, err = svc.ReopenSeatUnit(ctx, m.SeatMapID, m.Coaches[0].SeatUnits[0].SeatUnitRef, ReopenSeatUnitRequest{ExpectedSeatMapVersion: m.SeatMapVersion, ReopenReason: "MANUAL_CORRECTION", OperatorRef: "op"})
+	if err == nil {
+		t.Fatal("expected immutable published map reopen error")
+	}
+	pref := &domain.SeatPreferences{AcceptStanding: false, AdjacencyPreference: domain.AdjacencyAdjacent, AdjacencyGroupRef: "grp", PreferenceVersion: "pv1"}
+	a1 := allocReq("sb-1", "tvl-1", "hold-1", pref)
+	r1, err := svc.AllocateSeat(ctx, a1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a2 := allocReq("sb-2", "tvl-2", "hold-2", pref)
+	r2, err := svc.AllocateSeat(ctx, a2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r1.SeatRef.CoachNo != "01" || r2.SeatRef.CoachNo != "01" || r1.SeatRef.SeatMapID != r2.SeatRef.SeatMapID {
+		t.Fatalf("expected same map adjacency: %#v %#v", r1.SeatRef, r2.SeatRef)
+	}
+	if r2.SeatRef.Degraded {
+		t.Fatalf("expected second traveler in group to satisfy adjacency, got %#v", r2.SeatRef)
+	}
+	standingPref := &domain.SeatPreferences{AcceptStanding: true, PreferenceVersion: "pv-standing"}
+	r3, err := svc.AllocateSeat(ctx, allocReq("sb-3", "tvl-3", "hold-3", standingPref))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r3.Status != domain.AllocationStatusStanding || r3.SeatRef.AllocationType != domain.AllocationTypeStanding {
+		t.Fatalf("expected standing, got %#v", r3)
+	}
+	if len(pub.payloads["AdjacentAllocationSolved"]) < 2 {
+		t.Fatalf("expected adjacency solver events, got %#v", pub.types)
+	}
+	if got := pub.payloads["AdjacentAllocationSolved"][1]["degraded"]; got != false {
+		t.Fatalf("expected solved adjacent allocation without degradation, got %#v", pub.payloads["AdjacentAllocationSolved"][1])
+	}
+	expectEvents := map[string]bool{"SeatMapBuilt": false, "SeatMapVersionPublished": false, "AdjacencyGroupCreated": false, "AdjacentAllocationSolved": false, "SeatAllocated": false, "StandingAssigned": false}
+	for _, typ := range pub.types {
+		if _, ok := expectEvents[typ]; ok {
+			expectEvents[typ] = true
+		}
+	}
+	for typ, seen := range expectEvents {
+		if !seen {
+			t.Fatalf("missing event %s in %#v", typ, pub.types)
+		}
+	}
+}
+
+func allocReq(sb, tvl, hold string, pref *domain.SeatPreferences) AllocateSeatRequest {
+	return AllocateSeatRequest{SegmentBookingID: sb, JourneyOrderID: "ord-1", TravelerRef: tvl, SegmentRef: "seg-1", ScheduledServiceRef: "ss-1", ServiceDate: "2026-08-02", CapacityHoldID: hold, CapacityUnitRef: "cap-standard", Interval: domain.StationInterval{FromSeq: 1, ToSeq: 3}, ClassRef: "standard", IssuePurpose: "INITIAL", SeatPreferences: pref, ExpiresAt: time.Now().Add(time.Hour)}
+}

--- a/services/seat-assignment/internal/application/service.go
+++ b/services/seat-assignment/internal/application/service.go
@@ -366,9 +366,13 @@ func (s *Service) confirmSeatAllocation(ctx context.Context, allocationID, entit
 func (s *Service) handlePostSalesApplied(ctx context.Context, e kitmsg.EventEnvelope) error {
 	var p map[string]any
 	_ = json.Unmarshal(e.Payload, &p)
+	reason := releaseReasonForEntitlementEvent(e.EventType, str(p, "reason"))
+	releasedAt := releaseTimeForEntitlementEvent(e.EventType, p)
 	if allocationID := str(p, "seatAllocationId"); allocationID != "" {
-		reason := releaseReasonForEntitlementEvent(e.EventType, str(p, "reason"))
-		return s.releaseSeatAllocation(ctx, allocationID, reason, releaseTimeForEntitlementEvent(e.EventType, p), e)
+		return s.releaseSeatAllocation(ctx, allocationID, reason, releasedAt, e)
+	}
+	if segmentBookingID := str(p, "segmentBookingId"); segmentBookingID != "" {
+		return s.releaseSeatAllocationsBySegmentBooking(ctx, segmentBookingID, reason, releasedAt, e)
 	}
 	id := str(p, "assignmentId")
 	if id == "" {
@@ -397,27 +401,55 @@ func (s *Service) handlePostSalesApplied(ctx context.Context, e kitmsg.EventEnve
 }
 
 func (s *Service) releaseSeatAllocation(ctx context.Context, allocationID, releaseReason string, releasedAt time.Time, e kitmsg.EventEnvelope) error {
+	return s.tx(ctx, func(tx context.Context) error {
+		allocation, expected, err := s.repo.GetSeatAllocation(tx, allocationID)
+		if err != nil {
+			return nil
+		}
+		return s.releaseStoredSeatAllocation(tx, allocation, expected, releaseReason, releasedAt, e)
+	})
+}
+
+func (s *Service) releaseSeatAllocationsBySegmentBooking(ctx context.Context, segmentBookingID, releaseReason string, releasedAt time.Time, e kitmsg.EventEnvelope) error {
+	return s.tx(ctx, func(tx context.Context) error {
+		const pageSize = 100
+		for offset := 0; ; offset += pageSize {
+			allocations, total, err := s.repo.FindSeatAllocations(tx, segmentBookingID, "", pageSize, offset)
+			if err != nil {
+				return err
+			}
+			for i := range allocations {
+				allocation, expected, err := s.repo.GetSeatAllocation(tx, allocations[i].SeatAllocationID)
+				if err != nil {
+					continue
+				}
+				if err := s.releaseStoredSeatAllocation(tx, allocation, expected, releaseReason, releasedAt, e); err != nil {
+					return err
+				}
+			}
+			if offset+len(allocations) >= total || len(allocations) == 0 {
+				return nil
+			}
+		}
+	})
+}
+
+func (s *Service) releaseStoredSeatAllocation(ctx context.Context, allocation *domain.ContractSeatAllocation, expected int64, releaseReason string, releasedAt time.Time, e kitmsg.EventEnvelope) error {
+	if allocation.Status == domain.AllocationStatusReleased || allocation.Status == domain.AllocationStatusExpired {
+		return nil
+	}
 	if releaseReason == "" {
 		releaseReason = "MANUAL_CORRECTION"
 	}
 	if releasedAt.IsZero() {
 		releasedAt = time.Now().UTC()
 	}
-	return s.tx(ctx, func(tx context.Context) error {
-		allocation, expected, err := s.repo.GetSeatAllocation(tx, allocationID)
-		if err != nil {
-			return nil
-		}
-		if allocation.Status == domain.AllocationStatusReleased || allocation.Status == domain.AllocationStatusExpired {
-			return nil
-		}
-		allocation.Release(releasedAt)
-		if err := s.repo.UpdateSeatAllocation(tx, allocation, expected); err != nil {
-			return derr("CONFLICT", err.Error())
-		}
-		payload := map[string]any{"seatAllocationId": allocation.SeatAllocationID, "segmentBookingId": allocation.SegmentBookingID, "journeyOrderId": allocation.JourneyOrderID, "travelerRef": allocation.TravelerRef, "capacityHoldId": allocation.CapacityHoldID, "seatRef": allocation.SeatRef, "releaseReason": releaseReason, "releasedAt": releasedAt.UTC(), "sourceEventId": e.EventID, "status": allocation.Status}
-		return s.publish(tx, []domain.Event{{EventType: "SeatAllocationReleased", AggregateID: allocation.SeatAllocationID, Version: 2, OccurredAt: releasedAt.UTC(), CorrelationID: e.CorrelationID, CausationID: e.EventID, Payload: payload}})
-	})
+	allocation.Release(releasedAt)
+	if err := s.repo.UpdateSeatAllocation(ctx, allocation, expected); err != nil {
+		return derr("CONFLICT", err.Error())
+	}
+	payload := map[string]any{"seatAllocationId": allocation.SeatAllocationID, "segmentBookingId": allocation.SegmentBookingID, "journeyOrderId": allocation.JourneyOrderID, "travelerRef": allocation.TravelerRef, "capacityHoldId": allocation.CapacityHoldID, "seatRef": allocation.SeatRef, "releaseReason": releaseReason, "releasedAt": releasedAt.UTC(), "sourceEventId": e.EventID, "status": allocation.Status}
+	return s.publish(ctx, []domain.Event{{EventType: "SeatAllocationReleased", AggregateID: allocation.SeatAllocationID, Version: 2, OccurredAt: releasedAt.UTC(), CorrelationID: e.CorrelationID, CausationID: e.EventID, Payload: payload}})
 }
 
 func releaseReasonForEntitlementEvent(eventType, entitlementReason string) string {

--- a/services/seat-assignment/internal/application/service.go
+++ b/services/seat-assignment/internal/application/service.go
@@ -2,13 +2,17 @@ package application
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
+	"github.com/trainticket/greenfield/platform/go-kit/ids"
 	kitmsg "github.com/trainticket/greenfield/platform/go-kit/messaging"
 	"github.com/trainticket/greenfield/services/seat-assignment/internal/domain"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 type DomainError struct{ Code, Message string }
@@ -28,6 +32,16 @@ type Repository interface {
 	FindAssignments(context.Context, string, string, string) ([]domain.SeatAssignment, error)
 	SaveAssignment(context.Context, *domain.SeatAssignment) error
 	UpdateAssignment(context.Context, *domain.SeatAssignment, int64) error
+	SaveSeatMap(context.Context, *domain.ContractSeatMap) error
+	UpdateSeatMap(context.Context, *domain.ContractSeatMap, int64) error
+	GetSeatMap(context.Context, string) (*domain.ContractSeatMap, int64, error)
+	FindSeatMaps(context.Context, string, string, string, int, int) ([]domain.ContractSeatMap, int, error)
+	SaveSeatAllocation(context.Context, *domain.ContractSeatAllocation) error
+	UpdateSeatAllocation(context.Context, *domain.ContractSeatAllocation, int64) error
+	GetSeatAllocation(context.Context, string) (*domain.ContractSeatAllocation, int64, error)
+	FindSeatAllocations(context.Context, string, string, int, int) ([]domain.ContractSeatAllocation, int, error)
+	FindActiveSeatAllocations(context.Context, string, string) ([]domain.ContractSeatAllocation, error)
+	FindSeatAllocationsByCapacityRecovery(context.Context, string, string, domain.StationInterval) ([]domain.ContractSeatAllocation, error)
 }
 
 type Service struct {
@@ -214,10 +228,14 @@ func (s *Service) Release(ctx context.Context, assignmentID, corr, cause string)
 }
 func (s *Service) HandleSubscribedEvent(ctx context.Context, envelope kitmsg.EventEnvelope) error {
 	switch envelope.EventType {
-	case "TicketIssued":
+	case "TicketIssued", "EntitlementIssued":
 		return s.handleTicketIssued(ctx, envelope)
-	case "PostSalesApplied":
+	case "PostSalesApplied", "EntitlementVoided", "EntitlementIssueFailed":
 		return s.handlePostSalesApplied(ctx, envelope)
+	case "CapacityReleased":
+		return s.handleCapacityReleased(ctx, envelope)
+	case "CapacityHoldExpired":
+		return s.handleCapacityHoldExpired(ctx, envelope)
 	case "BookingSagaStepSucceeded":
 		return s.handleBookingSaga(ctx, envelope)
 	case "SeatAllocationRequested":
@@ -304,6 +322,9 @@ func deriveDepartureDate(segmentRef string) string {
 func (s *Service) handleTicketIssued(ctx context.Context, e kitmsg.EventEnvelope) error {
 	var p map[string]any
 	_ = json.Unmarshal(e.Payload, &p)
+	if allocationID := str(p, "seatAllocationId"); allocationID != "" {
+		return s.confirmSeatAllocation(ctx, allocationID, str(p, "entitlementId"), e)
+	}
 	id := str(p, "assignmentId")
 	if id == "" {
 		id = str(p, "seatAssignmentId")
@@ -314,9 +335,41 @@ func (s *Service) handleTicketIssued(ctx context.Context, e kitmsg.EventEnvelope
 	_, err := s.Confirm(ctx, id, "", e.CorrelationID, e.EventID)
 	return err
 }
+
+func (s *Service) confirmSeatAllocation(ctx context.Context, allocationID, entitlementID string, e kitmsg.EventEnvelope) error {
+	if entitlementID == "" {
+		return nil
+	}
+	now := time.Now().UTC()
+	return s.tx(ctx, func(tx context.Context) error {
+		allocation, expected, err := s.repo.GetSeatAllocation(tx, allocationID)
+		if err != nil {
+			return nil
+		}
+		if allocation.Status == domain.AllocationStatusConfirmed {
+			return nil
+		}
+		if allocation.Status != domain.AllocationStatusAllocated && allocation.Status != domain.AllocationStatusStanding {
+			return nil
+		}
+		t := now
+		allocation.ConfirmedAt = &t
+		allocation.Status = domain.AllocationStatusConfirmed
+		if err := s.repo.UpdateSeatAllocation(tx, allocation, expected); err != nil {
+			return derr("CONFLICT", err.Error())
+		}
+		payload := map[string]any{"seatAllocationId": allocation.SeatAllocationID, "segmentBookingId": allocation.SegmentBookingID, "journeyOrderId": allocation.JourneyOrderID, "travelerRef": allocation.TravelerRef, "entitlementId": entitlementID, "seatRef": allocation.SeatRef, "confirmedAt": now, "sourceEventId": e.EventID, "status": allocation.Status}
+		return s.publish(tx, []domain.Event{{EventType: "SeatAllocationConfirmed", AggregateID: allocation.SeatAllocationID, Version: 2, OccurredAt: now, CorrelationID: e.CorrelationID, CausationID: e.EventID, Payload: payload}})
+	})
+}
+
 func (s *Service) handlePostSalesApplied(ctx context.Context, e kitmsg.EventEnvelope) error {
 	var p map[string]any
 	_ = json.Unmarshal(e.Payload, &p)
+	if allocationID := str(p, "seatAllocationId"); allocationID != "" {
+		reason := releaseReasonForEntitlementEvent(e.EventType, str(p, "reason"))
+		return s.releaseSeatAllocation(ctx, allocationID, reason, releaseTimeForEntitlementEvent(e.EventType, p), e)
+	}
 	id := str(p, "assignmentId")
 	if id == "" {
 		id = str(p, "seatAssignmentId")
@@ -341,6 +394,68 @@ func (s *Service) handlePostSalesApplied(ctx context.Context, e kitmsg.EventEnve
 		}
 	}
 	return nil
+}
+
+func (s *Service) releaseSeatAllocation(ctx context.Context, allocationID, releaseReason string, releasedAt time.Time, e kitmsg.EventEnvelope) error {
+	if releaseReason == "" {
+		releaseReason = "MANUAL_CORRECTION"
+	}
+	if releasedAt.IsZero() {
+		releasedAt = time.Now().UTC()
+	}
+	return s.tx(ctx, func(tx context.Context) error {
+		allocation, expected, err := s.repo.GetSeatAllocation(tx, allocationID)
+		if err != nil {
+			return nil
+		}
+		if allocation.Status == domain.AllocationStatusReleased || allocation.Status == domain.AllocationStatusExpired {
+			return nil
+		}
+		allocation.Release(releasedAt)
+		if err := s.repo.UpdateSeatAllocation(tx, allocation, expected); err != nil {
+			return derr("CONFLICT", err.Error())
+		}
+		payload := map[string]any{"seatAllocationId": allocation.SeatAllocationID, "segmentBookingId": allocation.SegmentBookingID, "journeyOrderId": allocation.JourneyOrderID, "travelerRef": allocation.TravelerRef, "capacityHoldId": allocation.CapacityHoldID, "seatRef": allocation.SeatRef, "releaseReason": releaseReason, "releasedAt": releasedAt.UTC(), "sourceEventId": e.EventID, "status": allocation.Status}
+		return s.publish(tx, []domain.Event{{EventType: "SeatAllocationReleased", AggregateID: allocation.SeatAllocationID, Version: 2, OccurredAt: releasedAt.UTC(), CorrelationID: e.CorrelationID, CausationID: e.EventID, Payload: payload}})
+	})
+}
+
+func releaseReasonForEntitlementEvent(eventType, entitlementReason string) string {
+	switch eventType {
+	case "EntitlementIssueFailed":
+		return "ISSUE_FAILED"
+	case "EntitlementVoided":
+		switch strings.ToUpper(strings.TrimSpace(entitlementReason)) {
+		case "CHANGE":
+			return "CHANGED"
+		case "DISRUPTION":
+			return "DISRUPTION"
+		case "MANUAL_CORRECTION":
+			return "MANUAL_CORRECTION"
+		default:
+			return "VOIDED"
+		}
+	default:
+		return "MANUAL_CORRECTION"
+	}
+}
+
+func releaseTimeForEntitlementEvent(eventType string, payload map[string]any) time.Time {
+	keys := []string{"releasedAt"}
+	switch eventType {
+	case "EntitlementVoided":
+		keys = append([]string{"voidedAt"}, keys...)
+	case "EntitlementIssueFailed":
+		keys = append([]string{"failedAt"}, keys...)
+	}
+	for _, key := range keys {
+		if raw := str(payload, key); raw != "" {
+			if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+				return parsed.UTC()
+			}
+		}
+	}
+	return time.Now().UTC()
 }
 func (s *Service) handleBookingSaga(ctx context.Context, e kitmsg.EventEnvelope) error {
 	var p map[string]any
@@ -383,8 +498,19 @@ func (s *Service) publish(ctx context.Context, events []domain.Event) error {
 		return nil
 	}
 	for _, ev := range events {
-		env, err := kitmsg.NewEventEnvelope(ev.EventType, domain.Producer, ev.CorrelationID, ev.Payload, kitmsg.EnvelopeOptions{Now: ev.OccurredAt, CausationID: ev.CausationID, Context: ctx})
+		body, err := json.Marshal(ev.Payload)
 		if err != nil {
+			return derr("UNAVAILABLE", err.Error())
+		}
+		env := kitmsg.EventEnvelope{EventID: deterministicSeatAssignmentEventID(ev.EventType, ev.AggregateID, ev.Version), EventType: strings.TrimSpace(ev.EventType), OccurredAt: ev.OccurredAt.UTC(), CorrelationID: ids.CanonicalCorrelationID(ev.CorrelationID), Producer: domain.Producer, SchemaVersion: kitmsg.SchemaVersion, Payload: body}
+		if strings.TrimSpace(ev.CausationID) != "" {
+			env.CausationID = ids.CanonicalCausationID(ev.CausationID)
+		}
+		if traceparent, tracestate := traceContextFromContext(ctx); traceparent != "" {
+			env.Traceparent = traceparent
+			env.Tracestate = tracestate
+		}
+		if err := env.Validate(); err != nil {
 			return derr("UNAVAILABLE", err.Error())
 		}
 		if err := s.publisher.Publish(ctx, env); err != nil {
@@ -392,6 +518,21 @@ func (s *Service) publish(ctx context.Context, events []domain.Event) error {
 		}
 	}
 	return nil
+}
+
+func deterministicSeatAssignmentEventID(eventType, aggregateID string, aggregateVersion int64) string {
+	seed := fmt.Sprintf("seat-assignment:%s:%s:%d", strings.TrimSpace(eventType), strings.TrimSpace(aggregateID), aggregateVersion)
+	sum := sha256.Sum256([]byte(seed))
+	b := sum[:16]
+	b[6] = (b[6] & 0x0f) | 0x70
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("evt-%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+func traceContextFromContext(ctx context.Context) (string, string) {
+	carrier := propagation.MapCarrier{}
+	propagation.TraceContext{}.Inject(ctx, carrier)
+	return strings.TrimSpace(carrier.Get("traceparent")), strings.TrimSpace(carrier.Get("tracestate"))
 }
 func dto(a domain.SeatAssignment, seat domain.Seat) AssignmentDTO {
 	return AssignmentDTO{AssignmentId: a.AssignmentId, SeatId: a.SeatId, TravelerRef: a.TravelerRef, CarNumber: seat.CarNumber, Row: seat.Row, Letter: seat.Letter, Position: seat.Position, Status: a.Status, ExpiresAt: a.ExpiresAt}

--- a/services/seat-assignment/internal/domain/seatmap_contract.go
+++ b/services/seat-assignment/internal/domain/seatmap_contract.go
@@ -1,0 +1,286 @@
+package domain
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	SeatMapStatusDraft      = "DRAFT"
+	SeatMapStatusPublished  = "PUBLISHED"
+	SeatMapStatusSuperseded = "SUPERSEDED"
+	SeatMapStatusRetired    = "RETIRED"
+
+	AllocationStatusAllocated = "ALLOCATED"
+	AllocationStatusStanding  = "STANDING"
+	AllocationStatusConfirmed = "CONFIRMED"
+	AllocationStatusReleased  = "RELEASED"
+	AllocationStatusExpired   = "EXPIRED"
+
+	AllocationTypeSeat     = "SEAT"
+	AllocationTypeBerth    = "BERTH"
+	AllocationTypeStanding = "STANDING"
+
+	AdjacencyNone            = "NONE"
+	AdjacencySameCoach       = "SAME_COACH"
+	AdjacencySameRow         = "SAME_ROW"
+	AdjacencyAdjacent        = "ADJACENT"
+	AdjacencySameCompartment = "SAME_COMPARTMENT"
+
+	DegradationNone             = "NONE"
+	DegradationNoAdjacentBlock  = "NO_ADJACENT_BLOCK"
+	DegradationStandingAssigned = "STANDING_ASSIGNED"
+)
+
+type ContractSeatMap struct {
+	SeatMapID           string     `json:"seatMapId"`
+	ScheduledServiceRef string     `json:"scheduledServiceRef"`
+	ServiceDate         string     `json:"serviceDate"`
+	CompositionVersion  string     `json:"compositionVersion"`
+	SeatMapVersion      int        `json:"seatMapVersion"`
+	Source              string     `json:"source"`
+	CompositionSeed     string     `json:"compositionSeed"`
+	MappingVersion      string     `json:"mappingVersion"`
+	Status              string     `json:"status"`
+	Coaches             []Coach    `json:"coaches"`
+	CreatedAt           time.Time  `json:"createdAt"`
+	PublishedAt         *time.Time `json:"publishedAt,omitempty"`
+	RetiredAt           *time.Time `json:"retiredAt,omitempty"`
+}
+
+type Coach struct {
+	CoachRef   string     `json:"coachRef"`
+	CoachNo    string     `json:"coachNo"`
+	ClassRef   string     `json:"classRef"`
+	CoachType  string     `json:"coachType"`
+	Assignable bool       `json:"assignable"`
+	SeatUnits  []SeatUnit `json:"seatUnits"`
+}
+
+type SeatUnit struct {
+	SeatUnitRef       string `json:"seatUnitRef"`
+	CoachRef          string `json:"coachRef"`
+	CoachNo           string `json:"coachNo"`
+	SeatNo            string `json:"seatNo"`
+	AllocationType    string `json:"allocationType"`
+	BerthPosition     string `json:"berthPosition,omitempty"`
+	SeatPosition      string `json:"seatPosition,omitempty"`
+	RowNo             string `json:"rowNo,omitempty"`
+	AdjacencyGroupKey string `json:"adjacencyGroupKey,omitempty"`
+	Assignable        bool   `json:"assignable"`
+	UnavailableReason string `json:"unavailableReason,omitempty"`
+}
+
+func NewContractSeatMap(scheduledServiceRef, serviceDate, compositionVersion, compositionSeed, mappingVersion, changeScenario string, now time.Time) (*ContractSeatMap, error) {
+	if strings.TrimSpace(scheduledServiceRef) == "" || strings.TrimSpace(serviceDate) == "" || strings.TrimSpace(compositionVersion) == "" || strings.TrimSpace(compositionSeed) == "" || strings.TrimSpace(mappingVersion) == "" {
+		return nil, fmt.Errorf("scheduledServiceRef, serviceDate, compositionVersion, compositionSeed and mappingVersion are required")
+	}
+	seatCount := 8
+	if strings.EqualFold(changeScenario, "SMALL") || strings.EqualFold(compositionSeed, "SMALL") {
+		seatCount = 2
+	}
+	topologySeed := deterministicTopologySeed(scheduledServiceRef, serviceDate, compositionVersion, compositionSeed, mappingVersion)
+	seatMapID := deterministicPrefixedID("smap", topologySeed, "seat-map")
+	coachRef := deterministicPrefixedID("coach", topologySeed, "coach", "01")
+	units := make([]SeatUnit, 0, seatCount)
+	letters := []string{"A", "B", "C", "D"}
+	for i := 0; i < seatCount; i++ {
+		row := (i / len(letters)) + 1
+		letter := letters[i%len(letters)]
+		pos := PositionAisle
+		if letter == "A" || letter == "D" {
+			pos = PositionWindow
+		}
+		seatNo := fmt.Sprintf("%02d%s", row, letter)
+		units = append(units, SeatUnit{SeatUnitRef: deterministicPrefixedID("su", topologySeed, "seat-unit", "01", seatNo), CoachRef: coachRef, CoachNo: "01", SeatNo: seatNo, AllocationType: AllocationTypeSeat, SeatPosition: pos, RowNo: fmt.Sprintf("%02d", row), AdjacencyGroupKey: fmt.Sprintf("01-%02d", row), Assignable: true})
+	}
+	return &ContractSeatMap{SeatMapID: seatMapID, ScheduledServiceRef: scheduledServiceRef, ServiceDate: serviceDate, CompositionVersion: compositionVersion, SeatMapVersion: 1, Source: "SIM_SEED", CompositionSeed: compositionSeed, MappingVersion: mappingVersion, Status: SeatMapStatusDraft, Coaches: []Coach{{CoachRef: coachRef, CoachNo: "01", ClassRef: "standard", CoachType: AllocationTypeSeat, Assignable: true, SeatUnits: units}}, CreatedAt: now.UTC()}, nil
+}
+
+func deterministicTopologySeed(parts ...string) string {
+	trimmed := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed = append(trimmed, strings.TrimSpace(part))
+	}
+	return strings.Join(trimmed, "|")
+}
+
+func deterministicPrefixedID(prefix string, parts ...string) string {
+	seed := strings.Join(append([]string{"seat-assignment-topology", strings.TrimSpace(prefix)}, parts...), "|")
+	sum := sha256.Sum256([]byte(seed))
+	b := sum[:16]
+	b[6] = (b[6] & 0x0f) | 0x70
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%s-%x-%x-%x-%x-%x", strings.TrimSpace(prefix), b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+func (m *ContractSeatMap) Publish(expectedVersion int, now time.Time) error {
+	if m.SeatMapVersion != expectedVersion || m.Status != SeatMapStatusDraft {
+		return ErrInvalidTransition
+	}
+	m.SeatMapVersion++
+	t := now.UTC()
+	m.PublishedAt = &t
+	m.Status = SeatMapStatusPublished
+	return nil
+}
+
+func (m *ContractSeatMap) Retire(expectedVersion int, reason string, now time.Time) error {
+	if m.SeatMapVersion != expectedVersion {
+		return ErrInvalidTransition
+	}
+	if m.Status != SeatMapStatusDraft && m.Status != SeatMapStatusPublished && m.Status != SeatMapStatusSuperseded {
+		return ErrInvalidTransition
+	}
+	m.SeatMapVersion++
+	t := now.UTC()
+	m.RetiredAt = &t
+	if strings.EqualFold(reason, "SUPERSEDED") {
+		m.Status = SeatMapStatusSuperseded
+	} else {
+		m.Status = SeatMapStatusRetired
+	}
+	return nil
+}
+
+func (m *ContractSeatMap) MarkSeatUnitUnavailable(ref, reason string, expectedVersion int) error {
+	if m.SeatMapVersion != expectedVersion || m.Status == SeatMapStatusPublished {
+		return ErrInvalidTransition
+	}
+	unit, ok := m.FindUnit(ref)
+	if !ok {
+		return ErrSeatUnavailable
+	}
+	unit.Assignable = false
+	unit.UnavailableReason = strings.TrimSpace(reason)
+	m.SeatMapVersion++
+	return nil
+}
+
+func (m *ContractSeatMap) ReopenSeatUnit(ref string, expectedVersion int) error {
+	if m.SeatMapVersion != expectedVersion || m.Status == SeatMapStatusPublished {
+		return ErrInvalidTransition
+	}
+	unit, ok := m.FindUnit(ref)
+	if !ok {
+		return ErrSeatUnavailable
+	}
+	unit.Assignable = true
+	unit.UnavailableReason = ""
+	m.SeatMapVersion++
+	return nil
+}
+
+func (m *ContractSeatMap) FindUnit(ref string) (*SeatUnit, bool) {
+	for ci := range m.Coaches {
+		for ui := range m.Coaches[ci].SeatUnits {
+			if m.Coaches[ci].SeatUnits[ui].SeatUnitRef == ref {
+				return &m.Coaches[ci].SeatUnits[ui], true
+			}
+		}
+	}
+	return nil, false
+}
+
+func (m ContractSeatMap) UnitByRef(ref string) (SeatUnit, bool) {
+	for _, coach := range m.Coaches {
+		for _, unit := range coach.SeatUnits {
+			if unit.SeatUnitRef == ref {
+				return unit, true
+			}
+		}
+	}
+	return SeatUnit{}, false
+}
+
+func (m ContractSeatMap) AssignableUnits(classRef string) []SeatUnit {
+	out := []SeatUnit{}
+	for _, coach := range m.Coaches {
+		if !coach.Assignable || !strings.EqualFold(coach.ClassRef, classRef) {
+			continue
+		}
+		for _, unit := range coach.SeatUnits {
+			if unit.Assignable {
+				out = append(out, unit)
+			}
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].CoachNo+out[i].SeatNo < out[j].CoachNo+out[j].SeatNo })
+	return out
+}
+
+type StationInterval struct {
+	FromSeq int `json:"fromSeq"`
+	ToSeq   int `json:"toSeq"`
+}
+
+func (i StationInterval) Valid() bool { return i.FromSeq >= 0 && i.ToSeq > i.FromSeq }
+func (i StationInterval) Overlaps(o StationInterval) bool {
+	return i.FromSeq < o.ToSeq && o.FromSeq < i.ToSeq
+}
+
+type SeatPreferences struct {
+	AcceptStanding          bool     `json:"acceptStanding"`
+	AdjacencyPreference     string   `json:"adjacencyPreference,omitempty"`
+	AdjacencyGroupRef       string   `json:"adjacencyGroupRef,omitempty"`
+	PreferredSeatPositions  []string `json:"preferredSeatPositions,omitempty"`
+	PreferredBerthPositions []string `json:"preferredBerthPositions,omitempty"`
+	SameCompartment         bool     `json:"sameCompartment,omitempty"`
+	AvoidSeatUnitRefs       []string `json:"avoidSeatUnitRefs,omitempty"`
+	PreferenceVersion       string   `json:"preferenceVersion"`
+}
+
+type SeatRef struct {
+	SeatAllocationID  string `json:"seatAllocationId"`
+	AllocationType    string `json:"allocationType"`
+	SeatMapID         string `json:"seatMapId,omitempty"`
+	SeatMapVersion    int    `json:"seatMapVersion,omitempty"`
+	SeatUnitRef       string `json:"seatUnitRef,omitempty"`
+	CoachNo           string `json:"coachNo,omitempty"`
+	SeatNo            string `json:"seatNo,omitempty"`
+	BerthPosition     string `json:"berthPosition,omitempty"`
+	DisplayLabel      string `json:"displayLabel"`
+	Degraded          bool   `json:"degraded"`
+	DegradationReason string `json:"degradationReason,omitempty"`
+}
+
+type ContractSeatAllocation struct {
+	SeatAllocationID    string           `json:"seatAllocationId"`
+	SegmentBookingID    string           `json:"segmentBookingId"`
+	JourneyOrderID      string           `json:"journeyOrderId"`
+	TravelerRef         string           `json:"travelerRef"`
+	SegmentRef          string           `json:"segmentRef"`
+	ScheduledServiceRef string           `json:"scheduledServiceRef"`
+	ServiceDate         string           `json:"serviceDate"`
+	CapacityHoldID      string           `json:"capacityHoldId"`
+	CapacityUnitRef     string           `json:"capacityUnitRef"`
+	Interval            StationInterval  `json:"interval"`
+	SeatRef             SeatRef          `json:"seatRef"`
+	Status              string           `json:"status"`
+	Preferences         *SeatPreferences `json:"preferences,omitempty"`
+	CreatedAt           time.Time        `json:"createdAt"`
+	ConfirmedAt         *time.Time       `json:"confirmedAt,omitempty"`
+	ReleasedAt          *time.Time       `json:"releasedAt,omitempty"`
+	ExpiresAt           time.Time        `json:"expiresAt"`
+}
+
+func (a *ContractSeatAllocation) Release(now time.Time) {
+	if a.Status == AllocationStatusReleased || a.Status == AllocationStatusExpired {
+		return
+	}
+	t := now.UTC()
+	a.ReleasedAt = &t
+	a.Status = AllocationStatusReleased
+}
+
+func (a *ContractSeatAllocation) Expire(now time.Time) {
+	if a.Status == AllocationStatusReleased || a.Status == AllocationStatusExpired || a.Status == AllocationStatusConfirmed {
+		return
+	}
+	t := now.UTC()
+	a.ReleasedAt = &t
+	a.Status = AllocationStatusExpired
+}

--- a/services/seat-assignment/migrations/001_seat_assignment.sql
+++ b/services/seat-assignment/migrations/001_seat_assignment.sql
@@ -7,3 +7,10 @@ CREATE TABLE IF NOT EXISTS outbox (seq bigserial PRIMARY KEY, event_id text NOT 
 CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq ON outbox (seq) WHERE published_at IS NULL;
 CREATE TABLE IF NOT EXISTS processed_events (event_id text PRIMARY KEY, stream text, processed_at timestamptz NOT NULL DEFAULT now());
 CREATE TABLE IF NOT EXISTS idempotency_records (key text PRIMARY KEY, request_hash text NOT NULL, status_code int NOT NULL, response_body jsonb, created_at timestamptz NOT NULL DEFAULT now());
+CREATE TABLE IF NOT EXISTS seat_maps (id text PRIMARY KEY, version bigint NOT NULL, data jsonb NOT NULL, updated_at timestamptz NOT NULL DEFAULT now());
+CREATE INDEX IF NOT EXISTS idx_seat_maps_service_date_status ON seat_maps ((data->>'scheduledServiceRef'), (data->>'serviceDate'), (data->>'status'));
+CREATE TABLE IF NOT EXISTS seat_allocations (id text PRIMARY KEY, version bigint NOT NULL, data jsonb NOT NULL, updated_at timestamptz NOT NULL DEFAULT now());
+CREATE INDEX IF NOT EXISTS idx_seat_allocations_segment_booking ON seat_allocations ((data->>'segmentBookingId'));
+CREATE INDEX IF NOT EXISTS idx_seat_allocations_hold ON seat_allocations ((data->>'capacityHoldId'));
+CREATE INDEX IF NOT EXISTS idx_seat_allocations_service_date ON seat_allocations ((data->>'scheduledServiceRef'), (data->>'serviceDate'));
+CREATE INDEX IF NOT EXISTS idx_seat_allocations_status ON seat_allocations ((data->>'status'));


### PR DESCRIPTION
## Summary
- Add contracted SeatMap lifecycle endpoints and internal seat-allocation API with adjacency-aware allocation and STANDING fallback.
- Persist SeatMaps/SeatAllocations and publish contract events to events:seat-assignment.
- Fix respec blockers: deterministic SIM topology refs, seatAllocationId confirmation/release paths, capacity recovery matching, and deterministic event IDs.

## Validation
- go test ./services/seat-assignment/...
- git diff --check origin/refactor/greenfield-ddd...HEAD