### PR TITLE
Re-land the still-valid half of the nine stale PRs

### DIFF
--- a/deploy/e2e/14-waitlist.sh
+++ b/deploy/e2e/14-waitlist.sh
@@ -271,6 +271,16 @@ PYEX
   req POST booking-orchestration "/api/v1/internal/booking-sagas/$WL_SAGA/request-reservation" "{\"segmentRef\":\"$SEG_F\",\"travelerRef\":\"$TVL_C\",\"segmentBookingId\":\"$WL_SB\"}"
   check_code 200 "staff requests reservation for waitlist order"
   sleep 5
+  # Waitlist is no-direct-payment: the promoted customer still completes the purchase
+  # by capturing a payment against the fulfillment order, exactly as buy_one does
+  # (reserve -> pay -> entitlement). Without this the saga stays in PENDING_PAYMENT
+  # and the order never reaches CONFIRMED.
+  req POST payment /api/v1/payment-intents "{\"businessRef\":\"$WL_ORDER\",\"purpose\":\"purchase\",\"amount\":{\"currency\":\"CNY\",\"minorUnits\":10750},\"payerRef\":\"$ACCT_C\"}"
+  check_code 201 "create payment intent for waitlist order"
+  WL_PI=$(jget "['paymentIntentId']")
+  req POST payment "/api/v1/payment-intents/$WL_PI/capture" '{}'
+  [ "$LAST_CODE" = 200 ] || [ "$LAST_CODE" = 201 ] && ok "capture payment for waitlist order [$LAST_CODE]" || bad "capture payment for waitlist order [$LAST_CODE]"
+  sleep 5
   req POST entitlement-ticketing /api/v1/entitlements "{\"segmentBookingId\":\"$WL_SB\",\"journeyOrderId\":\"$WL_ORDER\",\"travelerRef\":\"$TVL_C\",\"segmentRef\":\"$SEG_F\",\"issuePurpose\":\"INITIAL\"}"
   check_code 201 "staff issues entitlement for waitlist order"
 fi

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/persistence/DataSources.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/persistence/DataSources.java
@@ -16,12 +16,25 @@ public final class DataSources {
         config.setPassword(parsed.password());
         config.setMaximumPoolSize(Integer.parseInt(
             System.getenv().getOrDefault("HIKARI_MAX_POOL_SIZE", "10")));
-        config.setMinimumIdle(1);
+        // Keep warm spares so a single server-closed connection does not leave the
+        // pool empty and force an on-demand connect while a request is already in
+        // flight. A minimumIdle of 1 produced "Connection is not available, request
+        // timed out ... (total=1, active=1)" whenever a closed connection coincided
+        // with a burst.
+        config.setMinimumIdle(Integer.parseInt(
+            System.getenv().getOrDefault("HIKARI_MIN_IDLE", "3")));
         config.setPoolName("platform-java-kit-postgres");
         config.setKeepaliveTime(30_000);
-        config.setMaxLifetime(600_000);
-        config.setConnectionTimeout(5_000);
+        // Recycle well before any server-side or proxy idle cutoff so a stale
+        // connection is never handed to a request.
+        config.setMaxLifetime(300_000);
+        // Headroom to acquire or replace a connection while Postgres is briefly slow
+        // (reconnect storms) instead of surfacing a 500 to the caller.
+        config.setConnectionTimeout(15_000);
         config.setValidationTimeout(3_000);
+        // connectionTestQuery stays unset: the pgjdbc JDBC4 isValid() aliveness check
+        // on checkout already evicts a closed connection and hands out a fresh one,
+        // which is cheaper and more reliable than a test query.
         return new HikariDataSource(config);
     }
 }

--- a/platform/ts-kit/dist/storage.js
+++ b/platform/ts-kit/dist/storage.js
@@ -77,20 +77,33 @@ export async function withTransaction(pool, operation) {
         client.release();
     }
 }
+// A probe timeout leaves `SELECT 1` in flight -- nothing cancels it. Returning
+// that connection to the pool hands the next borrower this probe's response as
+// its own, and the double release that follows throws from inside a pg callback
+// where no caller can catch it, taking the process down. Passing an error to
+// release destroys the connection instead of pooling it, which is the only safe
+// disposal for a connection with unread results.
+const ABANDONED = new Error("readiness probe abandoned this connection");
 export async function checkPostgresReadiness(pool, timeoutMs = 200) {
-    let client;
     const connectPromise = pool.connect();
+    let client;
     try {
         client = await withTimeout(connectPromise, timeoutMs);
+    }
+    catch {
+        // The connect itself timed out, so there is no client to release here; the
+        // pool may still hand one out later, and that one has to be disposed of too.
+        connectPromise.then((late) => late.release(ABANDONED)).catch(() => { });
+        return false;
+    }
+    try {
         await withTimeout(client.query("SELECT 1"), timeoutMs);
+        client.release();
         return true;
     }
     catch {
-        connectPromise.then((c) => c.release()).catch(() => { });
+        client.release(ABANDONED);
         return false;
-    }
-    finally {
-        client?.release();
     }
 }
 export class MigrationRunner {

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
@@ -94,7 +94,15 @@ public class PostSalesApplicationService {
         if (isTerminalNonRefundable(postSalesCase)) {
             throw new OrderNotRefundableException();
         }
-        if (postSalesCase.status().name().equals("APPROVED")) {
+        // Approval is convergent: a case already executing or applied is done, and a case
+        // left in APPROVED by an earlier call still needs to be pushed into EXECUTING.
+        // Previously APPROVED returned immediately without starting execution, so the
+        // case never emitted PostSalesExecutionStarted and the choreography stalled.
+        if (postSalesCase.status() == PostSalesCaseStatus.EXECUTING || postSalesCase.status() == PostSalesCaseStatus.APPLIED) {
+            return postSalesCase;
+        }
+        if (postSalesCase.status() == PostSalesCaseStatus.APPROVED) {
+            startApprovedExecution(postSalesCase, sourceCommandId, correlationId);
             return postSalesCase;
         }
         if (postSalesCase.decision() == null) {
@@ -107,9 +115,14 @@ public class PostSalesApplicationService {
                 .map(PostSalesPolicyContext::incrementAppliedChangeCount)
                 .ifPresent(policyContextStore::save);
         }
+        startApprovedExecution(postSalesCase, sourceCommandId, correlationId);
+        return postSalesCase;
+    }
+
+    private void startApprovedExecution(PostSalesCase postSalesCase, String sourceCommandId, String correlationId) {
+        postSalesCase.startExecution(clock.instant(), sourceCommandId, sourceCommandId, correlationId);
         repository.save(postSalesCase);
         publishNewEvents(postSalesCase);
-        return postSalesCase;
     }
 
     public PostSalesCase get(String caseId) {

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesPolicyContextMapper.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesPolicyContextMapper.java
@@ -3,12 +3,16 @@ package com.trainticket.postsales.application;
 import com.trainticket.postsales.application.PostSalesPolicyContext.RefundWaterfallComponents;
 import com.trainticket.postsales.domain.Money;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 final class PostSalesPolicyContextMapper {
     private static final String DEFAULT_CURRENCY = "CNY";
@@ -51,6 +55,8 @@ final class PostSalesPolicyContextMapper {
         ));
     }
 
+    private static final Pattern SEGMENT_REF_DATE = Pattern.compile("(\\d{4})-(\\d{2})-(\\d{2})");
+
     private static Optional<Instant> earliestDeparture(Map<?, ?> payload, List<Map<?, ?>> segments) {
         List<Instant> candidates = new ArrayList<>();
         for (String field : List.of("departureTime", "departureAt")) {
@@ -61,7 +67,36 @@ final class PostSalesPolicyContextMapper {
                 text(segment, field).map(Instant::parse).ifPresent(candidates::add);
             }
         }
+        // A JourneyOrderCreated/Confirmed payload may carry only segmentRefs — canonical
+        // slugs such as seg-web-2026-08-01-<hash> — with no explicit departure time. The
+        // policy context would then be dropped entirely and every refund quote returns
+        // zero. The service date is embedded in the slug, so derive start-of-day UTC from
+        // it as a last-resort departure.
+        if (candidates.isEmpty()) {
+            for (String segmentRef : textList(payload.get("segmentRefs"))) {
+                departureFromSegmentRef(segmentRef).ifPresent(candidates::add);
+            }
+        }
         return PostSalesPolicyContext.earliest(candidates);
+    }
+
+    private static Optional<Instant> departureFromSegmentRef(String segmentRef) {
+        if (segmentRef == null) {
+            return Optional.empty();
+        }
+        Matcher matcher = SEGMENT_REF_DATE.matcher(segmentRef);
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(LocalDate.of(
+                Integer.parseInt(matcher.group(1)),
+                Integer.parseInt(matcher.group(2)),
+                Integer.parseInt(matcher.group(3))
+            ).atStartOfDay(ZoneOffset.UTC).toInstant());
+        } catch (RuntimeException exception) {
+            return Optional.empty();
+        }
     }
 
     private static Map<String, String> travelerTypes(Object travelerRefsValue) {

--- a/services/post-sales/src/test/java/com/trainticket/postsales/application/PostSalesApplicationServicePolicyIntegrationTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/application/PostSalesApplicationServicePolicyIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.trainticket.postsales.domain.Money;
 import com.trainticket.postsales.domain.PostSalesCase;
+import com.trainticket.postsales.domain.PostSalesCaseStatus;
 import com.trainticket.postsales.domain.PostSalesCaseType;
 import com.trainticket.postsales.domain.PostSalesScope;
 import java.time.Clock;
@@ -133,6 +134,37 @@ class PostSalesApplicationServicePolicyIntegrationTest {
         assertEquals(1_500, evaluated.decision().amountSnapshot().extraChargeAmount().toMinorUnits());
         assertEquals(1_500, evaluated.decision().changeAssessment().changeFee().toMinorUnits());
         assertEquals(0, evaluated.decision().changeAssessment().fareDifference().toMinorUnits());
+    }
+
+    @Test
+    void approveStartsExecutionSoTheCaseCanConvergeToApplied() {
+        InMemoryPostSalesPolicyContextStore contextStore = new InMemoryPostSalesPolicyContextStore();
+        PostSalesApplicationService service = service(contextStore, quote("adjq-apply", 8_750, "CNY", 0, "CNY"));
+        service.recordPolicyContext(PostSalesPolicyContext.fallback("ord-apply", NOW.plusSeconds(3 * 86_400), 1, Money.of("107.50", "CNY")));
+        PostSalesCase postSalesCase = service.open(command("ord-apply", PostSalesCaseType.REFUND, "idem-apply"));
+        service.evaluate("psc-" + postSalesCase.caseId(), "cmd-evaluate", "corr-policy");
+
+        PostSalesCase approved = service.approve("psc-" + postSalesCase.caseId(), "cmd-approve", "corr-policy");
+
+        assertEquals(PostSalesCaseStatus.EXECUTING, approved.status());
+
+        service.applyForSegmentBooking("oi-1", "evt-capacity", "corr-policy");
+
+        assertEquals(PostSalesCaseStatus.APPLIED, service.get("psc-" + postSalesCase.caseId()).status());
+    }
+
+    @Test
+    void approveIsIdempotentOnceTheCaseIsExecuting() {
+        InMemoryPostSalesPolicyContextStore contextStore = new InMemoryPostSalesPolicyContextStore();
+        PostSalesApplicationService service = service(contextStore, quote("adjq-idem", 8_750, "CNY", 0, "CNY"));
+        service.recordPolicyContext(PostSalesPolicyContext.fallback("ord-idem", NOW.plusSeconds(3 * 86_400), 1, Money.of("107.50", "CNY")));
+        PostSalesCase postSalesCase = service.open(command("ord-idem", PostSalesCaseType.REFUND, "idem-idem"));
+        service.evaluate("psc-" + postSalesCase.caseId(), "cmd-evaluate", "corr-policy");
+        service.approve("psc-" + postSalesCase.caseId(), "cmd-approve", "corr-policy");
+
+        PostSalesCase again = service.approve("psc-" + postSalesCase.caseId(), "cmd-approve-2", "corr-policy");
+
+        assertEquals(PostSalesCaseStatus.EXECUTING, again.status());
     }
 
     private static PostSalesApplicationService service(

--- a/services/seat-assignment/internal/adapters/storage/postgres.go
+++ b/services/seat-assignment/internal/adapters/storage/postgres.go
@@ -271,8 +271,16 @@ func (r *Repository) FindActiveSeatAllocations(ctx context.Context, scheduledSer
 	}
 	return out, rows.Err()
 }
-func (r *Repository) FindSeatAllocationsByCapacityRecovery(ctx context.Context, holdID, capacityUnitRef string, interval domain.StationInterval) ([]domain.ContractSeatAllocation, error) {
-	rows, err := r.tx.DBFor(ctx).Query(ctx, "SELECT data FROM seat_allocations WHERE data->>'capacityHoldId'=$1 AND data->>'capacityUnitRef'=$2 AND (data->'interval'->>'fromSeq')::int=$3 AND (data->'interval'->>'toSeq')::int=$4 ORDER BY id", holdID, capacityUnitRef, interval.FromSeq, interval.ToSeq)
+
+// FindSeatAllocationsByCapacityRecovery returns the allocations tied to a capacity
+// hold. A hold release or expiry is always whole-hold (release_hold takes only a
+// holdId), so capacityHoldId alone identifies the allocations to recover. The
+// event's capacityUnitRef and interval describe the HOLD's pool slot (e.g. "01A"
+// over {0,1}), which need not equal the allocation's requested unit and interval
+// (e.g. "cap-standard" over {1,3}); filtering on them matched nothing and the seat
+// was never released.
+func (r *Repository) FindSeatAllocationsByCapacityRecovery(ctx context.Context, holdID, _ string, _ domain.StationInterval) ([]domain.ContractSeatAllocation, error) {
+	rows, err := r.tx.DBFor(ctx).Query(ctx, "SELECT data FROM seat_allocations WHERE data->>'capacityHoldId'=$1 ORDER BY id", holdID)
 	if err != nil {
 		return nil, err
 	}

--- a/services/seat-assignment/internal/application/seatmap_service.go
+++ b/services/seat-assignment/internal/application/seatmap_service.go
@@ -608,7 +608,10 @@ func intFromAny(raw any) int {
 }
 
 func (s *Service) transitionAllocationsByCapacityRecovery(ctx context.Context, match capacityRecoveryMatch, e kitmsg.EventEnvelope, apply func(*domain.ContractSeatAllocation, time.Time), eventType, timeKey string, extra map[string]any) error {
-	if match.HoldID == "" || match.CapacityUnitRef == "" || !match.Interval.Valid() {
+	// A hold release or expiry is whole-hold, so a holdId is sufficient to recover
+	// the tied allocations; capacityUnitRef and interval reflect the hold's pool slot
+	// and need not match the allocation's requested values.
+	if match.HoldID == "" {
 		return nil
 	}
 	transitionedAt := time.Now().UTC()

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -130,10 +130,13 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
     return [...this.entries.values()].some((entry) => isActiveStatus(entry.status) && entry.travelerRefs[0] === travelerRef && entry.intentFingerprint === intentFingerprint);
   }
 
+  // Mirrors PostgresWaitlistRepository: queue identity keys on segmentRef alone,
+  // because the entry's departureDate is deadline-derived when the create request
+  // omits it and the CapacityReleased trigger carries no departureDate at all.
   private buildQueue(segmentRef: string, departureDate: string, seatClass?: string): WaitlistQueue {
-    const matching = [...this.entries.values()].filter((entry) => entry.status !== "CLOSED" && entry.segmentRef === segmentRef && entry.departureDate === departureDate && (!seatClass || entry.seatClass === seatClass));
+    const matching = [...this.entries.values()].filter((entry) => entry.status !== "CLOSED" && entry.segmentRef === segmentRef && (!seatClass || entry.seatClass === seatClass));
     const classForQueue = (seatClass ?? matching[0]?.seatClass ?? "SECOND") as FareClass;
-    return new WaitlistQueue(segmentRef, departureDate, classForQueue, matching.filter((entry) => entry.seatClass === classForQueue));
+    return new WaitlistQueue(segmentRef, matching[0]?.departureDate ?? departureDate, classForQueue, matching.filter((entry) => entry.seatClass === classForQueue));
   }
 
   private snapshot(entry: WaitlistEntry): WaitlistEntrySnapshot {

--- a/services/waitlist/src/bootstrap.ts
+++ b/services/waitlist/src/bootstrap.ts
@@ -90,7 +90,7 @@ export async function bootstrap(options: BootstrapOptions = {}) {
       ? storage.runCommand((repository, publisher) => new WaitlistApplicationService(repository, publisher).expireDueOffers())
       : inMemoryApplicationService().expireDueOffers();
     operation.catch((error: unknown) => app.log.error({ err: error }, "waitlist offer expiry scan failed"));
-  }, Number.parseInt(process.env.WAITLIST_EXPIRY_SCAN_MS ?? "60000", 10));
+  }, Number.parseInt(process.env.WAITLIST_EXPIRY_SCAN_MS ?? "15000", 10));
   expiryTimer.unref();
   const archivalTimer = setInterval(() => {
     const operation = storage

--- a/services/waitlist/src/storage.ts
+++ b/services/waitlist/src/storage.ts
@@ -45,12 +45,19 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
     return this.snapshot(entry);
   }
 
-  async findTopQueued(segmentRef: string, departureDate: string, seatClass?: string): Promise<WaitlistEntry | undefined> {
-    const params: unknown[] = [segmentRef, departureDate];
-    const seatClause = seatClass ? "AND seat_class = $3" : "";
+  // A segmentRef (seg-<uuid>) is minted per service-segment instance, so it already
+  // identifies the service and its date — departureDate is redundant here, and it is
+  // also unreliable on the entry: when the create request omits it the entry's
+  // departure_date is derived from the request deadline rather than the segment's
+  // real date, and the CapacityReleased fulfillment trigger carries no departureDate
+  // at all. Keying the queue on segment_ref (plus class) is what lets freed capacity
+  // actually promote the queued entry.
+  async findTopQueued(segmentRef: string, _departureDate: string, seatClass?: string): Promise<WaitlistEntry | undefined> {
+    const params: unknown[] = [segmentRef];
+    const seatClause = seatClass ? "AND seat_class = $2" : "";
     if (seatClass) params.push(seatClass);
     const result = await this.db.query(
-      `SELECT * FROM waitlist_entries WHERE segment_ref = $1 AND departure_date = $2 ${seatClause} AND status = 'QUEUED' ORDER BY priority_score DESC, created_at ASC, entry_id ASC LIMIT 1`,
+      `SELECT * FROM waitlist_entries WHERE segment_ref = $1 ${seatClause} AND status = 'QUEUED' ORDER BY priority_score DESC, created_at ASC, entry_id ASC LIMIT 1`,
       params,
     ) as QueryResult<WaitlistRow>;
     return result.rows[0] ? entryFromRow(result.rows[0]) : undefined;
@@ -77,12 +84,14 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
     return result.rows[0] ? entryFromRow(result.rows[0]) : undefined;
   }
 
-  async queueFor(segmentRef: string, departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> {
-    const params: unknown[] = [segmentRef, departureDate];
-    const seatClause = seatClass ? "AND seat_class = $3" : "";
+  // Queue identity keys on segment_ref alone (see findTopQueued) so the queue is not
+  // split by unreliable deadline-derived departure_date values.
+  async queueFor(segmentRef: string, _departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> {
+    const params: unknown[] = [segmentRef];
+    const seatClause = seatClass ? "AND seat_class = $2" : "";
     if (seatClass) params.push(seatClass);
     const result = await this.db.query(
-      `SELECT * FROM waitlist_entries WHERE segment_ref = $1 AND departure_date = $2 ${seatClause} AND status <> 'CLOSED' ORDER BY priority_score DESC, created_at ASC, entry_id ASC`,
+      `SELECT * FROM waitlist_entries WHERE segment_ref = $1 ${seatClause} AND status <> 'CLOSED' ORDER BY priority_score DESC, created_at ASC, entry_id ASC`,
       params,
     ) as QueryResult<WaitlistRow>;
     const entries = result.rows.map(entryFromRow);


### PR DESCRIPTION
Re-lands the still-valid content of the nine stale open PRs against current HEAD, so they can all be closed.

Each of the nine was re-checked against HEAD after pulling. Two had already been fixed, one was already fully implemented under different names, one was half-superseded, and five were still genuinely missing.

## Landed here

| Commit | Closes | Problem |
|---|---|---|
| `java-kit: keep warm spares...` | #417 | `minimumIdle=1` let a single server-closed connection empty the pool; a burst then hit `Connection is not available ... (total=1, active=1)`. |
| `seat-assignment: match capacity recovery on the hold id alone` | #412 | The recovery query also filtered on `capacityUnitRef`/interval, which describe the *hold's* pool slot rather than the allocation's requested unit, so it matched nothing and released holds never freed their seat. |
| `waitlist: key the queue on segmentRef alone` | #413 | Queue lookups also matched `departure_date`, which is deadline-derived when the create request omits it and absent entirely from the `CapacityReleased` trigger — so freed capacity never promoted the queued entry. |
| `post-sales: derive the refund departure from the segmentRef slug` | #414 | A payload carrying only `segmentRefs` dropped the policy context, so every refund quote returned zero. |
| `post-sales: start execution on approval` | #394 (partly) | `approve()` returned early on an already-`APPROVED` case without starting execution, so `PostSalesExecutionStarted` was never published and the case parked in `APPROVED` forever. |
| `e2e: capture the promoted customer's payment in 14-waitlist` | #416 | The script never paid for the promoted order, so the saga stayed `PENDING_PAYMENT` and the suite failed on the service rather than on the script. |
| `ts-kit: rebuild the committed dist` | — | Incidental: cd7a5a7b fixed `src/storage.ts` but not the committed `dist/storage.js`. Images are unaffected (they build from src), but local test runs resolve the package through `dist` and so ran the old code. |

## Deliberately not re-landed

**#394's change-pricing half.** It switched `evaluateQuotedChange` back to `evaluateChange(originalFare, originalFare + amountDue)`. That is superseded by df5fb9c8, which made the fare-pricing `amountDue` authoritative precisely so the change fee is not applied twice. Re-landing it fails `changeUsesFarePricingAmountDueWithoutReapplyingChangeFee` (5000 becomes 6500) and `sameFareChangeQuoteReturnsContractedDefaultChangeFeeAsAmountDue` (1500 becomes 3000). Only the convergence half is kept.

**#394's `PostSalesApplied` enrichment.** It added a top-level `scope` field and `resultSummary.refundableAmount`. `scope` is not in the `PostSalesApplied` contract, and no consumer reads either field.

## Already fixed at HEAD, nothing to land

- **#411** — `_parse_occurred_at` already accepts `Any` and handles the `datetime` case.
- **#415** — the stub segment departure is already `now + 30d` and `JourneyOrderCreated` already carries `segments`.
- **#346** — REQ-331 is fully implemented: `handle_journey_order_created` builds the `segmentRef -> orderId` projection, `handle_segment_signal` ingests `SegmentDelayed`/`SegmentCancelled` from both fulfillment and provider-integration (distinguishing `evidence.sourceSystem` by producer) and fans out through `report_disruption`, and `handle_service_alert_published` maintains the ServiceAlert read model. The contract doc's "Consumed upstream events" table lists all four subscriptions. The PR branch merely used different names (`find_orders_by_segment_ref`, `handle_provider_signal`).

## Tests

- post-sales `71/71` (2 new convergence tests)
- waitlist `57/57`
- java-kit `61/61`
- seat-assignment `go test ./...` green
- disruption-recovery `26/26`

Java modules were compiled with `-Dmaven.compiler.release=21` locally (the toolchain here has no JDK 25); no Java 25 language features are involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
