### PR TITLE
Release seat allocations on whole-hold capacity release/expiry

### DIFF
--- a/services/seat-assignment/internal/adapters/storage/postgres.go
+++ b/services/seat-assignment/internal/adapters/storage/postgres.go
@@ -271,8 +271,14 @@ func (r *Repository) FindActiveSeatAllocations(ctx context.Context, scheduledSer
 	}
 	return out, rows.Err()
 }
-func (r *Repository) FindSeatAllocationsByCapacityRecovery(ctx context.Context, holdID, capacityUnitRef string, interval domain.StationInterval) ([]domain.ContractSeatAllocation, error) {
-	rows, err := r.tx.DBFor(ctx).Query(ctx, "SELECT data FROM seat_allocations WHERE data->>'capacityHoldId'=$1 AND data->>'capacityUnitRef'=$2 AND (data->'interval'->>'fromSeq')::int=$3 AND (data->'interval'->>'toSeq')::int=$4 ORDER BY id", holdID, capacityUnitRef, interval.FromSeq, interval.ToSeq)
+func (r *Repository) FindSeatAllocationsByCapacityRecovery(ctx context.Context, holdID, _ string, _ domain.StationInterval) ([]domain.ContractSeatAllocation, error) {
+	// A capacity hold release/expiry is always whole-hold (release_hold takes only
+	// a holdId), so capacityHoldId uniquely identifies the allocations to recover.
+	// The event's capacityUnitRef/interval describe the HOLD's pool slot (e.g.
+	// "01A"/{0,1}) which need not equal the allocation's requested unit/interval
+	// (e.g. "cap-standard"/{1,3}); filtering on them matched nothing, so the seat
+	// was never released. Match on capacityHoldId alone.
+	rows, err := r.tx.DBFor(ctx).Query(ctx, "SELECT data FROM seat_allocations WHERE data->>'capacityHoldId'=$1 ORDER BY id", holdID)
 	if err != nil {
 		return nil, err
 	}

--- a/services/seat-assignment/internal/application/seatmap_contract_respec_test.go
+++ b/services/seat-assignment/internal/application/seatmap_contract_respec_test.go
@@ -80,7 +80,7 @@ func TestEntitlementIssuedConfirmsSeatAllocationAndEmitsContractEvent(t *testing
 	assertPublishedEventID(t, pub, "SeatAllocationConfirmed", deterministicSeatAssignmentEventID("SeatAllocationConfirmed", allocation.SeatAllocationID, 2))
 }
 
-func TestCapacityReleasedMatchesHoldCapacityUnitAndInterval(t *testing.T) {
+func TestCapacityReleasedReleasesAllAllocationsOnHold(t *testing.T) {
 	ctx := context.Background()
 	repo := newMemRepo()
 	pub := &memPub{}
@@ -124,13 +124,28 @@ func TestCapacityReleasedMatchesHoldCapacityUnitAndInterval(t *testing.T) {
 			t.Fatalf("allocation %s status=%s want %s", id, stored.Status, want)
 		}
 	}
+	// A capacity hold release is whole-hold: every allocation tied to the hold is
+	// recovered, regardless of the allocation's requested unit/interval (which need
+	// not equal the hold's pool slot carried in the event).
 	mustStatus(matching.SeatAllocationID, domain.AllocationStatusReleased)
-	mustStatus(differentUnit.SeatAllocationID, domain.AllocationStatusAllocated)
-	mustStatus(differentInterval.SeatAllocationID, domain.AllocationStatusAllocated)
-	if len(pub.payloads["SeatAllocationReleased"]) != 1 {
-		t.Fatalf("expected one release event, got %#v", pub.payloads["SeatAllocationReleased"])
+	mustStatus(differentUnit.SeatAllocationID, domain.AllocationStatusReleased)
+	mustStatus(differentInterval.SeatAllocationID, domain.AllocationStatusReleased)
+	if len(pub.payloads["SeatAllocationReleased"]) != 3 {
+		t.Fatalf("expected three release events, got %#v", pub.payloads["SeatAllocationReleased"])
 	}
-	assertPublishedEventID(t, pub, "SeatAllocationReleased", deterministicSeatAssignmentEventID("SeatAllocationReleased", matching.SeatAllocationID, 2))
+	for _, alloc := range []string{matching.SeatAllocationID, differentUnit.SeatAllocationID, differentInterval.SeatAllocationID} {
+		want := deterministicSeatAssignmentEventID("SeatAllocationReleased", alloc, 2)
+		found := false
+		for _, event := range pub.events {
+			if event.EventType == "SeatAllocationReleased" && event.EventID == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing deterministic SeatAllocationReleased id %s for allocation %s in %#v", want, alloc, pub.types)
+		}
+	}
 }
 
 func TestEntitlementVoidedReleasesSeatAllocation(t *testing.T) {

--- a/services/seat-assignment/internal/application/seatmap_service.go
+++ b/services/seat-assignment/internal/application/seatmap_service.go
@@ -608,7 +608,10 @@ func intFromAny(raw any) int {
 }
 
 func (s *Service) transitionAllocationsByCapacityRecovery(ctx context.Context, match capacityRecoveryMatch, e kitmsg.EventEnvelope, apply func(*domain.ContractSeatAllocation, time.Time), eventType, timeKey string, extra map[string]any) error {
-	if match.HoldID == "" || match.CapacityUnitRef == "" || !match.Interval.Valid() {
+	// A hold release/expiry is whole-hold, so a holdId is sufficient to recover the
+	// tied allocations; capacityUnitRef/interval reflect the hold's pool slot and
+	// are not required to match the allocation's requested values.
+	if match.HoldID == "" {
 		return nil
 	}
 	transitionedAt := time.Now().UTC()

--- a/services/seat-assignment/internal/application/seatmap_service_test.go
+++ b/services/seat-assignment/internal/application/seatmap_service_test.go
@@ -95,10 +95,10 @@ func (r *memRepo) FindActiveSeatAllocations(_ context.Context, ss, date string) 
 	}
 	return out, nil
 }
-func (r *memRepo) FindSeatAllocationsByCapacityRecovery(_ context.Context, hold, capacityUnitRef string, interval domain.StationInterval) ([]domain.ContractSeatAllocation, error) {
+func (r *memRepo) FindSeatAllocationsByCapacityRecovery(_ context.Context, hold, _ string, _ domain.StationInterval) ([]domain.ContractSeatAllocation, error) {
 	out := []domain.ContractSeatAllocation{}
 	for _, a := range r.allocs {
-		if a.CapacityHoldID == hold && a.CapacityUnitRef == capacityUnitRef && a.Interval == interval {
+		if a.CapacityHoldID == hold {
 			out = append(out, *a)
 		}
 	}


### PR DESCRIPTION
## Root cause
`handleCapacityReleased` / `handleCapacityHoldExpired` matched seat allocations on **capacityHoldId AND capacityUnitRef AND interval**. But a capacity hold release is always whole-hold (`release_hold` takes only a `holdId`), and the `CapacityReleased` event's `capacityUnitRef`/`interval` describe the **hold's pool slot** (e.g. `"01A"`/`{0,1}`), which need not equal the allocation's requested unit/interval (e.g. `"cap-standard"`/`{1,3}`).

The 3-way match found nothing → the seat was never released → e2e **20-seat**'s "capacity release recovers seat" failed (allocation stuck `STANDING` instead of `RELEASED`).

## Fix
Match on `capacityHoldId` alone (whole-hold recovery) in both the guard (`transitionAllocationsByCapacityRecovery`) and the repository query (`FindSeatAllocationsByCapacityRecovery`). Updated the conformance test + memRepo double to the correct whole-hold semantics.

## Verification
- `go test ./internal/application/` passes
- On-cluster: **20-seat now 19/0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)