### PR TITLE
Fix reporting occurredAt datetime parsing (dash-revenue never rebuilt)

### DIFF
--- a/services/reporting/src/reporting/application/service.py
+++ b/services/reporting/src/reporting/application/service.py
@@ -195,10 +195,19 @@ def _payload_value(payload: Mapping[str, Any], *keys: str) -> Any:
     return None
 
 
-def _parse_occurred_at(value: str) -> datetime:
+def _parse_occurred_at(value: Any) -> datetime:
+    # EventEnvelope.occurredAt is typed ``datetime | str``: from_json_dict parses
+    # the wire timestamp into an aware datetime, while hand-built envelopes may
+    # still carry an RFC3339 string. Handle both — the previous str-only code
+    # called ``datetime.replace("Z", ...)`` on a datetime, whose replace() expects
+    # integer kwargs, raising "'str' object cannot be interpreted as an integer"
+    # and turning every consumed fact into a transient failure (dashboards never
+    # rebuilt, events:reporting stayed empty).
+    if isinstance(value, datetime):
+        return value.astimezone(UTC) if value.tzinfo is not None else value.replace(tzinfo=UTC)
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
-    except ValueError:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(UTC)
+    except (ValueError, AttributeError):
         return utc_now()
 
 


### PR DESCRIPTION
## Root cause
`EventEnvelope.occurredAt` is typed `datetime | str`; `from_json_dict` parses the wire timestamp into an **aware datetime**. reporting's `_parse_occurred_at` assumed a `str` and called `value.replace("Z", "+00:00")` — on a `datetime`, `replace()` expects integer kwargs, raising `'str' object cannot be interpreted as an integer`.

Every consumed revenue fact (`PaymentCaptured`, `JourneyOrderConfirmed`, …) therefore became a **transient failure**:
- `dash-revenue` stayed at seed status `building`
- no `ReadModelRebuilt` was ever published (`events:reporting` empty)
- failing **03-refund** (status must be ready/stale, events:reporting XLEN>0) and **05-fulfillment** (dashboard fact count must change)

## Fix
`_parse_occurred_at` now handles both `datetime` and `str`.

## Verification (on-cluster)
Injecting a `PaymentCaptured` after the fix:
- `dash-revenue` → `ready`
- `eventCount` 128 → 129
- `ReadModelRebuilt` published to `events:reporting`

🤖 Generated with [Claude Code](https://claude.com/claude-code)