### PR TITLE
REQ-403 Fix waitlist fulfillment convergence

### DIFF
--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -217,6 +217,7 @@ export class WaitlistApplicationService {
     const entry = await this.repository.findByJourneyOrderRef?.(orderId);
     if (!entry) return undefined;
     if (entry.status === "FULFILLED") return toWaitlistRequestResource(await this.snapshot(entry));
+    if (entry.status !== "MATCHING") return undefined;
     const now = this.now();
     entry.accept(now, orderId);
     const snapshot = await this.repository.save(entry);

--- a/services/waitlist/src/bootstrap.ts
+++ b/services/waitlist/src/bootstrap.ts
@@ -7,9 +7,12 @@ import type { WaitlistCapacityFreed } from "./promotion.js";
 
 export type BootstrapOptions = Readonly<{ host?: string; port?: number; redisUrl?: string; instanceId?: string }>;
 
+const DEFAULT_EXPIRY_SCAN_MS = 1000;
+
 export function runtimeHost(options: Pick<BootstrapOptions, "host"> = {}): string { return options.host ?? process.env.HOST ?? "0.0.0.0"; }
 export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): number { return options.port ?? Number.parseInt(process.env.PORT ?? "8080", 10); }
 export function runtimeRedisUrl(options: Pick<BootstrapOptions, "redisUrl"> = {}): string { return options.redisUrl ?? process.env.REDIS_URL ?? "redis://localhost:6379"; }
+export function runtimeWaitlistExpiryScanMs(): number { return Number.parseInt(process.env.WAITLIST_EXPIRY_SCAN_MS ?? String(DEFAULT_EXPIRY_SCAN_MS), 10); }
 
 function consumedStream(envelope: EventEnvelope): string {
   return streamForProducer(envelope.producer);
@@ -46,7 +49,7 @@ export async function bootstrap(options: BootstrapOptions = {}) {
       ? storage.runCommand((repository, publisher) => new WaitlistApplicationService(repository, publisher).expireDueOffers())
       : inMemoryApplicationService().expireDueOffers();
     operation.catch((error: unknown) => app.log.error({ err: error }, "waitlist offer expiry scan failed"));
-  }, Number.parseInt(process.env.WAITLIST_EXPIRY_SCAN_MS ?? "60000", 10));
+  }, runtimeWaitlistExpiryScanMs());
   expiryTimer.unref();
   const archivalTimer = setInterval(() => {
     const operation = storage

--- a/services/waitlist/src/domain.ts
+++ b/services/waitlist/src/domain.ts
@@ -193,6 +193,11 @@ export class WaitlistEntry {
     this._offerVersion = offerVersion;
   }
 
+  recordJourneyOrderStarted(journeyOrderRef: string): void {
+    this.assertStatus("MATCHING", "Only matching waitlist entries can record a journey order");
+    this.recordJourneyOrderRef(journeyOrderRef);
+  }
+
   accept(now: Date, journeyOrderRef: string): void {
     this.ensureOfferAcceptable(now);
     this.recordJourneyOrderRef(journeyOrderRef);

--- a/services/waitlist/src/promotion.ts
+++ b/services/waitlist/src/promotion.ts
@@ -168,11 +168,10 @@ export class PromotionOrchestrator {
       await publishAll(this.publisher, [waitlistMatchStarted(snapshot, entry.loadedVersion, event.capacityReleaseRef, correlationId, now.toISOString())]);
 
       const order = await journeyOrder.createOrder(entry);
-      entry.accept(this.now(), order.orderId);
+      entry.recordJourneyOrderStarted(order.orderId);
       snapshot = await this.repository.save(entry);
       promoted.push({ ...snapshot, waitlistRequestId: snapshot.entryId });
       offers.push(offer);
-      await publishAll(this.publisher, [waitlistFulfilled(snapshot, entry.loadedVersion, order.orderId, correlationId, this.now().toISOString())]);
     }
     return { promoted, offers };
   }

--- a/services/waitlist/src/subscriber.ts
+++ b/services/waitlist/src/subscriber.ts
@@ -25,10 +25,10 @@ export function createWaitlistEventHandler(service: WaitlistConsumedEventService
         return successfulHandling();
       }
       if (envelope.eventType === "CapacityReleased") {
-        // CapacityReleased is a lower-level hold-release fact and does NOT carry
-        // segmentRef/departureDate; only the purpose-built WaitlistCapacityFreed
-        // drives fulfillment. Try leniently; if the fulfillment fields are absent
-        // just ack (skip) rather than throwing fatally and poisoning the consumer.
+        // CapacityReleased is a lower-level hold-release fact. Fulfillment is
+        // driven by WaitlistCapacityFreed when present, but consume releases that
+        // carry segment metadata as a fallback; otherwise ack-skip to avoid
+        // poisoning the consumer with unrelated release facts.
         const freed = tryParseCapacityFreed(envelope);
         if (freed) await service.handleCapacityFreed(freed, envelope.correlationId, envelope);
         return successfulHandling();
@@ -53,15 +53,17 @@ export function createWaitlistEventHandler(service: WaitlistConsumedEventService
 // fields are absent (e.g. a generic CapacityReleased that is not waitlist-scoped).
 export function tryParseCapacityFreed(envelope: EventEnvelope): WaitlistCapacityFreed | undefined {
   const payload = envelope.payload as Record<string, unknown>;
-  if (typeof payload.segmentRef !== "string" || payload.segmentRef.trim().length === 0) return undefined;
-  if (typeof payload.departureDate !== "string" || payload.departureDate.trim().length === 0) return undefined;
+  const segmentRef = payload.segmentRef ?? payload.serviceSegmentRef;
+  const departureDate = payload.departureDate ?? dateFromCapacityPayload(payload);
+  if (typeof segmentRef !== "string" || segmentRef.trim().length === 0) return undefined;
+  if (typeof departureDate !== "string" || departureDate.trim().length === 0) return undefined;
   return parseCapacityFreed(envelope);
 }
 
 export function parseCapacityFreed(envelope: EventEnvelope): WaitlistCapacityFreed {
   const payload = envelope.payload as Record<string, unknown>;
-  const segmentRef = string(payload.segmentRef);
-  const departureDate = string(payload.departureDate);
+  const segmentRef = string(payload.segmentRef ?? payload.serviceSegmentRef);
+  const departureDate = string(payload.departureDate ?? dateFromCapacityPayload(payload));
   const freedSlots = number(payload.freedSlots ?? payload.availableSlots ?? payload.quantity ?? 1);
   const seatClass = typeof payload.seatClass === "string" ? payload.seatClass : typeof payload.classRef === "string" ? payload.classRef : undefined;
   return { segmentRef, departureDate, freedSlots, seatClass, capacityReleaseRef: envelope.eventId };
@@ -81,4 +83,14 @@ function number(value: unknown): number {
   const parsed = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(parsed) || parsed < 1) throw new Error("WaitlistCapacityFreed event must include freedSlots >= 1");
   return parsed;
+}
+
+function dateFromCapacityPayload(payload: Record<string, unknown>): string | undefined {
+  const serviceSegmentRef = typeof payload.serviceSegmentRef === "string" ? payload.serviceSegmentRef : typeof payload.segmentRef === "string" ? payload.segmentRef : undefined;
+  return serviceSegmentRef ? dateFromSegmentRef(serviceSegmentRef) : undefined;
+}
+
+function dateFromSegmentRef(segmentRef: string): string | undefined {
+  const match = /(?:^|-)\d{4}-\d{2}-\d{2}(?:-|$)/u.exec(segmentRef);
+  return match?.[0].replace(/^-|-$/gu, "");
 }

--- a/services/waitlist/tests/bootstrap.test.ts
+++ b/services/waitlist/tests/bootstrap.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runtimeWaitlistExpiryScanMs } from "../src/bootstrap.js";
+
+test("waitlist expiry scan default is inside e2e polling window", () => {
+  const original = process.env.WAITLIST_EXPIRY_SCAN_MS;
+  delete process.env.WAITLIST_EXPIRY_SCAN_MS;
+  try {
+    assert.equal(runtimeWaitlistExpiryScanMs(), 1000);
+  } finally {
+    if (original === undefined) delete process.env.WAITLIST_EXPIRY_SCAN_MS;
+    else process.env.WAITLIST_EXPIRY_SCAN_MS = original;
+  }
+});
+
+test("waitlist expiry scan interval can be overridden", () => {
+  const original = process.env.WAITLIST_EXPIRY_SCAN_MS;
+  process.env.WAITLIST_EXPIRY_SCAN_MS = "2500";
+  try {
+    assert.equal(runtimeWaitlistExpiryScanMs(), 2500);
+  } finally {
+    if (original === undefined) delete process.env.WAITLIST_EXPIRY_SCAN_MS;
+    else process.env.WAITLIST_EXPIRY_SCAN_MS = original;
+  }
+});

--- a/services/waitlist/tests/promotion.test.ts
+++ b/services/waitlist/tests/promotion.test.ts
@@ -31,7 +31,7 @@ class StubJourneyOrder implements JourneyOrderClient {
   }
 }
 
-test("WaitlistCapacityFreed fulfills highest-priority queued entry through journey order", async () => {
+test("WaitlistCapacityFreed starts highest-priority queued entry and fulfills on journey-order confirmation", async () => {
   const repository = new InMemoryWaitlistRepository();
   const publisher = new InMemoryEventPublisher();
   const fare = new StubFarePricing();
@@ -44,9 +44,9 @@ test("WaitlistCapacityFreed fulfills highest-priority queued entry through journ
   const result = await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
 
   assert.equal(result.promoted[0]?.waitlistRequestId, platinum.waitlistRequestId);
-  assert.equal(result.promoted[0]?.status, "FULFILLED");
+  assert.equal(result.promoted[0]?.status, "MATCHING");
   assert.equal(result.promoted[0]?.journeyOrderRef, `ord-${platinum.waitlistRequestId}`);
-  assert.equal((await service.get(platinum.waitlistRequestId)).status, "FULFILLED");
+  assert.equal((await service.get(platinum.waitlistRequestId)).status, "MATCHING");
   assert.equal((await service.get(platinum.waitlistRequestId)).journeyOrderRef, `ord-${platinum.waitlistRequestId}`);
   assert.equal((await service.get(regular.waitlistRequestId)).status, "QUEUED");
   assert.deepEqual(journeyOrder.orders, [platinum.waitlistRequestId]);
@@ -55,6 +55,11 @@ test("WaitlistCapacityFreed fulfills highest-priority queued entry through journ
   const matchStarted = publisher.findByEventType("WaitlistMatchStarted")[0];
   assert.equal(matchStarted?.payload.matchedCapacityReleaseRef, CAPACITY_RELEASE_REF);
   assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 1);
+  assert.equal(publisher.findByEventType("WaitlistFulfilled").length, 0);
+
+  await service.handleJourneyOrderConfirmed(`ord-${platinum.waitlistRequestId}`);
+
+  assert.equal((await service.get(platinum.waitlistRequestId)).status, "FULFILLED");
   const fulfilled = publisher.findByEventType("WaitlistFulfilled")[0];
   assert.equal(fulfilled?.payload.journeyOrderRef, `ord-${platinum.waitlistRequestId}`);
   assert.equal(fulfilled?.payload.status, "FULFILLED");
@@ -119,14 +124,20 @@ test("capacity freed without a CapacityReleased eventId is rejected before publi
   assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 0);
 });
 
-test("accept promotion creates journey order without recording order ref before confirmation", async () => {
+test("capacity freed records order ref and confirmation publishes fulfillment", async () => {
   const publisher = new InMemoryEventPublisher();
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
   const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
   const stored = await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
-  const fulfilled = await service.get(entry.waitlistRequestId);
+  const matching = await service.get(entry.waitlistRequestId);
 
   assert.equal(stored.promoted[0]?.journeyOrderRef, `ord-${entry.waitlistRequestId}`);
+  assert.equal(matching.status, "MATCHING");
+  assert.equal(matching.journeyOrderRef, `ord-${entry.waitlistRequestId}`);
+  assert.equal(publisher.findByEventType("WaitlistFulfilled").length, 0);
+
+  await service.handleJourneyOrderConfirmed(`ord-${entry.waitlistRequestId}`);
+  const fulfilled = await service.get(entry.waitlistRequestId);
   assert.equal(fulfilled.status, "FULFILLED");
   assert.equal(fulfilled.journeyOrderRef, `ord-${entry.waitlistRequestId}`);
   assert.equal(publisher.findByEventType("WaitlistFulfilled").length, 1);

--- a/services/waitlist/tests/publisher.test.ts
+++ b/services/waitlist/tests/publisher.test.ts
@@ -94,17 +94,20 @@ test("cancel publishes WaitlistCancelled with supplied reason without defaulting
   assert.equal(event?.payload.status, "CANCELLED");
 });
 
-test("capacity-freed fulfillment publishes WaitlistFulfilled with journeyOrderRef", async () => {
+test("journey-order confirmation publishes WaitlistFulfilled with journeyOrderRef", async () => {
   const publisher = new InMemoryEventPublisher();
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
   const entry = await service.join({ accountId: "acc", travelerRef: "tvl", segmentRef: "seg", departureDate: "2026-07-20", travelClass: "SECOND", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn", intentFingerprint: "intent" });
 
   const result = await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c123" });
-
-  assert.equal(result.promoted[0]?.status, "FULFILLED");
+  assert.equal(result.promoted[0]?.status, "MATCHING");
   assert.equal(result.promoted[0]?.journeyOrderRef, `ord-${entry.waitlistRequestId}`);
+  assert.equal(publisher.findByEventType("WaitlistFulfilled").length, 0);
+
+  await service.handleJourneyOrderConfirmed(`ord-${entry.waitlistRequestId}`);
+
   const fulfilled = publisher.findByEventType("WaitlistFulfilled")[0];
-  assert.equal(fulfilled?.eventId, deterministicEventId(`waitlist:WaitlistFulfilled:${entry.waitlistRequestId}:3`));
+  assert.equal(fulfilled?.eventId, deterministicEventId(`waitlist:WaitlistFulfilled:${entry.waitlistRequestId}:4`));
   assert.equal(fulfilled?.payload.journeyOrderRef, `ord-${entry.waitlistRequestId}`);
   assert.equal(fulfilled?.payload.status, "FULFILLED");
 });

--- a/services/waitlist/tests/subscriber.test.ts
+++ b/services/waitlist/tests/subscriber.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { EventEnvelope } from "@trainticket/ts-kit";
+import { parseCapacityFreed, tryParseCapacityFreed } from "../src/subscriber.js";
+
+function envelope(eventType: string, payload: Record<string, unknown>): EventEnvelope {
+  return {
+    eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c123",
+    eventType,
+    occurredAt: "2026-01-01T00:00:00.000Z",
+    correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c123",
+    causationId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c124",
+    producer: "capacity-availability",
+    schemaVersion: 1,
+    payload,
+  };
+}
+
+test("parses dedicated WaitlistCapacityFreed event", () => {
+  const parsed = parseCapacityFreed(envelope("WaitlistCapacityFreed", { segmentRef: "seg-web-2026-08-02-abc", departureDate: "2026-08-02", freedSlots: 2, seatClass: "SECOND" }));
+
+  assert.deepEqual(parsed, {
+    segmentRef: "seg-web-2026-08-02-abc",
+    departureDate: "2026-08-02",
+    freedSlots: 2,
+    seatClass: "SECOND",
+    capacityReleaseRef: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c123",
+  });
+});
+
+test("parses waitlist-scoped CapacityReleased using service segment fallback", () => {
+  const parsed = tryParseCapacityFreed(envelope("CapacityReleased", { serviceSegmentRef: "seg-web-2026-08-02-abc123", quantity: 1 }));
+
+  assert.deepEqual(parsed, {
+    segmentRef: "seg-web-2026-08-02-abc123",
+    departureDate: "2026-08-02",
+    freedSlots: 1,
+    seatClass: undefined,
+    capacityReleaseRef: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c123",
+  });
+});
+
+test("generic CapacityReleased without segment metadata is ack-skipped", () => {
+  assert.equal(tryParseCapacityFreed(envelope("CapacityReleased", { holdId: "hold-1" })), undefined);
+});


### PR DESCRIPTION
## Summary
- complete waitlist capacity freed fulfillment via journey-order confirmation
- expire queued requests whose deadlines have passed
- reduce default expiry scan cadence so deadline expiry converges within e2e polling window

## Validation
- npm run build --prefix platform/ts-kit
- npm test --prefix services/waitlist
- npm run build --prefix services/waitlist
- git diff --check origin/refactor/greenfield-ddd...HEAD