### PR TITLE
Derive refund departure date from segmentRef slug (refund quotes were 0)

### DIFF
--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesPolicyContextMapper.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesPolicyContextMapper.java
@@ -51,6 +51,9 @@ final class PostSalesPolicyContextMapper {
         ));
     }
 
+    private static final java.util.regex.Pattern SEGMENT_REF_DATE =
+        java.util.regex.Pattern.compile("(\\d{4})-(\\d{2})-(\\d{2})");
+
     private static Optional<Instant> earliestDeparture(Map<?, ?> payload, List<Map<?, ?>> segments) {
         List<Instant> candidates = new ArrayList<>();
         for (String field : List.of("departureTime", "departureAt")) {
@@ -61,7 +64,36 @@ final class PostSalesPolicyContextMapper {
                 text(segment, field).map(Instant::parse).ifPresent(candidates::add);
             }
         }
+        // JourneyOrderCreated/Confirmed events carry only segmentRefs (canonical
+        // slugs like seg-web-2026-08-01-<hash>) — no explicit departureTime — so
+        // the refund policy context would otherwise be dropped and every refund
+        // quote returns 0. The service date is embedded in the slug; derive it
+        // (start-of-day UTC) as a fallback departure when no explicit time exists.
+        if (candidates.isEmpty()) {
+            for (String segmentRef : textList(payload.get("segmentRefs"))) {
+                departureFromSegmentRef(segmentRef).ifPresent(candidates::add);
+            }
+        }
         return PostSalesPolicyContext.earliest(candidates);
+    }
+
+    private static Optional<Instant> departureFromSegmentRef(String segmentRef) {
+        if (segmentRef == null) {
+            return Optional.empty();
+        }
+        java.util.regex.Matcher matcher = SEGMENT_REF_DATE.matcher(segmentRef);
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(java.time.LocalDate.of(
+                Integer.parseInt(matcher.group(1)),
+                Integer.parseInt(matcher.group(2)),
+                Integer.parseInt(matcher.group(3))
+            ).atStartOfDay(java.time.ZoneOffset.UTC).toInstant());
+        } catch (RuntimeException exception) {
+            return Optional.empty();
+        }
     }
 
     private static Map<String, String> travelerTypes(Object travelerRefsValue) {


### PR DESCRIPTION
## Root cause
post-sales builds its refund **policy context** from `JourneyOrderCreated`/`JourneyOrderConfirmed`, and `earliestDeparture` requires an explicit `departureTime`/`departureAt` to compute the refund tier. But those order events carry only `segmentRefs` (canonical slugs like `seg-web-2026-08-01-<hash>`) — no `departureTime`, no `segments` array — so `earliestDeparture` returned empty and `fromEventPayload` dropped the **entire** context (`Optional.empty()`).

With no policy context, every refund evaluation returned `refundableAmount = 0`, failing e2e **03-refund**'s refund quote and the downstream `RevenueRecognitionReversed` / `ReconciliationCompleted` chain.

## Fix
The service date is embedded in the segmentRef slug, so derive it (start-of-day UTC) as a fallback departure when no explicit `departureTime` is present — the same slug-is-date-authoritative pattern used in waitlist/seat-assignment.

## Verification (on-cluster)
`03-refund` refundable went **0 → 9500** — a correct **5% penalty** on the 100.00 fare for a >15-days-out cancellation (`TIER_GT_15_DAYS`). The refund pipeline is restored.

### Note on the remaining assertion
03 hardcodes `refundable == 8750` (assuming a 107.50 fare + flat 20.00 fee). The actual order fare is 100.00 and `RefundPolicyEngine` applies a **percentage** tier (5% at >15 days) = 9500. That gap is a stale test expectation / refund-rule-semantics question (flat fee vs percentage tier), not a defect in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)