### PR TITLE
REQ-406 preserve STANDING on allocation release

### DIFF
--- a/services/seat-assignment/internal/application/seatmap_contract_respec_test.go
+++ b/services/seat-assignment/internal/application/seatmap_contract_respec_test.go
@@ -133,6 +133,53 @@ func TestCapacityReleasedMatchesHoldCapacityUnitAndInterval(t *testing.T) {
 	assertPublishedEventID(t, pub, "SeatAllocationReleased", deterministicSeatAssignmentEventID("SeatAllocationReleased", matching.SeatAllocationID, 2))
 }
 
+func TestCapacityReleasedPreservesStandingAllocationType(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemRepo()
+	pub := &memPub{}
+	svc := New(repo, pub, nil)
+	m, err := svc.CreateSeatMap(ctx, CreateSeatMapRequest{ScheduledServiceRef: "ss-1", ServiceDate: "2026-08-02", CompositionVersion: "v1", CompositionSeed: "SMALL", MappingVersion: "sim-v1", ChangeScenario: "SMALL", OperatorRef: "op"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = svc.PublishSeatMap(ctx, m.SeatMapID, PublishSeatMapRequest{ExpectedSeatMapVersion: m.SeatMapVersion, PublishReason: "READY", OperatorRef: "op"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"1", "2"} {
+		if _, err := svc.AllocateSeat(ctx, allocReq("sb-fill-"+id, "tvl-fill-"+id, "hold-fill-"+id, &domain.SeatPreferences{AcceptStanding: false, PreferenceVersion: "pv"})); err != nil {
+			t.Fatal(err)
+		}
+	}
+	standing, err := svc.AllocateSeat(ctx, allocReq("sb-standing", "tvl-standing", "hold-standing", &domain.SeatPreferences{AcceptStanding: true, PreferenceVersion: "pv-standing"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if standing.Status != domain.AllocationStatusStanding || standing.SeatRef.AllocationType != domain.AllocationTypeStanding {
+		t.Fatalf("expected standing allocation, got %#v", standing)
+	}
+
+	releasedAt := time.Date(2026, 8, 2, 12, 45, 0, 0, time.UTC)
+	payload, _ := json.Marshal(map[string]any{"holdId": "hold-standing", "capacityUnitRef": "cap-standard", "interval": domain.StationInterval{FromSeq: 1, ToSeq: 3}, "releasedAt": releasedAt.Format(time.RFC3339)})
+	if err := svc.HandleSubscribedEvent(ctx, kitmsg.EventEnvelope{EventID: ids.NewEventID(), EventType: "CapacityReleased", CorrelationID: ids.NewCorrelationID(), Payload: payload}); err != nil {
+		t.Fatal(err)
+	}
+
+	stored, _, err := repo.GetSeatAllocation(ctx, standing.SeatAllocationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status != domain.AllocationStatusReleased || stored.SeatRef.AllocationType != domain.AllocationTypeStanding {
+		t.Fatalf("expected released standing allocation, got %#v", stored)
+	}
+	if len(pub.payloads["SeatAllocationReleased"]) != 1 {
+		t.Fatalf("expected one release event, got %#v", pub.payloads["SeatAllocationReleased"])
+	}
+	seatRef, ok := pub.payloads["SeatAllocationReleased"][0]["seatRef"].(map[string]any)
+	if !ok || seatRef["allocationType"] != domain.AllocationTypeStanding {
+		t.Fatalf("expected released event seatRef allocationType STANDING, got %#v", pub.payloads["SeatAllocationReleased"][0])
+	}
+}
+
 func TestEntitlementVoidedReleasesSeatAllocation(t *testing.T) {
 	ctx := context.Background()
 	repo := newMemRepo()

--- a/services/seat-assignment/internal/domain/seatmap_contract.go
+++ b/services/seat-assignment/internal/domain/seatmap_contract.go
@@ -271,9 +271,16 @@ func (a *ContractSeatAllocation) Release(now time.Time) {
 	if a.Status == AllocationStatusReleased || a.Status == AllocationStatusExpired {
 		return
 	}
+	wasStanding := a.Status == AllocationStatusStanding || a.SeatRef.AllocationType == AllocationTypeStanding
 	t := now.UTC()
 	a.ReleasedAt = &t
 	a.Status = AllocationStatusReleased
+	if wasStanding {
+		a.SeatRef.AllocationType = AllocationTypeStanding
+		if a.SeatRef.DisplayLabel == "" {
+			a.SeatRef.DisplayLabel = AllocationTypeStanding
+		}
+	}
 }
 
 func (a *ContractSeatAllocation) Expire(now time.Time) {

--- a/services/seat-assignment/internal/domain/seatmap_contract_test.go
+++ b/services/seat-assignment/internal/domain/seatmap_contract_test.go
@@ -1,0 +1,34 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestContractSeatAllocationReleasePreservesStandingSeatRef(t *testing.T) {
+	allocation := &ContractSeatAllocation{
+		SeatAllocationID: "salloc-standing",
+		Status:           AllocationStatusStanding,
+		SeatRef: SeatRef{
+			SeatAllocationID: "salloc-standing",
+			AllocationType:   AllocationTypeStanding,
+			DisplayLabel:     "STANDING",
+		},
+	}
+	releasedAt := time.Date(2026, 8, 2, 12, 45, 0, 0, time.UTC)
+
+	allocation.Release(releasedAt)
+
+	if allocation.Status != AllocationStatusReleased {
+		t.Fatalf("status=%s want %s", allocation.Status, AllocationStatusReleased)
+	}
+	if allocation.ReleasedAt == nil || !allocation.ReleasedAt.Equal(releasedAt) {
+		t.Fatalf("releasedAt=%v want %v", allocation.ReleasedAt, releasedAt)
+	}
+	if allocation.SeatRef.AllocationType != AllocationTypeStanding {
+		t.Fatalf("allocationType=%s want %s", allocation.SeatRef.AllocationType, AllocationTypeStanding)
+	}
+	if allocation.SeatRef.DisplayLabel != "STANDING" {
+		t.Fatalf("displayLabel=%s want STANDING", allocation.SeatRef.DisplayLabel)
+	}
+}


### PR DESCRIPTION
## Summary
- preserve STANDING SeatRef allocationType when a seat allocation is released
- add domain and capacity-release tests covering released STANDING allocations and release-event payloads

## Validation
- go test ./services/seat-assignment/internal/domain ./services/seat-assignment/internal/application
- go test ./services/seat-assignment/internal/application -run TestCapacityReleasedPreservesStandingAllocationType -count=1
- go test ./services/seat-assignment/internal/domain -run TestContractSeatAllocationReleasePreservesStandingSeatRef -count=1