### PR TITLE
Harden shared Hikari pool against transient Postgres connection drops

### DIFF
--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/persistence/DataSources.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/persistence/DataSources.java
@@ -16,12 +16,25 @@ public final class DataSources {
         config.setPassword(parsed.password());
         config.setMaximumPoolSize(Integer.parseInt(
             System.getenv().getOrDefault("HIKARI_MAX_POOL_SIZE", "10")));
-        config.setMinimumIdle(1);
+        // Keep warm spares so a single closed/expired connection does not leave the
+        // pool empty and force an on-demand connect while a request is already in
+        // flight. A minIdle of 1 produced "Connection is not available, request
+        // timed out ... (total=1, active=1)" whenever a server-closed connection
+        // coincided with a burst; warm spares + a longer acquire timeout absorb it.
+        config.setMinimumIdle(Integer.parseInt(
+            System.getenv().getOrDefault("HIKARI_MIN_IDLE", "3")));
         config.setPoolName("platform-java-kit-postgres");
         config.setKeepaliveTime(30_000);
-        config.setMaxLifetime(600_000);
-        config.setConnectionTimeout(5_000);
+        // Recycle connections well before any server-side / proxy idle cutoff so a
+        // stale connection is never handed to a request.
+        config.setMaxLifetime(300_000);
+        // More headroom to acquire/replace a connection when Postgres is briefly
+        // slow (e.g. reconnect storms) instead of surfacing a 500 to the caller.
+        config.setConnectionTimeout(15_000);
         config.setValidationTimeout(3_000);
+        // Leave connectionTestQuery unset: the Postgres JDBC4 driver's isValid()
+        // aliveness check on checkout already evicts a closed connection and hands
+        // out a fresh one, which is cheaper and more reliable than a test query.
         return new HikariDataSource(config);
     }
 }


### PR DESCRIPTION
## Root cause
All Java services share `DataSources.fromDatabaseUrl`. Its pool used `minimumIdle=1` and `connectionTimeout=5s`, so when a **server-closed/expired connection coincided with a burst**, the pool had no warm spare and the on-demand reconnect timed out — surfacing `Connection is not available, request timed out after 5000ms (total=1, active=1)` / `This connection has been closed` as an HTTP 500. On the e2e this made **payment capture** (and thus 02-purchase / 22-paychan) intermittently fail (`capture payment [500]` → saga stuck `WAITING_PAYMENT` → order not confirmed).

## Fix
- `minimumIdle` 1 → **3** (env `HIKARI_MIN_IDLE`) — a single dropped connection never empties the pool; warm spares absorb bursts.
- `connectionTimeout` 5s → **15s** — headroom when Postgres is briefly slow (reconnect storms) instead of throwing to the caller.
- `maxLifetime` 10min → **5min** — recycle connections before any server/proxy idle cutoff can stale them.
- Keep JDBC4 `isValid()` aliveness on checkout (no `connectionTestQuery`) so a broken connection is evicted and replaced transparently.

## Verification (on-cluster)
Rebuilt + redeployed payment; ran **02-purchase ×3 → 15/0 each, `capture payment [200]` every time** (was intermittently 500). Applies to every Java service on rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)